### PR TITLE
500 errors in server look like 404s in client

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -107,7 +107,11 @@ export function Document(props) {
   }
   if (loadingError) {
     // Was it because of a 404?
-    if (typeof window !== "undefined" && loadingError instanceof Response) {
+    if (
+      typeof window !== "undefined" &&
+      loadingError instanceof Response &&
+      loadingError.status === 404
+    ) {
       return <NoMatch />;
     } else {
       return <LoadingError error={loadingError} />;
@@ -347,6 +351,9 @@ function LoadingError({ error }) {
           <code>{error.toString()}</code>
         </p>
       )}
+      <p>
+        <a href=".">Try reloading the page</a>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
Fixes #559

Here's how I tested it:

```diff
diff --git a/server/index.js b/server/index.js
index 0e2475b..204d8a6 100644
--- a/server/index.js
+++ b/server/index.js
@@ -174,6 +174,10 @@ app.get("/*", async (req, res) => {
 
     // Check that it even makes sense!
     if (specificFolder) {
+      if (Math.random() > 0.5) {
+        return res.status(500).send("No bueno");
+      }
       const t0 = performance.now();
       try {
         const built = await getOrCreateBuilder().start({
```

Then `yarn clean && yarn start` and I click around until an error happens. Looks like this:
<img width="1616" alt="Screen Shot 2020-05-07 at 4 41 27 PM" src="https://user-images.githubusercontent.com/26739/81342926-0c9d3900-9082-11ea-9d72-feabe97bbcfb.png">

And going to a page like http://localhost:3000/en-US/docs/Web/HTML/Element/audioXXX should still be the usual no-match error:
<img width="1616" alt="Screen Shot 2020-05-07 at 4 45 05 PM" src="https://user-images.githubusercontent.com/26739/81342966-23dc2680-9082-11ea-972e-ee10062eada3.png">
