### PR TITLE
Broken links flaws confused on some anchors

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1915,9 +1915,12 @@ class Builder {
           } else {
             // But does it have the correct case?!
             const found = this.allTitles.get(hrefNormalized);
-            if (found.mdn_url !== href) {
+            if (found.mdn_url !== href.split("#")[0]) {
               // Inconsistent case.
-              addBrokenLink(href, found.mdn_url);
+              addBrokenLink(
+                href,
+                found.mdn_url + absoluteURL.search + absoluteURL.hash
+              );
             }
           }
         }

--- a/testing/content/files/en-us/web/brokenlinks/index.html
+++ b/testing/content/files/en-us/web/brokenlinks/index.html
@@ -20,6 +20,10 @@ summary: Some fixable (redirects, case, prefix) and some not fixable
   keep the <code>#fragment</code> on the suggested href.</a></p>
 
 <p><a href="/en-us/DOCS/Web/api/BLOB">Wrong case</a></p>
+<p><a href="/en-US/docs/glossary/bézier_curve#identifier">Wrong case with hash</a></p>
+
+<p><a href="/en-US/docs/Glossary/Bézier_curve#identifier">Correct case with hash</a></p>
+
 <p><a href='/en-US/docs/Hopeless/Case'>Will not have a suggestion</></p>
 
 <p><a href="//www.peterbe.com">Leave me alone! I'm actually external</a></p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -270,7 +270,7 @@ test("broken links flaws", () => {
   const { flaws } = doc;
   // You have to be intimately familiar with the fixture to understand
   // why these flaws come out as they do.
-  expect(flaws.broken_links.length).toBe(8);
+  expect(flaws.broken_links.length).toBe(9);
   // Map them by 'href'
   const map = new Map(flaws.broken_links.map((x) => [x.href, x]));
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
@@ -293,6 +293,9 @@ test("broken links flaws", () => {
   expect(
     map.get("/en-US/docs/Web/HTML/Element/anchor#fragment").suggestion
   ).toBe("/en-US/docs/Web/HTML/Element/a#fragment");
+  expect(
+    map.get("/en-US/docs/glossary/bézier_curve#identifier").suggestion
+  ).toBe("/en-US/docs/Glossary/Bézier_curve#identifier");
 });
 
 test("check built flaws for /en-us/learn/css/css_layout/introduction/grid page", () => {


### PR DESCRIPTION
Fixes #898

To test, go to http://localhost:3000/en-US/docs/Web/HTML/Element/a#_flaws 
Without this patch you'd see what you see in the screenshot in the issue. 

Now you should see:
<img width="1392" alt="Screen Shot 2020-07-16 at 2 14 44 PM" src="https://user-images.githubusercontent.com/26739/87707188-bb3eb380-c76e-11ea-90fb-0030188dab85.png">

The `broken_links` checking will have two branches where it comes up with a suggestion
1. If the link is a redirect
2. If the link is in `this.allTitles` but under the wrong case. 

In both cases, when it makes the suggestion it needs to not forget the old fragment. 

What tripped me was that the links mentioned in the issue were actually perfectly fine. They were typed perfectly but ended up in the flaws because they had hash fragments on them. 
But when I was in there poking and debugging I noticed the other problem where the flaw might be that the case is wrong and if that was the case the hash fragment was lost. 