### PR TITLE
"Browser compatibility" isn't a clickable permalink header

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -1,25 +1,6 @@
 const cheerio = require("./monkeypatched-cheerio");
 const { packageBCD } = require("./resolve-bcd");
 
-/**
- * Given a cheerio doc, extract all the <h2> tags and make it a
- * structured thing.
- */
-function extractTOC($) {
-  const toc = [];
-  // Use .each() instead of .map() so we can do filtering lazily
-  // within each callback instead of having to .filter() first.
-  $("h2").each((i, element) => {
-    const $element = $(element);
-    const text = $element.text();
-    const id = $element.attr("id");
-    if (text && id) {
-      toc.push({ text, id });
-    }
-  });
-  return toc;
-}
-
 /** Extract and mutate the $ if it as a "Quick_Links" section.
  * But only if it exists.
  *
@@ -389,6 +370,5 @@ function extractSummary(sections) {
 module.exports = {
   extractSidebar,
   extractSections,
-  extractTOC,
   extractSummary,
 };

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -7,6 +7,7 @@ import { FeatureRow } from "./feature-row";
 import { PLATFORM_BROWSERS, Headers } from "./headers";
 import { Legend } from "./legend";
 import { listFeatures } from "./utils";
+import { DisplayH2 } from "../utils";
 
 import "./bcd.scss";
 // import "../../../kumastyles/wiki-compat-tables.scss";
@@ -123,7 +124,7 @@ export function BrowserCompatibilityTable({
   return (
     <BrowserCompatibilityErrorBoundary>
       <BrowserInfoContext.Provider value={browserInfo}>
-        {title && <h2 id={id}>{title}</h2>}
+        {title && <DisplayH2 id={id} title={title} />}
         <a
           className="bc-github-link external external-icon"
           href={getNewIssueURL()}

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 
+import { DisplayH2 } from "./utils";
+
 export function Prose({ section }) {
   return <div dangerouslySetInnerHTML={{ __html: section.content }} />;
 }
@@ -7,11 +9,7 @@ export function Prose({ section }) {
 export function ProseWithHeading({ id, section }) {
   return (
     <>
-      <h2 id={id}>
-        <a href={`#${id}`} title={`Permalink to ${section.title}`}>
-          {section.title}
-        </a>
-      </h2>
+      <DisplayH2 id={id} title={section.title} />
       <Prose section={section} />
     </>
   );

--- a/client/src/document/ingredients/utils.tsx
+++ b/client/src/document/ingredients/utils.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export function DisplayH2({ id, title }: { id: string; title: string }) {
+  return (
+    <h2 id={id}>
+      <a href={`#${id}`} title={`Permalink to ${title}`}>
+        {title}
+      </a>
+    </h2>
+  );
+}


### PR DESCRIPTION
Fixes #1322

Some interesting pages to try it on:

* http://localhost:3000/en-US/docs/Web/API/MediaSessionActionDetails - uses the `{{page}}` macro to embed sections from another document. 
* http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs - so many BCD tables
* http://localhost:3000/en-us/docs/Web/API/Web_Authentication_API - Lots of BCD tables but no `<h2>` for each