### PR TITLE
use @svgr/webpack for inline svgs in ssr

### DIFF
--- a/client/src/header/index.tsx
+++ b/client/src/header/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { useLocale } from "../hooks";
 import Login from "./login";
-import Logo from "./logo.svg";
+import { ReactComponent as Logo } from "./logo.svg";
 import MainMenu from "./main-menu";
 import Search from "./search";
 
@@ -14,7 +14,7 @@ export default function Header() {
   return (
     <header className="page-header">
       <a href={`/${locale}/`} className="logo" aria-label="MDN Web Docs">
-        <img src={Logo} alt="logo" />
+        <Logo />
       </a>
       <MainMenu />
       <Search />

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 const nodeExternals = require("webpack-node-externals");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-const webpack = require("webpack");
+// const webpack = require("webpack");
 
 module.exports = {
   context: path.resolve(__dirname, "."),
@@ -31,6 +31,10 @@ module.exports = {
         options: {
           transpileOnly: true,
         },
+      },
+      {
+        test: /\.svg$/,
+        use: ["@svgr/webpack"],
       },
       {
         test: /\.(png|svg|jpg|gif)$/,

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -34,7 +34,15 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        use: ["@svgr/webpack"],
+        use: [
+          {
+            loader: "@svgr/webpack",
+            options: {
+              svgo: true,
+              titleProp: true,
+            },
+          },
+        ],
       },
       {
         test: /\.(png|svg|jpg|gif)$/,


### PR DESCRIPTION
Fixes #882

It works!
<img width="666" alt="Screen Shot 2020-07-10 at 4 54 41 PM" src="https://user-images.githubusercontent.com/26739/87202380-6e6e5f00-c2ce-11ea-91fc-21e98b40fd46.png">

I found out about it on [this blog post](https://www.pluralsight.com/guides/how-to-load-svg-with-react-and-webpack) and it made sense. But there are choices and I didn't know how `create-react-app` does it but I noticed that you get `./node_modules/@svgr/webpack/` which gets put there by `create-react-app`:
```
▶ yarn why @svgr/webpack
yarn why v1.22.4
[1/4] 🤔  Why do we have the module "@svgr/webpack"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "@svgr/webpack@4.3.3"
info Reasons this module exists
   - "_project_#client#react-scripts" depends on it
   - Hoisted from "_project_#client#react-scripts#@svgr#webpack"
info Disk size without dependencies: "28KB"
info Disk size with unique dependencies: "1.99MB"
info Disk size with transitive dependencies: "52.98MB"
info Number of shared dependencies: 179
✨  Done in 1.36s.
```

So I thought I'd just piggyback off that. 

There are [options](https://react-svgr.com/docs/options/) but I don't understand what they are or what we need. I guess we could crack open `react-scripts` to find out what they do. 