### PR TITLE
make redirects and popularities loading lazy

### DIFF
--- a/build/search-index.js
+++ b/build/search-index.js
@@ -1,6 +1,7 @@
-const { popularities } = require("../content");
+const { getPopularities } = require("../content");
 
-const getPopularity = (item) => popularities[item.url] || 0;
+// getPopularities() is memoized so it's fast to call repeatedly
+const getPopularity = (item) => getPopularities().get(item.url) || 0;
 
 module.exports = class SearchIndex {
   _itemsByLocale = {};

--- a/content/document.js
+++ b/content/document.js
@@ -119,9 +119,6 @@ function archive(renderedHTML, rawHTML, metadata, wikiHistory) {
   );
 }
 
-// The module level cache
-let popularities = null;
-
 const read = memoize((folder, fields = null) => {
   fields = fields ? { body: false, metadata: false, ...fields } : fields;
 
@@ -145,14 +142,11 @@ const read = memoize((folder, fields = null) => {
   if (!fields || fields.metadata) {
     const locale = extractLocale(folder);
     const url = `/${locale}/docs/${metadata.slug}`;
-    if (!popularities) {
-      popularities = getPopularities();
-    }
     fullMetadata = {
       metadata: {
         ...metadata,
         locale,
-        popularity: popularities[url] || 0.0,
+        popularity: getPopularities().get(url) || 0.0,
       },
       url,
     };

--- a/content/document.js
+++ b/content/document.js
@@ -11,7 +11,7 @@ const {
   VALID_LOCALES,
   ROOTS,
 } = require("./constants");
-const popularities = require("./popularities");
+const getPopularities = require("./popularities");
 const { memoize, slugToFolder } = require("./utils");
 
 function buildPath(localeFolder, slug) {
@@ -119,6 +119,9 @@ function archive(renderedHTML, rawHTML, metadata, wikiHistory) {
   );
 }
 
+// The module level cache
+let popularities = null;
+
 const read = memoize((folder, fields = null) => {
   fields = fields ? { body: false, metadata: false, ...fields } : fields;
 
@@ -142,6 +145,9 @@ const read = memoize((folder, fields = null) => {
   if (!fields || fields.metadata) {
     const locale = extractLocale(folder);
     const url = `/${locale}/docs/${metadata.slug}`;
+    if (!popularities) {
+      popularities = getPopularities();
+    }
     fullMetadata = {
       metadata: {
         ...metadata,

--- a/content/index.js
+++ b/content/index.js
@@ -5,7 +5,7 @@ const {
   VALID_LOCALES,
 } = require("./constants");
 const Document = require("./document");
-const popularities = require("./popularities");
+const getPopularities = require("./popularities");
 const Redirect = require("./redirect");
 const Image = require("./image");
 const { buildURL, memoize, slugToFolder } = require("./utils");
@@ -16,7 +16,7 @@ module.exports = {
   ROOTS,
   VALID_LOCALES,
 
-  popularities,
+  getPopularities,
 
   Document,
   Redirect,

--- a/content/popularities.js
+++ b/content/popularities.js
@@ -3,6 +3,7 @@ const path = require("path");
 
 const { CONTENT_ROOT } = require("./constants");
 
-module.exports = JSON.parse(
-  fs.readFileSync(path.join(CONTENT_ROOT, "popularities.json"), "utf-8")
-);
+module.exports = () =>
+  JSON.parse(
+    fs.readFileSync(path.join(CONTENT_ROOT, "popularities.json"), "utf-8")
+  );

--- a/content/popularities.js
+++ b/content/popularities.js
@@ -3,7 +3,20 @@ const path = require("path");
 
 const { CONTENT_ROOT } = require("./constants");
 
-module.exports = () =>
-  JSON.parse(
-    fs.readFileSync(path.join(CONTENT_ROOT, "popularities.json"), "utf-8")
-  );
+// Module-level cache
+const popularities = new Map();
+
+function getPopularities() {
+  if (!popularities.size) {
+    Object.entries(
+      JSON.parse(
+        fs.readFileSync(path.join(CONTENT_ROOT, "popularities.json"), "utf-8")
+      )
+    ).forEach(([url, value]) => {
+      popularities.set(url, value);
+    });
+  }
+  return popularities;
+}
+
+module.exports = getPopularities;

--- a/server/flaws.js
+++ b/server/flaws.js
@@ -3,10 +3,22 @@ const path = require("path");
 
 const glob = require("glob");
 
-const { popularities } = require("../content");
+const { getPopularities } = require("../content");
 const { FLAW_LEVELS, options: buildOptions } = require("../build");
 
 const BUILD_OUT_ROOT = path.join(__dirname, "..", "client", "build");
+
+// Module-level cache
+const allPopularityValues = [];
+
+function getAllPopularityValues() {
+  if (!allPopularityValues.length) {
+    for (const value of getPopularities().values()) {
+      allPopularityValues.push(value);
+    }
+  }
+  return allPopularityValues;
+}
 
 function anyMatchSearchFlaws(searchFlaws, flaws) {
   for (const [flaw, search] of searchFlaws) {
@@ -84,7 +96,7 @@ function packageDocument(doc) {
   const popularity = {
     value: doc.popularity,
     ranking: doc.popularity
-      ? 1 + Object.values(popularities).filter((p) => p > doc.popularity).length
+      ? 1 + getAllPopularityValues().filter((p) => p > doc.popularity).length
       : NaN,
   };
   const flaws = packageFlaws(doc.flaws);
@@ -171,8 +183,7 @@ module.exports = (req, res) => {
     }
     if (popularityFilter) {
       const docRanking = doc.popularity
-        ? 1 +
-          Object.values(popularities).filter((p) => p > doc.popularity).length
+        ? 1 + getAllPopularityValues().filter((p) => p > doc.popularity).length
         : NaN;
       if (popularityFilter.min) {
         if (isNaN(docRanking) || docRanking > popularityFilter.min) {


### PR DESCRIPTION
Part of #1095

Without these changes, you can't run `cd import && CONTENT_ROOT=/some/path ARCHIVE_CONTENT_ROOT=/some/other node cli.js` because it tries to open the `popularities.json` simply be importing the module. Same with the `_redirects.txt` files. 