### PR TITLE
solution to broken css and jsxrefs

### DIFF
--- a/client/src/document/flaws.tsx
+++ b/client/src/document/flaws.tsx
@@ -87,9 +87,13 @@ function BrokenLinks({ urls }: { urls: string[] }) {
         if (correctURI) {
           // It can be fixed!
           anchor.classList.add("flawed--broken_link_redirect");
+          // XXX This would overwrite existing 'title' attributes
+          // but we can stuff it in a 'data-originaltitle' attribute.
           anchor.title = `Consider fixing! It's actually a redirect to ${correctURI}`;
         } else {
           anchor.classList.add("flawed--broken_link_404");
+          // XXX This would overwrite existing 'title' attributes
+          // but we can stuff it in a 'data-originaltitle' attribute.
           anchor.title = "Broken link! Links to a page that will not be found";
         }
       }
@@ -102,6 +106,7 @@ function BrokenLinks({ urls }: { urls: string[] }) {
         )
       )) {
         anchor.classList.remove("flawed--broken_link_redirect");
+        // XXX Restore if there was a 'data-originaltitle' attribute
         anchor.title = "";
       }
       for (const anchor of Array.from(
@@ -110,6 +115,7 @@ function BrokenLinks({ urls }: { urls: string[] }) {
         )
       )) {
         anchor.classList.remove("flawed--broken_link_404");
+        // XXX Restore if there was a 'data-originaltitle' attribute
         anchor.title = "";
       }
     };

--- a/client/src/mdn.scss
+++ b/client/src/mdn.scss
@@ -107,6 +107,17 @@ div.sidebar {
   }
 }
 
+// Temporary hack so that <a><code>...</code></a> becomes distinguishable
+// from <code>...</code>.
+a > code {
+  text-decoration: underline;
+}
+a.new > code,
+a.new:hover > code {
+  border-bottom: 1px dashed red;
+  text-decoration: none;
+}
+
 div.content {
   margin-left: 22.75%;
 

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1451,8 +1451,9 @@ class Builder {
     $("a[href][data-macro]").each((i, element) => {
       const a = $(element);
       const macroData = a.data("macro");
-      const [href, hash] = a.attr("href").split("#", 2);
+      // XXX check that the macroData is /xref$/
       if (macroData && href.startsWith("/")) {
+        const [href, hash] = a.attr("href").split("#", 2);
         a.removeAttr("data-macro");
         if (!this.allTitles.has(href.toLowerCase())) {
           // let cleanedHref = this.cleanUri(href);

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1451,9 +1451,11 @@ class Builder {
     $("a[href][data-macro]").each((i, element) => {
       const a = $(element);
       const macroData = a.data("macro");
-      // XXX check that the macroData is /xref$/
-      if (macroData && href.startsWith("/")) {
-        const [href, hash] = a.attr("href").split("#", 2);
+      const [href, hash] = a.attr("href").split("#", 2);
+      if (
+        macroData /* XXX check that the macroData is /xref$/ */ &&
+        href.startsWith("/")
+      ) {
         a.removeAttr("data-macro");
         if (!this.allTitles.has(href.toLowerCase())) {
           // let cleanedHref = this.cleanUri(href);

--- a/kumascript/macros/DOMxRef.ejs
+++ b/kumascript/macros/DOMxRef.ejs
@@ -48,4 +48,4 @@ let code = '';
 let endcode = '';
 if (!$3) { code = '<code>'; endcode = '</code>' }
 
-%><a href="<%- URL+anch %>"><%- code %><%- str %><%- endcode %></a>
+%><a macro="domxref" href="<%- URL+anch %>"><%- code %><%- str %><%- endcode %></a>

--- a/kumascript/macros/cssxref.ejs
+++ b/kumascript/macros/cssxref.ejs
@@ -13,7 +13,7 @@
 
   Examples:
   {{cssxref("background")}} =>
-      <a href="/en-US/docs/Web/CSS/background" title="The background CSS 
+      <a href="/en-US/docs/Web/CSS/background" title="The background CSS
       property is..."><code>background</code></a>
   {{cssxref("length")}} =>
       <a href="/en-US/docs/Web/CSS/length" title="The <length> CSS data type
@@ -22,7 +22,7 @@
       <a href="/en-US/docs/Web/CSS/linear-gradient" title="The CSS
       linear-gradient() function creates..."><code>linear-gradient()</code></a>
   {{cssxref("margin-top", "top margin")}} =>
-      <a href="/en-US/docs/Web/CSS/margin-top" title="The margin-top CSS 
+      <a href="/en-US/docs/Web/CSS/margin-top" title="The margin-top CSS
       property of an element sets..."><code>top margin</code></a>
   {{cssxref("filter", "", "#url")}} =>
       <a href="/en-US/docs/Web/CSS/filter#url()"><code>filter</code></a>
@@ -83,7 +83,7 @@ if (!$2) {
     }
 }
 
-var entry = "<a href=\"" + url + "\"" + (summary?" title=\""+summary+"\"":"") + "><code>" + str + "</code></a>";
+var entry = "<a data-macro=\"cssxref\" href=\"" + url + "\"" + (summary?" title=\""+summary+"\"":"") + "><code>" + str + "</code></a>";
 
 
 %><%- entry %>

--- a/kumascript/macros/htmlattrxref.ejs
+++ b/kumascript/macros/htmlattrxref.ejs
@@ -32,6 +32,6 @@ if ($1 && ($1 != undefined)) {
 var code    = !$3 ? '<code>'  : '';
 var endcode = !$3 ? '</code>' : '';
 
-var result = code + '<a href="' + url + '#attr-' + $0 +'">' + text + '</a>'+ endcode;
+var result = code + '<a data-macro="htmlattrxref" href="' + url + '#attr-' + $0 +'">' + text + '</a>'+ endcode;
 %>
 <%- result %>

--- a/kumascript/macros/jsapixref.ejs
+++ b/kumascript/macros/jsapixref.ejs
@@ -35,4 +35,4 @@ if (page && page.summary) {
 var code    = !$3 ? '<code>'  : '';
 var endcode = !$3 ? '</code>' : '';
 
-%><a href="<%- URL + $2 %>" title="<%-summary%>"><%- code %><%= str %><%- endcode %></a>
+%><a data-macro="jsapixref" href="<%- URL + $2 %>" title="<%-summary%>"><%- code %><%= str %><%- endcode %></a>

--- a/kumascript/macros/jsxref.ejs
+++ b/kumascript/macros/jsxref.ejs
@@ -47,4 +47,4 @@ if (anchor && anchor[0] != '#') {
 let code    = !$3 ? '<code>'  : '';
 let endcode = !$3 ? '</code>' : '';
 
-%><a href="<%- URL + anchor %>"><%- code %><%- str %><%- endcode %></a>
+%><a data-macro="jsxref" href="<%- URL + anchor %>"><%- code %><%- str %><%- endcode %></a>

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -182,7 +182,8 @@ class AllPagesInfo {
   getPage(url) {
     const uriKey = this.getUriKey(url);
     if (!this.pagesByUri.has(uriKey)) {
-      throw new Error(`${this.getDescription(url)} does not exist`);
+      return {};
+      // throw new Error(`${this.getDescription(url)} does not exist`);
     }
     return this.pagesByUri.get(uriKey);
   }


### PR DESCRIPTION
Fixes #598

There is a LOT to unpack here. And the hacky code is hacky so it'll have to stay a draft for a while. 

Basically, this hinges on that we fix some of the macros. Actually, all the `kumascript/macros/*xhref.ejs` so we'll need to make an exception to them as we keep copying over macros from github.com/mdn/kumascript. 

Anyway, the idea is:

* Don't throw if `getPage()` fails, but return an empty object instead. 
* For every xhref `<a>` tag, inject a (for example) `<a data-macro="domxref" href="...">`
* After having done the `this.renderMacros()` we postprocess the HTML with cheerio and analyze each tag. If the `href` in is fine, leave it. If it can be a redirect, just fix it. If it's completely busted, do that kuma does and remove the `href` attribute and add `class="new" title="Not been created yet"`. 

It really works well! Click around and on pages like http://localhost:3000/en-US/docs/Web/API/Element and http://localhost:3000/en-US/docs/Web/CSS/WebKit_Extensions and http://localhost:3000/en-US/docs/Learn/JavaScript/First_steps/Math etc. 

Now there's a LOT less failing macros (perhaps we can change the default flaw level setting to `macros:error, *:warn` !)
But most importantly; I don't yet fully understand the repercussions of what I've just done. It's a very invasive hack and needs a lot of mulling and insight from @escattone 

An interesting and important thing to consider is the `<a>` tags text. 
For example, on http://localhost:3000/en-US/docs/Web/CSS/WebKit_Extensions it corrected, from...
```html
<a href="/en-US/docs/Web/CSS/::-webkit-input-placeholder" title="The ::placeholder CSS pseudo-element represents the placeholder text in an input or textarea element.">
  <code>::-webkit-input-placeholder</code></a>
```
to...
```html
<a href="/en-US/docs/Web/CSS/::placeholder" title="The ::placeholder CSS pseudo-element represents the placeholder text in an input or textarea element.">
  <code>::-webkit-input-placeholder</code></a>
```
So, perhaps it should have instead become:
```html
<a href="/en-US/docs/Web/CSS/::placeholder" title="The ::placeholder CSS pseudo-element represents the placeholder text in an input or textarea element.">
  <code>::placeholder</code></a>
```
And that value (`::placeholder`) should be gotten from `this.allTitles(correctURI).title` maybe?
