### PR TITLE
link to BCD GitHub new-issue

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -127,8 +127,9 @@ export function BrowserCompatibilityTable({
         <a
           className="bc-github-link external external-icon"
           href={getNewIssueURL()}
-          rel="noopener"
-          title="Report an issue with this compatability data"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Report an issue with this compatibility data"
         >
           Report problems with this data on GitHub
         </a>

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -116,7 +116,7 @@ export function BrowserCompatibilityTable({
       .replace(/\$QUERY_ID/g, query)
       .trim();
     sp.set("body", body);
-    sp.set("title", query);
+    sp.set("title", `${query} - <PUT TITLE HERE>`);
     return `${url}?${sp.toString()}`;
   }
 
@@ -130,7 +130,7 @@ export function BrowserCompatibilityTable({
           rel="noopener"
           title="Report an issue with this compatability data"
         >
-          See something? Say something ...on GitHub
+          Report problems with this data on GitHub
         </a>
         <table key="bc-table" className="bc-table bc-table-web">
           <Headers {...{ platforms, browsers }} />


### PR DESCRIPTION
Fixes #1344

It started as a joke in my head with the phrase "See something? Say something." but that could be misinterpreted for a lingo that belongs in the dark world of counter-terrorism. Truth is, I wanted to make sure it's different from what it used to say because what it used to say was fine but many people have given up home on that link since it would only take you to the home page. 
So please take your time and think about the ideal link display/text. 
Another option is to make it louder graphically. We can start with using bold or italic or just a larger font size. Perhaps, with the help of @schalkneethling we can make it stand out in other ways. 
Another option is to display it under the table where it's already kinda crowded and mess with all the legends. 

On MDN...
<img width="1085" alt="Screen Shot 2020-10-01 at 6 55 25 AM" src="https://user-images.githubusercontent.com/26739/94801503-1ff3cc80-03b4-11eb-8212-6e6bcb910bed.png">

When you click it... (it does not open in a new window, should it?)
<img width="964" alt="Screen Shot 2020-10-01 at 6 55 40 AM" src="https://user-images.githubusercontent.com/26739/94801543-30a44280-03b4-11eb-8671-983f0367a23a.png">
<img width="967" alt="Screen Shot 2020-10-01 at 6 55 52 AM" src="https://user-images.githubusercontent.com/26739/94801561-3732ba00-03b4-11eb-8c61-29614ce08ea5.png">

I had to hardcode the domain to `https://developer.mozilla.org` because this code gets executed in both Node and in the browser and by doing it in Node (i.e. inside a GItHub Action) you won't yet know the full location domain. 