### PR TITLE
Crash server more gracefully

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -142,11 +142,16 @@ app.get("/*", async (req, res) => {
 
   const isJSONRequest = extraSuffix.endsWith(".json");
 
-  // TODO: Do something prettier here so you can see, on stdout, what
-  // documents get built on-the-fly.
-  console.time(`buildDocumentFromURL(${lookupURL})`);
-  const document = await buildDocumentFromURL(lookupURL);
-  console.timeEnd(`buildDocumentFromURL(${lookupURL})`);
+  let document;
+  try {
+    console.time(`buildDocumentFromURL(${lookupURL})`);
+    document = await buildDocumentFromURL(lookupURL);
+    console.timeEnd(`buildDocumentFromURL(${lookupURL})`);
+  } catch (error) {
+    console.error(`Error in buildDocumentFromURL(${lookupURL})`, error);
+    return res.status(500).send(error.toString());
+  }
+
   if (!document) {
     // redirect resolving can take some time, so we only do it when there's no document
     // for the current route


### PR DESCRIPTION
Prior to this, if anything goes wrong deep inside `buildDocumentFromURL` the server just hangs and doesn't return anything. (Until you force `nodemon` to restart it)
And you get a warning that it's an unhandled rejection. Now you get

```
4:14:33 PM server.1    |  Error in buildDocumentFromURL(/en-us/docs/web/html/element/audio) Error: Oh crap!
4:14:33 PM server.1    |      at buildDocument (/Users/peterbe/dev/MOZILLA/MDN/yari/build/index.js:109:9)
4:14:33 PM server.1    |      at async buildDocumentFromURL (/Users/peterbe/dev/MOZILLA/MDN/yari/build/index.js:236:11)
4:14:33 PM server.1    |      at async /Users/peterbe/dev/MOZILLA/MDN/yari/server/index.js:148:16
```
 for example. 