### PR TITLE
run CI indpendent of branch name

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,6 +2,8 @@ name: auto-merge
 
 on:
   pull_request:
+    branches:
+      - master
 
 jobs:
   auto-merge:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,8 @@ name: NPM Publish
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -5,13 +5,7 @@ name: Testing Yari
 
 on:
   push:
-    branches:
-      - master
-      # Temporary whilst the super-project "MDN Fiori" is being developed.
-      - mdn-fiori
   pull_request:
-    branches:
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #1291

Now, a PR doesn't always have to be about merging into `master`. For example, I make a PR against your PR, the CI workflows will run there too. 
The exception is the `auto-merge.yml` which only ever makes sense when it's against the `master`. 

If this is "abused" in the future, we can revisit. Although I find that unlikely. 