### PR TITLE
crud mode

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense, lazy } from "react";
 import { Routes, Route } from "react-router-dom";
 
+import { CRUD_MODE } from "./constants";
 import { Homepage } from "./homepage";
 import { Document } from "./document";
 import Footer from "./footer";
@@ -46,7 +47,7 @@ export function App(appProps) {
         element={
           <Layout>
             <Routes>
-              {process.env.NODE_ENV === "development" && (
+              {CRUD_MODE && (
                 <>
                   <Route path="/_flaws" element={<AllFlaws />} />
                   <Route path="/_create/*" element={<DocumentCreate />} />

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,3 +1,8 @@
 export const DISABLE_AUTH = JSON.parse(
   process.env.REACT_APP_DISABLE_AUTH || "false"
 );
+
+export const CRUD_MODE = JSON.parse(
+  process.env.REACT_APP_CRUD_MODE ||
+    JSON.stringify(process.env.NODE_ENV === "development")
+);

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -2,6 +2,7 @@ import React, { lazy, Suspense, useEffect } from "react";
 import { Link, useParams, useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
+import { CRUD_MODE } from "../constants";
 import { useWebSocketMessageHandler } from "../web-socket";
 import { NoMatch } from "../routing";
 import { useDocumentURL } from "./hooks";
@@ -100,9 +101,11 @@ export function Document(props /* TODO: define a TS interface for this */) {
 
   const { github_url, folder } = doc.source;
 
+  const isServer = typeof window === "undefined";
+
   return (
     <main>
-      {process.env.NODE_ENV === "development" && !doc.isArchive && (
+      {!isServer && CRUD_MODE && !doc.isArchive && (
         <Suspense fallback={<p className="loading-toolbar">Loading toolbar</p>}>
           <Toolbar doc={doc} />
         </Suspense>

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -4,6 +4,7 @@ import { annotate, annotationGroup } from "rough-notation";
 import { RoughAnnotation } from "rough-notation/lib/model";
 import { diffWords } from "diff";
 
+import { CRUD_MODE } from "../../constants";
 import { humanizeFlawName } from "../../flaw-utils";
 import { useDocumentURL } from "../hooks";
 import {
@@ -167,7 +168,7 @@ export function ToggleDocumentFlaws({ doc }: { doc: Doc }) {
 }
 
 function Flaws({ doc, flaws }: { doc: Doc; flaws: FlawCount[] }) {
-  if (process.env.NODE_ENV !== "development") {
+  if (!CRUD_MODE) {
     throw new Error("This shouldn't be used in non-development builds");
   }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -3,6 +3,8 @@ import ReactDOM from "react-dom";
 import { BrowserRouter as Router } from "react-router-dom";
 import "./index.scss";
 import "typeface-zilla-slab";
+
+import { CRUD_MODE } from "./constants";
 import { App } from "./app";
 import { GAProvider } from "./ga-context";
 import { UserDataProvider } from "./user-context";
@@ -33,7 +35,15 @@ let app = (
   </GAProvider>
 );
 
-if (process.env.NODE_ENV === "development") {
+const isServer = typeof window === "undefined";
+
+// Remember, CRUD_MODE, if not explicitly set, will be that
+// of NODE_ENV==='development' which is what you get when you use the
+// create-react-app dev server.
+// But you might be using CRUD_MODE without create-react-app's dev server,
+// and in that case you still need to avoid using React.Suspense because
+// that only works in client rendering.
+if (!isServer && CRUD_MODE) {
   // We only use a WebSocket to listen for document changes in development
   app = (
     <React.Suspense fallback>

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -202,3 +202,15 @@ host name instead. That means you can log in _from_ Yari with a single click.
 
 This removes sign-in and `whoami` XHR fetching.
 Useful when using Yari purely for content editing as authentication is then not required.
+
+### `REACT_APP_CRUD_MODE`
+
+**Default: `NODE_ENV==='development'`**
+
+Basically, these are the optional, lazy-loaded features of the app that only
+make sense when you're working on authoring the content. For example the
+Toolbar bar appears based on this.
+
+It defaults to `NODE_ENV==='development'` if not set which means that
+it's enable by default when doing development with the `localhost:3000`
+dev server.


### PR DESCRIPTION
Here's how to test it:

```bash
export REACT_APP_CRUD_MODE=true
yarn prepare-build
yarn start:server
open http://localhost:5000
```

Now you can do all the fancy CRUD stuff you can do when using the `create-react-app` dev server (`localhost:3000`) but all running from Express instead. 
The advantage: Once built, it takes less than a second to boot up a server you can use for previewing and CRUD'ing etc. 
