### PR TITLE
make 'yarn start' faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:client": "yarn workspace client build",
     "build:ssr": "yarn workspace ssr build",
     "clean": "rm -fr client/build && rm -fr ssr/dist && rm -fr content/_all-titles.json",
-    "prebuild": "yarn build:ssr && yarn build:client && node content build --ensure-titles",
+    "ensuretitles": "node content build --ensure-titles",
+    "prebuild": "npm-run-all --parallel --aggregate-output build:ssr build:client ensuretitles",
     "start": "yarn run prebuild && nf start"
   },
   "private": true,
@@ -31,7 +32,8 @@
     "pretty-quick": "2.0.1"
   },
   "dependencies": {
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.2",
+    "npm-run-all": "4.1.5"
   },
   "resolutions": {
     "braces": ">=2.3.1",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "build:client": "yarn workspace client build",
     "build:ssr": "yarn workspace ssr build",
     "clean": "rm -fr client/build && rm -fr ssr/dist && rm -fr content/_all-titles.json",
-    "ensuretitles": "node content build --ensure-titles",
-    "prebuild": "npm-run-all --parallel --aggregate-output build:ssr build:client ensuretitles",
+    "ensuretitles": "yarn run build:ssr && node content build --ensure-titles",
+    "prebuild": "npm-run-all --parallel --aggregate-output build:client ensuretitles",
     "start": "yarn run prebuild && nf start"
   },
   "private": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8042,6 +8042,11 @@ memory-fs@^0.4.0, memory-fs@^0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
 meow@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
@@ -8656,6 +8661,21 @@ npm-packlist@^1.1.6:
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
+
+npm-run-all@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
+  integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    chalk "^2.4.1"
+    cross-spawn "^6.0.5"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    pidtree "^0.3.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
 
 npm-run-path@^2.0.0:
   version "2.0.2"
@@ -9354,6 +9374,11 @@ picomatch@^2.0.7:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.1.tgz#21bac888b6ed8601f831ce7816e335bc779f0a4a"
   integrity sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==
+
+pidtree@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
+  integrity sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -11841,6 +11866,14 @@ string.prototype.matchall@^4.0.2:
     internal-slot "^1.0.2"
     regexp.prototype.flags "^1.3.0"
     side-channel "^1.0.2"
+
+string.prototype.padend@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz#dc08f57a8010dc5c153550318f67e13adbb72ac3"
+  integrity sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 string.prototype.trimleft@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Part of #475

How to test...
* Before you check out this branch run `rm -fr content/_all-titles.json && time yarn prebuild`
* Yarn will print something like `✨  Done in 51.44s.` when it has finished all things. Contrast that with the output about generating the all titles file (e.g. `Building list of all titles took 39.5 seconds`)

When you `rm -fr content/_all-titles.json && time yarn prebuild` with *this* branch you should still watch out for the `✨  Done in ...` output and the `Building list of all titles took ...` output. These are now supposed to be almost the same. 

But one thing to notice is that `npm-run-all` will now "buffer" all the individual `stdout` outputs until each (parallel) task has finished individually. Then, it sends this to `stdout` but all the color codes are gone because they're not run with TTY. 
One possible mitigation is to make `yarn prebuild` even "more user-friendly". Kinda like the olden days of starting a Linux computer; it would flood stdout with nerdy jibberish whereas the Mac/Windows would just show a pretty logo. So we could make `yarn prebuild` still use this parallel technique but instead make the output something like this:

```
* Running (yarn run build:ssr):      ...[WAITING ANIMTATION]
* Running (yarn run build:client):   ...[WAITING ANIMTATION]
* Running (yarn run ensuretitles):   ...[WAITING ANIMTATION]

(use -v to see verbose output)
```
Then, as time goes by the prompt changes to something like:
```
* Running (yarn run build:ssr):      👍🏼 done in 2.6 seconds
* Running (yarn run build:client):   👍🏼 done in 8.1 seconds
* Running (yarn run ensuretitles):   ...[WAITING ANIMTATION]

(use -v to see verbose output)
```

We'll have to walk a careful line. We wanna make the "developer" (in quotes because writers aren't exactly developers but by using command line and `yarn` they are too, in a sense) experience **good** but we mustn't kill ourselves with complexity. Having to learn and cope with basic command line stuff is important. And since a fancy prompt like this is an abstraction, abstractions are usually premature optimizations. 