### PR TITLE
wait longer for search result click

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -345,7 +345,7 @@ export class SearchWidget extends React.Component<{
       if (!this.dismounted) {
         this.setState({ showSearchResults: false });
       }
-    }, 200);
+    }, 300);
   };
 
   submitHandler = () => {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -345,7 +345,7 @@ export class SearchWidget extends React.Component<{
       if (!this.dismounted) {
         this.setState({ showSearchResults: false });
       }
-    }, 100);
+    }, 200);
   };
 
   submitHandler = () => {


### PR DESCRIPTION
Fixes #809

Sigh. What a rabbit hole. More fuel to the argument of jumping onto the [`downshift` bandwagon](https://github.com/mdn/yari/pull/814). 

The reason the `<input>` has a `onBlur` is because if you start typing something and then realize, "Nah! I don't want to search I want to scroll down or click this link". It's not nice to have to force the user to hide the displayed search results (by clearing the input field). Amazon.com does this. Go to https://www.amazon.com/ and start typing something in the search and then click somewhere outside the search results but not on a link. That blurs the search and hides the displayed results but it doesn't clear the input. 

But what happens is that when it triggers, that blur kills the DOM element that has a `onClick` on it. That's why the onBlur handler doesn't "unshow" the search results until after a 100ms. That way, the click still counts. 
But it turns out, 100ms is still too fast! If you just change it to 200ms it never cuts off the `onClick` event handler. But perhaps it does a much slower CPU. Who knows? 

(Note, the click actually triggers the same effect as the blur handler which is that it hides the search results. So the only point of the `onBlur` handler is there for those times when you click outside to hide the search results)

By the way, the bug can be [simulated here](https://codesandbox.io/s/nameless-forest-vixp7?file=/src/App.js) and note that this App is all hooks and really simple. If there's an easy way to fix that simulated App that accomplishes the goal, I'm all ears. 

In conclusion; this PR unbreaks the search result click (doesn't matter if you use the mouse or the keyboard by the way). 
But after this is done, we really should look into https://github.com/mdn/yari/pull/814 more closely because if a hack is what's needed to unbreak, what else craziness means the current implementation is ARIA compliant or works in responsive mode. 
