### PR TITLE
LIVE_SAMPLES_BASE_URL is clunky for most people

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -77,15 +77,17 @@ jobs:
           # functional tests have a gap in them but actually building
           # real content exposes it.
 
-          # Setting this will mean that every live sample will be served
-          # like this:
-          #  <iframe src="//en-US/docs/Foo/_samples_/index.html">
+          # Setting this to and empty string effectively means that the
+          # <iframe> src will end up being the relative URL of the current
+          # document as a base.
+          # I.e. like this, if the current document is '/en-US/docs/Foo':
+          #  <iframe src="/en-US/docs/Foo/_samples_/index.html">
           # ...for example.
           # Yes, it's potentially "insecure" because the iframe will execute
           # whatever code is inserted into the code example. But since the
           # whole (possible) domain for PR builds will never be somewhere
           # where there are interesting cookies, it's a safe choice.
-          export BUILD_LIVE_SAMPLES_BASE_URL=/
+          export BUILD_LIVE_SAMPLES_BASE_URL=
 
           export BUILD_NO_PROGRESSBAR=true
           export BUILD_FILES="${{ env.GIT_DIFF }}"

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -77,7 +77,7 @@ jobs:
           # functional tests have a gap in them but actually building
           # real content exposes it.
 
-          # Setting this to and empty string effectively means that the
+          # Setting this to an empty string effectively means that the
           # <iframe> src will end up being the relative URL of the current
           # document as a base.
           # I.e. like this, if the current document is '/en-US/docs/Foo':

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -77,6 +77,12 @@ jobs:
           # functional tests have a gap in them but actually building
           # real content exposes it.
 
+          # This environment variable actually only matters if you're going
+          # to be browsing the pages that are built but *if* we some day
+          # decide to ship PR builds to a public URL, it's good that it's
+          # using public base URL that could work outside people's laptops.
+          export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
+
           export BUILD_NO_PROGRESSBAR=true
           export BUILD_FILES="${{ env.GIT_DIFF }}"
           yarn prepare-build

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -77,11 +77,15 @@ jobs:
           # functional tests have a gap in them but actually building
           # real content exposes it.
 
-          # This environment variable actually only matters if you're going
-          # to be browsing the pages that are built but *if* we some day
-          # decide to ship PR builds to a public URL, it's good that it's
-          # using public base URL that could work outside people's laptops.
-          export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
+          # Setting this will mean that every live sample will be served
+          # like this:
+          #  <iframe src="//en-US/docs/Foo/_samples_/index.html">
+          # ...for example.
+          # Yes, it's potentially "insecure" because the iframe will execute
+          # whatever code is inserted into the code example. But since the
+          # whole (possible) domain for PR builds will never be somewhere
+          # where there are interesting cookies, it's a safe choice.
+          export BUILD_LIVE_SAMPLES_BASE_URL=/
 
           export BUILD_NO_PROGRESSBAR=true
           export BUILD_FILES="${{ env.GIT_DIFF }}"

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -91,6 +91,12 @@ jobs:
           # Or, we use a combination of both where we build archive content
           # either on the 1st of every month OR if it's manually triggered.
 
+          # The default for this environment variable is geared for writers
+          # (aka. local development). Usually defaults are supposed to be for
+          # secure production but this is an exception and default
+          # is not insecure.
+          export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
+
           # TODO: Only relevant once github.com/mdn/mdn-content is a thing.
           # export CONTENT_ROOT=mdn-content/content/files
 

--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -38,7 +38,7 @@ const renderFromURL = memoize(async (url) => {
       interactive_examples: {
         base_url: INTERACTIVE_EXAMPLES_BASE_URL,
       },
-      live_samples: { base_url: LIVE_SAMPLES_BASE_URL },
+      live_samples: { base_url: LIVE_SAMPLES_BASE_URL || url },
     },
     async (url) => {
       const [renderedHtml, errors] = await renderFromURL(info.cleanURL(url));

--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -15,11 +15,16 @@ if ($1 && $1.length > 0) {
     base = $1;
 }
 
-let url = new kuma.url.URL(base);
-wiki.ensureExistence(url.pathname);
-let liveSampleUrl = new kuma.url.URL(env.live_samples.base_url);
-url.host = liveSampleUrl.host;
-url.protocol = liveSampleUrl.protocol;
-url.pathname = url.pathname + '/_samples_/' + web.slugify(web.safeDecodeURIComponent($0));
+let url;
+if (env.live_samples.base_url.includes('://')) {
+    url = new kuma.url.URL(base);
+    wiki.ensureExistence(url.pathname);
+    let liveSampleUrl = new kuma.url.URL(env.live_samples.base_url);
+    url.host = liveSampleUrl.host;
+    url.protocol = liveSampleUrl.protocol;
+    url.pathname = url.pathname + '/_samples_/' + web.slugify(web.safeDecodeURIComponent($0));
+} else {
+    url = env.live_samples.base_url + '/_samples_/' + web.slugify(web.safeDecodeURIComponent($0));
+}
 %>
 <%= url %>

--- a/kumascript/src/constants.js
+++ b/kumascript/src/constants.js
@@ -1,5 +1,5 @@
 const LIVE_SAMPLES_BASE_URL =
-  process.env.BUILD_LIVE_SAMPLES_BASE_URL || "https://mdn.mozillademos.org";
+  process.env.BUILD_LIVE_SAMPLES_BASE_URL || "http://localhost:5000";
 
 const INTERACTIVE_EXAMPLES_BASE_URL =
   process.env.BUILD_INTERACTIVE_EXAMPLES_BASE_URL ||

--- a/kumascript/src/constants.js
+++ b/kumascript/src/constants.js
@@ -1,5 +1,9 @@
+// Allow the `process.env.BUILD_LIVE_SAMPLES_BASE_URL` to be falsy
+// if it *is* set.
 const LIVE_SAMPLES_BASE_URL =
-  process.env.BUILD_LIVE_SAMPLES_BASE_URL || "http://localhost:5000";
+  process.env.BUILD_LIVE_SAMPLES_BASE_URL !== undefined
+    ? process.env.BUILD_LIVE_SAMPLES_BASE_URL
+    : "http://localhost:5000";
 
 const INTERACTIVE_EXAMPLES_BASE_URL =
   process.env.BUILD_INTERACTIVE_EXAMPLES_BASE_URL ||


### PR DESCRIPTION
Fixes #977

Now if you start from scratch the live sample iframes work when you spin up http://localhost:3000
It's obviously wrong for shipping but that's why the better value is set into the GHA workflows so those files become ready for shipping out. 