### PR TITLE
check that the url has changed later

### DIFF
--- a/testing/tests/search.test.js
+++ b/testing/tests/search.test.js
@@ -12,12 +12,9 @@ describe("Site search", () => {
     await expect(page).toFill(SEARCH_SELECTOR, "fo");
     await expect(page).toMatch("<foo>: A test tag");
     await expect(page).toClick('[aria-selected="true"]');
-    // expect puppeteer does not wait for url changes implicitly, so we
-    // have to make it explicit
-    await page.waitForNavigation();
-    // Should have been redirected too...
-    await expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
     await expect(page).toMatchElement("h1", { text: "<foo>: A test tag" });
+    // Should have been redirected too...
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
   });
 
   test("input placeholder changes when focused", async () => {

--- a/testing/tests/search.test.js
+++ b/testing/tests/search.test.js
@@ -14,6 +14,9 @@ describe("Site search", () => {
     await expect(page).toClick('[aria-selected="true"]');
     await expect(page).toMatchElement("h1", { text: "<foo>: A test tag" });
     // Should have been redirected too...
+    // Note! It's important that this happens *after* the `.toMatchElement`
+    // on the line above because expect-puppeteer doesn't have a wait to
+    // properly wait for the (pushState) URL to have changed.
     expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
   });
 


### PR DESCRIPTION
Part of #920

I only today noticed that my TS integration in VSCode tells me that there's nothing to `await` when you use `expect(page.url())` because it doesn't report a promise. It makes sense because it's [not available in expect-puppeteer](https://github.com/smooth-code/jest-puppeteer/issues/365). 

The bad thing about this fix is that's a bit weird. Hopefully, my code comment can alleviate some of that. 