### PR TITLE
fix prism ssr parsing

### DIFF
--- a/ssr/syntax-highlighter.js
+++ b/ssr/syntax-highlighter.js
@@ -74,8 +74,8 @@ export function fixSyntaxHighlighting(document) {
           // The language is whatever string comes after the `brush(:)`
           // portion of the class name.
           const elem = $(blob);
-          const className = elem.attr("class");
-          const match = className.match(/brush:?\s([\w_-]+)/);
+          const className = elem.attr("class").toLowerCase();
+          const match = className.match(/brush:?\s*([\w_-]+)/);
           if (!match) {
             return;
           }

--- a/ssr/syntax-highlighter.js
+++ b/ssr/syntax-highlighter.js
@@ -70,14 +70,16 @@ export function fixSyntaxHighlighting(document) {
 
       if (!mutations) {
         // Legacy ones that haven't come from Markdown
-        $("pre[class^=brush]").each((_, blob) => {
+        $("pre[class*=brush]").each((_, blob) => {
+          // The language is whatever string comes after the `brush(:)`
+          // portion of the class name.
           const elem = $(blob);
-          const name = elem
-            .attr("class")
-            .replace(/^brush:/, "")
-            .trim()
-            .split(" ")[0]
-            .replace("'", "");
+          const className = elem.attr("class");
+          const match = className.match(/brush:?\s([\w_-]+)/);
+          if (!match) {
+            return;
+          }
+          const name = match[1];
           const prismLang = Prism.languages[name];
           if (!prismLang) {
             return; // bail!


### PR DESCRIPTION
Now it works:

<img width="897" alt="Screen Shot 2020-08-14 at 10 47 31 AM" src="https://user-images.githubusercontent.com/26739/90261928-a0b63380-de1b-11ea-9fd3-5f01708c706d.png">

[It didn't before](http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)

The reason is that it used to not work because you don't always have `brush: ...` at the beginning of the string. Also, it's not always a `:` after the word `brush`. 

As of this fix, it'll correctly pick out `js` from either `brush: js` or `syntaxbox brush js` or `brush js notranslate`.