### PR TITLE
Sorting by # flaws should take filtering into account

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -331,9 +331,16 @@ app.get("/_flaws", (req, res) => {
           ((b.popularity.value || 0) - (a.popularity.value || 0))
         );
       case "flaws":
-        // This is kinda bogus and slow.
-        const vA = a.flaws.reduce((x, y) => x + y.value, 0);
-        const vB = b.flaws.reduce((x, y) => x + y.value, 0);
+        const vA = a.flaws
+          .filter(({ name }) => {
+            return !filteredFlaws.size || filteredFlaws.has(name);
+          })
+          .reduce((x, y) => x + y.value, 0);
+        const vB = b.flaws
+          .filter(({ name }) => {
+            return !filteredFlaws.size || filteredFlaws.has(name);
+          })
+          .reduce((x, y) => x + y.value, 0);
         return sortMultiplier * (vB - vA);
       case "mdn_url":
         if (a.mdn_url.toLowerCase() < b.mdn_url.toLowerCase()) {


### PR DESCRIPTION
Fixes #597

To test:

1. `yarn start` and `node content build -l en-us -f learn`
1. Go to http://localhost:3000/en-US/_flaws?flaws=macros&sort_by=flaws

It now sorts by the number of `macros` errors. 