### PR TITLE
Absolute next urls in sign in

### DIFF
--- a/client/src/header/auth-modal.tsx
+++ b/client/src/header/auth-modal.tsx
@@ -5,8 +5,19 @@ import "../kumastyles/minimalist/components/auth-modal.scss";
 
 Modal.setAppElement("#root");
 
+// Why using `next=${window.location.href}` instead of `next=${window.location.pathname}`?
+// The reason is that you might be doing local development with Yari and
+// that means that logging in takes you to a different domain entirely.
+// In local development, you want to tell that other server that
+// "Hey I came from this other development domain". And when it's all in
+// production, the Yari and the Kuma, it's harmless to do this because the
+// domain will actually be identical. django-allauth *discards* the `?next`
+// parameter if it is an absolute URL with a different host name. That's
+// right and sensible, but it's totally worth doing an exception for the
+// greater development experience of mixing Kuma and Yari all in development
+// mode.
 const authURL = (provider) =>
-  `/users/${provider}/login/?next=${window.location.pathname}`;
+  `/users/${provider}/login/?next=${window.location.href}`;
 
 export default function AuthModal(props: Omit<Modal.Props, "isOpen">) {
   return (

--- a/client/src/header/signin-link.tsx
+++ b/client/src/header/signin-link.tsx
@@ -10,7 +10,7 @@ export default function SignInLink({ className }: { className?: string }) {
   return (
     <>
       <a
-        href={`/${locale}/users/account/signup-landing?next=${window.location.pathname}`}
+        href={`/${locale}/users/account/signup-landing?next=${window.location.href}`}
         rel="nofollow"
         className={className ? className : undefined}
         onClick={(event) => {

--- a/client/src/kuma-redirects.ts
+++ b/client/src/kuma-redirects.ts
@@ -7,7 +7,6 @@ function isKumaURL(pathname) {
 function toKumaURL(url: URL) {
   const newURL = new URL(url.toString());
   newURL.host = process.env.REACT_APP_KUMA_HOST || "";
-  newURL.searchParams.set("DEV_ORIGIN", window.location.origin);
   return newURL.toString();
 }
 
@@ -18,9 +17,7 @@ function redirectKumaURLs() {
 }
 
 /**
- * Redirects URLs that should be handled within kuma for now. It also adds a
- * query parameter named DEV_ORIGIN which kuma checks for in dev mode
- * to redirect back and set auth cookies for this domain as well.
+ * Redirects URLs that should be handled within kuma for now.
  */
 export function interceptAndRedirectKumaURLs() {
   if (


### PR DESCRIPTION
To test this you first need to have `kuma` running with this: https://github.com/mdn/kuma/pull/7332

To be honest, I'm not entirely sure what that `isKumaURL` business does inside the `kuma-redirects.ts`. 
My solution only requires that you change the `?next=` URL to be absolute. But the intercept stuff still needs to be there. 

Perhaps I'm missing something but all that interception stuff and `popstate` I'm not sure we really need. What we could also just do is this:
```diff
const authURL = (provider) =>
-  `/users/${provider}/login/?next=${window.location.href}`;
+ `${NODE_ENV==='development' && REACT_APP_KUMA_HOST || ''}/users/${provider}/login/?next=${window.location.href}`;
```

We might just need a similar trick in `signin-link.tsx` for that hyper you'd get if you right-click (Open in a new Tab) when you "ignore" the auth modal. 
To me, this feels like a less complicated solution and entirely encapsulate here in `client/src/header/` rather than having to mess in `app.tsx`.

What do you think?