### PR TITLE
Make DocumentSpy lazy loaded

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -1,0 +1,6 @@
+.loading-document-spy {
+  position: absolute;
+  font-size: 70%;
+  top: 0;
+  right: 5px;
+}

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, lazy, Suspense } from "react";
 import { Link, useParams } from "react-router-dom";
 
 import { NoMatch } from "../routing";
@@ -16,8 +16,10 @@ import { BrowserCompatibilityTable } from "./ingredients/browser-compatibility-t
 import { DocumentTranslations } from "./languages";
 import { EditThisPage } from "./editthispage";
 
-// XXX Make this lazy!
-import { DocumentSpy } from "./spy";
+import "./index.scss";
+
+// Lazy sub-components
+const DocumentSpy = lazy(() => import("./spy"));
 
 export function Document(props) {
   const params = useParams();
@@ -142,8 +144,15 @@ export function Document(props) {
           {doc.contributors && <Contributors contributors={doc.contributors} />}
         </div>
       </div>
+
       {process.env.NODE_ENV === "development" && (
-        <DocumentSpy onMessage={onMessage} />
+        <Suspense
+          fallback={
+            <p className="loading-document-spy">Loading document spy</p>
+          }
+        >
+          <DocumentSpy onMessage={onMessage} />
+        </Suspense>
       )}
     </div>
   );

--- a/client/src/document/spy.tsx
+++ b/client/src/document/spy.tsx
@@ -7,7 +7,7 @@ import { Link } from "react-router-dom";
 
 import "./spy.css";
 
-export function DocumentSpy({ onMessage }) {
+export default function DocumentSpy({ onMessage }) {
   // null - never connected before
   // true - connected
   // false - no longer connected


### PR DESCRIPTION
Fixes #486

On `master`
```
File sizes after gzip:

  53.68 KB  build/static/js/2.71854ddc.chunk.js
  10.65 KB  build/static/js/main.1ef91198.chunk.js
  5.09 KB   build/static/css/main.26b1250e.chunk.css
  772 B     build/static/js/runtime-main.cea588d5.js
  532 B     build/static/css/2.3a14348e.chunk.css
```

On this branch:
```
File sizes after gzip:

  53.41 KB (-275 B)  build/static/js/2.ec8ee9a2.chunk.js
  10.68 KB (+31 B)   build/static/js/main.44a539d3.chunk.js
  5.08 KB (-18 B)    build/static/css/main.29f476ed.chunk.css
  1.46 KB (+725 B)   build/static/js/runtime-main.45594010.js
  1.03 KB            build/static/js/3.876b0feb.chunk.js
  532 B              build/static/css/2.3a14348e.chunk.css
  180 B              build/static/css/3.23cdc1f6.chunk.css
```

