### PR TITLE
new searchwidget inside kumastyles

### DIFF
--- a/client/src/header/search.tsx
+++ b/client/src/header/search.tsx
@@ -1,12 +1,13 @@
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 
-import { useLocale } from "../hooks";
+// import { useLocale } from "../hooks";
+import { SearchNavigateWidget } from '../search'
 import CloseIcon from "../kumastyles/general/close.svg";
 import SearchIcon from "../kumastyles/general/search.svg";
 
 export default function Search() {
-  const locale = useLocale();
+  // const locale = useLocale();
   const [showForm, setShowForm] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -37,7 +38,8 @@ export default function Search() {
 
   return (
     <div className={`header-search ${showForm ? "show-form" : ""}`}>
-      <form
+      <SearchNavigateWidget  />
+      {/* <form
         id="nav-main-search"
         action={`/${locale}/search`}
         method="get"
@@ -58,7 +60,7 @@ export default function Search() {
           pattern="(.|\s)*\S(.|\s)*"
           required
         />
-      </form>
+      </form> */}
       <button className="toggle-form" onClick={handleClick}>
         {/* In order for transitions to work correctly we need
             the `CloseIcon` icon to be in the DOM prior to transitioning.

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -6,6 +6,9 @@ import useSWR from "swr";
 import FuzzySearch from "./fuzzy-search";
 import "./search.scss";
 
+import { useLocale } from "./hooks";
+import SearchIcon from "./kumastyles/general/search.svg";
+
 function isMobileUserAgent() {
   return (
     typeof window !== "undefined" &&
@@ -166,6 +169,7 @@ function useFocusOnSlash(inputRef: React.RefObject<null | HTMLInputElement>) {
 
 function InnerSearchNavigateWidget() {
   const navigate = useNavigate();
+  const locale = useLocale();
 
   const [searchIndex, initializeSearchIndex] = useSearchIndex();
   const [resultItems, setResultItems] = useState<ResultItem[]>([]);
@@ -250,17 +254,30 @@ function InnerSearchNavigateWidget() {
 
   return (
     <form
+      action={`/${locale}/search`}
       {...getComboboxProps({
         className: "search-widget",
-        onSubmit: (e) => {
-          e.preventDefault();
-        },
+        id: "nav-main-search",
+        role: "search",
+        // onSubmit: (e) => {
+        //   e.preventDefault();
+        // },
       })}
     >
+      <img src={SearchIcon} alt="search" className="search-icon" />
+
+      <label htmlFor="main-q" className="visually-hidden">
+        Search MDN
+      </label>
+
       <input
         {...getInputProps({
           type: "search",
-          className: isOpen ? "has-search-results" : undefined,
+          className: isOpen
+            ? "has-search-results search-input-field"
+            : "search-input-field",
+          id: "main-q",
+          name: "q",
           placeholder: isFocused
             ? searchIndex
               ? ACTIVE_PLACEHOLDER
@@ -336,5 +353,3 @@ export function SearchNavigateWidget() {
     </SearchErrorBoundary>
   );
 }
-
-export default SearchNavigateWidget;


### PR DESCRIPTION
I mean, it kinda works
<img width="634" alt="Screen Shot 2020-07-16 at 2 56 29 PM" src="https://user-images.githubusercontent.com/26739/87710982-9c432000-c774-11ea-8be4-e42d66f7278d.png">

I just don't know what I'm doing with the styles. 
Also, even if we can get the search results to appear underneath the search widget correctly aligned, I don't think we're quite done because I think the search results should probably tie in better with the search input field. 
I don't think it's a must that the search results fit perfectly (e.g. the width of the widget matches the width of the input field). But it would be nice if the gap between wasn't too large. 

I'm asking for a review from you @Gregoor in hope that you know what the problem is but I'd love to get @schalkneethling to take a look in case you know what the problem is. 