### PR TITLE
strip all div.bc-data tables when dumping rendered HTML

### DIFF
--- a/import/import.js
+++ b/import/import.js
@@ -1016,6 +1016,11 @@ function getCleanedRenderedHTML(html) {
     mutations++;
   });
 
+  $("div.bc-data[id]").each((i, element) => {
+    const $element = $(element);
+    $element.empty();
+  });
+
   if (mutations) {
     return $("#_body").html();
   }


### PR DESCRIPTION
In Yari, when building a page, it replaces any `<div class="bc-data" id="...">` with its own React based BCD table. 
In doing so, it discards everything that was in there already. So it's a waste to have it in the rendered HTML anyway. 

If you do this, you save a total of 238MB when you sum the bytes from all the tables HTML. 

After this change, the `translated-content` repo is now only 1.3GB. Seem worth doing. 