### PR TITLE
no slugToFolder transform for live sample request

### DIFF
--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -1,6 +1,5 @@
 const express = require("express");
 
-const { slugToFoldername } = require("content");
 const { STATIC_ROOT } = require("./constants");
 
 // Lowercase every request because every possible file we might have
@@ -9,15 +8,6 @@ const { STATIC_ROOT } = require("./constants");
 // sensitive.
 const slugRewrite = (req, res, next) => {
   req.url = req.url.toLowerCase();
-
-  if (req.url.includes("/_samples_/")) {
-    // We need to convert incoming live-sample URL's like:
-    //   /en-us/docs/web/css/:indeterminate/_samples_/progress_bar
-    // to:
-    //   /en-us/docs/web/css/_colon_indeterminate/_samples_/progress_bar
-    // since they should be served directly by the static middleware.
-    req.url = slugToFoldername(req.url);
-  }
   next();
 };
 


### PR DESCRIPTION
I just realized that I must've still had that line commented out when I tested your PR. I think we don't want that line there, at least samples aren't even working for me in local mode without it.

What we do ultimately want our static server to do (and also our lambda at edge) is rewrite urls to foldernames, but that shouldn't be live sample requests, should it?