### PR TITLE
Exclude Kitchensink from indexing

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -102,9 +102,14 @@ async function buildDocuments() {
       fs.copyFileSync(filePath, path.join(outPath, path.basename(filePath)));
     }
 
+    // Decide whether it should be indexed (sitemaps, robots meta tag, search-index)
+    document.noIndexing =
+      (document.isArchive && !document.isTranslated) ||
+      document.metadata.slug === "MDN/Kitchensink";
+
     // Collect non-archived documents' slugs to be used in sitemap building and
-    // search index building
-    if (!document.isArchive || document.isTranslated) {
+    // search index building.
+    if (!document.noIndexing) {
       const { locale, slug } = document.metadata;
       if (!docPerLocale[locale]) {
         docPerLocale[locale] = [];

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -68,7 +68,7 @@ export default function render(renderApp, doc) {
     $('meta[name="description"]').attr("content", pageDescription);
   }
 
-  if (doc.isArchive && !doc.isTranslated) {
+  if (!doc.noIndexing) {
     $('<meta name="robots" content="noindex, nofollow">').insertAfter(
       $("meta").eq(-1)
     );


### PR DESCRIPTION
Fixes #1403

Now, view-source:http://localhost:5000/en-US/docs/MDN/Kitchensink/ will contain `<meta name="robots" content="noindex, nofollow">`
And the sitemaps.xml.gz won't list it either. 