### PR TITLE
prefer documents on disk over redirects

### DIFF
--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -130,7 +130,13 @@ const info = {
   },
 
   getPage(url, { throwIfDoesNotExist = false, followRedirects = true } = {}) {
-    const document = Document.findByURL(info.cleanURL(url, followRedirects));
+    // Always start by looking it up *without* following redirects.
+    let document = Document.findByURL(info.cleanURL(url, false));
+    // Usually, `followRedirects` is disabled if the caller definitely is not
+    // not interested in following redirects (e.g. listing sub-pages)
+    if (!document && followRedirects) {
+      document = Document.findByURL(info.cleanURL(url, true));
+    }
     if (!document) {
       // The macros expect an empty object if the URL does not exist, so
       // "throwIfDoesNotExist" should only be used within "info" itself.


### PR DESCRIPTION
Fixes #1377

Here's how I tested it:

1. In `content/files/en-us/mdn/kitchensink/index.html` there exists this: `{{domxref("HTMLElement")}}`
2. Confirm that that's a perfectly healthy document: `files/en-us/web/api/htmlelement/index.html`
3. Edit `files/en-us/_redirects.txt` and add: `echo '/en-US/docs/Web/API/HTMLElement /en-US/docs/Web/API/window/window' >> files/en-us/_redirects.txt`
4. [View the kitchensink](http://localhost:3000/en-US/docs/MDN/Kitchensink) and find the mention of "DOM Interface" and the link that follows. 

That link becomes (on `master`):
```html
<a href="/en-US/docs/Web/API/Window/window" data-flaw-src="{{domxref(&quot;HTMLElement&quot;)}}"><code>HTMLElement</code></a>
```

With the code in this branch:
```html
<a href="/en-US/docs/Web/API/HTMLElement"><code>HTMLElement</code></a>
```
which is what's expected. 
