### PR TITLE
only remove 'span.alllinks'

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1226,10 +1226,9 @@ class Builder {
       // decodeEntities: false
     });
 
-    // Remove those '<span class="alllinks"><a href="/en-US/docs/tag/Web">View All...</a></span>' links
-    // Remove any completely empty <p>, <dl>, or <div> tags.
-    // XXX costs about 5% longer time
-    $("p:empty,dl:empty,div:empty,span.alllinks").remove();
+    // Remove those '<span class="alllinks"><a href="/en-US/docs/tag/Web">View All...</a></span>' links.
+    // If a document has them, they don't make sense in a Yari world anyway.
+    $("span.alllinks").remove();
 
     // XXX should we get some of this stuff from this.allTitles instead?!
     // XXX see https://github.com/mdn/yari/issues/502


### PR DESCRIPTION
This line dates back to the very beginning of yari coming into life. 
But a lots of empty tags are a reality with Kuma HTML as it creates the right margins that you're used to seeing. This is not a great place to fix that. 

In fact, after we have completely migrated MySQL into git and shut down the Wiki, we can go in and do a mass edit of all the `index.html` sources and remove all `span.alllinks` directly in the source. For now, let's just get rid of them in the post-processing. 