### PR TITLE
Display the CONTENT_ROOT when starting the server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
+const chalk = require("chalk");
 const express = require("express");
 const send = require("send");
 const proxy = require("express-http-proxy");
@@ -194,6 +195,18 @@ app.get("/*", async (req, res) => {
     res.send(renderHTML(document, lookupURL));
   }
 });
+
+if (!fs.existsSync(path.resolve(CONTENT_ROOT))) {
+  console.log(chalk.red(`${path.resolve(CONTENT_ROOT)} does not exist!`));
+  process.exit(1);
+}
+
+console.log(
+  `CONTENT_ROOT: ${chalk.bold(CONTENT_ROOT)}`,
+  path.resolve(CONTENT_ROOT) !== CONTENT_ROOT
+    ? chalk.grey(`(absolute path: ${path.resolve(CONTENT_ROOT)})`)
+    : ""
+);
 
 const PORT = parseInt(process.env.SERVER_PORT || "5000");
 app.listen(PORT, () => console.log(`Listening on port ${PORT}`));


### PR DESCRIPTION
Fixes #1264

This is admittedly serving the `yarn start` inside Content as a fallback if something goes wrong. 
But you can use it in yari too. For example, if you have a typo in your `.env`:
```
▶ yarn start:server
yarn run v1.22.4
$ node server
/Users/peterbe/dev/MOZILLA/MDN/content/fileXXXs does not exist!
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

It also gives you a nice warning when you do `yarn dev` since the `server` part will "crash".

If all goes well, it will print:

```
▶ yarn start:server
yarn run v1.22.4
$ node server
CONTENT_ROOT: ../content/files (absolute path: /Users/peterbe/dev/MOZILLA/MDN/content/files)
Listening on port 5000
```