### PR TITLE
better flaws (fixes #915 and #930)

### DIFF
--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -1508,7 +1508,21 @@ class Builder {
       }
     }
 
-    return [renderedHtml, macroFlaws.concat(liveSampleFlaws)];
+    // Remove duplicate flaws. During the rendering process, it's possible for identical
+    // flaws to be introduced when different dependency paths share common prerequisites.
+    // For example, document A may have prerequisite documents B and C, and in turn,
+    // document C may also have prerequisite B, and the rendering of document B generates
+    // one or more flaws.
+    const flaws = [
+      ...new Map(
+        macroFlaws.concat(liveSampleFlaws).map((f) => [
+          // This should ensure a unique key for each flaw.
+          [f.name, f.errorMessage, f.line, f.column, f.filepath].join("+"),
+          f,
+        ])
+      ).values(),
+    ];
+    return [renderedHtml, flaws];
   }
 
   async processFolder(source, folder, config) {

--- a/content/scripts/build.js
+++ b/content/scripts/build.js
@@ -456,27 +456,9 @@ class Builder {
     for (const prerequisite of kumascript.getPrerequisites(rawHtml)) {
       const prerequisiteUri = this.cleanUri(prerequisite.uri);
       if (!this.allTitles.has(prerequisiteUri)) {
-        allPrerequisiteFlaws.push(
-          fileInfo.updateFlaw(
-            prerequisite.createFlaw(
-              `${uri} transcludes ${prerequisiteUri}, which does not exist`
-            )
-          )
-        );
         continue;
       }
-      const titleData = this.allTitles.get(prerequisiteUri);
-      const folder = titleData.file;
-      if (titleData.source !== source.filepath) {
-        allPrerequisiteFlaws.push(
-          fileInfo.updateFlaw(
-            prerequisite.createFlaw(
-              `${uri} transcludes ${prerequisiteUri}, which is from a different source`
-            )
-          )
-        );
-        continue;
-      }
+      const { file: folder } = this.allTitles.get(prerequisiteUri);
       const {
         metadata: prerequisiteMetadata,
         rawHtml: prerequisiteRawHtml,
@@ -518,7 +500,7 @@ class Builder {
     );
 
     for (const flaw of flaws) {
-      fileInfo.updateFlaw(flaw);
+      flaw.updateFileInfo(fileInfo);
     }
 
     return [renderedHtml, flaws.concat(allPrerequisiteFlaws)];
@@ -1426,7 +1408,7 @@ class Builder {
           sampleIDObject
         );
         if (liveSamplePage.flaw) {
-          liveSampleFlaws.push(fileInfo.updateFlaw(liveSamplePage.flaw));
+          liveSampleFlaws.push(liveSamplePage.flaw.updateFileInfo(fileInfo));
           continue;
         }
         const liveSampleDir = path.join(
@@ -1460,33 +1442,9 @@ class Builder {
       const otherUri = buildMDNUrl(metadata.locale, slug);
       const otherCleanUri = this.cleanUri(otherUri);
       if (!this.allTitles.has(otherCleanUri)) {
-        // I suppose we could use any, but let's use the first
-        // mention of the sampleID within the original source file.
-        const firstSampleID = sampleIDs[0];
-        liveSampleFlaws.push(
-          fileInfo.updateFlaw(
-            firstSampleID.createFlaw(
-              `${uri} references live sample(s) from ${otherCleanUri}, which does not exist`
-            )
-          )
-        );
         continue;
       }
-      const otherTitleData = this.allTitles.get(otherCleanUri);
-      const otherFolder = otherTitleData.file;
-      if (otherTitleData.source !== source.filepath) {
-        // Again let's just use the first mention of sampleID within
-        // the original source file.
-        const firstSampleID = sampleIDs[0];
-        liveSampleFlaws.push(
-          fileInfo.updateFlaw(
-            firstSampleID.createFlaw(
-              `${uri} references live sample(s) from ${otherCleanUri}, which is from a different source`
-            )
-          )
-        );
-        continue;
-      }
+      const { file: otherFolder } = this.allTitles.get(otherCleanUri);
       const {
         metadata: otherMetadata,
         rawHtml: otherRawHtml,

--- a/content/scripts/document.js
+++ b/content/scripts/document.js
@@ -151,14 +151,6 @@ const read = (
     fileInfo: {
       path: filePath,
       frontMatterOffset,
-      updateFlaw: (flaw) => {
-        // This is used to update flaws with this information.
-        flaw.filepath = filePath;
-        // The extra `- 1` is because of the added newline that
-        // is only present because of the serialized linebreak.
-        flaw.updateOffset(frontMatterOffset - 1);
-        return flaw;
-      },
     },
   };
 };

--- a/content/scripts/document.js
+++ b/content/scripts/document.js
@@ -151,6 +151,14 @@ const read = (
     fileInfo: {
       path: filePath,
       frontMatterOffset,
+      updateFlaw: (flaw) => {
+        // This is used to update flaws with this information.
+        flaw.filepath = filePath;
+        // The extra `- 1` is because of the added newline that
+        // is only present because of the serialized linebreak.
+        flaw.updateOffset(frontMatterOffset - 1);
+        return flaw;
+      },
     },
   };
 };

--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -16,6 +16,7 @@ if ($1 && $1.length > 0) {
 }
 
 let url = new kuma.url.URL(base);
+wiki.checkExistence(url.pathname);
 let liveSampleUrl = new kuma.url.URL(env.live_samples.base_url);
 url.host = liveSampleUrl.host;
 url.protocol = liveSampleUrl.protocol;

--- a/kumascript/src/api/wiki.js
+++ b/kumascript/src/api/wiki.js
@@ -73,11 +73,9 @@ module.exports = {
     const pathDescription = this.info.getDescription(path);
 
     if (!result) {
-      // There was no cached result for the path. One
-      // possibility is that the requested path was in archived
-      // content, so it was never pre-rendered and cached.
+      // If there was no cached result for the path, it doesn't exist.
       throw new Error(
-        `unable to find pre-rendered HTML for prerequisite ${pathDescription}`
+        `${this.env.path.toLowerCase()} transcludes ${pathDescription}, which does not exist`
       );
     }
 
@@ -105,6 +103,17 @@ module.exports = {
   // Returns the page object for the specified page.
   getPage(path) {
     return this.info.getPage(path || this.env.url);
+  },
+
+  // Throw an error if the given document path does not exist.
+  checkExistence(path) {
+    if (!this.info.hasPage(path)) {
+      throw new Error(
+        `${this.env.path.toLowerCase()} references ${this.info.getDescription(
+          path
+        )}, which does not exist`
+      );
+    }
   },
 
   // Retrieve the full uri of a given wiki page.

--- a/kumascript/src/errors.js
+++ b/kumascript/src/errors.js
@@ -16,11 +16,36 @@ class SourceCodeError {
     // instances of this class. Otherwise we'd need to monkey-patch
     // the `.toJSON` of `Error` which feels fragile.
     this.errorMessage = error.message;
+    this.offset = 0;
     this.line = line;
     this.column = column;
     this.macroName = macroName;
     this.sourceContext = this.getSourceContext(source);
     this.fatal = fatal;
+  }
+
+  updateOffset(value) {
+    // Update the "offset" property to account for things like front-matter in the
+    // source. If the offset changes, this method will update related information.
+    // NOTE: We're not using a getter/setter for "offset", which would be a more
+    //       robust interface, so that the code that converts this instance to/from
+    //       JSON can remain simple.
+    const cleanValue = parseInt(value);
+    if (cleanValue >= 0 && this.offset !== cleanValue) {
+      // First, let's calculate the change in offset.
+      const offsetDelta = cleanValue - this.offset;
+      // Now, let's update things. First, the offset itself.
+      this.offset += offsetDelta;
+      // Next, let's update the line number.
+      this.line += offsetDelta;
+      // Finally, let's update the line numbers in the source context to reflect the new offset.
+      this.sourceContext = this.sourceContext.replace(
+        /^\s{0,4}(\d{1,5}) \| /gm,
+        (match, p1) => {
+          return (parseInt(p1) + offsetDelta).toString().padStart(5) + " | ";
+        }
+      );
+    }
   }
 
   // TODO(djf): a lot of our HTML documents have really long lines and

--- a/kumascript/src/errors.js
+++ b/kumascript/src/errors.js
@@ -48,6 +48,14 @@ class SourceCodeError {
     }
   }
 
+  updateFileInfo(fileInfo) {
+    this.filepath = fileInfo.path;
+    // The extra `- 1` is because of the added newline that
+    // is only present because of the serialized linebreak.
+    this.updateOffset(fileInfo.frontMatterOffset - 1);
+    return this;
+  }
+
   // TODO(djf): a lot of our HTML documents have really long lines and
   // showing line-oriented errors when the column number is > 100
   // doesn't really make sense. Perhaps we can modify this function to

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -147,7 +147,7 @@ class AllPagesInfo {
 
   getDescription(url) {
     const uriKey = this.getUriKey(url);
-    let description = `"${uriKey}"`;
+    let description = `${uriKey}`;
     if (uriKey !== url.toLowerCase()) {
       description += ` (derived from "${url}")`;
     }
@@ -189,6 +189,11 @@ class AllPagesInfo {
       return {};
     }
     return this.pagesByUri.get(uriKey);
+  }
+
+  hasPage(url) {
+    const uriKey = this.getUriKey(url);
+    return this.pagesByUri.has(uriKey);
   }
 
   cacheResult(uri, result) {

--- a/kumascript/tests/macros/EmbedLiveSample.test.js
+++ b/kumascript/tests/macros/EmbedLiveSample.test.js
@@ -8,6 +8,7 @@ describeMacro("EmbedLiveSample", function () {
     macro.ctx.env.live_samples = {
       base_url: "https://mdn.mozillademos.org",
     };
+    macro.ctx.info.hasPage = jest.fn((path) => true);
   });
   itMacro("One argument: ID", function (macro) {
     macro.ctx.env.url =
@@ -239,6 +240,20 @@ describeMacro("EmbedLiveSample", function () {
         "</iframe>"
     );
   });
+  itMacro(
+    'Five arguments: ID, "", "", "", other non-existent slug',
+    async function (macro) {
+      macro.ctx.env.path = "/en-US/docs/Web/Events/focus";
+      macro.ctx.env.url = `https://developer.mozilla.org${macro.ctx.env.path}`;
+      macro.ctx.info.getDescription = jest.fn((url) => url.toLowerCase());
+      macro.ctx.info.hasPage = jest.fn((path) => false);
+      await expect(
+        macro.call("Event delegation", "", "", "", "Web/Events/blur")
+      ).rejects.toThrow(
+        "/en-us/docs/web/events/focus references /en-us/docs/web/events/blur, which does not exist"
+      );
+    }
+  );
   itMacro('Five arguments: ID, "", "", "", XSS Attempt (failed)', function (
     macro
   ) {

--- a/kumascript/tests/macros/LiveSampleURL.test.js
+++ b/kumascript/tests/macros/LiveSampleURL.test.js
@@ -1,9 +1,12 @@
 /**
  * @prettier
  */
-const { assert, itMacro, describeMacro } = require("./utils");
+const { assert, itMacro, describeMacro, beforeEachMacro } = require("./utils");
 
 describeMacro("LiveSampleURL", function () {
+  beforeEachMacro(function (macro) {
+    macro.ctx.info.hasPage = jest.fn((path) => true);
+  });
   itMacro("Production settings", function (macro) {
     macro.ctx.env.live_samples = {
       base_url: "https://mdn.mozillademos.org",
@@ -27,6 +30,23 @@ describeMacro("LiveSampleURL", function () {
         "https://developer.mozilla.org/en-US/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_2"
       ),
       "https://mdn.mozillademos.org/en-US/docs/HTML/Forms/How_to_build_custom_form_widgets/Example_2/_samples_/No_JS"
+    );
+  });
+  itMacro("Override with nonexistent page URL)", async (macro) => {
+    macro.ctx.env.live_samples = {
+      base_url: "https://mdn.mozillademos.org",
+    };
+    macro.ctx.info.hasPage = jest.fn((path) => false);
+    macro.ctx.info.getDescription = jest.fn((url) => url.toLowerCase());
+    macro.ctx.env.path = "/en-US/docs/Learn/HTML";
+    macro.ctx.env.url = `https://developer.mozilla.org${macro.ctx.env.path}`;
+    await expect(
+      macro.call(
+        "No_JS",
+        "https://developer.mozilla.org/en-US/docs/does/not/exist"
+      )
+    ).rejects.toThrow(
+      "/en-us/docs/learn/html references /en-us/docs/does/not/exist, which does not exist"
     );
   });
   itMacro("Staging settings", function (macro) {

--- a/kumascript/tests/macros/dekiscript-page.test.js
+++ b/kumascript/tests/macros/dekiscript-page.test.js
@@ -154,7 +154,7 @@ describeMacro("dekiscript-page", function () {
     itMacro("One argument (throws error)", function (macro) {
       const junk_url = "/en-US/docs/junk";
       expect(() => macro.ctx.page.translations(junk_url)).toThrow(
-        `"${junk_url.toLowerCase()}" does not exist`
+        `${junk_url.toLowerCase()} does not exist`
       );
     });
   });

--- a/testing/content/files/en-us/web/foo/index.html
+++ b/testing/content/files/en-us/web/foo/index.html
@@ -13,3 +13,7 @@ tags:
 <div>
   {{EmbedInteractiveExample("pages/tabbed/video.html", "tabbed-standard")}}
 </div>
+
+<p>Let's include some other pages:</p>
+<div>{{page("web/fubar")}}</div>
+<div>{{page("web/fixable-flaws")}}</div>

--- a/testing/content/files/en-us/web/fubar/index.html
+++ b/testing/content/files/en-us/web/fubar/index.html
@@ -6,6 +6,7 @@ tags:
   - slang
   - acronym
 ---
-<p>Let's include another page:</p>
+<p>Let's include some other pages:</p>
 <div>{{page("web/fixable-flaws")}}</div>
 <div>{{page("does-not-exist")}}</div>
+<dic>{{ EmbedLiveSample('example', '300', '300', "", "does/not/exist") }}</div>

--- a/testing/content/files/en-us/web/fubar/index.html
+++ b/testing/content/files/en-us/web/fubar/index.html
@@ -1,0 +1,11 @@
+---
+title: '<fubar>: A test page'
+slug: Web/Fubar
+summary: This is the fubar test page
+tags:
+  - slang
+  - acronym
+---
+<p>Let's include another page:</p>
+<div>{{page("web/fixable-flaws")}}</div>
+<div>{{page("does-not-exist")}}</div>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -29,7 +29,7 @@ test("content built foo page", () => {
   expect(doc.flaws.macros[0].name).toBe("MacroExecutionError");
   expect(doc.flaws.macros[0].errorMessage).toEqual(
     expect.stringContaining(
-      'unable to find pre-rendered HTML for prerequisite "/en-us/docs/does-not-exist"'
+      '/en-us/docs/web/fubar transcludes /en-us/docs/does-not-exist (derived from "does-not-exist"), which does not exist'
     )
   );
   expect(doc.flaws.macros[0].line).toBe(11);
@@ -41,78 +41,81 @@ test("content built foo page", () => {
   expect(doc.flaws.macros[0].filepath).toMatch(
     /\/en-us\/web\/fubar\/index\.html$/
   );
-  expect(doc.flaws.macros[1].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[1].macroSource).toBe("{{CSSxRef('dumber')}}");
-  expect(doc.flaws.macros[1].line).toBe(9);
-  expect(doc.flaws.macros[1].column).toBe(7);
-  expect(doc.flaws.macros[1].sourceContext).toEqual(
-    expect.stringContaining("    9 |   <li>{{CSSxRef('dumber')}}</li>")
+  expect(doc.flaws.macros[1].name).toBe("MacroExecutionError");
+  expect(doc.flaws.macros[1].errorMessage).toEqual(
+    expect.stringContaining(
+      "/en-us/docs/web/fubar references /en-us/docs/does/not/exist, which does not exist"
+    )
   );
-  expect(doc.flaws.macros[1].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[1].redirectInfo.current).toBe("dumber");
-  expect(doc.flaws.macros[1].redirectInfo.suggested).toBe("number");
+  expect(doc.flaws.macros[1].line).toBe(12);
+  expect(doc.flaws.macros[1].column).toBe(6);
+  // Check that the line numbers in the source context have been adjusted by the offset.
+  expect(doc.flaws.macros[1].sourceContext).toEqual(
+    expect.stringContaining(
+      `   12 | <dic>{{ EmbedLiveSample('example', '300', '300', "", "does/not/exist") }}</div>`
+    )
+  );
   expect(doc.flaws.macros[1].filepath).toMatch(
-    /\/en-us\/web\/fixable_flaws\/index\.html$/
+    /\/en-us\/web\/fubar\/index\.html$/
   );
   expect(doc.flaws.macros[2].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[2].macroSource).toBe(
-    '{{htmlattrxref("href", "anchor")}}'
-  );
-  expect(doc.flaws.macros[2].line).toBe(10);
+  expect(doc.flaws.macros[2].macroSource).toBe("{{CSSxRef('dumber')}}");
+  expect(doc.flaws.macros[2].line).toBe(9);
   expect(doc.flaws.macros[2].column).toBe(7);
   expect(doc.flaws.macros[2].sourceContext).toEqual(
+    expect.stringContaining("    9 |   <li>{{CSSxRef('dumber')}}</li>")
+  );
+  expect(doc.flaws.macros[2].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[2].redirectInfo.current).toBe("dumber");
+  expect(doc.flaws.macros[2].redirectInfo.suggested).toBe("number");
+  expect(doc.flaws.macros[2].filepath).toMatch(
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
+  );
+  expect(doc.flaws.macros[3].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[3].macroSource).toBe(
+    '{{htmlattrxref("href", "anchor")}}'
+  );
+  expect(doc.flaws.macros[3].line).toBe(10);
+  expect(doc.flaws.macros[3].column).toBe(7);
+  expect(doc.flaws.macros[3].sourceContext).toEqual(
     expect.stringContaining(
       '   10 |   <li>{{htmlattrxref("href", "anchor")}}</li>'
     )
   );
-  expect(doc.flaws.macros[2].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[2].redirectInfo.current).toBe("anchor");
-  expect(doc.flaws.macros[2].redirectInfo.suggested).toBe("a");
-  expect(doc.flaws.macros[2].filepath).toMatch(
+  expect(doc.flaws.macros[3].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[3].redirectInfo.current).toBe("anchor");
+  expect(doc.flaws.macros[3].redirectInfo.suggested).toBe("a");
+  expect(doc.flaws.macros[3].filepath).toMatch(
     /\/en-us\/web\/fixable_flaws\/index\.html$/
   );
-  expect(doc.flaws.macros[3].name).toBe("MacroBrokenLinkError");
-  expect(doc.flaws.macros[3].macroSource).toBe(
+  expect(doc.flaws.macros[4].name).toBe("MacroBrokenLinkError");
+  expect(doc.flaws.macros[4].macroSource).toBe(
     '{{CSSxRef("will-never-be-fixable")}}'
   );
-  expect(doc.flaws.macros[3].line).toBe(11);
-  expect(doc.flaws.macros[3].column).toBe(7);
-  expect(doc.flaws.macros[3].sourceContext).toEqual(
+  expect(doc.flaws.macros[4].line).toBe(11);
+  expect(doc.flaws.macros[4].column).toBe(7);
+  expect(doc.flaws.macros[4].sourceContext).toEqual(
     expect.stringContaining(
       '   11 |   <li>{{CSSxRef("will-never-be-fixable")}}</li>'
     )
   );
-  expect(doc.flaws.macros[3].filepath).toMatch(
+  expect(doc.flaws.macros[4].filepath).toMatch(
     /\/en-us\/web\/fixable_flaws\/index\.html$/
   );
-  expect(doc.flaws.macros[4].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[4].macroSource).toBe("{{CSSxRef('dumber')}}");
-  expect(doc.flaws.macros[4].line).toBe(12);
-  expect(doc.flaws.macros[4].column).toBe(7);
-  expect(doc.flaws.macros[4].sourceContext).toEqual(
+  expect(doc.flaws.macros[5].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[5].macroSource).toBe("{{CSSxRef('dumber')}}");
+  expect(doc.flaws.macros[5].line).toBe(12);
+  expect(doc.flaws.macros[5].column).toBe(7);
+  expect(doc.flaws.macros[5].sourceContext).toEqual(
     expect.stringContaining(
       "   12 |   <li>{{CSSxRef('dumber')}} second time!</li>"
     )
   );
-  expect(doc.flaws.macros[4].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[4].redirectInfo.current).toBe("dumber");
-  expect(doc.flaws.macros[4].redirectInfo.suggested).toBe("number");
-  expect(doc.flaws.macros[4].filepath).toMatch(
-    /\/en-us\/web\/fixable_flaws\/index\.html$/
-  );
-  expect(doc.flaws.macros[5].name).toBe("MacroExecutionError");
-  expect(doc.flaws.macros[5].errorMessage).toBe(
-    "/en-us/docs/web/fubar transcludes /en-us/docs/does-not-exist, which does not exist"
-  );
-  expect(doc.flaws.macros[5].line).toBe(11);
-  expect(doc.flaws.macros[5].column).toBe(6);
-  expect(doc.flaws.macros[5].sourceContext).toEqual(
-    expect.stringContaining('   11 | <div>{{page("does-not-exist")}}</div>')
-  );
-  expect(doc.flaws.macros[5].filepath).toBeDefined();
-  expect(doc.flaws.macros[5].filepath.endsWith("")).toBeTruthy();
+  expect(doc.flaws.macros[5].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[5].redirectInfo.current).toBe("dumber");
+  expect(doc.flaws.macros[5].redirectInfo.suggested).toBe("number");
   expect(doc.flaws.macros[5].filepath).toMatch(
-    /\/en-us\/web\/fubar\/index\.html$/
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
   );
 
   const htmlFile = path.join(builtFolder, "index.html");
@@ -405,9 +408,9 @@ test("check built flaws for /en-us/learn/css/css_layout/introduction/grid page",
   const jsonFile = path.join(builtFolder, "index.json");
   expect(fs.existsSync(jsonFile)).toBeTruthy();
 
-  // Let's make sure there are only 3 "macros" flaws.
+  // Let's make sure there are only 2 "macros" flaws.
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(doc.flaws.macros.length).toBe(3);
+  expect(doc.flaws.macros.length).toBe(2);
 });
 
 describe("fixing flaws", () => {

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -25,6 +25,96 @@ test("content built foo page", () => {
   expect(doc.modified).toBeTruthy();
   expect(doc.source).toBeTruthy();
 
+  expect(doc.flaws.macros.length).toBe(6);
+  expect(doc.flaws.macros[0].name).toBe("MacroExecutionError");
+  expect(doc.flaws.macros[0].errorMessage).toEqual(
+    expect.stringContaining(
+      'unable to find pre-rendered HTML for prerequisite "/en-us/docs/does-not-exist"'
+    )
+  );
+  expect(doc.flaws.macros[0].line).toBe(11);
+  expect(doc.flaws.macros[0].column).toBe(6);
+  // Check that the line numbers in the source context have been adjusted by the offset.
+  expect(doc.flaws.macros[0].sourceContext).toEqual(
+    expect.stringContaining('   11 | <div>{{page("does-not-exist")}}</div>')
+  );
+  expect(doc.flaws.macros[0].filepath).toMatch(
+    /\/en-us\/web\/fubar\/index\.html$/
+  );
+  expect(doc.flaws.macros[1].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[1].macroSource).toBe("{{CSSxRef('dumber')}}");
+  expect(doc.flaws.macros[1].line).toBe(9);
+  expect(doc.flaws.macros[1].column).toBe(7);
+  expect(doc.flaws.macros[1].sourceContext).toEqual(
+    expect.stringContaining("    9 |   <li>{{CSSxRef('dumber')}}</li>")
+  );
+  expect(doc.flaws.macros[1].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[1].redirectInfo.current).toBe("dumber");
+  expect(doc.flaws.macros[1].redirectInfo.suggested).toBe("number");
+  expect(doc.flaws.macros[1].filepath).toMatch(
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
+  );
+  expect(doc.flaws.macros[2].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[2].macroSource).toBe(
+    '{{htmlattrxref("href", "anchor")}}'
+  );
+  expect(doc.flaws.macros[2].line).toBe(10);
+  expect(doc.flaws.macros[2].column).toBe(7);
+  expect(doc.flaws.macros[2].sourceContext).toEqual(
+    expect.stringContaining(
+      '   10 |   <li>{{htmlattrxref("href", "anchor")}}</li>'
+    )
+  );
+  expect(doc.flaws.macros[2].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[2].redirectInfo.current).toBe("anchor");
+  expect(doc.flaws.macros[2].redirectInfo.suggested).toBe("a");
+  expect(doc.flaws.macros[2].filepath).toMatch(
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
+  );
+  expect(doc.flaws.macros[3].name).toBe("MacroBrokenLinkError");
+  expect(doc.flaws.macros[3].macroSource).toBe(
+    '{{CSSxRef("will-never-be-fixable")}}'
+  );
+  expect(doc.flaws.macros[3].line).toBe(11);
+  expect(doc.flaws.macros[3].column).toBe(7);
+  expect(doc.flaws.macros[3].sourceContext).toEqual(
+    expect.stringContaining(
+      '   11 |   <li>{{CSSxRef("will-never-be-fixable")}}</li>'
+    )
+  );
+  expect(doc.flaws.macros[3].filepath).toMatch(
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
+  );
+  expect(doc.flaws.macros[4].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[4].macroSource).toBe("{{CSSxRef('dumber')}}");
+  expect(doc.flaws.macros[4].line).toBe(12);
+  expect(doc.flaws.macros[4].column).toBe(7);
+  expect(doc.flaws.macros[4].sourceContext).toEqual(
+    expect.stringContaining(
+      "   12 |   <li>{{CSSxRef('dumber')}} second time!</li>"
+    )
+  );
+  expect(doc.flaws.macros[4].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[4].redirectInfo.current).toBe("dumber");
+  expect(doc.flaws.macros[4].redirectInfo.suggested).toBe("number");
+  expect(doc.flaws.macros[4].filepath).toMatch(
+    /\/en-us\/web\/fixable_flaws\/index\.html$/
+  );
+  expect(doc.flaws.macros[5].name).toBe("MacroExecutionError");
+  expect(doc.flaws.macros[5].errorMessage).toBe(
+    "/en-us/docs/web/fubar transcludes /en-us/docs/does-not-exist, which does not exist"
+  );
+  expect(doc.flaws.macros[5].line).toBe(11);
+  expect(doc.flaws.macros[5].column).toBe(6);
+  expect(doc.flaws.macros[5].sourceContext).toEqual(
+    expect.stringContaining('   11 | <div>{{page("does-not-exist")}}</div>')
+  );
+  expect(doc.flaws.macros[5].filepath).toBeDefined();
+  expect(doc.flaws.macros[5].filepath.endsWith("")).toBeTruthy();
+  expect(doc.flaws.macros[5].filepath).toMatch(
+    /\/en-us\/web\/fubar\/index\.html$/
+  );
+
   const htmlFile = path.join(builtFolder, "index.html");
   expect(fs.existsSync(htmlFile)).toBeTruthy();
   const html = fs.readFileSync(htmlFile, "utf-8");


### PR DESCRIPTION
Fixes #915 and #930 

This PR took longer than expected because of all of the options I explored. In the end, for flaw de-duplication, I decided to go with a simpler approach (but less elegant because it doesn't prevent duplicates, it just removes them) because the more elegant approach would complicate @Gregoor 's planned refactor.

With this PR, every macro flaw returned from `renderMacrosAndBuildLiveSamples()` or `renderMacros()` is ensured to have the correct:
- `filepath`
- `line` -- adjusted to account for the front-matter of its corresponding file
- `sourceContext` -- i.e., its line numbers have also been adjusted to account for the front-matter of its corresponding file

I've also added some new tests.

Here are some screenshots of http://localhost:3000/en-US/docs/Web/HTML/Element/input/range#_flaws. Notice there are no duplicates, the line numbers are correct, and the source contexts also reflect the correct line numbers:

<img width="739" alt="image" src="https://user-images.githubusercontent.com/3743693/87838746-e0095880-c84c-11ea-93ba-9d5488167f9d.png">


