### PR TITLE
display initialize search error instead of throwing

### DIFF
--- a/client/src/search.scss
+++ b/client/src/search.scss
@@ -87,6 +87,9 @@ $search-border-color-focus: #0096bfab;
     div.nothing-found {
       font-style: italic;
     }
+    div.searchindex-error {
+      color: red;
+    }
     .fuzzy-engaged {
       font-size: 80%;
       font-style: italic;

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -248,7 +248,7 @@ function InnerSearchNavigateWidget() {
 
   useFocusOnSlash(inputRef);
 
-  const displaySearchResults = isOpen || searchIndexError;
+  const showResults = isOpen || searchIndexError;
 
   return (
     <form
@@ -262,7 +262,7 @@ function InnerSearchNavigateWidget() {
       <input
         {...getInputProps({
           type: "search",
-          className: displaySearchResults ? "has-search-results" : undefined,
+          className: showResults ? "has-search-results" : undefined,
           placeholder: isFocused
             ? searchIndex
               ? ACTIVE_PLACEHOLDER
@@ -286,7 +286,7 @@ function InnerSearchNavigateWidget() {
       />
 
       <div {...getMenuProps()}>
-        {displaySearchResults && (
+        {showResults && (
           <div className="search-results">
             {searchIndexError ? (
               <div className="searchindex-error">

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -248,7 +248,7 @@ function InnerSearchNavigateWidget() {
 
   useFocusOnSlash(inputRef);
 
-  const displaySearchResults = isOpen || searchIndexError
+  const displaySearchResults = isOpen || searchIndexError;
 
   return (
     <form

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -35,7 +35,7 @@ type SearchIndex = {
   titles: Titles;
 };
 
-function useSearchIndex(): [null | SearchIndex, () => void] {
+function useSearchIndex(): [null | SearchIndex, null | Error, () => void] {
   const [shouldInitialize, setShouldInitialize] = useState(false);
   const [searchIndex, setSearchIndex] = useState<null | SearchIndex>(null);
   const locale = useParams().locale || "en-US";
@@ -53,10 +53,6 @@ function useSearchIndex(): [null | SearchIndex, () => void] {
     },
     { revalidateOnFocus: false }
   );
-
-  if (error) {
-    throw error;
-  }
 
   useEffect(() => {
     if (!titles) {
@@ -79,7 +75,7 @@ function useSearchIndex(): [null | SearchIndex, () => void] {
     setSearchIndex({ flex, fuzzy, titles });
   }, [shouldInitialize, titles, url]);
 
-  return [searchIndex, () => setShouldInitialize(true)];
+  return [searchIndex, error, () => setShouldInitialize(true)];
 }
 
 // The fuzzy search is engaged if the search term starts with a '/'
@@ -167,7 +163,11 @@ function useFocusOnSlash(inputRef: React.RefObject<null | HTMLInputElement>) {
 function InnerSearchNavigateWidget() {
   const navigate = useNavigate();
 
-  const [searchIndex, initializeSearchIndex] = useSearchIndex();
+  const [
+    searchIndex,
+    searchIndexError,
+    initializeSearchIndex,
+  ] = useSearchIndex();
   const [resultItems, setResultItems] = useState<ResultItem[]>([]);
   const [isFocused, setIsFocused] = useState(false);
 
@@ -284,11 +284,15 @@ function InnerSearchNavigateWidget() {
       />
 
       <div {...getMenuProps()}>
-        {isOpen && (
+        {(isOpen || searchIndexError) && (
           <div className="search-results">
-            {resultItems.length === 0 && (
+            {searchIndexError ? (
+              <div className="searchindex-error">
+                Error initializing search index
+              </div>
+            ) : resultItems.length === 0 && inputValue ? (
               <div className="nothing-found">nothing found</div>
-            )}
+            ) : null}
             {resultItems.map((item, i) => (
               <div
                 {...getItemProps({

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -248,6 +248,8 @@ function InnerSearchNavigateWidget() {
 
   useFocusOnSlash(inputRef);
 
+  const displaySearchResults = isOpen || searchIndexError
+
   return (
     <form
       {...getComboboxProps({
@@ -260,7 +262,7 @@ function InnerSearchNavigateWidget() {
       <input
         {...getInputProps({
           type: "search",
-          className: isOpen ? "has-search-results" : undefined,
+          className: displaySearchResults ? "has-search-results" : undefined,
           placeholder: isFocused
             ? searchIndex
               ? ACTIVE_PLACEHOLDER
@@ -284,7 +286,7 @@ function InnerSearchNavigateWidget() {
       />
 
       <div {...getMenuProps()}>
-        {(isOpen || searchIndexError) && (
+        {displaySearchResults && (
           <div className="search-results">
             {searchIndexError ? (
               <div className="searchindex-error">


### PR DESCRIPTION
Fixes #910

It's not amazing but I think it's an improvement. 
<img width="479" alt="Screen Shot 2020-07-15 at 3 56 19 PM" src="https://user-images.githubusercontent.com/26739/87590330-98e85f80-c6b4-11ea-86d6-19403d32136f.png">

To test:

1. `yarn clean && yarn start`
2. Go to http://localhost:3000 and hover over the search at least once to it gets built
3. Refresh the page and DON'T focus on mouse hover over the search input
4. `cd client/build/en-us` and `echo "CORRUPTED JSON" >> titles.json`
5. Now focus the search input in the browser

