### PR TITLE
Refactor use of `read(... , {metadata: true})`

### DIFF
--- a/build/bcd-urls.js
+++ b/build/bcd-urls.js
@@ -76,9 +76,7 @@ function normalizeBCDURLs(doc, options) {
       // Now we need to scrutinize if that's a url we can fully
       // recognize. (But only if it's a relative link)
       const urlLC = url.toLowerCase();
-      const found = Document.findByURL(urlLC, {
-        metadata: true,
-      });
+      const found = Document.findByURL(urlLC);
       if (found) {
         continue;
       }
@@ -94,9 +92,7 @@ function normalizeBCDURLs(doc, options) {
         // For example, there might be a redirect but where it
         // goes to is not in this.allTitles.
         // This can happen if it's a "fundamental redirect" for example.
-        const finalDocument = Document.findByURL(resolved, {
-          metadata: true,
-        });
+        const finalDocument = Document.findByURL(resolved);
         const suggestion = finalDocument ? finalDocument.url : null;
         addBadBCDLinkFlaw(query, key, url, suggestion);
         block.mdn_url = suggestion;

--- a/build/check-images.js
+++ b/build/check-images.js
@@ -137,9 +137,7 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
           } else {
             // This will always be non-null because independent of the
             // image name, if the file didn't exist the document doesn't exist.
-            const parentDocument = Document.findByURL(path.dirname(finalSrc), {
-              metadata: true,
-            });
+            const parentDocument = Document.findByURL(path.dirname(finalSrc));
 
             // Base the final URL on the parent document + image file name lowercase.
             finalSrc = `${parentDocument.url}/${path

--- a/build/document-utils.js
+++ b/build/document-utils.js
@@ -14,7 +14,7 @@ function addBreadcrumbData(url, document) {
     // be a page on its own. For example: /en-US/docs/Web/ is a page,
     // and so is /en-US/ but there might not be a page for /end-US/docs/.
 
-    const parentDoc = Document.findByURL(parentURL, { metadata: true });
+    const parentDoc = Document.findByURL(parentURL);
     if (parentDoc) {
       parents.unshift({
         uri: parentURL,

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -93,7 +93,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
         // Got to fake the domain to sensible extract the .search and .hash
         const absoluteURL = new URL(href, "http://www.example.com");
         const hrefNormalized = href.split("#")[0];
-        const found = Document.findByURL(hrefNormalized, { metadata: true });
+        const found = Document.findByURL(hrefNormalized);
         if (!found) {
           // Before we give up, check if it's a redirect
           const resolved = Redirect.resolve(hrefNormalized);
@@ -103,9 +103,7 @@ function injectFlaws(doc, $, options, { rawContent }) {
             // For example, there might be a redirect but where it
             // goes to is not in this.allTitles.
             // This can happen if it's a "fundamental redirect" for example.
-            const finalDocument = Document.findByURL(resolved, {
-              metadata: true,
-            });
+            const finalDocument = Document.findByURL(resolved);
             addBrokenLink(
               a,
               checked.get(href),

--- a/build/page-title.js
+++ b/build/page-title.js
@@ -17,9 +17,7 @@ function getPageTitle(doc) {
   const rootParentURL = getRootURL(docURL);
   let title = doc.title;
   if (rootParentURL && rootParentURL !== docURL) {
-    const parentDoc = Document.findByURL(rootParentURL.toLowerCase(), {
-      metadata: true,
-    });
+    const parentDoc = Document.findByURL(rootParentURL.toLowerCase());
     if (parentDoc && parentDoc.metadata && parentDoc.metadata.title) {
       title += ` - ${parentDoc.metadata.title}`;
     }

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -119,7 +119,7 @@ const info = {
   },
 
   getPage(url, { throwIfDoesNotExist = false } = {}) {
-    const document = Document.findByURL(info.cleanURL(url), { metadata: true });
+    const document = Document.findByURL(info.cleanURL(url));
     if (!document) {
       // The macros expect an empty object if the URL does not exist, so
       // "throwIfDoesNotExist" should only be used within "info" itself.
@@ -141,9 +141,7 @@ const info = {
       tags: tags || [],
       translations: [], //TODO Object.freeze(buildTranslationObjects(data)),
       get subpages() {
-        return Document.findChildren(document.url, {
-          metadata: true,
-        })
+        return Document.findChildren(document.url)
           .map((document) => info.getPage(document.url))
           .filter((p) => p && p.url);
       },

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -16,8 +16,7 @@ function postEvent(type, data = {}) {
 function postDocumentInfo(filePath, changeType) {
   try {
     const document = Document.read(
-      path.dirname(path.relative(CONTENT_ROOT, filePath)),
-      { metadata: true }
+      path.dirname(path.relative(CONTENT_ROOT, filePath))
     );
     if (!document) {
       return;


### PR DESCRIPTION
Fixes #1292

The use of `fields` was meant when you only needed some of the metadata. E.g.
```javascript
Document.findByURL("/en-US/docs/Web/API/Index".toLowerCase()), { metadata: true }).metadata.title;
```
But when you needed the body or the raw content you were supposed to omit the fields param:
```javascript
Document.findByURL("/en-US/docs/Web/API/Index".toLowerCase())).rawHTML;
Document.findByURL("/en-US/docs/Web/API/Index".toLowerCase())).rawContent;
```

But it's no point. The `read()` function didn't do any less. It still read the whole `index.html` file and the front-matter parsing. 

