### PR TITLE
Download of fixable flaw images should be lowercased

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -252,7 +252,10 @@ async function fixFixableFlaws(doc, options, document) {
         });
         const destination = path.join(
           Document.getFolderPath(document.metadata),
-          path.basename(url.pathname)
+          path
+            .basename(decodeURI(url.pathname))
+            .replace(/\s+/g, "_")
+            .toLowerCase()
         );
         fs.writeFileSync(destination, imageBuffer);
         console.log(`Downloaded ${flaw.src} to ${destination}`);


### PR DESCRIPTION
Fixes #1412

I opened http://localhost:3000/en-US/docs/Learn/Server-side/First_steps/Client-Server_overview#_flaws
and it complained about 2 external images. Both images's names had uppercase characters and whitespace (URL encoded).
Now, when you press the "Fix fixable flaws" button and then check what it did to $CONTENT_ROOT, you'll find:

```
▶ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   files/en-us/learn/server-side/first_steps/client-server_overview/index.html

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	files/en-us/learn/server-side/first_steps/client-server_overview/basic_static_app_server.png
	files/en-us/learn/server-side/first_steps/client-server_overview/web_application_with_html_and_steps.png

no changes added to commit (use "git add" and/or "git commit -a")
```

And the HTML diff becomes:

```diff
diff --git a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
index 8e189b17..93ebcb01 100644
--- a/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
+++ b/files/en-us/learn/server-side/first_steps/client-server_overview/index.html
@@ -35,7 +35,7 @@ tags:
 
 <h2 id="Web_servers_and_HTTP_a_primer">Web servers and HTTP (a primer)</h2>
 
-<p>Web browsers communicate with <a href="https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_web_server">web servers</a> using the <strong>H</strong>yper<strong>T</strong>ext <strong>T</strong>ransfer <strong>P</strong>rotocol (<a href="/en-US/docs/Web/HTTP">HTTP</a>). When you click a link on a web page, submit a form, or run a search, the browser sends an <em>HTTP Request</em> to the server.</p>
+<p>Web browsers communicate with <a href="/en-US/docs/Learn/Common_questions/What_is_a_web_server">web servers</a> using the <strong>H</strong>yper<strong>T</strong>ext <strong>T</strong>ransfer <strong>P</strong>rotocol (<a href="/en-US/docs/Web/HTTP">HTTP</a>). When you click a link on a web page, submit a form, or run a search, the browser sends an <em>HTTP Request</em> to the server.</p>
 
 <p>This request includes:</p>
 
@@ -216,7 +216,7 @@ Content-Length: 0
 
 <p>Let's recap on how this works, by looking again at the static site architecture diagram we looked at in the last article.</p>
 
-<p><img alt="A simplified diagram of a static web server." src="https://mdn.mozillademos.org/files/13841/Basic%20Static%20App%20Server.png"></p>
+<p><img alt="A simplified diagram of a static web server." src="basic_static_app_server.png"></p>
 
 <p>When a user wants to navigate to a page, the browser sends an HTTP <code>GET</code> request specifying the URL of its HTML page. The server retrieves the requested document from its file system and returns an HTTP response containing the document and an <a href="/en-US/docs/Web/HTTP/Status">HTTP Response status code</a> of "<code>200 OK</code>" (indicating success). The server might return a different status code, for example "<code>404 Not Found</code>" if the file is not present on the server, or "<code>301 Moved Permanently</code>" if the file exists but has been redirected to a different location.</p>
 
@@ -238,7 +238,7 @@ Content-Length: 0
 
 <p>The diagram below shows the main elements of the "team coach" website, along with numbered labels for the sequence of operations when the coach accesses their "best team" list. The parts of the site that make it dynamic are the <em>Web Application</em> (this is how we will refer to the server-side code that processes HTTP requests and returns HTTP responses), the <em>Database</em>, which contains information about players, teams, coaches and their relationships, and the <em>HTML Templates</em>.</p>
 
-<p><img alt="This is a diagram of a simple web server with step numbers for each of step of the client-server interaction." src="https://mdn.mozillademos.org/files/13829/Web%20Application%20with%20HTML%20and%20Steps.png" style="height: 584px; width: 1226px;"></p>
+<p><img alt="This is a diagram of a simple web server with step numbers for each of step of the client-server interaction." src="web_application_with_html_and_steps.png" style="height: 584px; width: 1226px;"></p>
 
 <p>After the coach submits the form with the team name and number of players, the sequence of operations is:</p>
 

```