### PR TITLE
Fix ID for prose.syntax section

### DIFF
--- a/content/files/en-us/web/css/text-shadow/index.html
+++ b/content/files/en-us/web/css/text-shadow/index.html
@@ -26,7 +26,7 @@ tags:
 
 <p class="hidden">The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone <a href="https://github.com/mdn/interactive-examples">https://github.com/mdn/interactive-examples</a> and send us a pull request.</p>
 
-<h2 id="Syntax_2">Syntax</h2>
+<h2 id="Syntax">Syntax</h2>
 
 <pre class="brush:css no-line-numbers notranslate">/* offset-x | offset-y | blur-radius | color */
 text-shadow: 1px 1px 2px black;


### PR DESCRIPTION
This is needed to make the linter happy. See https://github.com/mdn/sprints/issues/3438.