### PR TITLE
canonical URL to MDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,3 +300,28 @@ from the file `mdn-web-docs.svg` in the repository root. This file is then
 converted to favicons using [realfavicongenerator.net](https://realfavicongenerator.net/).
 To generate new favicons, edit or replace the `mdn-web-docs.svg` file
 and then re-upload that to realfavicongenerator.net.
+
+## Canonical links
+
+By default, every generated `.html` page gets something like this:
+
+    <link ref="canonical" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video">
+    <meta name="robots" content="noindex, nofollow">
+
+in the `<head>` container tag. The purpose is to not accidentally present
+a staging or testing version of the site other than the eventual
+production instance. This makes sure that Googlebot doesn't incorrectly
+stores in indexes it.
+
+Another thing it creates is a `/robots.txt` file in the root of the build
+directory. It contains just this:
+
+    User-Agent: *
+    Disallow: /
+
+To disable this functionality in the rendered HTML set the environment
+variable `CLI_ALLOW_INDEXING_BOTS` to any truthy value.
+
+You can also set this directly on the cli with:
+
+    yarn workspace cli start --allow-indexing-bots

--- a/cli/index.js
+++ b/cli/index.js
@@ -121,12 +121,17 @@ function buildHtmlAndJson({
 
   let rendered = null;
   if (buildHtml) {
+    // The options specifically for React rendering but with added options
+    // that are not relevant or needed inside the serialized options
+    // that get included in the HTML.
+    const renderingOptions = { ...options, allowIndexingBots };
+
     try {
       rendered = render(
         <ServerLocation url={uri}>
           <App {...options} />
         </ServerLocation>,
-        { ...options, allowIndexingBots }
+        renderingOptions
       );
     } catch (ex) {
       console.error(`Rendering HTML failed!

--- a/cli/render.js
+++ b/cli/render.js
@@ -47,6 +47,17 @@ export default (renderApp, options) => {
     $("#root").after(documentDataTag);
   }
 
+  if (!options.allowIndexingBots) {
+    $("head")
+      .append(
+        $('<link ref="canonical">').attr(
+          "href",
+          `https://developer.mozilla.org${doc.mdn_url}`
+        )
+      )
+      .append($('<meta name="robots" content="noindex, nofollow">'));
+  }
+
   $("title").text(pageTitle);
 
   $("#root").html(rendered);


### PR DESCRIPTION
Fixes #103

Some day we might need to break this up a bit and get smarter. For example, there might be weird and specific needs we need to put in a `/robots.txt` file. But for now this'll do. It works the same as we're doing with the temporary beta.developer.mozilla.org domain. 