### PR TITLE
speed up dumper

### DIFF
--- a/content/scripts/document.js
+++ b/content/scripts/document.js
@@ -7,7 +7,7 @@ function buildPath(contentPath, slug) {
   return path.join(contentPath, slugToFoldername(slug));
 }
 
-async function create(contentPath, html, meta, wikiHistory = null) {
+function create(contentPath, html, meta, wikiHistory = null) {
   const folder = buildPath(contentPath, meta.slug);
   fs.mkdirSync(folder, { recursive: true });
 

--- a/content/scripts/document.js
+++ b/content/scripts/document.js
@@ -9,17 +9,14 @@ function buildPath(contentPath, slug) {
 
 async function create(contentPath, html, meta, wikiHistory = null) {
   const folder = buildPath(contentPath, meta.slug);
-  await fs.promises.mkdir(folder, { recursive: true });
+  fs.mkdirSync(folder, { recursive: true });
 
-  await fs.promises.writeFile(path.join(folder, "index.html"), html);
+  fs.writeFileSync(path.join(folder, "index.html"), html);
 
-  await fs.promises.writeFile(
-    path.join(folder, "index.yaml"),
-    yaml.safeDump(meta)
-  );
+  fs.writeFileSync(path.join(folder, "index.yaml"), yaml.safeDump(meta));
 
   if (wikiHistory) {
-    await fs.promises.writeFile(
+    fs.writeFileSync(
       path.join(folder, "wikihistory.json"),
       JSON.stringify(wikiHistory, null, 2)
     );

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -551,7 +551,7 @@ async function processDocument(
     wikiHistory.contributors = docContributors;
   }
 
-  await Document.create(
+  Document.create(
     contentPath,
     isArchive ? doc.rendered_html : doc.html,
     meta,


### PR DESCRIPTION
Thanks for doing https://github.com/mdn/yari/pull/644. I like it but I immediately noticed a chance to optimize it. 
Now, the perf of the dumper doesn't really matter but the results are so interesting that it might just be worth merging this one. 

I coped the `content/scripts/document.js` to `document-sync.js` and made the same modifications as this PR. Then I wrote this bash script:

```bash
cp /tmp/document-sync.js content/scripts/document.js
time node content import --start-clean

echo "************** PAUSE ************"

cp /tmp/document-async.js content/scripts/document.js
time node content import --start-clean

echo "**************** END ***************"
```
which I ran about 10 times in a row whilst I left the computer for dinner. 

Since the `time` command just prints to stdout, I'm "using my eyes" to estimate the averages.

* With `document-async.js` (aka. what's [in `master`](https://github.com/mdn/yari/blob/master/content/scripts/document.js)) it spits out: `Took 2m40s seconds to process 133,789 rows.` and `Roughly 835.2 rows/sec.`
* With `document-sync.js` (this PR) it spits out: `Took 1m14s seconds to process 133,789 rows.` and `Roughly 1801.4 rows/sec.`

That's a pretty considerable difference!
Now, not all laptops and SSD drives are the same but the numbers without a doubt interesting. 