### PR TITLE
cli output about rate of building documents

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -116,11 +116,31 @@ async function buildDocuments() {
       JSON.stringify(items)
     );
   }
+  return slugPerLocale;
 }
 
 if (require.main === module) {
-  buildDocuments().catch((error) => {
-    console.error("error while building documents:", error);
-    process.exit(1);
-  });
+  const t0 = new Date();
+  buildDocuments()
+    .then((slugPerLocale) => {
+      const t1 = new Date();
+      const count = Object.values(slugPerLocale).reduce(
+        (a, b) => a + b.length,
+        0
+      );
+      const seconds = (t1 - t0) / 1000;
+      const took =
+        seconds > 60
+          ? `${(seconds / 60).toFixed(1)} minutes`
+          : `${seconds.toFixed(1)} seconds`;
+      console.log(
+        `Built ${count.toLocaleString()} in ${took}, at a rate of ${(
+          count / seconds
+        ).toFixed(1)} documents per second.`
+      );
+    })
+    .catch((error) => {
+      console.error("error while building documents:", error);
+      process.exit(1);
+    });
 }


### PR DESCRIPTION
It adds line noise but I like that it's exclusively outside and only ever relevant in the CLI usage. 
Also, I didn't want to get fancy with `chalk` and `ms` for formatting because then it would complicate what doesn't need to be complicated at this point. 