### PR TITLE
disallow content folders with whitespace

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -150,6 +150,9 @@ const read = memoize((folder) => {
   if (!filePath) {
     return;
   }
+  if (filePath.includes(" ")) {
+    throw new Error("Folder contains whitespace which is not allowed.");
+  }
   const isTranslated =
     CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT);
   const isArchive =


### PR DESCRIPTION
Fixes #758

Now, if you've created a folder with a space in it you'll notice it as soon as you type `yarn start`. Mine says:
```
5:06:54 PM server.1     |  Error while adding document /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/glossary/not allowed/index.html to index: Error: Folder contains whitespace which is not allowed.
5:06:54 PM server.1     |      at Object.read (/Users/peterbe/dev/MOZILLA/MDN/yari/content/document.js:154:11)
5:06:54 PM server.1     |      at postDocumentInfo (/Users/peterbe/dev/MOZILLA/MDN/yari/server/document-watch.worker.js:18:31)
5:06:54 PM server.1     |      at FSWatcher.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/server/document-watch.worker.js:61:3)
5:06:54 PM server.1     |      at FSWatcher.emit (events.js:314:20)
5:06:54 PM server.1     |      at FSWatcher.emitWithAll (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/chokidar/index.js:534:8)
5:06:54 PM server.1     |      at FSWatcher._emit (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/chokidar/index.js:626:8)
5:06:54 PM server.1     |      at FsEventsHandler.emitAdd (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/chokidar/lib/fsevents-handler.js:421:14)
5:06:54 PM server.1     |      at ReaddirpStream.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/chokidar/lib/fsevents-handler.js:490:16)
5:06:54 PM server.1     |      at ReaddirpStream.emit (events.js:314:20)
5:06:54 PM server.1     |      at addChunk (_stream_readable.js:304:12)
```

And if you try to `yarn build` it, which is what the `PR-Build` workflow does in mdn/content, you'd get this:
```
▶ BUILD_FOLDERSEARCH=glossary/not yarn build
yarn run v1.22.4
$ cd build && cross-env NODE_ENV=production node cli.js
Building roots: [ '/Users/peterbe/dev/MOZILLA/MDN/content/files' ]
error while building documents: Error: Folder contains whitespace which is not allowed.
    at /Users/peterbe/dev/MOZILLA/MDN/yari/content/document.js:154:11
    at /Users/peterbe/dev/MOZILLA/MDN/yari/content/utils.js:60:19
    at Object.iter (/Users/peterbe/dev/MOZILLA/MDN/yari/content/document.js:311:15)
    at iter.next (<anonymous>)
    at buildDocuments (/Users/peterbe/dev/MOZILLA/MDN/yari/build/cli.js:37:14)
    at Object.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/build/cli.js:184:3)
    at Module._compile (internal/modules/cjs/loader.js:1201:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1221:10)
    at Module.load (internal/modules/cjs/loader.js:1050:32)
    at Function.Module._load (internal/modules/cjs/loader.js:938:14)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```