### PR TITLE
lazy load build HTML

### DIFF
--- a/ssr/render.js
+++ b/ssr/render.js
@@ -15,7 +15,7 @@ const lazy = (creator) => {
 };
 
 const readBuildHTML = lazy(() => {
-  html = fs.readFileSync(
+  const html = fs.readFileSync(
     path.resolve(__dirname, "../../client/build/index.html"),
     "utf8"
   );

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -3,29 +3,32 @@ import path from "path";
 import cheerio from "cheerio";
 import { renderToString } from "react-dom/server";
 
-function readBuildHtml() {
-  return fs.readFileSync(
+const lazy = (creator) => {
+  let res;
+  let processed = false;
+  return () => {
+    if (processed) return res;
+    res = creator.apply(this, arguments);
+    processed = true;
+    return res;
+  };
+};
+
+const readBuildHTML = lazy(() => {
+  html = fs.readFileSync(
     path.resolve(__dirname, "../../client/build/index.html"),
     "utf8"
   );
-}
-
-let buildHtml = "";
-if (process.env.NODE_ENV !== "development") {
-  // read it once
-  buildHtml = readBuildHtml();
-  if (!buildHtml.includes('<div id="root"></div>')) {
+  if (!html.includes('<div id="root"></div>')) {
     throw new Error(
       'The render depends on being able to inject into <div id="root"></div>'
     );
   }
-}
+  return html;
+});
 
 export default function render(renderApp, doc) {
-  if (process.env.NODE_ENV === "development") {
-    // Reread on every request
-    buildHtml = readBuildHtml();
-  }
+  const buildHtml = readBuildHTML();
   const $ = cheerio.load(buildHtml);
 
   const rendered = renderToString(renderApp);


### PR DESCRIPTION
This paves the way for starting the server before the client has been built. Basically, it used to be that simply importing (`require('./ssr/dist/main')`) would trigger this `fs.readFileSync`. But you actually don't need to until you need to start properly SSR render a document. 