### PR TITLE
double colon directories

### DIFF
--- a/content/scripts/utils.js
+++ b/content/scripts/utils.js
@@ -10,6 +10,7 @@ function slugToFoldername(slug) {
       // happen is that it leads to two *different slugs* becoming
       // *same* folder name.
       .replace(/\*/g, "_star_")
+      .replace(/::/g, "_doublecolon_")
       .replace(/:/g, "_colon_")
       .replace(/\?/g, "_question_")
 


### PR DESCRIPTION
Fixes #609

Now it becomes...

```
▶ ls content/files/en-us/web/css/_doublecolon_-ms-fill/
index.html       index.yaml       wikihistory.json
```

and 

```
▶ ls client/build/en-us/docs/web/css/_doublecolon_-ms-fill
_index.hash         _preferred-name.txt index.html          index.json
```