### PR TITLE
simplified language selector

### DIFF
--- a/client/src/header/language-menu.tsx
+++ b/client/src/header/language-menu.tsx
@@ -23,7 +23,9 @@ export default function LanguageMenu({
 
   return (
     <form>
+      <label htmlFor="select_language">Change language</label>{" "}
       <select
+        id="select_language"
         name="language"
         defaultValue={locale}
         onChange={(event) => {

--- a/client/src/header/language-menu.tsx
+++ b/client/src/header/language-menu.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import LANGUAGES from "../languages.json";
-import Dropdown from "./dropdown";
 import { Translation } from "../document/types";
 
 export default function LanguageMenu({
@@ -12,6 +11,8 @@ export default function LanguageMenu({
   locale: string;
   translations: Translation[];
 }) {
+  const navigate = useNavigate();
+
   // For the menu label, we want to use the name of the document language.
   // We need a special case for English because English documents can
   // appear in pages for other locales, and in that case we need a
@@ -19,30 +20,40 @@ export default function LanguageMenu({
   // locale of the page and the locale of the document should match
   // and we can just use the document language string without translation.
   const verbose = LANGUAGES[locale];
-  const chooseLanguageString = `Current language is ${
-    (verbose && verbose.English) || locale
-  }. Choose your preferred language.`;
 
   return (
-    <Dropdown
-      id="header-language-menu"
-      componentClassName="language-menu"
-      label={(verbose && verbose.English) || locale}
-      right={true}
-      ariaOwns="language-menu"
-      ariaLabel={chooseLanguageString}
-    >
-      {translations.map((t) => {
-        const verbose = LANGUAGES[t.locale];
-        const url = `/${t.locale}/docs/${t.slug}`;
-        return (
-          <li key={url} lang={t.locale} role="menuitem">
-            <Link to={url} title={verbose ? verbose.English : t.locale}>
-              <bdi>{verbose ? verbose.native : t.locale}</bdi>
-            </Link>
-          </li>
-        );
-      })}
-    </Dropdown>
+    <form>
+      <select
+        name="language"
+        defaultValue={locale}
+        onChange={(event) => {
+          const { value: url } = event.target;
+          // If the selection was the existing document, do nothing
+          if (url !== locale) {
+            // Redirect
+            navigate(url);
+          }
+        }}
+      >
+        {/*
+          This option is alway there and always first.
+          The reason it doesn't have the `disabled` attribute is because it
+          might not render when viewing the select un-opened and instead what
+          you see is the second option.
+          The onChange callback is a protection for doing nothing if the
+          already current locale is chosen.
+         */}
+        <option value={locale}>{verbose ? verbose.native : locale}</option>
+        {translations.map((t) => {
+          const verbose = LANGUAGES[t.locale];
+          const url = `/${t.locale}/docs/${t.slug}`;
+          return (
+            <option key={url} value={url}>
+              {verbose ? verbose.native : t.locale}
+            </option>
+          );
+        })}
+      </select>
+    </form>
   );
 }


### PR DESCRIPTION
Part of #1320

When on an English page:
<img width="612" alt="Screen Shot 2020-09-29 at 10 40 47 AM" src="https://user-images.githubusercontent.com/26739/94573633-47c22380-0240-11eb-9439-c423126ebc35.png">

If you focus it:
<img width="269" alt="Screen Shot 2020-09-29 at 10 41 21 AM" src="https://user-images.githubusercontent.com/26739/94573713-590b3000-0240-11eb-8f99-b1149323a4b8.png">

The most contentious thing to discuss is: What if you stumble in on http://localhost:5000/ja/docs/Web/HTML/Element/option and you can't read Japanese. 
<img width="569" alt="Screen Shot 2020-09-29 at 10 43 16 AM" src="https://user-images.githubusercontent.com/26739/94573943-97a0ea80-0240-11eb-9816-65c4943faad0.png">
You might attempt to look for the word "English" somewhere on the page. But you won't find it because it's not there until you focus the `<select>`:
<img width="211" alt="Screen Shot 2020-09-29 at 10 43 44 AM" src="https://user-images.githubusercontent.com/26739/94573998-a8e9f700-0240-11eb-9897-b422bfdbc2f5.png">
**Is that a problem?**

The other thing is, **is this widget accessible?** There's no submit button (hidden or displayed) after the select. Instead, I'm relying on a `<select onChange={...}>` event handler. 