### PR TITLE
allow CONTENT_ARCHIVE_ROOT to not have to be relative

### DIFF
--- a/content/constants.js
+++ b/content/constants.js
@@ -16,9 +16,13 @@ const CONTENT_ROOT = (() => {
   return root;
 })();
 
-const CONTENT_ARCHIVE_ROOT = process.env.CONTENT_ARCHIVE_ROOT
-  ? path.join(__dirname, "..", process.env.CONTENT_ARCHIVE_ROOT)
-  : null;
+const CONTENT_ARCHIVE_ROOT = (() => {
+  const root = process.env.CONTENT_ARCHIVE_ROOT;
+  if (root && !fs.existsSync(root)) {
+    return path.join(__dirname, "..", root);
+  }
+  return root;
+})();
 
 // Make a combined array of all truthy roots. This way, you don't
 // need to constantly worry about CONTENT_ARCHIVE_ROOT potentially being

--- a/import/README.md
+++ b/import/README.md
@@ -1,0 +1,18 @@
+# dumper
+
+This code is a bit rough but it's ultimately just meant to be used one
+single time in its life existence. Once we've run it and checked it in
+and moved on with our post-Wiki life, we can burn this.
+
+## Example run
+
+You can set `CONTENT_ROOT` and `CONTENT_ARCHIVE_ROOT` to any folder
+but it's **important that directories exists** otherwise Yari will
+assume you're referring to relative folders.
+
+```bash
+cd import
+export CONTENT_ROOT=/Users/peterbe/dev/MOZILLA/MDN/content/files
+export CONTENT_ARCHIVE_ROOT=/Users/peterbe/dev/MOZILLA/MDN/archivecontent/files
+node cli.js
+```


### PR DESCRIPTION
Part of #1095

I need this to be able to use the dumper to write to folders outside the `yari` folder. 