### PR TITLE
use latest deployer aws credentials

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -157,8 +157,8 @@ jobs:
           export DEPLOYER_BUCKET_NAME=mdn-content-dev
           export DEPLOYER_BUCKET_PREFIX=main
 
-          export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_AWS_SECRET_ACCESS_KEY }}
 
           poetry run deployer upload --help
           poetry run deployer upload ../client/build


### PR DESCRIPTION
I created a new AWS IAM user for the deployer, as well as its associated IAM policies for S3 and Lamabda. They work!