### PR TITLE
InheritanceDiagram to produce live samples

### DIFF
--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -1,4 +1,4 @@
-const { Document, memoize } = require("../content");
+const { Document } = require("../content");
 
 const {
   INTERACTIVE_EXAMPLES_BASE_URL,

--- a/kumascript/src/live-sample.js
+++ b/kumascript/src/live-sample.js
@@ -129,9 +129,19 @@ function getLiveSampleIDs(slug, source) {
   for (let token of tokens) {
     if (
       token.type === "MACRO" &&
-      normalizeMacroName(token.name) === "embedlivesample" &&
-      token.args.length
+      ((normalizeMacroName(token.name) === "embedlivesample" &&
+        token.args.length) ||
+        token.name === "InheritanceDiagram")
     ) {
+      // The InheritanceDiagram is a special macro that, unlike other EmbedLiveSample
+      // macros in that it itself renders the "EmbedLiveSample" with a set of
+      // hardcoded options. The only thing that is variable and comes from the
+      // the raw HTML is the size. So make an exception for this otherwise, the
+      // HTML element ID is lost and this function won't discovered that it is
+      // in fact a live sample here.
+      if (token.name === "InheritanceDiagram") {
+        token.args = ["inheritance_diagram", ...token.args];
+      }
       // Some of the localized pages URI-encode their first argument,
       // the live-sample ID, even though they don't need to do that,
       // so let's first call "safeDecodeURIComponent" just in case.

--- a/kumascript/src/live-sample.js
+++ b/kumascript/src/live-sample.js
@@ -127,21 +127,18 @@ function getLiveSampleIDs(slug, source) {
   // be different from the current slug, from which to extract the sample ID.
   let result = [];
   for (let token of tokens) {
-    if (
-      token.type === "MACRO" &&
-      ((normalizeMacroName(token.name) === "embedlivesample" &&
-        token.args.length) ||
-        token.name === "InheritanceDiagram")
-    ) {
+    if (token.type !== "MACRO") continue;
+    const normalizedMacroName = normalizeMacroName(token.name);
+    if (normalizedMacroName === "inheritancediagram") {
       // The InheritanceDiagram is a special macro that, unlike other EmbedLiveSample
       // macros in that it itself renders the "EmbedLiveSample" with a set of
       // hardcoded options. The only thing that is variable and comes from the
       // the raw HTML is the size. So make an exception for this otherwise, the
       // HTML element ID is lost and this function won't discovered that it is
       // in fact a live sample here.
-      if (token.name === "InheritanceDiagram") {
-        token.args = ["inheritance_diagram", ...token.args];
-      }
+      token.args = ["inheritance_diagram", ...token.args];
+      result.push(new LiveSampleID("inheritance_diagram", source, token));
+    } else if (normalizedMacroName === "embedlivesample" && token.args.length) {
       // Some of the localized pages URI-encode their first argument,
       // the live-sample ID, even though they don't need to do that,
       // so let's first call "safeDecodeURIComponent" just in case.


### PR DESCRIPTION
Fixes #1397

This fixes the problem. Now
http://localhost:3000/en-US/docs/Web/API/FocusEvent and http://localhost:3000/en-US/docs/Web/API/HTMLDataListElement work. 

I'm just not entirely sure this was the right fix. Seems a bit hacky. 