### PR TITLE
Prevent toolbar relayouting

### DIFF
--- a/client/src/document/toolbar/watcher.scss
+++ b/client/src/document/toolbar/watcher.scss
@@ -1,5 +1,7 @@
 .document-watcher {
   font-size: 70%;
+  max-width: 200px;
+  width: 100%;
   padding: 3px;
   border-radius: 0 0 3px 3px;
   text-align: right;

--- a/client/src/document/toolbar/watcher.tsx
+++ b/client/src/document/toolbar/watcher.tsx
@@ -50,7 +50,7 @@ export default function Watcher({ onDocumentUpdate }) {
   }, [documentURL, onDocumentUpdate]);
 
   if (connected === null) {
-    return null;
+    return <div className="document-watcher" />;
   }
 
   return (


### PR DESCRIPTION
The jumpiness is a little distracting when switching between documents