### PR TITLE
Use of fake v1 API fails

### DIFF
--- a/server/fake-v1-api.js
+++ b/server/fake-v1-api.js
@@ -13,7 +13,7 @@ const express = require("express");
 const router = express();
 
 router.get("*", (req, res) => {
-  const folder = path.resolve(path.join("..", "fake-v1-api"));
+  const folder = path.resolve("./fake-v1-api");
   if (!fs.existsSync(folder)) {
     throw new Error(
       `If you're going to fake v1 API requests you have to create the folder: ${folder}`


### PR DESCRIPTION
Fixes #1035

To test,

1. First start with `master` (or any branch that is not *this* branch)
2. Add `SERVER_FAKE_V1_API=true` and `REACT_APP_KUMA_HOST=localhost.org:8000` in your `.env`
3. `yarn start`
4. View a page.

It should complain that you haven't created a folder called `fake-v1-api` in the yari root. Or rather, without this branch it'll complain about that folder not existing outside of the `yari` project root. 