### PR TITLE
ignore clicks on search result items children

### DIFF
--- a/client/src/search.scss
+++ b/client/src/search.scss
@@ -59,20 +59,28 @@ $search-border-color-focus: #0096bfab;
     width: 400px;
     top: 40px;
 
-    div {
+    > div {
       padding: 5px;
       border-bottom: 1px solid #efefef;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      &:hover,
+      &.highlit {
+        background-color: #efefef;
+      }
+
+      > * {
+        pointer-events: none;
+      }
     }
-    div:hover,
-    div.highlit {
-      background-color: #efefef;
-    }
-    div:hover {
-      cursor: pointer;
-    }
-    div:last-child {
-      border-bottom: none;
-    }
+
     mark {
       background-color: #f3f7bd;
     }


### PR DESCRIPTION
Fixes #809 

CSS fix, so I feel okay merging it without another devs review.

What I don't feel okay with is that I don't quite grasp which child element would even be stealing the click event and why only in these weird harder to reproduce circumstances.

@tobinmori could you checkout this branch and see whether it also fixes it for you? I had a reliable result element for which it would happen before and now it doesn't anymore but I'd feel better if you can also confirm it.