### PR TITLE
cope with new slugs created

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -669,15 +669,14 @@ class Builder {
     self.summarizeResults(counts, flawCounts, t1 - t0);
   }
 
-  ensureAllTitles(forceRegenerate = false) {
+  ensureAllTitles() {
     if (!this.selfHash) {
       throw new Error("this.selfHash hasn't been set yet");
     }
     if (
       this.allTitles.size &&
       this.allTitles.get("_hash") === this.selfHash &&
-      !this.options.regenerateAllTitles &&
-      !forceRegenerate
+      !this.options.regenerateAllTitles
     ) {
       // No reason to proceed, the titles have already been loaded into memory.
       return;
@@ -690,8 +689,7 @@ class Builder {
     // But first, see if we can use the title from the last build.
     if (
       fs.existsSync(ALL_TITLES_JSON_FILEPATH) &&
-      !this.options.regenerateAllTitles &&
-      !forceRegenerate
+      !this.options.regenerateAllTitles
     ) {
       this.allTitles = new Map(
         Object.entries(
@@ -1498,7 +1496,7 @@ class Builder {
       // the first ever edit on it.
       // For example, if you edit a document's front-matter to change
       // the slug. Then it's a new mdnUrl since the watcher started.
-      this.ensureAllTitles(true);
+      this.processFolderTitle(source, folder, this._getAllPopularities());
     }
 
     if (this.excludeSlug(mdn_url)) {


### PR DESCRIPTION
Fixes #677

Steps to test:

1. `yarn clean && yarn start`
2. Create a brand new folder: `mkdir content/files/en-us/somethingnew`
3. Save a new `index.html` in it. E.g.:
```
---
slug: Brandspankingnew
title: Brand spanking new
summary: BLa bla
---
<p>Hi!</p>

```
4. Save file. 
5. Go to http://localhost:3000 and expect to find it in the search and be able to go to it. 

Second Steps to test:

1. `yarn clean && yarn start`
2. Find an existing `index.html`. Eg. `emacs content/files/en-us/glossary/jpeg/index.html`
3. Change the `slug` to something new. 

Now, what we **could** do is be really smart. 
When a `processFolder()` is called from the watcher, it could check if this was a new slug but we can loop over all the values in `this.allTitles` to see if this file was already in there but had a different key. But this feels premature because I suspect that 99% of people will use your CRUD tools to rename slugs. And that'll deal with redirects. 