### PR TITLE
make web-ext-examples macros work again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,6 @@ titles.json
 /client/build/
 /ssr/dist/
 
-# Kumascript JSON file of cached web-extension examples.
-__cached-web-ext-examples.json
-
 # Can be removed once content lives in its own repo
 /archivecontent/files
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ titles.json
 /client/build/
 /ssr/dist/
 
+# Kumascript JSON file of cached web-extension examples.
+__cached-web-ext-examples.json
+
 # Can be removed once content lives in its own repo
 /archivecontent/files
 

--- a/kumascript/macros/WebExtAllExamples.ejs
+++ b/kumascript/macros/WebExtAllExamples.ejs
@@ -1,0 +1,67 @@
+<%
+
+/*
+The "examples.json" file from the https://github.com/mdn/webextensions-examples
+repository contains information about the examples living in that repository.
+
+This macro loads the "examples.json" file and uses it to build a table
+presenting that information.
+
+For example, the page at https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples
+is generated using this macro.
+
+*/
+
+const examplesBaseUrl = "https://github.com/mdn/webextensions-examples/tree/master/";
+const allExamples = await MDN.fetchWebExtExamples();
+const lang = env.locale;
+
+const s_name = mdn.localString({
+    "en-US": "Name"
+});
+
+const s_desc = mdn.localString({
+    "en-US": "Description"
+});
+
+const s_javascript_apis = mdn.localString({
+    "en-US": "JavaScript APIs"
+});
+
+const s_webextension_api_path = mdn.localString({
+    "en-US": "Add-ons/WebExtensions/API"
+});
+
+function writeJavaScriptAPIs(apisJSON) {
+  let output = "";
+  for (let jsAPI of apisJSON) {
+    var link = `/${lang}/${s_webextension_api_path}/${jsAPI.replace(".", "/")}`;
+    output += `<a href="${link}"><code>${jsAPI}</code></a><br/>`;
+  }
+  return output;
+}
+
+function writeAllExamples(examples) {
+  let output = "<table class=\"standard-table fullwidth-table\">";
+  output += `<tr>
+               <th>${s_name}</th>
+               <th>${s_desc}</th>
+               <th style=\"width: 40%\">${s_javascript_apis}</th>
+            </tr>`;
+
+  for (let example of examples) {
+    output += `<tr>`;
+    output += `  <td><a href="${examplesBaseUrl + example.name}">${example.name}</a></td>`;
+    output += `  <td>${example.description}</td>`;
+    output += `  <td>${writeJavaScriptAPIs(example.javascript_apis)}</td>`;
+    output += `</tr>`;
+  }
+  output += "</table>";
+  return output;
+}
+
+var output = writeAllExamples(allExamples);
+
+%>
+
+<%- output %>

--- a/kumascript/macros/WebExtExamples.ejs
+++ b/kumascript/macros/WebExtExamples.ejs
@@ -1,0 +1,112 @@
+<%
+
+/*
+The "examples.json" file from the https://github.com/mdn/webextensions-examples
+repository contains information about the examples living in that repository.
+
+This macro must be embedded in a WebExtensions API page, either of:
+
+* a "module" page (for example: "/en-US/Add-ons/WebExtensions/API/alarms" or "/en-US/Add-ons/WebExtensions/API/tabs")
+* an "API" page (for example: "/en-US/Add-ons/WebExtensions/API/alarms/create" or "/en-US/Add-ons/WebExtensions/API/tabs/executeScript")
+
+If it's embedded in a module page, it fetches all the examples that use any
+of the APIs in the given module, and outputs a list of links to those examples.
+
+If it's embedded in an API page, it fetches all the examples that use the
+given API, and outputs a list of links to those examples.
+
+It prepends this list with a header. By default the header is <h3>.
+The macro takes one optional argument, which is the name of the tag to use
+for the header. So if you want the header to be an <h2>, call it with "h2".
+*/
+
+const allExamples = await MDN.fetchWebExtExamples();
+const examplesBaseURL = "https://github.com/mdn/webextensions-examples/tree/master/";
+const desiredHeading = $0 || "h3";
+const lang = env.locale;
+
+const s_example_addons = mdn.localString({
+    "en-US": "Example extensions"
+});
+
+/*
+The `module` argument is the name of a JavaScript API module, like "alarms"
+or "tabs".
+
+This function returns an array of JSON objects representing examples which use
+any of the APIs under the given module.
+*/
+function getExamplesForModule(module) {
+  let examplesForModule = [];
+  for (let example of allExamples) {
+    for (let jsAPI of example.javascript_apis) {
+      jsAPI = jsAPI.split(".")[0];
+      if (jsAPI === module) {
+        examplesForModule.push(example);
+        break;
+      }
+    }
+  }
+  return examplesForModule;
+}
+
+/*
+The `module` argument is the name of a JavaScript API module, like "alarms"
+or "tabs".
+
+The `api` argument is the name of a JavaScript API in that module, like "create"
+or "executeScript".
+
+This function returns an array of JSON objects representing examples which the
+given API, like "alarms.create" or "tabs.executeScript".
+*/
+function getExamplesForAPI(module, api) {
+  let examplesForAPI = [];
+  let moduleAndAPI = `${module}.${api}`;
+  for (let example of allExamples) {
+    for (let jsAPI of example.javascript_apis) {
+      if (moduleAndAPI === jsAPI) {
+        examplesForAPI.push(example);
+        break;
+      }
+    }
+  }
+  return examplesForAPI;
+}
+
+/*
+Given an array of JSON objects representing example add-ons,
+this function outputs:
+* a header
+* a list of links to the example source in GitHub
+*/
+function writeExampleLinks(examples) {
+  let output = "";
+  if (examples.length > 0) {
+    output = `<${desiredHeading}>${s_example_addons}</${desiredHeading}>`;
+    output += "<ul>";
+    for (let example of examples) {
+      output += `<li><a href="${examplesBaseURL}${example.name}">${example.name}</a></li>`;
+    }
+    output += "</ul>";
+  }
+  return output;
+}
+
+let output = "";
+let pieces = env.slug.split("/");
+let leaf = pieces[pieces.length-1];
+let parent = pieces[pieces.length-2];
+
+// If the immediate parent of this page is named "API", assume we are in a module page, like "alarms" or "tabs".
+if (parent == "API") {
+  output = writeExampleLinks(getExamplesForModule(leaf));
+}
+// Otherwise, assume we are in an API page, like "alarms.create" or "tabs.executeScript".
+else {
+  output = writeExampleLinks(getExamplesForAPI(parent, leaf));
+}
+
+%>
+
+<%- output %>

--- a/kumascript/package.json
+++ b/kumascript/package.json
@@ -11,6 +11,7 @@
     "cheerio": "^1.0.0-rc.3",
     "cssesc": "^3.0.0",
     "ejs": "3.1.3",
+    "got": "^11.5.1",
     "mdn-browser-compat-data": "1.0.33",
     "mdn-data": "2.0.11",
     "sanitize-filename": "^1.6.3"

--- a/kumascript/src/api/mdn.js
+++ b/kumascript/src/api/mdn.js
@@ -1,9 +1,7 @@
 /**
  * @prettier
  */
-const fs = require("fs");
 const url = require("url");
-const path = require("path");
 const got = require("got");
 const util = require("./util.js");
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1769,6 +1769,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sindresorhus/is@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-3.1.0.tgz#d8735532635bea69ad39119df5f0f10099bd09dc"
+  integrity sha512-n4J+zu52VdY43kdi/XdI9DzuMr1Mur8zFL5ZRG2opCans9aiFwkPxHYFEb5Xgy7n1Z4K6WfI4FpqUqsh3E8BPQ==
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.2.tgz#505f55c74e0272b43f6c52d81946bed7058fc0e2"
@@ -1893,6 +1898,13 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@szmarczak/http-timer@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"
+  integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
+  dependencies:
+    defer-to-connect "^2.0.0"
+
 "@testing-library/dom@^7.17.1":
   version "7.21.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.21.1.tgz#c59f50fddc33db34547a7860f969dbede110623d"
@@ -1966,6 +1978,16 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cacheable-request@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
+  integrity sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==
+  dependencies:
+    "@types/http-cache-semantics" "*"
+    "@types/keyv" "*"
+    "@types/node" "*"
+    "@types/responselike" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1990,6 +2012,11 @@
   integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   dependencies:
     "@types/node" "*"
+
+"@types/http-cache-semantics@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
+  integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
@@ -2028,6 +2055,13 @@
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
+
+"@types/keyv@*":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.1.tgz#e45a45324fca9dab716ab1230ee249c9fb52cfa7"
+  integrity sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/mime-types@^2.1.0":
   version "2.1.0"
@@ -2090,6 +2124,13 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/responselike@*", "@types/responselike@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
+  integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -3525,6 +3566,11 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+cacheable-lookup@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.3.tgz#049fdc59dffdd4fc285e8f4f82936591bd59fec3"
+  integrity sha512-W+JBqF9SWe18A72XFzN/V/CULFzPm7sBXzzR6ekkE+3tLG72wFZrBiBZhrZuDoYexop4PHJVdFAKb/Nj9+tm9w==
+
 cacheable-request@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
@@ -3537,6 +3583,19 @@ cacheable-request@^6.0.0:
     lowercase-keys "^2.0.0"
     normalize-url "^4.1.0"
     responselike "^1.0.2"
+
+cacheable-request@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
+  integrity sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==
+  dependencies:
+    clone-response "^1.0.2"
+    get-stream "^5.1.0"
+    http-cache-semantics "^4.0.0"
+    keyv "^4.0.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
+    responselike "^2.0.0"
 
 call-me-maybe@^1.0.1:
   version "1.0.1"
@@ -4667,6 +4726,13 @@ decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -4706,6 +4772,11 @@ defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+
+defer-to-connect@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.0.tgz#83d6b199db041593ac84d781b5222308ccf4c2c1"
+  integrity sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==
 
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
@@ -6473,6 +6544,23 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
+got@^11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.5.1.tgz#bf098a270fe80b3fb88ffd5a043a59ebb0a391db"
+  integrity sha512-reQEZcEBMTGnujmQ+Wm97mJs/OK6INtO6HmLI+xt3+9CvnRwWjXutUvb2mqr+Ao4Lu05Rx6+udx9sOQAmExMxA==
+  dependencies:
+    "@sindresorhus/is" "^3.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.1"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.0"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -6838,6 +6926,14 @@ http-signature@~1.2.0:
     assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
+
+http2-wrapper@^1.0.0-beta.5.0:
+  version "1.0.0-beta.5.2"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz#8b923deb90144aea65cf834b016a340fc98556f3"
+  integrity sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.0.0"
 
 https-browserify@^1.0.0:
   version "1.0.0"
@@ -8629,6 +8725,11 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -8725,6 +8826,13 @@ keyv@^3.0.0:
   integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
   dependencies:
     json-buffer "3.0.0"
+
+keyv@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.1.tgz#9fe703cb4a94d6d11729d320af033307efd02ee6"
+  integrity sha512-xz6Jv6oNkbhrFCvCP7HQa8AaII8y8LRpoSm661NOKLr4uHuBwhX4epXrPQgF3+xdJnN4Esm5X0xwY4bOlALOtw==
+  dependencies:
+    json-buffer "3.0.1"
 
 killable@^1.0.1:
   version "1.0.1"
@@ -9334,6 +9442,11 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
 mini-css-extract-plugin@0.9.0:
   version "0.9.0"
@@ -10163,6 +10276,11 @@ p-cancelable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+
+p-cancelable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.0.0.tgz#4a3740f5bdaf5ed5d7c3e34882c6fb5d6b266a6e"
+  integrity sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==
 
 p-defer@^1.0.0:
   version "1.0.0"
@@ -11572,6 +11690,11 @@ querystringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
   integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
 
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
 raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
@@ -12118,6 +12241,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resolve-alpn@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
+  integrity sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -12216,6 +12344,13 @@ responselike@^1.0.2:
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
+
+responselike@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
+  integrity sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==
+  dependencies:
+    lowercase-keys "^2.0.0"
 
 restore-cursor@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #951 

This PR is a possible approach to resolving #951. The recent inclusion of the `/en-US/docs/mozilla/add-ons/webextensions` tree of documents re-introduced the need for the `WebExtExamples` and `WebExtAllExamples` macros, both of which make a network call to get https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json. The philosophy of this PR is to keep the `kumascript` rendering details as hidden as possible from the rest of the build process.