### PR TITLE
unique-per-doc ID maps non-fatal error to DOM

### DIFF
--- a/kumascript/macros/htmlattrxref.ejs
+++ b/kumascript/macros/htmlattrxref.ejs
@@ -22,8 +22,10 @@ const attrLC = $0.toLowerCase();
 
 var text = ($2 && ($2!=undefined)) ? $2 : attrLC;
 
-if ($1 && ($1 != undefined)) {
-    url = '/' + lang + '/docs/Web/HTML/Element/' + $1;
+let basePath;
+if ($1) {
+    basePath = '/' + lang + '/docs/Web/HTML/Element/';
+    url = basePath + $1;
 } else {
     url = '/' + lang + '/docs/Web/HTML/' + globalAttrSlug;
 }
@@ -32,7 +34,7 @@ if (!$3) {
   text = `<code>${text}</code>`;
 }
 
-const result = web.smartLink(`${url}#attr-${attrLC}`, null, text, $0, url);
+const result = web.smartLink(`${url}#attr-${attrLC}`, null, text, $1, basePath);
 
 %>
 <%- result %>

--- a/kumascript/src/api/web.js
+++ b/kumascript/src/api/web.js
@@ -24,6 +24,8 @@ module.exports = {
   },
 
   smartLink(href, title, content, subpath, basepath) {
+    let flawID;
+    let flawIDAttribute = "";
     const page = this.info.getPage(href);
     // Get the pathname only (no hash) of the incoming "href" URI.
     const hrefpath = this.info.getPathname(href);
@@ -31,7 +33,7 @@ module.exports = {
     const hrefhash = new URL(href, DUMMY_BASE_URL).hash;
     if (page.url) {
       if (hrefpath.toLowerCase() !== page.url.toLowerCase()) {
-        this.env.recordNonFatalError(
+        flawID = this.env.recordNonFatalError(
           "redirected-link",
           `${hrefpath} redirects to ${page.url}`,
           {
@@ -39,17 +41,24 @@ module.exports = {
             suggested: page.url.replace(basepath, ""),
           }
         );
+        flawIDAttribute = ` data-flaw-id="${flawID}"`;
       }
       const titleAttribute = title ? ` title="${title}"` : "";
-      return `<a href="${page.url + hrefhash}"${titleAttribute}>${content}</a>`;
+      return `<a href="${
+        page.url + hrefhash
+      }"${titleAttribute}${flawIDAttribute}>${content}</a>`;
     }
-    this.env.recordNonFatalError("broken-link", `${hrefpath} does not exist`);
+    flawID = this.env.recordNonFatalError(
+      "broken-link",
+      `${hrefpath} does not exist`
+    );
+    flawIDAttribute = ` data-flaw-id="${flawID}"`;
     // Let's get a potentially localized title for when the document is missing.
     const titleWhenMissing = this.mdn.getLocalString(
       L10N_COMMON_STRINGS,
       "summary"
     );
-    return `<a class="new" title="${titleWhenMissing}">${content}</a>`;
+    return `<a class="new" title="${titleWhenMissing}"${flawIDAttribute}>${content}</a>`;
   },
 
   // Try calling "decodeURIComponent", but if there's an error, just

--- a/kumascript/src/render.js
+++ b/kumascript/src/render.js
@@ -146,6 +146,8 @@ async function render(source, templates, pageEnvironment, allPagesInfo) {
   let nonFatalErrors = [];
   // This tracks the token for the "recordNonFatalError()" function.
   let currentToken;
+  // The error ID has to be unique per document only.
+  let lastUsedErrorID = 0;
 
   function recordNonFatalError(kind, message, redirectInfo = null) {
     let NonFatalErrorClass;
@@ -160,7 +162,10 @@ async function render(source, templates, pageEnvironment, allPagesInfo) {
     } else {
       throw Error(`unsupported kind of non-fatal error requested: "${kind}"`);
     }
-    nonFatalErrors.push(new NonFatalErrorClass(...args));
+    const macroError = new NonFatalErrorClass(...args);
+    macroError.id = ++lastUsedErrorID;
+    nonFatalErrors.push(macroError);
+    return macroError.id;
   }
 
   // Create the Environment object that we'll use to render all of

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -95,11 +95,20 @@ test("content built bar page", () => {
   expect(doc.popularity).toBe(0.51);
   expect(doc.modified).toBeTruthy();
   expect(doc.source).toBeTruthy();
+  expect(doc.flaws.macros.length).toBe(9);
+  // Ensure that each of the "macros" flaws with ID's, has a unique ID.
+  const flawsWithIds = doc.flaws.macros.filter((f) => f.id);
+  expect(flawsWithIds.length).toBe(9);
+  expect(new Set(flawsWithIds.map((f) => f.id)).size).toBe(9);
+
+  const mapID2Flaw = new Map(flawsWithIds.map((f) => [f.id, f]));
 
   const htmlFile = path.join(builtFolder, "index.html");
   expect(fs.existsSync(htmlFile)).toBeTruthy();
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
+  expect($("a[data-flaw-id]").length).toEqual(9);
+
   const brokenLinks = $("a.new");
   expect(brokenLinks.length).toEqual(4);
   brokenLinks.each((index, element) => {
@@ -108,21 +117,43 @@ test("content built bar page", () => {
     } else {
       expect($(element).text()).toBe("bigfoot");
     }
+    const flaw = mapID2Flaw.get($(element).data("flaw-id"));
+    expect(flaw.name).toBe("MacroBrokenLinkError");
+    expect(flaw.macroSource).toMatch(/\"bigfoot\"\)/);
     expect($(element).attr("title")).toMatch(
       /The documentation about this has not yet been written/
     );
   });
+
   const numberLinks = $('a[href="/en-US/docs/Web/CSS/number"]');
   expect(numberLinks.length).toEqual(2);
   numberLinks.each((index, element) => {
     expect($(element).attr("title")).toBe("This is the number test page.");
   });
   expect(numberLinks.eq(0).text()).toBe("<dumber>");
+  const dumberFlawID = numberLinks.eq(0).data("flaw-id");
+  expect(dumberFlawID).toBeTruthy();
+  const dumberFlaw = mapID2Flaw.get(dumberFlawID);
+  expect(dumberFlaw.name).toBe("MacroRedirectedLinkError");
+  expect(dumberFlaw.macroSource).toBe('{{CSSxRef("dumber")}}');
+  expect(dumberFlaw.redirectInfo.current).toBe("dumber");
+  expect(dumberFlaw.redirectInfo.suggested).toBe("number");
   expect(numberLinks.eq(1).text()).toBe("<number>");
+  expect(numberLinks.eq(1).data("flaw-id")).toBeFalsy();
+
   const blobLinks = $('a[href="/en-US/docs/Web/API/Blob"]:not([title])');
   expect(blobLinks.length).toEqual(2);
   expect(blobLinks.eq(0).text()).toBe("Bob");
+  const bobFlawID = blobLinks.eq(0).data("flaw-id");
+  expect(bobFlawID).toBeTruthy();
+  const bobFlaw = mapID2Flaw.get(bobFlawID);
+  expect(bobFlaw.name).toBe("MacroRedirectedLinkError");
+  expect(bobFlaw.macroSource).toBe('{{DOMxRef("Bob")}}');
+  expect(bobFlaw.redirectInfo.current).toBe("Bob");
+  expect(bobFlaw.redirectInfo.suggested).toBe("Blob");
   expect(blobLinks.eq(1).text()).toBe("Blob");
+  expect(blobLinks.eq(1).data("flaw-id")).toBeFalsy();
+
   const hrefLinks = $(
     'a[href="/en-US/docs/Web/HTML/Element/a#attr-href"]:not([title])'
   );
@@ -130,19 +161,46 @@ test("content built bar page", () => {
   hrefLinks.each((index, element) => {
     expect($(element).text()).toBe("href");
   });
+  const anchorFlawID = hrefLinks.eq(0).data("flaw-id");
+  expect(anchorFlawID).toBeTruthy();
+  const anchorFlaw = mapID2Flaw.get(anchorFlawID);
+  expect(anchorFlaw.name).toBe("MacroRedirectedLinkError");
+  expect(anchorFlaw.macroSource).toBe('{{htmlattrxref("href", "anchor")}}');
+  expect(anchorFlaw.redirectInfo.current).toBe("anchor");
+  expect(anchorFlaw.redirectInfo.suggested).toBe("a");
+  expect(hrefLinks.eq(1).data("flaw-id")).toBeFalsy();
+
   const strictModeLinks = $(
     'a[href="/en-US/docs/Web/JavaScript/Reference/Strict_mode"]:not([title])'
   );
   expect(strictModeLinks.length).toEqual(2);
   expect(strictModeLinks.eq(0).text()).toBe("Stern_mode");
+  const sternFlawID = strictModeLinks.eq(0).data("flaw-id");
+  expect(sternFlawID).toBeTruthy();
+  const sternFlaw = mapID2Flaw.get(sternFlawID);
+  expect(sternFlaw.name).toBe("MacroRedirectedLinkError");
+  expect(sternFlaw.macroSource).toBe('{{jsxref("Stern_mode")}}');
+  expect(sternFlaw.redirectInfo.current).toBe("Stern_mode");
+  expect(sternFlaw.redirectInfo.suggested).toBe("Strict_mode");
   expect(strictModeLinks.eq(1).text()).toBe("Strict_mode");
+  expect(strictModeLinks.eq(1).data("flaw-id")).toBeFalsy();
+
   const booleanLinks = $(
     'a[href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean"]:not([title])'
   );
   expect(booleanLinks.length).toEqual(3);
   expect(booleanLinks.eq(0).text()).toBe("Flag");
+  const flagFlawID = booleanLinks.eq(0).data("flaw-id");
+  expect(flagFlawID).toBeTruthy();
+  const flagFlaw = mapID2Flaw.get(flagFlawID);
+  expect(flagFlaw.name).toBe("MacroRedirectedLinkError");
+  expect(flagFlaw.macroSource).toBe('{{jsxref("Flag")}}');
+  expect(flagFlaw.redirectInfo.current).toBe("Flag");
+  expect(flagFlaw.redirectInfo.suggested).toBe("Boolean");
   expect(booleanLinks.eq(1).text()).toBe("Boolean");
+  expect(booleanLinks.eq(1).data("flaw-id")).toBeFalsy();
   expect(booleanLinks.eq(2).text()).toBe("bOOleAn");
+  expect(booleanLinks.eq(2).data("flaw-id")).toBeFalsy();
 });
 
 test("broken links flaws", () => {


### PR DESCRIPTION
Fixes #756 

This PR adds a `data-flaw-id` attribute to each `<a>` tag created by `web.smartLink()` when it detects and creates a non-fatal flaw related to the link, and the value of the `data-flaw-id` attribute maps to the value of the `id` attribute of the flaw created. Only non-fatal flaws will have `id` attributes, and the values of the `id` attributes will be unique per document only.

While writing tests, I found a bug within `kumascript/macros/htmlattrxref.ejs`, which I also fixed within this PR.