### PR TITLE
server and default build root

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ const Document = require("content/scripts/document");
 const { Sources } = require("content/scripts/sources");
 const { slugToFoldername } = require("content/scripts/utils");
 const {
+  DEFAULT_BUILD_ROOT,
   DEFAULT_LIVE_SAMPLES_BASE_URL,
   DEFAULT_POPULARITIES_FILEPATH,
   FLAW_LEVELS,
@@ -206,10 +207,9 @@ function getOrCreateBuilder(options) {
   if (!builder) {
     const sources = new Sources();
     // The server doesn't have command line arguments like the content CLI
-    // does so we need to entirely rely on environment variables.
-    if (process.env.BUILD_ROOT) {
-      sources.add(normalizeContentPath(process.env.BUILD_ROOT));
-    }
+    // does so we need to entirely rely on defaults.
+    sources.add(normalizeContentPath(DEFAULT_BUILD_ROOT));
+
     builder = new Builder(
       sources,
       {


### PR DESCRIPTION
Fixes #781

@tobinmori If you can do the Quickstart but instead download this branch, I think it would be review enough :)

```
git clone https://github.com/peterbe/yari.git
cd yari
git checkout 781-server-and-default-build-root
yarn 
yarn start
open http://localhost:3000/en-US/docs/Web/HTML/Element/audio
```