### PR TITLE
Double-escape inside search widget should blur input

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -247,6 +247,17 @@ export class SearchWidgetClass extends React.Component {
     if (event.key === "Escape") {
       if (this.state.showSearchResults) {
         this.setState({ showSearchResults: false });
+      } else {
+        // If there's nothing left in the input field, force a blur.
+        // The reason for doing this is that you might have used
+        // a keyboard shortcut to trigger focus on the input field
+        // and there's no way to escape that focus.
+        if (!this.state.q) {
+          this.blurHandler();
+          if (this.inputRef.current) {
+            this.inputRef.current.blur();
+          }
+        }
       }
     } else if (event.key === "ArrowDown" || event.key === "Tab") {
       // Increment 'highlitResult' if possible.


### PR DESCRIPTION
Fixes #621

To test:

1. Go to a page on http://localhost:3000
2. Press <kbd>?</kbd> to focus on the search input. 
3. Press <kbd>Esc</kbd>

Note that it only works if you have nothing typed into the field which is deliberate.