### PR TITLE
recently viewed documents on the home page

### DIFF
--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Doc } from "../types";
 import { EditActions } from "./edit-actions";
 import { ToggleDocumentFlaws } from "./flaws";
@@ -7,6 +7,26 @@ import WatchInfo from "./watch-info";
 import "./index.scss";
 
 export default function Toolbar({ doc }: { doc: Doc }) {
+  // Every time the toolbar is used to view a document, log that in localStorage
+  // as a list of recent document views. This can be used on the homepage to
+  // help you navigate back to pages you frequently visit.
+  useEffect(() => {
+    const localStorageKey = "viewed-documents";
+    const entry = {
+      url: doc.mdn_url,
+      title: doc.title,
+      timestamp: new Date().getTime(),
+    };
+    const previousVisits = JSON.parse(
+      localStorage.getItem(localStorageKey) || "[]"
+    );
+    const visits = [
+      entry,
+      ...previousVisits.filter((v) => v.url !== entry.url),
+    ];
+    localStorage.setItem(localStorageKey, JSON.stringify(visits.slice(0, 20)));
+  }, [doc]);
+
   return (
     <div className="toolbar">
       <div className="toolbar-first-row">

--- a/client/src/homepage/hooks.tsx
+++ b/client/src/homepage/hooks.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from "react";
+
+function getIsDocumentHidden() {
+  return !document.hidden;
+}
+
+export function usePageVisibility() {
+  const [isVisible, setIsVisible] = React.useState(getIsDocumentHidden());
+  const onVisibilityChange = () => setIsVisible(getIsDocumentHidden());
+  useEffect(() => {
+    const visibilityChange = "visibilitychange";
+    document.addEventListener(visibilityChange, onVisibilityChange, false);
+    return () => {
+      document.removeEventListener(visibilityChange, onVisibilityChange);
+    };
+  });
+  return isVisible;
+}

--- a/client/src/homepage/index.tsx
+++ b/client/src/homepage/index.tsx
@@ -1,13 +1,25 @@
-import React from "react";
+import React, { lazy, Suspense } from "react";
 import { Link } from "react-router-dom";
 import Search from "../header/search";
 import "./index.scss";
 
+// Lazy sub-components
+const ViewedDocuments = lazy(() => import("./viewed-documents"));
+
 export function Homepage() {
+  const isServer = typeof window === "undefined";
+
   return (
     <div id="homepage">
       <h2>Welcome to MDN</h2>
       <Search />
+
+      {!isServer && (
+        <Suspense fallback={null}>
+          <ViewedDocuments />
+        </Suspense>
+      )}
+
       <h3>Sample pages</h3>
       <ul>
         <li>

--- a/client/src/homepage/viewed-documents.scss
+++ b/client/src/homepage/viewed-documents.scss
@@ -1,0 +1,3 @@
+#recently-viewed-documents a small {
+  color: grey;
+}

--- a/client/src/homepage/viewed-documents.tsx
+++ b/client/src/homepage/viewed-documents.tsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 
 import { usePageVisibility } from "./hooks";
 
+import "./viewed-documents.scss";
+
 type Entry = {
   url: string;
   title: string;
@@ -57,8 +59,11 @@ export default function ViewedDocuments() {
   }, [isVisible]);
 
   return (
-    <div>
-      <h3>Recently viewed documents</h3>
+    <article
+      id="recently-viewed-documents"
+      aria-labelledby="recently-viewed-documents"
+    >
+      <h2>Recently viewed documents</h2>
       {!entries ? (
         <Banner>Loading recently viewed documents</Banner>
       ) : entries.length ? (
@@ -74,7 +79,9 @@ export default function ViewedDocuments() {
               return (
                 <tr key={entry.url}>
                   <td>
-                    <Link to={entry.url}>{entry.title}</Link>
+                    <Link to={entry.url}>
+                      {entry.title} <small>{entry.url}</small>
+                    </Link>
                   </td>
                   <td>{friendlyDateDisplay(new Date(entry.timestamp))}</td>
                 </tr>
@@ -85,10 +92,10 @@ export default function ViewedDocuments() {
       ) : (
         <Banner>No recently viewed documents at the moment</Banner>
       )}
-    </div>
+    </article>
   );
 }
 
 function Banner({ children }) {
-  return <p style={{ margin: 30, fontStyle: "italic" }}>{children}</p>;
+  return <p className="notification">{children}</p>;
 }

--- a/client/src/homepage/viewed-documents.tsx
+++ b/client/src/homepage/viewed-documents.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { usePageVisibility } from "./hooks";
+
+type Entry = {
+  url: string;
+  title: string;
+  timestamp: number;
+};
+
+// Simpler and cheaper than a proper library
+function friendlyDateDisplay(date: Date): string {
+  const today = new Date();
+  const dateString = date.toDateString();
+  const secondsDiff = (today.getTime() - date.getTime()) / 1000;
+  if (secondsDiff < 60) {
+    return "seconds ago";
+  }
+  if (secondsDiff < 60 * 15) {
+    return "minutes ago";
+  }
+  if (today.toDateString() === dateString) {
+    return "today";
+  }
+  const yesterday = new Date(today.getTime() - 1000 * 3600 * 24);
+  if (yesterday.toDateString() === dateString) {
+    return "yesterday";
+  }
+  return dateString;
+}
+
+export default function ViewedDocuments() {
+  const isVisible = usePageVisibility();
+  const [entries, setEntries] = useState<Entry[] | null>(null);
+
+  useEffect(() => {
+    if (isVisible) {
+      const localStorageKey = "viewed-documents";
+      const previousVisits = JSON.parse(
+        localStorage.getItem(localStorageKey) || "[]"
+      );
+      const newEntries: Entry[] = [];
+      // console.log(previousVisits);
+      for (const visit of previousVisits) {
+        newEntries.push({
+          url: visit.url,
+          title: visit.title,
+          timestamp: visit.timestamp,
+        });
+      }
+
+      if (newEntries.length) {
+        setEntries(newEntries);
+      }
+    }
+  }, [isVisible]);
+
+  return (
+    <div>
+      <h3>Recently viewed documents</h3>
+      {!entries ? (
+        <Banner>Loading recently viewed documents</Banner>
+      ) : entries.length ? (
+        <table>
+          <thead>
+            <tr>
+              <th>Document</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => {
+              return (
+                <tr key={entry.url}>
+                  <td>
+                    <Link to={entry.url}>{entry.title}</Link>
+                  </td>
+                  <td>{friendlyDateDisplay(new Date(entry.timestamp))}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <Banner>No recently viewed documents at the moment</Banner>
+      )}
+    </div>
+  );
+}
+
+function Banner({ children }) {
+  return <p style={{ margin: 30, fontStyle: "italic" }}>{children}</p>;
+}


### PR DESCRIPTION
This is a kinda rushed job but I quite like it and it's something I've been wanting for myself. If you like it, let's keep it. 
<img width="737" alt="Screen Shot 2020-09-30 at 4 31 00 PM" src="https://user-images.githubusercontent.com/26739/94736710-a8358b80-033a-11eb-8f10-0101ed012ca4.png">


Note that all this code is lazy-loaded in the client only so none of it will bloat the JS/CSS bundle we ship to production. 
