### PR TITLE
add notes about target blank implicit noopener behavior

### DIFF
--- a/content/files/en-us/web/html/element/a/index.html
+++ b/content/files/en-us/web/html/element/a/index.html
@@ -89,6 +89,10 @@ tags:
  <div class="blockIndicator warning">
  <p><strong>Note:</strong> Linking to another page with <code>target="_blank"</code> will run the new page in the same process as your page. If the new page executes JavaScript, your page's performance may suffer. This can also be avoided by using <code>rel="noreferrer noopener"</code>.</p>
  </div>
+
+<div class="note">
+ <p><strong>Note:</strong> In newer browser versions (e.g. Firefox 79+) setting <code>target="_blank"</code> on <code>&lt;a&gt;</code> elements implicitly provides the same behavior as setting <code>rel="noopener"</code>.</p>
+ </div>
  </dd>
  <dt id="type">{{HTMLAttrDef("type")}}</dt>
  <dd>Hints at the linked URL’s format with a {{Glossary("MIME type")}}. No built-in functionality.</dd>
@@ -312,7 +316,7 @@ document.querySelector('a').addEventListener('click', event =&gt;
 
 <p><code>&lt;a&gt;</code> elements can have consequences for users’ security and privacy. See <a href="/en-US/docs/Web/Security/Referer_header:_privacy_and_security_concerns"><code>Referer</code> header: privacy and security concerns</a> for information.</p>
 
-<p>Using <code>target="_blank"</code> without <code>rel="noreferrer"</code> and <code>rel="noopener"</code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/">vulnerability description</a>).</p>
+<p>Using <code>target="_blank"</code> without <code>rel="noreferrer"</code> and <code>rel="noopener"</code> makes the website vulnerable to {{domxref("window.opener")}} API exploitation attacks (<a href="https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/">vulnerability description</a>), although note that, in newer browser versions (e.g. Firefox 79+) setting <code>target="_blank"</code> implicitly provides the same behavior as setting <code>rel="noopener"</code>.</p>
 
 <h2 id="Accessibility">Accessibility</h2>
 


### PR DESCRIPTION
As per https://bugzilla.mozilla.org/show_bug.cgi?id=1522083

Notes added in attributes and security & privacy sections to explain new behavior