### PR TITLE
Deal with unresolved Document.findByURL urls

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -35,7 +35,8 @@ export function Document(props /* TODO: define a TS interface for this */) {
     async (url) => {
       const response = await fetch(url);
       if (!response.ok) {
-        throw new Error(`${response.status} on ${url}`);
+        const text = await response.text();
+        throw new Error(`${response.status} on ${url}: ${text}`);
       }
       const { doc } = await response.json();
       if (response.redirected) {

--- a/content/document.js
+++ b/content/document.js
@@ -285,6 +285,7 @@ module.exports = {
   read,
   update,
   del,
+  urlToFolderPath,
 
   findByURL,
   findAll,

--- a/content/files/en-us/glossary/happyness/index.html
+++ b/content/files/en-us/glossary/happyness/index.html
@@ -1,0 +1,6 @@
+---
+title: 'Happiness or Happyness?'
+slug: Happiness
+---
+
+<p>Just a test page to see what happens.</p>

--- a/content/files/en-us/glossary/happyness/index.html
+++ b/content/files/en-us/glossary/happyness/index.html
@@ -1,6 +1,0 @@
----
-title: 'Happiness or Happyness?'
-slug: Glossary/Happiness
----
-
-<p>Just a test page to see what happens.</p>

--- a/content/files/en-us/glossary/happyness/index.html
+++ b/content/files/en-us/glossary/happyness/index.html
@@ -1,6 +1,6 @@
 ---
 title: 'Happiness or Happyness?'
-slug: Happiness
+slug: Glossary/Happiness
 ---
 
 <p>Just a test page to see what happens.</p>

--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -15,7 +15,14 @@ const { HTMLTool } = require("./src/api/util.js");
 
 const renderFromURL = memoize(async (url) => {
   const prerequisiteErrorsByKey = new Map();
-  const { rawHTML, metadata, fileInfo } = Document.findByURL(url);
+  const document = Document.findByURL(url);
+  if (!document) {
+    throw new Error(
+      `From URL ${url} no folder on disk could be found. ` +
+        `Tried to find a folder called ${Document.urlToFolderPath(url)}`
+    );
+  }
+  const { rawHTML, metadata, fileInfo } = document;
   const [renderedHtml, errors] = await renderMacros(
     rawHTML,
     {

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -23,6 +23,17 @@ function postDocumentInfo(filePath, changeType) {
       return;
     }
 
+    // We check that the metadata (through `document.url`)
+    // matches the filePath by using `Document.urlToFolderPath`.
+    // This would prevent the document from being added in the first place
+    // if the filePath doesn't map correctly to the URL, but in reverse.
+    if (!filePath.includes(Document.urlToFolderPath(document.url))) {
+      console.warn(
+        `The slug of ${filePath} doesn't match the folder is located in.`
+      );
+      return;
+    }
+
     postEvent(changeType, { filePath, document });
   } catch (e) {
     console.error(`Error while adding document ${filePath} to index:`, e);

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const {
   buildDocumentFromURL,
   buildLiveSamplePageFromURL,
 } = require("../build");
-const { CONTENT_ROOT, Redirect, Image } = require("../content");
+const { CONTENT_ROOT, Document, Redirect, Image } = require("../content");
 const { prepareDoc, renderHTML } = require("../ssr/dist/main");
 
 const { STATIC_ROOT, PROXY_HOSTNAME, FAKE_V1_API } = require("./constants");
@@ -176,7 +176,15 @@ app.get("/*", async (req, res) => {
     if (redirectURL !== lookupURL) {
       return res.redirect(301, redirectURL + extraSuffix);
     }
-    return res.sendStatus(404);
+
+    // It doesn't resolve to a file on disk and it's not a redirect.
+    // Try to send a slightly better error at least.
+    return res
+      .status(404)
+      .send(
+        `From URL ${lookupURL} no folder on disk could be found. ` +
+          `Tried to find a folder called ${Document.urlToFolderPath(lookupURL)}`
+      );
   }
 
   prepareDoc(document);


### PR DESCRIPTION
Fixes #1037

Now, instead you get an error message which is a lot easier to comprehend:
```
error while building documents: Error: From URL /en-US/docs/Glossary/Happiness no folder on disk could be found. Tried to find a folder called en-us/glossary/happiness
    at /Users/peterbe/dev/MOZILLA/MDN/yari/kumascript/index.js:20:11
    at Object.render (/Users/peterbe/dev/MOZILLA/MDN/yari/content/utils.js:54:19)
    at buildDocument (/Users/peterbe/dev/MOZILLA/MDN/yari/build/index.js:101:50)
    at buildDocuments (/Users/peterbe/dev/MOZILLA/MDN/yari/build/cli.js:59:65)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
error Command failed with exit code 1.
```

It doesn't solved the problem but at least the error isn't so cryptic. 