### PR TITLE
fix build performance issue

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -55,14 +55,15 @@ function getCurrentGitBranch(fallback = "master") {
         "branch",
         "--show-current",
       ]);
-      if (spawned.error) {
+      if (spawned.error || spawned.status) {
         console.warn(
-          "Unable to run 'git branch' to find out name of the current branch. Error:",
-          spawned.error
+          "\nUnable to run 'git branch' to find out name of the current branch:\n",
+          spawned.error ? spawned.error : spawned.stderr.toString().trim()
         );
-        return fallback;
+        // I don't think it makes sense to keep trying, so let's cache the fallback.
+        _currentGitBranch = fallback;
       } else {
-        return spawned.stdout.toString().trim();
+        _currentGitBranch = spawned.stdout.toString().trim();
       }
     }
   }


### PR DESCRIPTION
This PR fixes the largest contributor to the build performance degradation (the build times were roughly doubling). The problems were within `getCurrentGitBranch()`:
- Most importantly, it was never caching the successful result of `git branch --show-current`.
- It was also never detecting the error case where the `git branch --show-current` completes without a `child_process` error (`spawned.error` is _falsy_), but with a `git branch` error (`spawned.status` is _truthy_) which was my case since I was using an older version of `git` that didn't support `--show-current` for the `git branch` command. Also, when an error occurs I don't think we should keep trying to run the child-process command on every single call to `processFolder`, but instead just cache the `fallback`.

There seems to be at least one more performance issue that has been introduced within the last week or so. Instead of build times around 5.4 minutes for `node content build --start-clean -l en-us`, now I'm seeing about 6.4 minutes. I'll keep looking but so far it seems to be a commit prior to https://github.com/mdn/yari/commit/f18163bba4f6d1dc2403081ef6347a4c177fa336 that added an extra minute to the full English builds.
