### PR TITLE
fix broken_links flaws when repeated

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -15,16 +15,39 @@ function injectFlaws(doc, $, options, { rawContent }) {
   // link to a document that's going to fail with a 404 Not Found.
   if (options.flawLevels.get("broken_links") !== FLAW_LEVELS.IGNORE) {
     // This is needed because the same href can occur multiple time.
-    // Especially when there's...
-    //    <a href="/foo/bar#one">
-    //    <a href="/foo/bar#two">
-    const checked = new Set();
+    // For example:
+    //    <a href="/foo/bar">
+    //    <a href="/foo/other">
+    //    <a href="/foo/bar">  (again!)
+    // In this case, when we call `addBrokenLink()` that third time, we know
+    // this refers to the second time it appears. That's important for the
+    // sake of finding which match, in the original source (rawContent),
+    // it belongs to.
+    const checked = new Map();
+
+    // Our cache for looking things up by `href`. This basically protects
+    // us from calling `findMatchesInText()` more than once.
+    const matches = new Map();
 
     // A closure function to help making it easier to append flaws
-    function addBrokenLink($element, href, suggestion = null) {
-      for (const match of findMatchesInText(href, rawContent, {
-        attribute: "href",
-      })) {
+    function addBrokenLink($element, index, href, suggestion = null) {
+      if (!matches.has(href)) {
+        matches.set(
+          href,
+          Array.from(
+            findMatchesInText(href, rawContent, {
+              attribute: "href",
+            })
+          )
+        );
+      }
+      // findMatchesInText() is a generator function so use `Array.from()`
+      // to turn it into an array so we can use `.forEach()` because that
+      // gives us an `i` for every loop.
+      matches.get(href).forEach((match, i) => {
+        if (i !== index) {
+          return;
+        }
         if (!("broken_links" in doc.flaws)) {
           doc.flaws.broken_links = [];
         }
@@ -37,14 +60,18 @@ function injectFlaws(doc, $, options, { rawContent }) {
         doc.flaws.broken_links.push(
           Object.assign({ explanation, id, href, suggestion }, match)
         );
-      }
+      });
     }
 
     $("a[href]").each((i, element) => {
       const a = $(element);
       const href = a.attr("href");
-      if (checked.has(href)) return;
-      checked.add(href);
+
+      // This gives us insight into how many times this exact `href`
+      // has been encountered in the doc.
+      // Then, when we call addBrokenLink() we can include an index so that
+      // that function knows which match it's referring to.
+      checked.set(href, checked.has(href) ? checked.get(href) + 1 : 0);
 
       if (href.startsWith("https://developer.mozilla.org/")) {
         // It might be a working 200 OK link but the link just shouldn't
@@ -52,6 +79,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
         const absoluteURL = new URL(href);
         addBrokenLink(
           a,
+          checked.get(href),
           href,
           absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
         );
@@ -74,6 +102,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
             });
             addBrokenLink(
               a,
+              checked.get(href),
               href,
               finalDocument
                 ? finalDocument.url + absoluteURL.search + absoluteURL.hash
@@ -88,6 +117,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
             // Inconsistent case.
             addBrokenLink(
               a,
+              checked.get(href),
               href,
               found.url + absoluteURL.search + absoluteURL.hash
             );

--- a/testing/content/files/en-us/web/brokenlinks_repeats/index.html
+++ b/testing/content/files/en-us/web/brokenlinks_repeats/index.html
@@ -1,0 +1,8 @@
+---
+title: 'A page peppered with broken links with repeats'
+slug: Web/BrokenLinks_Repeats
+---
+
+<p><a href="/en-US/docs/Web/CSS/dumber" title="First title">Will redirect</a></p>
+<p><a href='/en-US/docs/Web/CSS/dumber' title="Second title">Also, make it appear as text too</a></p>
+<p><a href="/en-US/docs/Web/CSS/dumber" title="Third title">Repeated a third time</a></p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -437,6 +437,30 @@ test("broken links flaws", () => {
   ).toBe("/en-US/docs/Glossary/Bézier_curve#identifier");
 });
 
+test("repeated broken links flaws", () => {
+  // This fixture has the same broken link, that redirects, 3 times.
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "brokenlinks_repeats"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  const { flaws } = doc;
+  // You have to be intimately familiar with the fixture to understand
+  // why these flaws come out as they do.
+  expect(flaws.broken_links.length).toBe(3);
+
+  // Map them by 'id'
+  const map = new Map(flaws.broken_links.map((x) => [x.id, x]));
+  expect(map.size).toBe(3);
+  expect(map.get("link1").suggestion).toBe("/en-US/docs/Web/CSS/number");
+  expect(map.get("link2").suggestion).toBe("/en-US/docs/Web/CSS/number");
+  expect(map.get("link3").suggestion).toBe("/en-US/docs/Web/CSS/number");
+});
+
 test("check built flaws for /en-us/learn/css/css_layout/introduction/grid page", () => {
   expect(fs.existsSync(buildRoot)).toBeTruthy();
   const builtFolder = path.join(


### PR DESCRIPTION
It *used* to be:
1. Loop over every `<a href="...">`
2. For each unique `href`, find all matches and add each match to `doc.flaws.broken_links`

So if you have
```
<a href="foo">One</a>
<a href="foo">Two</a>
<a href="foo">Three</a>
```
It would analyze `foo` once and add it 3 times. But the 2nd and 3rd wouldn't get its own unique `id`. 
So you'd end up with this rendered:
```html
<a href="foo" data-flaw="link1">One</a>
<a href="foo">Two</a>
<a href="foo">Three</a>
```


*Now* it's like this instead:
1. Loop over every `<a href="...">`
2. For every `href`, find *its* match

The rendered output will now become:
```html
<a href="foo" data-flaw="link1">One</a>
<a href="foo" data-flaw="link2">Two</a>
<a href="foo" data-flaw="link3">Three</a>
```
