### PR TITLE
Broken links checking needs to be smarter about anchor links

### DIFF
--- a/client/src/document/flaws.tsx
+++ b/client/src/document/flaws.tsx
@@ -80,11 +80,15 @@ function BrokenLinks({ urls }: { urls: string[] }) {
     for (const anchor of [
       ...document.querySelectorAll<HTMLAnchorElement>("div.content a[href]"),
     ]) {
-      const pathname = new URL(anchor.href).pathname;
+      const hrefURL = new URL(anchor.href);
+      const { pathname, hash } = hrefURL;
       if (pathname in data.redirects) {
         // Trouble! But is it a redirect?
-        const correctURI = data.redirects[pathname];
+        let correctURI = data.redirects[pathname];
         if (correctURI) {
+          if (hash) {
+            correctURI += hash;
+          }
           // It can be fixed!
           anchor.classList.add("flawed--broken_link_redirect");
           anchor.title = `Consider fixing! It's actually a redirect to ${correctURI}`;

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1440,10 +1440,17 @@ class Builder {
     // The 'broken_links' flaw check looks for internal links that
     // link to a document that's going to fail with a 404 Not Found.
     if (this.options.flawLevels.get("broken_links") !== FLAW_LEVELS.IGNORE) {
+      // This is needed because the same href can occur multiple time.
+      // Especially when there's...
+      //    <a href="/foo/bar#one">
+      //    <a href="/foo/bar#two">
+      const checked = new Set();
+
       $("a[href]").each((i, element) => {
         const a = $(element);
         const href = a.attr("href").split("#")[0];
-        if (href.startsWith("/")) {
+        if (href.startsWith("/") && !checked.has(href)) {
+          checked.add(href);
           if (!this.allTitles.has(href.toLowerCase())) {
             if (!doc.flaws.hasOwnProperty("broken_links")) {
               doc.flaws.broken_links = [];


### PR DESCRIPTION
Fixes #595

To test

1. `yarn clean && yarn start`
2. Go to http://localhost:3000/en-us/docs/web/css/background#_flaws
3. Hover over all the orange links "Formal syntax" section. 