### PR TITLE
use integers for msLong()

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1076,7 +1076,7 @@ class Builder {
       console.log(
         chalk.yellow(
           `Processed ${totalProcessed.toLocaleString()} in ${msLong(
-            totalProcessedTime
+            Math.round(totalProcessedTime)
           )} (roughly ${rate.toFixed(1)} docs/sec)`
         )
       );


### PR DESCRIPTION
Before:
<img width="441" alt="Screen Shot 2020-07-13 at 9 37 23 PM" src="https://user-images.githubusercontent.com/26739/87370600-670ab800-c551-11ea-8b3d-dd3519d5b322.png">

After:
<img width="339" alt="Screen Shot 2020-07-13 at 9 39 06 PM" src="https://user-images.githubusercontent.com/26739/87370614-738f1080-c551-11ea-9aed-6bf730784d54.png">

I don't think we need to know how many milliseconds it took, in finer granularity than milliseconds. 