### PR TITLE
unit test rendering <Document/>

### DIFF
--- a/client/src/document/index.test.tsx
+++ b/client/src/document/index.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+const { render, waitFor } = require("@testing-library/react");
+import { Route, Routes, MemoryRouter } from "react-router-dom";
+
+import { Document } from "./index";
+
+declare var global: Window;
+
+const sampleDocumentState = Object.freeze({
+  doc: Object.freeze({
+    title: "Sample Page",
+    summary: "This is the summary",
+    mdn_url: "/en-US/docs/Sample/Page",
+    sidebarHTML: "<ul><li>One</li></ul>",
+    body: [
+      {
+        type: "prose",
+        value: {
+          content: "<p>Hello World!</p>",
+        },
+      },
+    ],
+    popularity: 0.01,
+    modified: "2019-10-10T16:39:07.157Z",
+    source: {
+      folder: "en-us/sample/page",
+      github_url: "http://github.com/mdn/yari/yada/yada",
+    },
+  }),
+});
+
+describe("test viewing a simple document", () => {
+
+  test("render document with props should not crash", async () => {
+    const xhrSpy = jest.spyOn(global, "fetch");
+
+    const { getByText } = render(
+      <MemoryRouter initialEntries={["/en-US/docs/Sample/Page"]}>
+        <Routes>
+          <Route
+            path="/:locale/docs/*"
+            element={
+              <Document doc={Object.assign({}, sampleDocumentState.doc)} />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(xhrSpy).not.toHaveBeenCalled();
+    await waitFor(() => getByText(/Hello World!/));
+    await waitFor(() => getByText(/Sample Page/));
+  });
+
+  test("render document without props should not crash", async () => {
+    // Mock Fetch API
+    const xhrSpy = jest.spyOn(global, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve(Object.assign({}, sampleDocumentState)),
+      } as Response)
+    );
+    const { getByText } = render(
+      <MemoryRouter initialEntries={["/en-US/docs/Sample/Page"]}>
+        <Routes>
+          <Route path="/:locale/docs/*" element={<Document />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(xhrSpy).toHaveBeenCalledTimes(1);
+    await waitFor(() => getByText(/Hello World!/));
+    await waitFor(() => getByText(/Sample Page/));
+  });
+
+});


### PR DESCRIPTION
Fixes #636

It doesn't do a whole lot and we're already testing to view documents with headless testing. 
But I still think this one is important to have around. 

* If the headless tests break because of a fundamental bug, the unit tests will flag that sooner with a hopefully nicer error and it'll make it easier to debug the headless tests. 
* In this current form, the tests don't actually do much but it lays the foundation for more advanced testing once the `<Document/>` or any of it's inner details get more complicated to the point where it's actually faster to debug it by writing unit tests. 
* We're still not actually testing implementation details since I think these tests stay pretty high up.