### PR TITLE
detect dependency loops

### DIFF
--- a/content/utils.js
+++ b/content/utils.js
@@ -38,14 +38,14 @@ function isPromise(p) {
  * Note: The parameter are turned into a cache key quite naively, so
  * different object key order would lead to new cache entries.
  */
-function memoize(fn) {
+function memoize(fn, cacheKeyFunc = null) {
   if (process.env.NODE_ENV !== "production") {
     return fn;
   }
 
   const cache = new Map();
   return (...args) => {
-    const key = JSON.stringify(args);
+    const key = cacheKeyFunc ? cacheKeyFunc(...args) : JSON.stringify(args);
 
     if (cache.has(key)) {
       return cache.get(key);

--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -13,59 +13,78 @@ const {
 } = require("./src/live-sample.js");
 const { HTMLTool } = require("./src/api/util.js");
 
-const renderFromURL = memoize(async (url) => {
-  const prerequisiteErrorsByKey = new Map();
-  const document = Document.findByURL(url);
-  if (!document) {
-    throw new Error(
-      `From URL ${url} no folder on disk could be found. ` +
-        `Tried to find a folder called ${Document.urlToFolderPath(url)}`
-    );
-  }
-  const { rawHTML, metadata, fileInfo } = document;
-  const [renderedHtml, errors] = await renderMacros(
-    rawHTML,
-    {
-      ...{
-        url,
-        locale: metadata.locale,
-        slug: metadata.slug,
-        title: metadata.title,
-        tags: metadata.tags || [],
-        selective_mode: false,
-      },
-      interactive_examples: {
-        base_url: INTERACTIVE_EXAMPLES_BASE_URL,
-      },
-      live_samples: { base_url: LIVE_SAMPLES_BASE_URL || url },
-    },
-    async (url) => {
-      const [renderedHtml, errors] = await renderFromURL(info.cleanURL(url));
-      // Remove duplicate flaws. During the rendering process, it's possible for identical
-      // flaws to be introduced when different dependency paths share common prerequisites.
-      // For example, document A may have prerequisite documents B and C, and in turn,
-      // document C may also have prerequisite B, and the rendering of document B generates
-      // one or more flaws.
-      for (const error of errors) {
-        prerequisiteErrorsByKey.set(error.key, error);
-      }
-      return renderedHtml;
-    }
-  );
+const DEPENDENCY_LOOP_INTRO =
+  'The following documents form a circular dependency when rendering (via the "page" and/or "IncludeSubnav" macros):';
 
-  // For now, we're just going to inject section ID's.
-  // TODO: Sanitize the HTML and also filter the "src"
-  //       attributes of any iframes.
-  const tool = new HTMLTool(renderedHtml);
-  tool.injectSectionIDs();
-  return [
-    tool.html(),
-    // The prerequisite errors have already been updated with their own file information.
-    [...prerequisiteErrorsByKey.values()].concat(
-      errors.map((e) => e.updateFileInfo(fileInfo))
-    ),
-  ];
-});
+const renderFromURL = memoize(
+  async (url, urls_seen = null) => {
+    url = url.toLowerCase();
+    urls_seen = urls_seen || new Set([]);
+    if (urls_seen.has(url)) {
+      throw new Error(
+        `${DEPENDENCY_LOOP_INTRO}\n${[...urls_seen, url].join(" ⭢ ")}`
+      );
+    }
+    urls_seen.add(url);
+    const prerequisiteErrorsByKey = new Map();
+    const document = Document.findByURL(url);
+    if (!document) {
+      throw new Error(
+        `From URL ${url} no folder on disk could be found. ` +
+          `Tried to find a folder called ${Document.urlToFolderPath(url)}`
+      );
+    }
+    const { rawHTML, metadata, fileInfo } = document;
+    const [renderedHtml, errors] = await renderMacros(
+      rawHTML,
+      {
+        ...{
+          url,
+          locale: metadata.locale,
+          slug: metadata.slug,
+          title: metadata.title,
+          tags: metadata.tags || [],
+          selective_mode: false,
+        },
+        interactive_examples: {
+          base_url: INTERACTIVE_EXAMPLES_BASE_URL,
+        },
+        live_samples: { base_url: LIVE_SAMPLES_BASE_URL || url },
+      },
+      async (url) => {
+        const [renderedHtml, errors] = await renderFromURL(
+          info.cleanURL(url),
+          urls_seen
+        );
+        // Remove duplicate flaws. During the rendering process, it's possible for identical
+        // flaws to be introduced when different dependency paths share common prerequisites.
+        // For example, document A may have prerequisite documents B and C, and in turn,
+        // document C may also have prerequisite B, and the rendering of document B generates
+        // one or more flaws.
+        for (const error of errors) {
+          prerequisiteErrorsByKey.set(error.key, error);
+        }
+        return renderedHtml;
+      }
+    );
+
+    // For now, we're just going to inject section ID's.
+    // TODO: Sanitize the HTML and also filter the "src"
+    //       attributes of any iframes.
+    const tool = new HTMLTool(renderedHtml);
+    tool.injectSectionIDs();
+    return [
+      tool.html(),
+      // The prerequisite errors have already been updated with their own file information.
+      [...prerequisiteErrorsByKey.values()].concat(
+        errors.map((e) => e.updateFileInfo(fileInfo))
+      ),
+    ];
+  },
+  (url) => {
+    return url.toLowerCase();
+  }
+);
 
 module.exports = {
   buildLiveSamplePage,

--- a/testing/content/files/en-us/chicken_and_egg/chicken/index.html
+++ b/testing/content/files/en-us/chicken_and_egg/chicken/index.html
@@ -1,0 +1,13 @@
+---
+title: Chicken
+slug: Chicken_and_egg/chicken
+---
+
+<h2 id="Introduction">Introduction</h2>
+
+<p>I'm the Chicken page. I think I came first!</p>
+<p>The <a href="/en-US/docs/Chicken_and_egg/egg">egg</a> did not come first.</p>
+
+<h2>Family</h2>
+
+{{page("/en-US/docs/Chicken_and_egg/egg", "Introduction")}}

--- a/testing/content/files/en-us/chicken_and_egg/egg/index.html
+++ b/testing/content/files/en-us/chicken_and_egg/egg/index.html
@@ -1,0 +1,13 @@
+---
+title: Egg
+slug: Chicken_and_egg/egg
+---
+
+<h2 id="Introduction">Introduction</h2>
+
+<p>I'm the Egg page. I think I came first!</p>
+<p>The <a href="/en-US/docs/Chicken_and_egg/chicken">chicken</a> did not come first.</p>
+
+<h2>Family</h2>
+
+{{page("/en-US/docs/Chicken_and_egg/chicken", "Introduction")}}

--- a/testing/content/files/en-us/chicken_and_egg/index.html
+++ b/testing/content/files/en-us/chicken_and_egg/index.html
@@ -1,0 +1,12 @@
+---
+title: Chicken and Egg
+slug: Chicken_and_egg
+---
+
+<p>This page has two <i>children</i>. They are:</p>
+
+<h3>Chicken...</h3>
+{{page("/en-US/docs/Chicken_and_egg/chicken", "Introduction")}}
+
+<h3>Egg...</h3>
+{{page("/en-US/docs/Chicken_and_egg/egg", "Introduction")}}


### PR DESCRIPTION
Fixes #1270 

Add ability to detect circular dependencies when kumascript-rendering documents.

http://localhost:3000/en-US/docs/Web/API/MediaSessionAction#_flaws
http://localhost:3000/en-US/docs/Web/API/MediaSessionActionDetails#_flaws
