### PR TITLE
Trash Trash?

### DIFF
--- a/content/scripts/constants.js
+++ b/content/scripts/constants.js
@@ -26,6 +26,7 @@ const DEFAULT_EXCLUDE_SLUG_PREFIXES = [
   "Template_talk:",
   "User:",
   "User_talk:",
+  "Trash",
 
   // The following come from 'NOINDEX_SLUG_PREFIXES' in
   // https://github.com/mdn/kuma/blob/master/kuma/wiki/constants.py#L668

--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -39,6 +39,7 @@ const ARCHIVE_SLUG_ENGLISH_PREFIXES = [
   "Sandbox",
   "SpiderMonkey",
   "Thunderbird",
+  "Trash",
   "XML_Web_Services",
   "XUL",
   "XULREF",


### PR DESCRIPTION
Fixes #573

Run `node content import --start-clean` and then:
```
▶ cat  content/files/en-us/_redirects.txt | rg Trash

```
Note the empty output. It used to be lots and lots of lines. 