### PR TITLE
Code examples should be wrapped in a code element

### DIFF
--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -73,7 +73,8 @@ function syntaxHighlight($, doc) {
     }
     const code = $pre.text();
     const html = Prism.highlight(code, grammar, name);
-    $pre.html(html);
+    const $code = $("<code>").html(html);
+    $pre.empty().append($code);
   });
 }
 


### PR DESCRIPTION
Fixes #1281

Now, we're doing what Prism does when it runs in the browser. It too, looks for any `<pre>` extracts its text, runs Prism itself and then wraps it by putting it all in a `<code>` element first. 
But what Prism also does is that they copy the languge class-name into the code. E.g. 
```html
<pre class="language-js">function</pre>
```
becomes:
```html
<pre class="language-js"><code class="language-js"><span class="keyword">function</span></code></pre>
```
whereas here in Yari, I ignore that. 
