### PR TITLE
Importer should write raw.html as well

### DIFF
--- a/content/scripts/importer.js
+++ b/content/scripts/importer.js
@@ -759,7 +759,6 @@ async function processDocument(
     isArchive ? doc.rendered_html : doc.html,
     meta,
     isArchive ? wikiHistory : null,
-    null,
     isArchive ? doc.html : null
   );
 }


### PR DESCRIPTION
Fixes #798

Here's how I tested it:

1. `rm -fr archivedcontent`
2. `node content import`
3. `ls -l archivecontent/files/en-us/mozilla/projects/spidermonkey/jsapi_reference/js_defineownproperty/`
4. `cat archivecontent/files/en-us/xul/attribute/onunload/index.html | head -n 13`
5. `cat archivecontent/files/en-us/mozilla/projects/spidermonkey/jsapi_reference/js_defineownproperty/raw.html | head -n 6`
