### PR TITLE
handle foldersearch with nothing better

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -535,7 +535,10 @@ class Builder {
         .map((m) => Array.from(m.values()).reduce((a, b) => a + b, 0))
         .reduce((a, b) => a + b);
       if (!countTodo) {
-        throw new Error("No folders found to process!");
+        this.logger.warn(
+          chalk.red("No folders found to process. Did you filter too much?")
+        );
+        return;
       }
       self.initProgressbar(countTodo);
     }

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -532,7 +532,7 @@ class Builder {
       const countTodo = self.sources
         .entries()
         .map((source) => self.countLocaleFolders(source))
-        .map((m) => Array.from(m.values()).reduce((a, b) => a + b))
+        .map((m) => Array.from(m.values()).reduce((a, b) => a + b, 0))
         .reduce((a, b) => a + b);
       if (!countTodo) {
         throw new Error("No folders found to process!");


### PR DESCRIPTION
Fixes #593

Given that this is ultimately a problem with the cli parameters, I wonder if we should instead just show the one line ("No folders found to process!") in red without the stack trace. 
<img width="748" alt="Screen Shot 2020-05-15 at 7 47 51 AM" src="https://user-images.githubusercontent.com/26739/82047322-9f406800-9680-11ea-8d1c-a90923ea91e5.png">
