### PR TITLE
Move create document link

### DIFF
--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { useDocumentURL } from "../hooks";
 
@@ -71,6 +71,8 @@ export function EditActions({ folder }: { folder: string }) {
     }
   }
 
+  const params = useParams();
+
   if (!folder) {
     return null;
   }
@@ -88,6 +90,11 @@ export function EditActions({ folder }: { folder: string }) {
       <button className="delete" onClick={deleteDocument}>
         Delete document
       </button>
+      <Link
+        to={`/en-US/_create?initial_slug=${encodeURIComponent(params["*"])}`}
+      >
+        Create new document
+      </Link>
       <br />
       {editorOpeningError ? (
         <p className="error-message editor-opening-error">

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -71,7 +71,7 @@ export function EditActions({ folder }: { folder: string }) {
     }
   }
 
-  const params = useParams();
+  const { "*": slug } = useParams();
 
   if (!folder) {
     return null;
@@ -90,9 +90,7 @@ export function EditActions({ folder }: { folder: string }) {
       <button className="delete" onClick={deleteDocument}>
         Delete document
       </button>
-      <Link
-        to={`/en-US/_create?initial_slug=${encodeURIComponent(params["*"])}`}
-      >
+      <Link to={`/en-US/_create?initial_slug=${encodeURIComponent(slug)}`}>
         Create new document
       </Link>
       <br />

--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
 import { Doc } from "../types";
 import { EditActions } from "./edit-actions";
 import { ToggleDocumentFlaws } from "./flaws";
@@ -14,15 +13,9 @@ export default function Toolbar({
   doc: Doc;
   onDocumentUpdate: Function;
 }) {
-  const params = useParams();
   return (
     <div className="toolbar">
       <div className="toolbar-first-row">
-        <Link
-          to={`/en-US/_create?initial_slug=${encodeURIComponent(params["*"])}`}
-        >
-          Create new document
-        </Link>
         <EditActions folder={doc.source.folder} />
         <Watcher onDocumentUpdate={onDocumentUpdate} />
       </div>


### PR DESCRIPTION
This moves the "Create new document" link to be to the right of the document actions

fix #834