### PR TITLE
add basic tests for kumascript rendering

### DIFF
--- a/testing/.env
+++ b/testing/.env
@@ -6,3 +6,4 @@ BUILD_ROOT=testing/content/files
 BUILD_ARCHIVE_ROOT=testing/archivecontent/files
 BUILD_ALLOW_STALE_TITLES=false
 BUILD_POPULARITIES_FILEPATH=testing/content/popularities.json
+BUILD_LIVE_SAMPLES_BASE_URL=http://localhost:5000

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/index.html
@@ -1,0 +1,23 @@
+---
+title: A Test Introduction to CSS Flexbox Layout
+slug: Learn/CSS/CSS_layout/Introduction/Flex
+summary: A test article showing flexbox layout.
+tags:
+  - Examples
+  - Beginner
+  - CSS
+  - Layout
+  - Learn
+  - flexbox
+---
+<h2 id="Flexbox">Flexbox</h2>
+<!--
+Grab the content of the live samples from a different page. This tests
+that the page must be fully rendered before extracting the live samples,
+and also tests that prerequisites are handled as part of the rendering
+and live-sample-building process.
+-->
+<div id="Flex_1">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_1") }}</div>
+<p>{{ EmbedLiveSample('Flex_1', '300', '200') }}</p>
+<div id="Flex_2">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_2") }}</div>>
+<p>{{ EmbedLiveSample('Flex_2', '300', '200') }}</p>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/index.html
@@ -1,0 +1,70 @@
+---
+title: Stuff for CSS Flex layout
+slug: Learn/CSS/CSS_layout/Introduction/Flex/Stuff
+summary: A test article containing stuff for flex.
+tags:
+  - Stuff
+  - Beginner
+  - CSS
+  - Introduction
+  - Layout
+  - Learn
+  - flexbox
+---
+<div id="Flex_1">
+<div class="hidden">
+<h6 id="Flexbox_Example_1">Flexbox Example 1</h6>
+
+<pre class="brush: css">* {box-sizing: border-box;}
+
+.wrapper &gt; div {
+    border-radius: 5px;
+    background-color: rgb(207,232,220);
+    padding: 1em;
+}
+    </pre>
+</div>
+
+<pre class="brush: css">.wrapper {
+  display: flex;
+}
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+  &lt;div class="box1"&gt;One&lt;/div&gt;
+  &lt;div class="box2"&gt;Two&lt;/div&gt;
+  &lt;div class="box3"&gt;Three&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+</div>
+
+<div id="Flex_2">
+<div class="hidden">
+<h6 id="Flexbox_Example_2">Flexbox Example 2</h6>
+
+<pre class="brush: css">    * {box-sizing: border-box;}
+
+    .wrapper &gt; div {
+        border-radius: 5px;
+        background-color: rgb(207,232,220);
+        padding: 1em;
+    }
+    </pre>
+</div>
+
+<pre class="brush: css">.wrapper {
+    display: flex;
+}
+
+.wrapper &gt; div {
+    flex: 1;
+}
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box1"&gt;One&lt;/div&gt;
+    &lt;div class="box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box3"&gt;Three&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+</div>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/wikihistory.json
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2020-04-21T08:33:20.154Z",
+  "contributors": ["chrisdavidmills"]
+}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/wikihistory.json
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2020-04-21T08:33:20.154Z",
+  "contributors": ["chrisdavidmills"]
+}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/grid/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/grid/index.html
@@ -1,0 +1,23 @@
+---
+title: A Test Introduction to CSS Grid Layout
+slug: Learn/CSS/CSS_layout/Introduction/Grid
+summary: A test article showing grid layout.
+tags:
+  - Examples
+  - Beginner
+  - CSS
+  - Grids
+  - Layout
+  - Learn
+---
+<h2 id="Grid_Layout">Grid Layout</h2>
+<!--
+Grab the content of the live samples from a different page. This tests
+that the page must be fully rendered before extracting the live samples,
+and also tests that prerequisites are handled as part of the rendering
+and live-sample-building process.
+-->
+<div id="Grid_1">{{ Page("Learn/CSS/CSS_layout/Introduction/Grid/Stuff", "Grid_1") }}</div>
+{{ EmbedLiveSample('Grid_1', '300', '330') }}
+<div id="Grid_2">{{ Page("Learn/CSS/CSS_layout/Introduction/Grid/Stuff", "Grid_2") }}</div>
+{{ EmbedLiveSample('Grid_2', '300', '330') }}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/grid/stuff/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/grid/stuff/index.html
@@ -1,0 +1,90 @@
+---
+title: Stuff for Grid Layout
+slug: Learn/CSS/CSS_layout/Introduction/Grid/Stuff
+summary: A test article containing stuff for grid.
+tags:
+  - Stuff
+  - Beginner
+  - CSS
+  - Grids
+  - Introduction
+  - Layout
+  - Learn
+---
+<div id="Grid_1">
+<div class="hidden">
+<h6 id="Grid_example_1">Grid example 1</h6>
+
+<pre class="brush: css">    * {box-sizing: border-box;}
+
+    .wrapper &gt; div {
+        border-radius: 5px;
+        background-color: rgb(207,232,220);
+        padding: 1em;
+    }
+    </pre>
+</div>
+
+<pre class="brush: css">.wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 100px 100px;
+    grid-gap: 10px;
+}
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box1"&gt;One&lt;/div&gt;
+    &lt;div class="box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box3"&gt;Three&lt;/div&gt;
+    &lt;div class="box4"&gt;Four&lt;/div&gt;
+    &lt;div class="box5"&gt;Five&lt;/div&gt;
+    &lt;div class="box6"&gt;Six&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+</div>
+
+<div id="Grid_2">
+<div class="hidden">
+<h6 id="Grid_example_2">Grid example 2</h6>
+
+<pre class="brush: css">    * {box-sizing: border-box;}
+
+    .wrapper &gt; div {
+        border-radius: 5px;
+        background-color: rgb(207,232,220);
+        padding: 1em;
+    }
+    </pre>
+</div>
+
+<pre class="brush: css">.wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 100px 100px;
+    grid-gap: 10px;
+}
+
+.box1 {
+    grid-column: 2 / 4;
+    grid-row: 1;
+}
+
+.box2 {
+    grid-column: 1;
+    grid-row: 1 / 3;
+}
+
+.box3 {
+    grid-row: 2;
+    grid-column: 3;
+}
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box1"&gt;One&lt;/div&gt;
+    &lt;div class="box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box3"&gt;Three&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+</div>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/grid/stuff/wikihistory.json
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/grid/stuff/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2020-04-21T08:33:20.154Z",
+  "contributors": ["chrisdavidmills"]
+}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/grid/wikihistory.json
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/grid/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2020-04-21T08:33:20.154Z",
+  "contributors": ["chrisdavidmills"]
+}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/index.html
@@ -1,0 +1,78 @@
+---
+title: A Test Introduction to CSS layout
+slug: Learn/CSS/CSS_layout/Introduction
+summary: A test article showing some layout technologies.
+tags:
+  - Article
+  - Beginner
+  - CSS
+  - Floats
+  - Grids
+  - Introduction
+  - Layout
+  - Learn
+  - Positioning
+  - Tables
+  - flexbox
+  - flow
+---
+<div>{{LearnSidebar}}</div>
+
+<!--
+Embed some of the live samples from different pages. This tests that
+the code can handle a mix of live samples, some from the page itself,
+and some from other pages.
+-->
+
+<h2 id="Flexbox">Flexbox</h2>
+<p>{{ EmbedLiveSample('Flex_1', '300', '200', "", "Learn/CSS/CSS_layout/Introduction/Flex") }}</p>
+<p>{{ EmbedLiveSample('Flex_2', '300', '200', "", "Learn/CSS/CSS_layout/Introduction/Flex") }}</p>
+
+<h2 id="Grid_Layout">Grid Layout</h2>
+<p>{{ EmbedLiveSample('Grid_1', '300', '330', "", "Learn/CSS/CSS_layout/Introduction/Grid") }}</p>
+<div id="Grid_2">
+<div class="hidden">
+<h6 id="Grid_example_2">Grid example 2</h6>
+
+<pre class="brush: css">    * {box-sizing: border-box;}
+
+    .wrapper &gt; div {
+        border-radius: 5px;
+        background-color: rgb(207,232,220);
+        padding: 1em;
+    }
+    </pre>
+</div>
+
+<pre class="brush: css">.wrapper {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 100px 100px;
+    grid-gap: 10px;
+}
+
+.box1 {
+    grid-column: 2 / 4;
+    grid-row: 1;
+}
+
+.box2 {
+    grid-column: 1;
+    grid-row: 1 / 3;
+}
+
+.box3 {
+    grid-row: 2;
+    grid-column: 3;
+}
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box1"&gt;One&lt;/div&gt;
+    &lt;div class="box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box3"&gt;Three&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+</div>
+
+<p>{{ EmbedLiveSample('Grid_2', '300', '330') }}</p>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/wikihistory.json
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2020-04-21T08:33:20.154Z",
+  "contributors": ["chrisdavidmills"]
+}

--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -25,4 +25,119 @@ describe("Basic viewing of functional pages", () => {
     await page.goto(testURL("/en-US/docs/Web/Foo"));
     await expect(page).toMatch("<foo>: A test tag");
   });
+
+  it("open the /en-US/docs/Learn/CSS/CSS_layout/Introduction page", async () => {
+    const uri = "/en-US/docs/Learn/CSS/CSS_layout/Introduction";
+    const flexSample1Uri = `${uri}/Flex/_samples_/Flex_1`;
+    const flexSample2Uri = `${uri}/Flex/_samples_/Flex_2`;
+    const gridSample1Uri = `${uri}/Grid/_samples_/Grid_1`;
+    const gridSample2Uri = `${uri}/_samples_/Grid_2`;
+    await page.goto(testURL(uri));
+    await expect(page).toMatch("A Test Introduction to CSS layout");
+    await expect(page).toMatchElement("h1", {
+      text: "A Test Introduction to CSS layout",
+    });
+    await expect(page).toMatchElement("#Flexbox", {
+      text: "Flexbox",
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${flexSample1Uri}"]`
+    );
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${flexSample2Uri}"]`
+    );
+    await expect(page).toMatchElement("#Grid_Layout", {
+      text: "Grid Layout",
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${gridSample1Uri}"]`
+    );
+    await expect(page).toMatchElement("#Grid_2 > pre.css.notranslate", {
+      text: /\.wrapper\s*\{\s*display\:\s*grid\;/,
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${gridSample2Uri}"]`
+    );
+    // Ensure that the live-sample pages were built.
+    for (const sampleUri of [
+      flexSample1Uri,
+      flexSample2Uri,
+      gridSample1Uri,
+      gridSample2Uri,
+    ]) {
+      await page.goto(testURL(sampleUri));
+      await expect(page).toMatchElement("body > div.wrapper > div.box1", {
+        text: "One",
+      });
+      await expect(page).toMatchElement("body > div.wrapper > div.box2", {
+        text: "Two",
+      });
+      await expect(page).toMatchElement("body > div.wrapper > div.box3", {
+        text: "Three",
+      });
+    }
+  });
+
+  it("open the /en-US/docs/Learn/CSS/CSS_layout/Introduction/Flex page", async () => {
+    const uri = "/en-US/docs/Learn/CSS/CSS_layout/Introduction/Flex";
+    const flexSample1Uri = `${uri}/_samples_/Flex_1`;
+    const flexSample2Uri = `${uri}/_samples_/Flex_2`;
+    await page.goto(testURL(uri));
+    await expect(page).toMatch("A Test Introduction to CSS Flexbox Layout");
+    await expect(page).toMatchElement("h1", {
+      text: "A Test Introduction to CSS Flexbox Layout",
+    });
+    await expect(page).toMatchElement("#Flexbox", {
+      text: "Flexbox",
+    });
+    await expect(page).toMatchElement("#Flex_1 > pre.css.notranslate", {
+      text: /\.wrapper\s*\{\s*display\:\s*flex\;\s*\}/,
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${flexSample1Uri}"]`
+    );
+    await expect(page).toMatchElement("#Flex_2 > pre.css.notranslate", {
+      text: /\.wrapper\s*\{\s*display\:\s*flex\;\s*\}.+flex\:\s*1\;/,
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${flexSample2Uri}"]`
+    );
+  });
+
+  it("open the /en-US/docs/Learn/CSS/CSS_layout/Introduction/Grid page", async () => {
+    const uri = "/en-US/docs/Learn/CSS/CSS_layout/Introduction/Grid";
+    const gridSample1Uri = `${uri}/_samples_/Grid_1`;
+    const gridSample2Uri = `${uri}/_samples_/Grid_2`;
+    await page.goto(testURL(uri));
+    await expect(page).toMatch("A Test Introduction to CSS Grid Layout");
+    await expect(page).toMatchElement("h1", {
+      text: "A Test Introduction to CSS Grid Layout",
+    });
+    await expect(page).toMatchElement("#Grid_Layout", {
+      text: "Grid Layout",
+    });
+    await expect(page).toMatchElement("#Grid_1 > pre.css.notranslate", {
+      text: /\.wrapper\s*\{\s*display\:\s*grid\;/,
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${gridSample1Uri}"]`
+    );
+    await expect(page).toMatchElement("#Grid_2 > pre.css.notranslate", {
+      text: /\.wrapper\s*\{\s*display\:\s*grid\;.+\.box1\s*\{/,
+    });
+    await expect(page).toMatchElement(
+      `iframe.live-sample-frame.sample-code-frame[src$="${gridSample2Uri}"]`
+    );
+    // Ensure that the live-sample page "gridSample2Uri" was built.
+    await page.goto(testURL(gridSample2Uri));
+    await expect(page).toMatchElement("body > div.wrapper > div.box1", {
+      text: "One",
+    });
+    await expect(page).toMatchElement("body > div.wrapper > div.box2", {
+      text: "Two",
+    });
+    await expect(page).toMatchElement("body > div.wrapper > div.box3", {
+      text: "Three",
+    });
+  });
 });


### PR DESCRIPTION
Fixes #698 

This PR adds the core tests for macro rendering as well as the building of live samples. The focus here is **not** on testing the breadth of macros that exist, but rather on testing these core aspects of rendering/live-sample-building:
- that recursion that can occur when rendering documents that depend on other documents, i.e. the rendering of one document may first require the rendering of one or more "prerequisite" documents, which in turn may require the rendering of their prerequisites and so on
- that prerequisite documents must be fully rendered before being incorporated into the document that is including them (via the `Page` or `IncludeSubnav` macro)
- that live samples can be included from a document different from the document they're being embedded within
- that documents must be fully rendered before extracting their live samples
- that prerequisites are also handled as part of the live-sample-building process
