### PR TITLE
better s3 keys and lambda function

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -125,7 +125,9 @@ jobs:
           # (aka. local development). Usually defaults are supposed to be for
           # secure production but this is an exception and default
           # is not insecure.
-          export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
+          #export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
+          # Temporary, for deployments to the mdn-content-dev bucket only.
+          export BUILD_LIVE_SAMPLES_BASE_URL=
 
           # TODO: Only relevant once github.com/mdn/mdn-content is a thing.
           # export CONTENT_ROOT=mdn-content/content/files

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -126,7 +126,9 @@ jobs:
           # secure production but this is an exception and default
           # is not insecure.
           #export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
-          # Temporary, for deployments to the mdn-content-dev bucket only.
+          # WARNING: The following is temporary, only because, for now, we're
+          #          deploying to the mdn-content-dev S3 bucket. Remove once
+          #          we start deploying to the mdn-content-prod S3 bucket!
           export BUILD_LIVE_SAMPLES_BASE_URL=
 
           # TODO: Only relevant once github.com/mdn/mdn-content is a thing.

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -243,7 +243,16 @@ class BucketManager:
 
     def get_key(self, build_directory, file_path):
         if file_path.name == "index.html":
-            # This simplifies our Lambda@Edge function that tansforms URL's to S3 keys.
+            # NOTE: All incoming requests, unless immediately served from the CDN
+            # cache, are first handled by our "origin-request" Lambda@Edge function,
+            # which tansforms incoming URL's to S3 keys. This line of code allows
+            # that function to remain as simple as possible, because we no longer
+            # have to determine when to add an "/index.html" suffix when transforming
+            # the incoming URL to it corresponding S3 key. We will simply store
+            # "/en-us/docs/web/index.html" as "/en-us/docs/web", which mirrors
+            # its URL. Also, note that the content type is not determined by the
+            # suffix of the S3 key, but is explicitly set from the full filepath
+            # when uploading the file.
             file_path = file_path.parent
         return f"{self.key_prefix}{str(file_path.relative_to(build_directory)).lower()}"
 

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -242,6 +242,9 @@ class BucketManager:
         return boto3.client("s3")
 
     def get_key(self, build_directory, file_path):
+        if file_path.name == "index.html":
+            # This simplifies our Lambda@Edge function that tansforms URL's to S3 keys.
+            file_path = file_path.parent
         return f"{self.key_prefix}{str(file_path.relative_to(build_directory)).lower()}"
 
     def get_redirect_keys(self, from_url, to_url):


### PR DESCRIPTION
Fixes #1371 
Fixes #1365 

This also temporarily fixes the `BUILD_LIVE_SAMPLES_BASE_URL` for the `production-build` GHA workflow. Since we're temporarily deploying to `mdn-content-dev`, we need to build with `export BUILD_LIVE_SAMPLES_BASE_URL=` or else the live-samples won't work.

The Lambda function defined here has already been published (version 48) and configured to work with our dev CF instance. I also did a full build of the latest `mdn/content` (using `export BUILD_LIVE_SAMPLES_BASE_URL=`) and deployed to `mdn-content-dev` with the `ryan` prefix:
- https://ryan.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/align-content (scroll down to the live sample)
- https://ryan.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/align-content/ (redirects)
- https://ryan.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/align-content/contributors.txt
- https://ryan.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/align-content/index.json