### PR TITLE
alert about macro flaws from other pages

### DIFF
--- a/client/src/document/toolbar/flaws.scss
+++ b/client/src/document/toolbar/flaws.scss
@@ -10,4 +10,10 @@
       font-weight: bold;
     }
   }
+
+  .macro-filepath-in-prerequisite {
+    font-size: 80%;
+    background-color: orange;
+    padding: 1px 5px;
+  }
 }


### PR DESCRIPTION
Part of #772

It's so ugly but it works.
<img width="1099" alt="Screen Shot 2020-07-15 at 5 15 31 PM" src="https://user-images.githubusercontent.com/26739/87597031-16b16880-c6bf-11ea-8754-427703c1587f.png">

It's so confusing that you're worrying about this page here but when you click the lines it opens something else and that surprises. This alert will give some attention to that. 

Does "In prerequisite macro" mean anything beyond the core team who actually works on the KS renderer :)