### PR TITLE
<pre> tags with html flaws

### DIFF
--- a/build/constants.js
+++ b/build/constants.js
@@ -27,6 +27,7 @@ const VALID_FLAW_CHECKS = new Set([
   "bad_bcd_queries",
   "bad_bcd_links",
   "images",
+  "pre_with_html",
 ]);
 
 // TODO (far future): Switch to "error" when number of flaws drops.

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -15,159 +15,188 @@ const {
 function injectFlaws(doc, $, options, { rawContent }) {
   if (doc.isArchive) return;
 
-  // The 'broken_links' flaw check looks for internal links that
-  // link to a document that's going to fail with a 404 Not Found.
-  if (options.flawLevels.get("broken_links") !== FLAW_LEVELS.IGNORE) {
-    // This is needed because the same href can occur multiple time.
-    // For example:
-    //    <a href="/foo/bar">
-    //    <a href="/foo/other">
-    //    <a href="/foo/bar">  (again!)
-    // In this case, when we call `addBrokenLink()` that third time, we know
-    // this refers to the second time it appears. That's important for the
-    // sake of finding which match, in the original source (rawContent),
-    // it belongs to.
-    const checked = new Map();
+  injectBrokenLinksFlaws(
+    options.flawLevels.get("broken_links"),
+    doc,
+    $,
+    rawContent
+  );
 
-    // Our cache for looking things up by `href`. This basically protects
-    // us from calling `findMatchesInText()` more than once.
-    const matches = new Map();
+  injectBadBCDQueriesFlaws(options.flawLevels.get("bad_bcd_queries"), doc, $);
+}
 
-    // A closure function to help making it easier to append flaws
-    function addBrokenLink($element, index, href, suggestion = null) {
-      if (!matches.has(href)) {
-        matches.set(
-          href,
-          Array.from(
-            findMatchesInText(href, rawContent, {
-              attribute: "href",
-            })
-          )
-        );
-      }
-      // findMatchesInText() is a generator function so use `Array.from()`
-      // to turn it into an array so we can use `.forEach()` because that
-      // gives us an `i` for every loop.
-      matches.get(href).forEach((match, i) => {
-        if (i !== index) {
-          return;
-        }
-        if (!("broken_links" in doc.flaws)) {
-          doc.flaws.broken_links = [];
-        }
-        const id = `link${doc.flaws.broken_links.length + 1}`;
-        const explanation = `Can't resolve ${href}`;
-        let fixable = false;
-        if (suggestion) {
-          $element.attr("href", suggestion);
-          fixable = true;
-        }
-        $element.attr("data-flaw", id);
-        doc.flaws.broken_links.push(
-          Object.assign({ explanation, id, href, suggestion, fixable }, match)
-        );
-      });
+// The 'broken_links' flaw check looks for internal links that
+// link to a document that's going to fail with a 404 Not Found.
+function injectBrokenLinksFlaws(level, doc, $, rawContent) {
+  if (level === FLAW_LEVELS.IGNORE) return;
+
+  // This is needed because the same href can occur multiple time.
+  // For example:
+  //    <a href="/foo/bar">
+  //    <a href="/foo/other">
+  //    <a href="/foo/bar">  (again!)
+  // In this case, when we call `addBrokenLink()` that third time, we know
+  // this refers to the second time it appears. That's important for the
+  // sake of finding which match, in the original source (rawContent),
+  // it belongs to.
+  const checked = new Map();
+
+  // Our cache for looking things up by `href`. This basically protects
+  // us from calling `findMatchesInText()` more than once.
+  const matches = new Map();
+
+  // A closure function to help making it easier to append flaws
+  function addBrokenLink($element, index, href, suggestion = null) {
+    if (!matches.has(href)) {
+      matches.set(
+        href,
+        Array.from(
+          findMatchesInText(href, rawContent, {
+            attribute: "href",
+          })
+        )
+      );
     }
-
-    $("a[href]").each((i, element) => {
-      const a = $(element);
-      const href = a.attr("href");
-
-      // This gives us insight into how many times this exact `href`
-      // has been encountered in the doc.
-      // Then, when we call addBrokenLink() we can include an index so that
-      // that function knows which match it's referring to.
-      checked.set(href, checked.has(href) ? checked.get(href) + 1 : 0);
-
-      if (href.startsWith("https://developer.mozilla.org/")) {
-        // It might be a working 200 OK link but the link just shouldn't
-        // have the full absolute URL part in it.
-        const absoluteURL = new URL(href);
-        addBrokenLink(
-          a,
-          checked.get(href),
-          href,
-          absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
-        );
-      } else if (href.startsWith("/") && !href.startsWith("//")) {
-        // Got to fake the domain to sensible extract the .search and .hash
-        const absoluteURL = new URL(href, "http://www.example.com");
-        const hrefNormalized = href.split("#")[0];
-        const found = Document.findByURL(hrefNormalized);
-        if (!found) {
-          // Before we give up, check if it's a redirect
-          const resolved = Redirect.resolve(hrefNormalized);
-          if (resolved) {
-            // Just because it's a redirect doesn't mean it ends up
-            // on a page we have.
-            // For example, there might be a redirect but where it
-            // goes to is not in this.allTitles.
-            // This can happen if it's a "fundamental redirect" for example.
-            const finalDocument = Document.findByURL(resolved);
-            addBrokenLink(
-              a,
-              checked.get(href),
-              href,
-              finalDocument
-                ? finalDocument.url + absoluteURL.search + absoluteURL.hash
-                : null
-            );
-          } else {
-            addBrokenLink(a, href);
-          }
-        } else {
-          // But does it have the correct case?!
-          if (found.url !== href.split("#")[0]) {
-            // Inconsistent case.
-            addBrokenLink(
-              a,
-              checked.get(href),
-              href,
-              found.url + absoluteURL.search + absoluteURL.hash
-            );
-          }
-        }
+    // findMatchesInText() is a generator function so use `Array.from()`
+    // to turn it into an array so we can use `.forEach()` because that
+    // gives us an `i` for every loop.
+    matches.get(href).forEach((match, i) => {
+      if (i !== index) {
+        return;
       }
+      if (!("broken_links" in doc.flaws)) {
+        doc.flaws.broken_links = [];
+      }
+      const id = `link${doc.flaws.broken_links.length + 1}`;
+      const explanation = `Can't resolve ${href}`;
+      let fixable = false;
+      if (suggestion) {
+        $element.attr("href", suggestion);
+        fixable = true;
+      }
+      $element.attr("data-flaw", id);
+      doc.flaws.broken_links.push(
+        Object.assign({ explanation, id, href, suggestion, fixable }, match)
+      );
     });
-    if (options.flawLevels.get("broken_links") === FLAW_LEVELS.ERROR) {
-      throw new Error(`broken_links flaws: ${doc.flaws.broken_links}`);
-    }
   }
 
-  if (options.flawLevels.get("bad_bcd_queries") !== FLAW_LEVELS.IGNORE) {
-    $("div.bc-data").each((i, element) => {
-      const dataQuery = $(element).attr("id");
-      if (!dataQuery) {
+  $("a[href]").each((i, element) => {
+    const a = $(element);
+    const href = a.attr("href");
+
+    // This gives us insight into how many times this exact `href`
+    // has been encountered in the doc.
+    // Then, when we call addBrokenLink() we can include an index so that
+    // that function knows which match it's referring to.
+    checked.set(href, checked.has(href) ? checked.get(href) + 1 : 0);
+
+    if (href.startsWith("https://developer.mozilla.org/")) {
+      // It might be a working 200 OK link but the link just shouldn't
+      // have the full absolute URL part in it.
+      const absoluteURL = new URL(href);
+      addBrokenLink(
+        a,
+        checked.get(href),
+        href,
+        absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
+      );
+    } else if (href.startsWith("/") && !href.startsWith("//")) {
+      // Got to fake the domain to sensible extract the .search and .hash
+      const absoluteURL = new URL(href, "http://www.example.com");
+      const hrefNormalized = href.split("#")[0];
+      const found = Document.findByURL(hrefNormalized);
+      if (!found) {
+        // Before we give up, check if it's a redirect
+        const resolved = Redirect.resolve(hrefNormalized);
+        if (resolved) {
+          // Just because it's a redirect doesn't mean it ends up
+          // on a page we have.
+          // For example, there might be a redirect but where it
+          // goes to is not in this.allTitles.
+          // This can happen if it's a "fundamental redirect" for example.
+          const finalDocument = Document.findByURL(resolved);
+          addBrokenLink(
+            a,
+            checked.get(href),
+            href,
+            finalDocument
+              ? finalDocument.url + absoluteURL.search + absoluteURL.hash
+              : null
+          );
+        } else {
+          addBrokenLink(a, href);
+        }
+      } else {
+        // But does it have the correct case?!
+        if (found.url !== href.split("#")[0]) {
+          // Inconsistent case.
+          addBrokenLink(
+            a,
+            checked.get(href),
+            href,
+            found.url + absoluteURL.search + absoluteURL.hash
+          );
+        }
+      }
+    }
+  });
+  if (
+    level === FLAW_LEVELS.ERROR &&
+    doc.flaws.broken_links &&
+    doc.flaws.broken_links.length
+  ) {
+    throw new Error(
+      `broken_links flaws: ${doc.flaws.broken_links.map(JSON.stringify)}`
+    );
+  }
+}
+
+// Bad BCD queries are when the `<div class="bc-data">` tags have an
+// ID (or even lack the `id` attribute) that don't match anything in the
+// @mdn/browser-compat-data package. E.g. Something like this:
+//
+//    <div class="bc-data" id="bcd:never.ever.heard.of">
+//
+function injectBadBCDQueriesFlaws(level, doc, $) {
+  if (level === FLAW_LEVELS.IGNORE) return;
+
+  $("div.bc-data").each((i, element) => {
+    const dataQuery = $(element).attr("id");
+    if (!dataQuery) {
+      if (!("bad_bcd_queries" in doc.flaws)) {
+        doc.flaws.bad_bcd_queries = [];
+      }
+      doc.flaws.bad_bcd_queries.push({
+        id: `bad_bcd_queries${doc.flaws.bad_bcd_queries.length}`,
+        explanation: "BCD table without an ID",
+        suggestion: null,
+      });
+    } else {
+      const query = dataQuery.replace(/^bcd:/, "");
+      const { data } = packageBCD(query);
+      if (!data) {
         if (!("bad_bcd_queries" in doc.flaws)) {
           doc.flaws.bad_bcd_queries = [];
         }
         doc.flaws.bad_bcd_queries.push({
           id: `bad_bcd_queries${doc.flaws.bad_bcd_queries.length}`,
-          explanation: "BCD table without an ID",
+          explanation: `No BCD data for query: ${query}`,
           suggestion: null,
         });
-      } else {
-        const query = dataQuery.replace(/^bcd:/, "");
-        const { data } = packageBCD(query);
-        if (!data) {
-          if (!("bad_bcd_queries" in doc.flaws)) {
-            doc.flaws.bad_bcd_queries = [];
-          }
-          doc.flaws.bad_bcd_queries.push({
-            id: `bad_bcd_queries${doc.flaws.bad_bcd_queries.length}`,
-            explanation: `No BCD data for query: ${query}`,
-            suggestion: null,
-          });
-        }
       }
-    });
-    if (options.flawLevels.get("broken_links") === FLAW_LEVELS.ERROR) {
-      throw new Error(
-        `bad_bcd_queries flaws: ${doc.flaws.bad_bcd_queries.map(
-          (f) => f.explanation
-        )}`
-      );
     }
+  });
+  if (
+    level === FLAW_LEVELS.ERROR &&
+    doc.flaws.bad_bcd_queries &&
+    doc.flaws.bad_bcd_queries.length
+  ) {
+    throw new Error(
+      `bad_bcd_queries flaws: ${doc.flaws.bad_bcd_queries.map(
+        (f) => f.explanation
+      )}`
+    );
   }
 }
 

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -23,6 +23,13 @@ function injectFlaws(doc, $, options, { rawContent }) {
   );
 
   injectBadBCDQueriesFlaws(options.flawLevels.get("bad_bcd_queries"), doc, $);
+
+  injectPreWithHTMLFlaws(
+    options.flawLevels.get("pre_with_html"),
+    doc,
+    $,
+    rawContent
+  );
 }
 
 // The 'broken_links' flaw check looks for internal links that
@@ -200,6 +207,106 @@ function injectBadBCDQueriesFlaws(level, doc, $) {
   }
 }
 
+// Over the years, we've accumulated a lot of Kuma-HTML where the <pre> tags
+// are actually full of HTML. Almost exclusively we've observed <pre> tags whose
+// content is the HTML produced by Prism in the browser. Instead, in these cases,
+// we should just have the code that it will syntax highlight.
+// Note! Having HTML in a <pre> tag is nothing weird or wrong. But if you have
+//
+//  <pre class="language-js">
+//    <code class="language-js">
+//     <span class="keyword">foo</span>
+//   </code>
+//  </pre>
+//
+// It's better just have the text itself inside the <pre> block:
+//  <pre class="language-js">
+//    foo
+//  </pre>
+//
+// This makes it easier to edit the code in raw form. It also makes it less
+// heavy because any HTML will be replaced with Prism HTML anyway.
+function injectPreWithHTMLFlaws(level, doc, $, rawContent) {
+  if (level === FLAW_LEVELS.IGNORE) return;
+
+  function escapeHTML(s) {
+    return s
+      .replace(/&/g, "&amp;")
+      .replace(/"/g, "&quot;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
+
+  function addFlaw($pre) {
+    if (!("pre_with_html" in doc.flaws)) {
+      doc.flaws.pre_with_html = [];
+    }
+
+    const id = `pre_with_html${doc.flaws.pre_with_html.length + 1}`;
+    const explanation = `<pre><code>CODE can be just <pre>CODE`;
+    const suggestion = escapeHTML($pre.text());
+
+    let fixable = false;
+    let html = $pre.html();
+    if (rawContent.includes(html)) {
+      fixable = true;
+    } else {
+      // Many times, the HTML found in the sources is what Cheerio would
+      // serialize as HTML but with the small difference that some entities
+      // are unnecessarily HTML encoded as entities. So, we try to ignore
+      // that and see if we can match it as serialized.
+      const htmlFixed = html.replace(/&apos;/g, "'");
+      if (rawContent.includes(htmlFixed)) {
+        html = htmlFixed;
+        fixable = true;
+      }
+    }
+
+    const flaw = { explanation, id, fixable, html, suggestion };
+
+    if (fixable) {
+      // Only if it's fixable, is the `html` perfectly findable in the raw content.
+      for (const { line, column } of findMatchesInText(html, rawContent)) {
+        flaw.line = line;
+        flaw.column = column;
+      }
+    }
+
+    // Actually mutate the cheerio instance so we benefit from the
+    // flaw detection immediately.
+    // Note that `$pre.text()` might contain unescaped HTML, but Cheerio will
+    // take care of that.
+    $pre.html(suggestion); // strips all other HTML but preserves whitespace
+    $pre.attr("data-flaw", id);
+
+    doc.flaws.pre_with_html.push(flaw);
+  }
+
+  // Matches all <code> that are preceded by
+  // a <pre class="...brush...">
+  // Note, when we (in Node) syntax highlight code, the first thing
+  // we look for is the `$("pre[class*=brush]")` selector.
+  // Note, in jQuery you can do `$("pre + code")` which means it only selects
+  // the `<code>` tags that are *immediately preceeding*. This is not supported
+  // in Cheerio :( but the `>` operator works. And since we're only looking
+  // at a specific classname on the <pre> the chances of picking up the wrong
+  // selectors is small.
+  $("pre[class*=brush] > code").each((i, element) => {
+    const $pre = $(element).parent();
+    addFlaw($pre);
+  });
+
+  if (
+    level === FLAW_LEVELS.ERROR &&
+    doc.flaws.pre_with_html &&
+    doc.flaws.pre_with_html.length
+  ) {
+    throw new Error(
+      `pre_with_html flaws: ${doc.flaws.pre_with_html.map(JSON.stringify)}`
+    );
+  }
+}
+
 async function fixFixableFlaws(doc, options, document) {
   if (!options.fixFlaws || document.isArchive) return;
 
@@ -229,7 +336,6 @@ async function fixFixableFlaws(doc, options, document) {
           )
         );
       }
-      // flaw.fixed = !options.fixFlawsDryRun;
     }
   }
 
@@ -253,6 +359,24 @@ async function fixFixableFlaws(doc, options, document) {
           )} to ${chalk.white.bold(flaw.suggestion)}`
         )
       );
+    }
+  }
+
+  // Any 'pre_with_html' with a suggestion...
+  for (const flaw of doc.flaws.pre_with_html || []) {
+    if (!flaw.suggestion || !flaw.fixable) {
+      continue;
+    }
+
+    if (!newRawHTML.includes(flaw.html)) {
+      throw new Error(`rawHTML doesn't contain flaw HTML (${flaw.html})`);
+    }
+    // It's not feasible to pin point exactly which `<pre>` tag this
+    // refers to, so do the same query we use when we find the
+    // flaw, but this time actually make the mutation.
+    newRawHTML = newRawHTML.replace(flaw.html, flaw.suggestion);
+    if (loud) {
+      console.log(chalk.grey(`Fixed pre_with_html`));
     }
   }
 

--- a/build/index.js
+++ b/build/index.js
@@ -242,7 +242,14 @@ async function buildDocument(document, documentOptions = {}) {
   const fileAttachments = checkImageReferences(doc, $, options, document);
 
   // With the sidebar out of the way, go ahead and check the rest
-  injectFlaws(doc, $, options, document);
+  try {
+    injectFlaws(doc, $, options, document);
+  } catch (error) {
+    console.warn(
+      `Injecting flaws into ${document.fileInfo.path} (${document.url}) failed.`
+    );
+    throw error;
+  }
 
   // If fixFlaws is on and the doc has fixable flaws, this returned
   // raw HTML string will be different.

--- a/client/src/document/types.tsx
+++ b/client/src/document/types.tsx
@@ -33,6 +33,12 @@ export interface ImageReferenceFlaw extends GenericFlaw {
 
 export interface BadBCDQueryFlaw extends GenericFlaw {}
 
+export interface PreWithHTMLFlaw extends GenericFlaw {
+  html: string;
+  line?: number;
+  column?: number;
+}
+
 export interface MacroErrorMessage extends GenericFlaw {
   name: string;
   error: {
@@ -54,6 +60,7 @@ type Flaws = {
   bad_bcd_queries: BadBCDQueryFlaw[];
   bad_bcd_links: BadBCDLinkFlaw[];
   images: ImageReferenceFlaw[];
+  pre_with_html: PreWithHTMLFlaw[];
 };
 
 export type Translation = {

--- a/client/src/flaw-utils.js
+++ b/client/src/flaw-utils.js
@@ -10,6 +10,7 @@ export function humanizeFlawName(name) {
     // function.
     bad_bcd_queries: "Bad BCD queries",
     bad_bcd_links: "Bad BCD links",
+    pre_with_html: "<pre> with HTML",
   };
   function fallback() {
     return name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, " ");

--- a/testing/content/files/en-us/learn/some_code/index.html
+++ b/testing/content/files/en-us/learn/some_code/index.html
@@ -1,0 +1,40 @@
+---
+title: A page with some code
+slug: Learn/Some_code
+---
+
+<p>First some &lt;pre&gt; blocks that are not peppered with HTML</p>
+<pre class="brush: css">    * {box-sizing: border-box;}
+
+    .wrapper &gt; div {
+        border-radius: 5px;
+        background-color: rgb(207,232,220);
+        padding: 1em;
+    }
+</pre>
+
+<pre class="brush: html">&lt;div class="wrapper"&gt;
+    &lt;div class="box1"&gt;One&lt;/div&gt;
+    &lt;div class="box2"&gt;Two&lt;/div&gt;
+    &lt;div class="box3"&gt;Three&lt;/div&gt;
+&lt;/div&gt;
+</pre>
+
+
+<p>A real example found in the Kuma-HTML source.<br>
+What the original author should have done is it to put the (html escaped)
+raw JS code in there. Not the HTML you get from Prism.
+</p>
+
+<pre class="brush: js line-numbers  language-js"><code><span class="token comment">// Display list of all BookInstances.</span>
+exports<span class="token punctuation">.</span><span class="token function-variable function">bookinstance_list</span> <span class="token operator">=</span> <span class="token keyword">function</span><span class="token punctuation">(</span><span class="token parameter">req<span class="token punctuation">,</span> res<span class="token punctuation">,</span> next</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+
+  BookInstance<span class="token punctuation">.</span><span class="token function">find</span><span class="token punctuation">(</span><span class="token punctuation">)</span>
+    <span class="token punctuation">.</span><span class="token function">populate</span><span class="token punctuation">(</span><span class="token string">'book'</span><span class="token punctuation">)</span>
+    <span class="token punctuation">.</span><span class="token function">exec</span><span class="token punctuation">(</span><span class="token keyword">function</span> <span class="token punctuation">(</span><span class="token parameter">err<span class="token punctuation">,</span> list_bookinstances</span><span class="token punctuation">)</span> <span class="token punctuation">{</span>
+      <span class="token keyword">if</span> <span class="token punctuation">(</span>err<span class="token punctuation">)</span> <span class="token punctuation">{</span> <span class="token keyword">return</span> <span class="token function">next</span><span class="token punctuation">(</span>err<span class="token punctuation">)</span><span class="token punctuation">;</span> <span class="token punctuation">}</span>
+      <span class="token comment">// Successful, so render</span>
+      res<span class="token punctuation">.</span><span class="token function">render</span><span class="token punctuation">(</span><span class="token string">'bookinstance_list'</span><span class="token punctuation">,</span> <span class="token punctuation">{</span> title<span class="token operator">:</span> <span class="token string">'Book Instance List'</span><span class="token punctuation">,</span> bookinstance_list<span class="token operator">:</span> list_bookinstances <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+    <span class="token punctuation">}</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+
+<span class="token punctuation">}</span><span class="token punctuation">;</span></code></pre>

--- a/testing/content/files/en-us/web/fixable_flaws/pre_with_html/index.html
+++ b/testing/content/files/en-us/web/fixable_flaws/pre_with_html/index.html
@@ -1,0 +1,8 @@
+---
+title: Fixable flawed <pre> tags with HTML
+slug: Web/Fixable_Flaws/Pre_with_html
+---
+
+<p>Fixable pre tag...</p>
+<pre class="brush: html notranslate"><code><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>pre</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>code</span><span class="token punctuation">&gt;</span></span>code
+</code></pre>

--- a/testing/tests/destructive.test.js
+++ b/testing/tests/destructive.test.js
@@ -97,7 +97,7 @@ describe("fixing flaws", () => {
     const dryRunNotices = stdout
       .split("\n")
       .filter((line) => regexPattern.test(line));
-    expect(dryRunNotices.length).toBe(2);
+    expect(dryRunNotices.length).toBe(3);
     expect(dryRunNotices[1]).toContain(pattern);
     expect(dryRunNotices[0]).toContain(path.join(pattern, "images"));
     const dryrunFiles = getChangedFiles(tempContentDir);
@@ -122,14 +122,22 @@ describe("fixing flaws", () => {
     expect(stdout).toContain(pattern);
 
     const files = getChangedFiles(tempContentDir);
-    expect(files.length).toBe(2);
+    expect(files.length).toBe(3);
     const imagesFile = files.find((f) =>
       f.includes(path.join(pattern, "images"))
     );
     const newRawHtmlImages = fs.readFileSync(imagesFile, "utf-8");
     expect(newRawHtmlImages).toContain('src="fixable.png"');
 
-    const regularFile = files.find((f) => f !== imagesFile);
+    const preWithHTMLFile = files.find((f) =>
+      f.includes(path.join(pattern, "pre_with_html"))
+    );
+    const newRawHtmlPreWithHTML = fs.readFileSync(preWithHTMLFile, "utf-8");
+    expect(newRawHtmlPreWithHTML).not.toContain("<code>");
+
+    const regularFile = files.find(
+      (f) => f !== imagesFile && f !== preWithHTMLFile
+    );
     const newRawHtml = fs.readFileSync(regularFile, "utf-8");
     expect(newRawHtml).toContain("{{CSSxRef('number')}}");
     expect(newRawHtml).toContain('{{htmlattrxref("href", "a")}}');

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -527,6 +527,28 @@ test("detect bad_bcd_links flaws from", () => {
   expect(flaw.query).toBe("api.Document.visibilityState");
 });
 
+test("detect pre_with_html flaws", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "learn",
+    "some_code"
+  );
+  expect(fs.existsSync(builtFolder)).toBeTruthy();
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.flaws.pre_with_html.length).toBe(1);
+  const flaw = doc.flaws.pre_with_html[0];
+  expect(flaw.explanation).toBe("<pre><code>CODE can be just <pre>CODE");
+  expect(flaw.id).toBeTruthy();
+  expect(flaw.fixable).toBe(true);
+  expect(flaw.html).toBeTruthy();
+  expect(flaw.suggestion).toBeTruthy();
+  expect(flaw.line).toBe(29);
+  expect(flaw.column).toBe(50);
+});
+
 test("image flaws", () => {
   const builtFolder = path.join(buildRoot, "en-us", "docs", "web", "images");
   const jsonFile = path.join(builtFolder, "index.json");


### PR DESCRIPTION
~This PR is a draft because it builds [on top of this refactoring PR](https://github.com/mdn/yari/pull/1410). That's why, at the time of writing, the diff looks huge.~

---------------



Fixes #1404

This got a bit more involved than I had hoped. 
Nevertheless, we have [over 200 documents](https://gist.github.com/peterbe/291c10e81976433f15aac6b2fad864fe) whose Kuma-HTML source is the Prism escaped HTML inside the `<pre>` tag rather than just the code itself. So some way, we have to tackle that. 

To test this, find one of the pages in https://gist.github.com/peterbe/291c10e81976433f15aac6b2fad864fe and view it on localhost:3000. 
It should pop up as a flaw and it should say it's fixable. E.g.
<img width="911" alt="Screen Shot 2020-10-09 at 12 37 13 PM" src="https://user-images.githubusercontent.com/26739/95609084-2b866980-0a2c-11eb-9a6e-d95245b97ba4.png">

When you press the "Fix fixable flaw" the page should render perfectly the same as before. 
But when you dig into the edit it did inside `$CONTENT_ROOT` on this page, you should see something like this:
```diff
diff --git a/files/en-us/web/api/speechsynthesisutterance/pitch/index.html b/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
index 1672eb37..e8aa016e 100644
--- a/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
+++ b/files/en-us/web/api/speechsynthesisutterance/pitch/index.html
@@ -30,13 +30,13 @@ speechSynthesisUtteranceInstance.pitch = 1.5;
 
 <h2 id="Examples">Examples</h2>
 
-<pre class="brush: js"><code class="language-js"><span class="keyword token">var</span> synth <span class="operator token">=</span> window<span class="punctuation token">.</span>speechSynthesis<span class="punctuation token">;</span>
+<pre class="brush: js">var synth = window.speechSynthesis;
 
-<span class="keyword token">var</span> inputForm <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'form'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> inputTxt <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'input'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
-<span class="keyword token">var</span> voiceSelect <span class="operator token">=</span> document<span class="punctuation token">.</span><span class="function token">querySelector</span><span class="punctuation token">(</span><span class="string token">'select'</span><span class="punctuation token">)</span><span class="punctuation token">;</span>
+var inputForm = document.querySelector('form');
+var inputTxt = document.querySelector('input');
+var voiceSelect = document.querySelector('select');
 
-<span class="keyword token">var</span> voices <span class="operator token">=</span> synth<span class="punctuation token">.</span><span class="function token">getVoices</span><span class="punctuation token">(</span><span class="punctuation token">)</span><span class="punctuation token">;</span></code>
+var voices = synth.getVoices();
 
   ...
 

```
Or, if viewed in raw:
```html
<pre class="brush: js">var synth = window.speechSynthesis;

var inputForm = document.querySelector('form');
var inputTxt = document.querySelector('input');
var voiceSelect = document.querySelector('select');

var voices = synth.getVoices();

  ...

inputForm.onsubmit = function(event) {
  event.preventDefault();

  var utterThis = new SpeechSynthesisUtterance(inputTxt.value);
  var selectedOption = voiceSelect.selectedOptions[0].getAttribute('data-name');
  for(i = 0; i &lt; voices.length ; i++) {
    if(voices[i].name === selectedOption) {
      utterThis.voice = voices[i];
    }
  }
  utterThis.pitch = 1.5;
  synth.speak(utterThis);
  inputTxt.blur();
}</pre>
```
Note that the little `<` character is HTML escaped in the final new raw Kuma-HTML. 
