### PR TITLE
highlight bad bcd queries better

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -99,7 +99,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
         doc.flaws.bad_bcd_queries.push("BCD table without an ID");
       } else {
         const query = dataQuery.replace(/^bcd:/, "");
-        const data = packageBCD(query);
+        const { data } = packageBCD(query);
         if (!data) {
           if (!("bad_bcd_queries" in doc.flaws)) {
             doc.flaws.bad_bcd_queries = [];

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -697,17 +697,18 @@ if (!compatData) {
 
 traverseFeatures(compatData, depth, '');
 
+output = `<div class="bc-data" id="bcd:${query}">`;
 if (features.length > 0) {
-    output = `<div class="bc-data" id="bcd:${query}">`;
     output += '<a class="bc-github-link" href="https://github.com/mdn/browser-compat-data">Update compatibility data on GitHub</a>';
     output += `<table class="bc-table bc-table-${bcCategory}">`;
     output += writeCompatHead();
     output += writeCompatBody();
     output += '</table>';
     output += writeLegend();
-    output += '</div>';
+
 } else {
-    output = s_no_data_found;
+    output += s_no_data_found;
 }
+output += '</div>';
 %>
 <%-output%>

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -40,7 +40,9 @@ describeMacro("Compat", function () {
     function (macro) {
       let actual = macro.call("foo.bar");
       let expected =
-        'No compatibility data found. Please contribute data for "foo.bar" (depth: 1) to the <a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.';
+        '<div class="bc-data" id="bcd:foo.bar">No compatibility data found. ' +
+        'Please contribute data for "foo.bar" (depth: 1) to the ' +
+        '<a href="https://github.com/mdn/browser-compat-data">MDN compatibility data repository</a>.</div>';
       return assert.eventually.equal(actual, expected);
     }
   );

--- a/testing/content/files/en-us/_wikihistory.json
+++ b/testing/content/files/en-us/_wikihistory.json
@@ -105,5 +105,9 @@
   "Web/API/Page_Visibility_API": {
     "modified": "2020-07-20T01:01:01.550Z",
     "contributors": ["peterbe"]
+  },
+  "Web/BadBCDQueries": {
+    "modified": "2020-08-10T01:01:01.550Z",
+    "contributors": ["peterbe"]
   }
 }

--- a/testing/content/files/en-us/web/badbcdqueries/index.html
+++ b/testing/content/files/en-us/web/badbcdqueries/index.html
@@ -1,0 +1,9 @@
+---
+title: Bad BCD Queries
+slug: Web/BadBCDQueries
+summary: That's not a great BCD query.
+---
+
+<h2 id="Browser_compatibility">Browser compatibility</h2>
+
+<p>{{Compat("api.Does.Not.exist")}}</p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -415,6 +415,26 @@ test("check built flaws for /en-us/learn/css/css_layout/introduction/grid page",
   expect(doc.flaws.macros.length).toBe(2);
 });
 
+test("detect bad_bcd_queries flaws", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "badbcdqueries"
+  );
+  expect(fs.existsSync(builtFolder)).toBeTruthy();
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.flaws.bad_bcd_queries.length).toBe(1);
+  // If the flaw is there, it's always an array because a document could
+  // potentially have multiple bad BCD queries.
+  expect(doc.flaws.bad_bcd_queries.length).toBe(1);
+  expect(doc.flaws.bad_bcd_queries[0]).toBe(
+    "No BCD data for query: api.Does.Not.exist"
+  );
+});
+
 test("detect bad_bcd_links flaws from", () => {
   const builtFolder = path.join(
     buildRoot,


### PR DESCRIPTION
Fixes #1011

I'm not super in love with how it looks but I think it works much better than nothing. 

*Test content*
<img width="1435" alt="Screen Shot 2020-08-06 at 3 55 21 PM" src="https://user-images.githubusercontent.com/26739/89576488-5ae6e300-d7fd-11ea-84b1-4cd18bd182ef.png">

*Real content deliberately messed up*
<img width="742" alt="Screen Shot 2020-08-06 at 3 24 38 PM" src="https://user-images.githubusercontent.com/26739/89576535-69cd9580-d7fd-11ea-827b-8b692939e2d1.png">
<img width="1046" alt="Screen Shot 2020-08-06 at 3 24 45 PM" src="https://user-images.githubusercontent.com/26739/89576537-6b975900-d7fd-11ea-9d57-053992d80b2c.png">

