### PR TITLE
longer default timeout on headless testing

### DIFF
--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -1,4 +1,5 @@
 require("expect-puppeteer");
+const { setDefaultOptions } = require("expect-puppeteer");
 
 // The default it 500ms. It has happened and it can happen again, that sometimes
 // it just takes a little longer than 500ms. Give it a healthy margin of a

--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -1,5 +1,10 @@
 require("expect-puppeteer");
 
+// The default it 500ms. It has happened and it can happen again, that sometimes
+// it just takes a little longer than 500ms. Give it a healthy margin of a
+// timeout so as to reduce the risk of it failing when there's nothing wrong.
+setDefaultOptions({ timeout: 1500 });
+
 function testURL(pathname = "/") {
   return "http://localhost:5000" + pathname;
 }


### PR DESCRIPTION
Because [it happened](https://github.com/mdn/yari/runs/1211695379?check_suite_focus=true).
I'm not sure if going from 500ms to 1,500ms actually would have saved the bacon that time, but this definitely will reduce the probability a bit. 