### PR TITLE
redirect when using localhost:3000

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useEffect } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
 import { useWebSocketMessageHandler } from "../web-socket";
@@ -27,6 +27,7 @@ const Toolbar = lazy(() => import("./toolbar"));
 export function Document(props /* TODO: define a TS interface for this */) {
   const documentURL = useDocumentURL();
   const { locale } = useParams();
+  const navigate = useNavigate();
 
   const dataURL = `${documentURL}/index.json`;
   const { data: doc, error } = useSWR<Doc>(
@@ -36,7 +37,11 @@ export function Document(props /* TODO: define a TS interface for this */) {
       if (!response.ok) {
         throw new Error(`${response.status} on ${url}`);
       }
-      return (await response.json()).doc;
+      const { doc } = await response.json();
+      if (response.redirected) {
+        navigate(doc.mdn_url);
+      }
+      return doc;
     },
     {
       initialData:


### PR DESCRIPTION
Fixes #972

First of all, to test, go to http://localhost:3000/en-US/docs/Web/CSS/CSS_Reference and it should automatically redirect to http://localhost:3000/en-US/docs/Web/CSS/Reference

Lemme justify why there are no tests.
We currently have no test suite for the dev environment. But it's going to come, but even then I'm not sure it's worth testing. 
The only way, in production, you can end up on a URL that redirects is **if you click** on a link that would redirect. E.g. 
```html
<a href="/en-US/docs/Web/OldName">
```
If you had gone directly to `https://developer.mozilla.org/en-US/docs/Web/OldName` (with `curl` for example) our S3 website would have an S3 entry for this because it comes from the deployer uploading an S3 key for every entry in `_redirects.txt`. So it would never start any React stuff at all on the old URL. 
And sure, there are potentially HTML blobs that contain `<a href="/en-US/docs/Web/OldName">` but...
* The fixable-flaws should (almost constantly) have rewritten this and even if you haven't committed a fixable flaw back into the source, the builder would have already (using cheerio) corrected the HTML blob. 
* These are not `<Link>` but good old `<a>` and will most likely remain like that for a very long time so it wouldn't have triggered the `useSWR` stuff anyway because the doc will be SSR loaded. 

I honestly can't think of a possible way that this could happen in production builds.