### PR TITLE
suggestions for broken links with hash fragments

### DIFF
--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -133,6 +133,13 @@ function BrokenLinks({
 
   const filepath = sourceFolder + "/index.html";
 
+  function equalUrls(url1: string, url2: string) {
+    return (
+      new URL(url1, "http://example.com").pathname ===
+      new URL(url2, "http://example.com").pathname
+    );
+  }
+
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
     sp.set("filepath", filepath);
@@ -158,10 +165,10 @@ function BrokenLinks({
       if (!link) {
         break;
       }
-      if (
-        anchor.href !== link.href &&
-        new URL(anchor.href).pathname !== link.href
-      ) {
+      // A `anchor.href` is always absolute with `http//localhost/...`.
+      // But `link.href` is not necessarily so, but it might.
+      // The only "hashing" that matters is the pathname.
+      if (!equalUrls(anchor.href, link.href)) {
         continue;
       }
       linkIndex++;
@@ -228,10 +235,7 @@ function BrokenLinks({
                     if (!link) {
                       break;
                     }
-                    if (
-                      anchor.href !== link.href &&
-                      new URL(anchor.href).pathname !== link.href
-                    ) {
+                    if (!equalUrls(anchor.href, link.href)) {
                       continue;
                     }
 

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1802,24 +1802,34 @@ class Builder {
             absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
           );
         } else if (href.startsWith("/") && !href.startsWith("//")) {
-          if (!this.allTitles.has(href.toLowerCase())) {
+          // Got to fake the domain to sensible extract the .search and .hash
+          const absoluteURL = new URL(href, "http://www.example.com");
+          const hrefNormalized = href.split("#")[0].toLowerCase();
+          if (!this.allTitles.has(hrefNormalized)) {
             // Before we give up, check if it's a redirect
-            if (this.allRedirects.has(href.toLowerCase())) {
+            if (this.allRedirects.has(hrefNormalized)) {
               // Just because it's a redirect doesn't mean it ends up
               // on a page we have.
               // For example, there might be a redirect but where it
               // goes to is not in this.allTitles.
               // This can happen if it's a "fundamental redirect" for example.
               const finalDocument = this.allTitles.get(
-                this.allRedirects.get(href.toLowerCase())
+                this.allRedirects.get(hrefNormalized)
               );
-              addBrokenLink(href, finalDocument ? finalDocument.mdn_url : null);
+              addBrokenLink(
+                href,
+                finalDocument
+                  ? finalDocument.mdn_url +
+                      absoluteURL.search +
+                      absoluteURL.hash
+                  : null
+              );
             } else {
               addBrokenLink(href);
             }
           } else {
             // But does it have the correct case?!
-            const found = this.allTitles.get(href.toLowerCase());
+            const found = this.allTitles.get(hrefNormalized);
             if (found.mdn_url !== href) {
               // Inconsistent case.
               addBrokenLink(href, found.mdn_url);

--- a/testing/content/files/en-us/web/brokenlinks/index.html
+++ b/testing/content/files/en-us/web/brokenlinks/index.html
@@ -16,6 +16,9 @@ summary: Some fixable (redirects, case, prefix) and some not fixable
 <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/Blob#Anchor">Also, too verbose but with anchor</a></p>
 <p><a href="https://developer.mozilla.org/en-US/docs/Web/API/Blob?a=b">Also, too verbose but with query string</a></p>
 
+<p><a href="/en-US/docs/Web/HTML/Element/anchor#fragment">This should have a suggestion and the suggestion should
+  keep the <code>#fragment</code> on the suggested href.</a></p>
+
 <p><a href="/en-us/DOCS/Web/api/BLOB">Wrong case</a></p>
 <p><a href='/en-US/docs/Hopeless/Case'>Will not have a suggestion</></p>
 

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -112,6 +112,7 @@ test("content built bar page", () => {
       /The documentation about this has not yet been written/
     );
   });
+  XXX = "WORK HARDER";
   const numberLinks = $('a[href="/en-US/docs/Web/CSS/number"]');
   expect(numberLinks.length).toEqual(2);
   numberLinks.each((index, element) => {

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -112,7 +112,6 @@ test("content built bar page", () => {
       /The documentation about this has not yet been written/
     );
   });
-  XXX = "WORK HARDER";
   const numberLinks = $('a[href="/en-US/docs/Web/CSS/number"]');
   expect(numberLinks.length).toEqual(2);
   numberLinks.each((index, element) => {
@@ -159,7 +158,7 @@ test("broken links flaws", () => {
   const { flaws } = doc;
   // You have to be intimately familiar with the fixture to understand
   // why these flaws come out as they do.
-  expect(flaws.broken_links.length).toBe(7);
+  expect(flaws.broken_links.length).toBe(8);
   // Map them by 'href'
   const map = new Map(flaws.broken_links.map((x) => [x.href, x]));
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
@@ -179,6 +178,9 @@ test("broken links flaws", () => {
   expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
     "/en-US/docs/Web/API/Blob"
   );
+  expect(
+    map.get("/en-US/docs/Web/HTML/Element/anchor#fragment").suggestion
+  ).toBe("/en-US/docs/Web/HTML/Element/a#fragment");
 });
 
 test("check built flaws for /en-us/learn/css/css_layout/introduction/grid page", () => {


### PR DESCRIPTION
Fixes #849 

[The issue](https://github.com/mdn/yari/issues/849) suggest using: http://localhost:3000/en-US/docs/Web/HTML/Element/a#_flaws which now looks like this:

<img width="1417" alt="Screen Shot 2020-07-02 at 2 27 47 PM" src="https://user-images.githubusercontent.com/26739/86396614-3df44880-bc70-11ea-8175-677e159ea337.png">

But also, a good way to test is to:

1. `yarn start:functional`
2. Go to http://localhost:3000/en-US/docs/Web/BrokenLinks#_flaws
