### PR TITLE
"View on MDN" in Toolbar

### DIFF
--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -71,7 +71,7 @@ export function EditActions({ folder }: { folder: string }) {
     }
   }
 
-  const { "*": slug } = useParams();
+  const { locale, "*": slug } = useParams();
 
   if (!folder) {
     return null;
@@ -79,6 +79,9 @@ export function EditActions({ folder }: { folder: string }) {
 
   return (
     <div className="edit-actions">
+      <a href={`https://developer.mozilla.org/${locale}/docs/${slug}`}>
+        View on MDN
+      </a>{" "}
       Edit{" "}
       <Link to={location.pathname.replace("/docs/", "/_edit/")}>
         in your <b>browser</b>


### PR DESCRIPTION
Fixes #697

I like that the toolbar looks like crap because it gives @schalkneethling a clear canvas to work with (when time allows).

<img width="684" alt="Screen Shot 2020-07-31 at 3 07 33 PM" src="https://user-images.githubusercontent.com/26739/89068651-ad2c8d80-d33f-11ea-9d33-d0635c1f9599.png">
