### PR TITLE
automatically fix broken_links flaws

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1723,7 +1723,7 @@ class Builder {
 
     // With the sidebar out of the way, go ahead and check the rest
     this.injectFlaws(source, doc, $, rawContent);
-    if (this.options.fixFlaws) {
+    if (newRawHtml && this.options.fixFlaws) {
       for (const flaw of doc.flaws.broken_links || []) {
         if (flaw.suggestion) {
           // The reason we're not using the parse HTML, as a cheerio object `$`

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -18,7 +18,10 @@ const ProgressBar = require("./progress-bar");
 const { printBasicDiff } = require("./print-diff");
 const { packageBCD } = require("./resolve-bcd");
 const { buildHtmlAndJsonFromDoc } = require("ssr");
-const { findMatchesInText } = require("./matches-in-text");
+const {
+  findMatchesInText,
+  replaceMatchesInText,
+} = require("./matches-in-text");
 const Document = require("./document");
 const {
   extractDocumentSections,
@@ -1564,6 +1567,7 @@ class Builder {
     // post-processing instead.
 
     let renderedHtml;
+    let newRawHtml = null;
     // When 'source.htmlAlreadyRendered' is true, it simply means that the 'index.html'
     // is already fully rendered HTML.
     if (source.htmlAlreadyRendered) {
@@ -1577,6 +1581,11 @@ class Builder {
         rawHtml,
         destinationDir
       );
+
+      // Copy of the original raw HTML that we're going to (potentially)
+      // repeatedly do string replaces on.
+      newRawHtml = rawHtml;
+
       if (flaws.length) {
         // The flaw objects might have a 'line' attribute, but the
         // original document it came from had front-matter in the file.
@@ -1593,21 +1602,6 @@ class Builder {
 
         if (this.options.fixFlaws) {
           // For flaws that can be changed, change the source itself.
-
-          // Copy of the original raw HTML that we're going to (potentially)
-          // repeatedly do string replaces on.
-          let newRawHtml = rawHtml;
-
-          // XXX at the moment, due to a bug, if a bad macro call is repeated
-          // you only get 1 flaw object.
-          // See https://github.com/mdn/yari/issues/756#issuecomment-654313496
-          // So if you have:
-          //
-          //  <p>First time:  {{cssref("willredirect")}}</p>
-          //  <p>Second time: {{cssref("willredirect")}}</p>
-          //
-          // ...you actually only get 1 `MacroRedirectedLinkError` flaw
-          // for these two occurences.
 
           flaws
             .filter((flaw) => {
@@ -1639,30 +1633,6 @@ class Builder {
               // `newRawHtml.includes(flaw.macroSource)` line above.
               flaws.splice(i, 1);
             });
-
-          if (newRawHtml !== rawHtml) {
-            // It was improved!!
-            // If you're running in dry-run mode, always assume verbose.
-            if (this.options.fixFlawsVerbose || this.options.fixFlawsDryRun) {
-              console.log(`\nIn ${folder}...`);
-              printBasicDiff(rawHtml, newRawHtml);
-            }
-            const rawHtmlFilepath = fileInfo.path;
-            if (this.options.fixFlawsDryRun) {
-              console.log(
-                chalk.yellow(
-                  `Would have modified "${rawHtmlFilepath}", if this was not a dry run.`
-                )
-              );
-            } else {
-              Document.update(
-                source.filepath,
-                folder,
-                newRawHtml,
-                metadataUntouched
-              );
-            }
-          }
         }
 
         if (this.options.flawLevels.get("macros") === FLAW_LEVELS.ERROR) {
@@ -1753,6 +1723,45 @@ class Builder {
 
     // With the sidebar out of the way, go ahead and check the rest
     this.injectFlaws(source, doc, $, rawContent);
+    if (this.options.fixFlaws) {
+      for (const flaw of doc.flaws.broken_links || []) {
+        if (flaw.suggestion) {
+          // The reason we're not using the parse HTML, as a cheerio object `$`
+          // is because the raw HTML we're dealing with isn't actually proper
+          // HTML. It's only proper HTML when the kumascript macros have been
+          // expanded.
+          newRawHtml = replaceMatchesInText(
+            flaw.href,
+            newRawHtml,
+            flaw.suggestion,
+            { inAttribute: "href" }
+          );
+        }
+      }
+    }
+
+    // If not caught by the cache and the `this.options.fixFlaws` changed
+    // rawHtml for the better, then deal with it.
+    // This can happened for any type of flaw. All we know, at this point,
+    // is that the string changed.
+    if (newRawHtml && newRawHtml !== rawHtml) {
+      // It was improved! Let's deal with that.
+      // If you're running in dry-run mode, always assume verbose.
+      if (this.options.fixFlawsVerbose || this.options.fixFlawsDryRun) {
+        console.log(`\nIn ${folder}...`);
+        printBasicDiff(rawHtml, newRawHtml);
+      }
+      const rawHtmlFilepath = fileInfo.path;
+      if (this.options.fixFlawsDryRun) {
+        console.log(
+          chalk.yellow(
+            `Would have modified "${rawHtmlFilepath}", if this was not a dry run.`
+          )
+        );
+      } else {
+        Document.update(source.filepath, folder, newRawHtml, metadataUntouched);
+      }
+    }
 
     // Post process HTML so that the right elements gets tagged so they
     // *don't* get translated by tools like Google Translate.

--- a/content/scripts/matches-in-text.js
+++ b/content/scripts/matches-in-text.js
@@ -17,4 +17,24 @@ function* findMatchesInText(needle, haystack, { inQuotes = false } = {}) {
   }
 }
 
-module.exports = { findMatchesInText };
+function replaceMatchesInText(
+  needle,
+  haystack,
+  replacement,
+  { inAttribute = null }
+) {
+  // Need to remove any characters that can affect a regex if we're going
+  // use the string in a manually constructed regex.
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  let rex;
+  if (inAttribute) {
+    rex = new RegExp(`${inAttribute}=['"](${escaped})['"]`, "g");
+  } else {
+    rex = new RegExp(`(${escaped})`, "g");
+  }
+  return haystack.replace(rex, (match, p1) => {
+    return match.replace(p1, replacement);
+  });
+}
+
+module.exports = { findMatchesInText, replaceMatchesInText };

--- a/testing/content/files/en-us/web/fixable_flaws/index.html
+++ b/testing/content/files/en-us/web/fixable_flaws/index.html
@@ -9,11 +9,13 @@ summary: Contains flaws that can be fixed.
   <li>{{CSSxRef('dumber')}}</li>
   <li>{{htmlattrxref("href", "anchor")}}</li>
   <li>{{CSSxRef("will-never-be-fixable")}}</li>
+  <li>{{CSSxRef('dumber')}} second time!</li>
 </ul>
 
 <p>Some plain links</p>
 <ul>
-  <li><a href="/en-US/docs/Web/API/Bob">About /en-US/docs/Web/API/Bob</a></li>
+  <li><a href="/en-US/docs/Web/CSS/dumber">Will redirect</a></li>
+  <li><a href='/en-US/docs/Web/CSS/dumber'>Duplicate</a></li>
   <li><a href="https://developer.mozilla.org/en-US/docs/Web/Foo">Foo</a></li>
   <li><a href="/en-us/DOCS/glossary/Bézier_CURVE">OK link but wrong case</a></li>
 </ul>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -384,7 +384,12 @@ describe("fixing flaws", () => {
   // to change files on disk.
   // This is why this test does so much.
   test("build with --fix-flaws", async () => {
-    const command = `node content build --fix-flaws -f ${pattern}`;
+    // The --no-cache option is important because otherwise, on consecutive
+    // runs, the caching might claim that it's already been built, on disk,
+    // so the flaw detection stuff never gets a chance to fix anything
+    // afterwards.
+    const command = `node content build --fix-flaws -f ${pattern} --no-cache`;
+
     const dryrunCommand = command + " --fix-flaws-dry-run";
     const dryrunStdout = execSync(dryrunCommand, {
       cwd: baseDir,
@@ -412,8 +417,10 @@ describe("fixing flaws", () => {
     const newRawHtml = fs.readFileSync(path.join(baseDir, files[0]), "utf-8");
     expect(newRawHtml).toContain("{{CSSxRef('number')}}");
     expect(newRawHtml).toContain('{{htmlattrxref("href", "a")}}');
-    // XXX Note, at the moment, we're only fixing macros.
-    // But as part of https://github.com/mdn/yari/issues/680 it is intended
-    // to fix other things such as broken links.
+    // Broken links that get fixed.
+    expect(newRawHtml).toContain('href="/en-US/docs/Web/CSS/number"');
+    expect(newRawHtml).toContain("href='/en-US/docs/Web/CSS/number'");
+    expect(newRawHtml).toContain('href="/en-US/docs/Glossary/Bézier_curve"');
+    expect(newRawHtml).toContain('href="/en-US/docs/Web/Foo"');
   });
 });


### PR DESCRIPTION
Part of #680

To test, ...one way:

1. `yarn clean && yarn start:functional`
2. `ENV_FILE=testing/.env node content build -f brokenlinks --fix-flaws --fix-flaws-dry-run` 
3. Enjoy the output or remove the `--fix-flaws-dry-run`, add `--no-cache`, followed by `git diff testing/content/files/en-us/web/brokenlinks/index.html` and `git checkout testing/content/files/en-us/web/brokenlinks/index.html`

Another way to test is to use some real content. E.g. 

1. `yarn clean && yarn prebuild`
2. `node content build -l en-us -f web/html/element --fix-flaws --fix-flaws-dry-run --no-progressbar`

The output of that is pretty extreme. But it works. 