### PR TITLE
500 error if process.env.EDITOR isn't set

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
+const chalk = require("chalk");
 const express = require("express");
 const send = require("send");
 const proxy = require("express-http-proxy");
@@ -206,4 +207,16 @@ app.get("/*", async (req, res) => {
 });
 
 const PORT = parseInt(process.env.SERVER_PORT || "5000");
-app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+app.listen(PORT, () => {
+  console.log(`Listening on port ${PORT}`);
+  if (process.env.EDITOR) {
+    console.log(`Your EDITOR is set to: ${chalk.bold(process.env.EDITOR)}`);
+  } else {
+    console.warn(
+      chalk.yellow(
+        "Warning! You have not set an EDITOR environment variable. " +
+          'Using the "Edit in your editor" button will probably fail.'
+      )
+    );
+  }
+});


### PR DESCRIPTION
Fixes #1228

Actually, not much is needed here. If your `EDITOR` isn't set, the `openEditor` (which depends on `env-editor`) does a pretty good job of throwing a nice error. 
<img width="1006" alt="Screen Shot 2020-09-22 at 11 42 18 AM" src="https://user-images.githubusercontent.com/26739/93905339-db3ba780-fcc8-11ea-8cce-54abcbfe767e.png">

And in the Toolbar you get a pretty decent experience. Better than it just hanging. 
<img width="551" alt="Screen Shot 2020-09-22 at 11 42 37 AM" src="https://user-images.githubusercontent.com/26739/93905379-ea225a00-fcc8-11ea-8803-039a3357bebf.png">
At least enough to give you some guidance that something's wrong. 