### PR TITLE
include raw html in archivecontent

### DIFF
--- a/content/scripts/document.js
+++ b/content/scripts/document.js
@@ -7,11 +7,25 @@ function buildPath(contentPath, slug) {
   return path.join(contentPath, slugToFoldername(slug));
 }
 
-function create(contentPath, html, metadata, wikiHistory = null) {
+function create(
+  contentPath,
+  html,
+  metadata,
+  wikiHistory = null,
+  rawHtml = null
+) {
   const folder = buildPath(contentPath, metadata.slug);
   fs.mkdirSync(folder, { recursive: true });
 
   saveFile(path.join(folder, "index.html"), html, metadata);
+
+  // The `rawHtml` is only applicable in the importer when it saves
+  // archived content. The archived content gets the *rendered* html
+  // saved but by storing the raw html too we can potentially resurrect
+  // the document if we decide to NOT archive it in the future.
+  if (rawHtml) {
+    fs.writeFileSync(path.join(folder, "raw.html"), rawHtml);
+  }
 
   if (wikiHistory) {
     fs.writeFileSync(

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -555,7 +555,8 @@ async function processDocument(
     contentPath,
     isArchive ? doc.rendered_html : doc.html,
     meta,
-    wikiHistory
+    wikiHistory,
+    isArchive ? doc.html : null
   );
 }
 


### PR DESCRIPTION
```
▶ ls -l archivecontent/files/en-us/mozilla/projects/spidermonkey/jsapi_reference/js_defineownproperty/
total 392
-rw-r--r--  1 peterbe  staff  189694 May 28 06:46 index.html
-rw-r--r--  1 peterbe  staff    2238 May 28 06:46 raw.html
-rw-r--r--  1 peterbe  staff     203 May 28 06:46 wikihistory.json
```

```
▶ cat archivecontent/files/en-us/xul/attribute/onunload/index.html | head -n 13
---
title: onunload
slug: XUL/Attribute/onunload
summary: >-
  Specifies a set of scripts to execute when the browser window is closed by the
  user. This code is used by some programmers to annoyingly pop up alert boxes
  preventing the users from leaving the page.
tags:
  - JavaScript
---
<div class="noinclude"><span class="breadcrumbs xulRefAttr_breadcrumbs">« <a href="/en-US/docs/XUL/XUL_Reference">XUL Reference home</a></span></div>

<dl>
```

```
▶ cat archivecontent/files/en-us/mozilla/projects/spidermonkey/jsapi_reference/js_defineownproperty/raw.html | head -n 6
<div>{{SpiderMonkeySidebar("JSAPI")}}</div>
<p>{{ obsolete_header("jsapi33") }}</p>
<p>{{ jsapi_minversion_header("1.8.5") }}</p>
<div class="summary">
<p>Please provide a description for this function.</p>
</div>
```

Now, if EVER decide to go back on any of these, we can. 