### PR TITLE
log errors shouldn't have newlines in them

### DIFF
--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -391,7 +391,7 @@ def upload_content(build_directory, content_roots, config):
     if failed_tasks:
         log.error(f"Total failures: {len(failed_tasks):,}")
         for task in failed_tasks:
-            log.error(f"\n{task} failed:\n{task.error}")
+            log.error(f"{task} failed: {task.error}")
 
     log.info(
         f"Total uploaded files: {totals.uploaded_files:,} "


### PR DESCRIPTION
The reason it's bad to use newlines characters in log lines is that it can cause problems with log files when it's written to by multiple threads. 
Also, without this change it would fill up 3 lines for every 1 error. 