### PR TITLE
waitforit

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
-server: yarn start:dev-server
+server: yarn build:client && yarn start:dev-server
+ssr: yarn start:ssr
 type-check: cd client && tsc --noEmit --watch
 web: yarn start:client

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "build:ssr": "cd ssr && webpack --config webpack.config.js --mode=production",
     "prepare-build": "yarn build:client && yarn build:ssr",
     "build": "cd build && cross-env NODE_ENV=production node cli.js",
-    "start": "yarn build:client && yarn build:ssr && nf start",
+    "start": "node waitforit.js 0.0.0.0:3000 0.0.0.0:5000",
+    "dev": "nf start",
     "start:client": "cd client && cross-env BROWSER=none PORT=3000 react-scripts start",
     "start:dev-server": "nodemon server --watch server --watch build --watch content --watch kumascript",
-    "start:static-server": "cross-env ENV_FILE=testing/.env node server/static.js"
+    "start:static-server": "cross-env ENV_FILE=testing/.env node server/static.js",
+    "start:ssr": "cd ssr && webpack --config webpack.config.js --mode=production --watch"
   },
   "engines": {
     "node": ">=12.0.0"

--- a/waitforit.js
+++ b/waitforit.js
@@ -1,0 +1,71 @@
+const fs = require("fs");
+const readline = require("readline");
+var net = require("net");
+var spawn = require("child_process").spawn;
+
+let upAndRunning = false;
+const remainingHosts = new Map(process.argv.slice(2).map((h) => [h, false]));
+
+const startTime = new Date();
+let pings = 0;
+var interval = setInterval(() => {
+  try {
+    if (pings > 100) {
+      throw new Error(`Giving up after ${pings} attempts.`);
+    }
+    pings++;
+    const text = ["Waiting for:"];
+    for (const [host, state] of remainingHosts) {
+      text.push(`${host.padEnd(12)}: ${state ? "✅" : "⏳"}`);
+    }
+    text.push(
+      `Been waiting ${((new Date() - startTime) / 1000).toFixed(0)} seconds`
+    );
+
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0, null);
+    process.stdout.write(text.join("\t"));
+
+    let innerPings = 0;
+    for (const [host, state] of remainingHosts.entries()) {
+      if (state) {
+        continue;
+      }
+      innerPings++;
+
+      const [hostname, port] = host.split(":");
+      new net.Socket()
+        .connect(parseInt(port), hostname, function () {
+          remainingHosts.set(host, true);
+        })
+        .on("close", function () {})
+        .on("error", function (error) {});
+    }
+    if (!innerPings) {
+      process.stdout.write("\n");
+      console.log("Looks that all hosts are up and running!\n");
+      upAndRunning = true;
+      clearInterval(interval);
+    }
+  } catch (error) {
+    console.error(error);
+    yarnCommand.kill("SIGHUP");
+    process.exitCode = 1;
+  }
+}, 1000);
+
+const yarnCommand = spawn("yarn", ["dev"]);
+
+yarnCommand.stdout.on("data", function (data) {
+  if (upAndRunning) process.stdout.write(data);
+  fs.appendFileSync("/tmp/stdout.log", data, "utf-8");
+});
+
+yarnCommand.stderr.on("data", function (data) {
+  fs.appendFileSync("/tmp/stderr.log", data, "utf-8");
+  if (upAndRunning) process.stdout.write(data);
+});
+
+yarnCommand.on("exit", function (code) {
+  clearInterval(interval);
+});


### PR DESCRIPTION
Friday fun. This way `yarn start` takes over the screen and just waits till `localhost:3000` and `localhost:5000` are ready. 
Once both servers response, `stdout` resumes to be that of `yarn dev`. 

It's kinda ugly still but it works reasonably. 