### PR TITLE
CLI tool to add redirects

### DIFF
--- a/redirects/cli.js
+++ b/redirects/cli.js
@@ -3,6 +3,7 @@ const program = require("@caporal/core").default;
 const chalk = require("chalk");
 
 const { add, resolve, load } = require("../content/redirect");
+const { VALID_LOCALES, Document } = require("../content");
 
 program
   .version("0.0.0")
@@ -36,12 +37,75 @@ program
   })
 
   .command("add", "Add a new redirect")
-  .option("--locale", "Which locale (defaults to 'en-US')")
-  .argument("<from>", "From-URL")
-  .argument("<to>", "To-URL")
+  .argument("<from>", "From-URL", {
+    validator: (value) => {
+      const locale = value.split("/")[1];
+      if (!locale || value.split("/")[2] !== "docs") {
+        throw new Error("The from-URL is expected to be /$locale/docs/");
+      }
+      const validValues = [...VALID_LOCALES.values()];
+      if (!validValues.includes(locale)) {
+        throw new Error(`'${locale}' not in ${validValues}`);
+      }
+      const document = Document.findByURL(value);
+      if (document) {
+        throw new Error(
+          `From-URL resolves to a file on disk (${document.fileInfo.path})`
+        );
+      }
+      const resolved = resolve(value);
+      if (resolved !== value) {
+        throw new Error(
+          `${value} is already matched as a redirect (to: '${resolved}')`
+        );
+      }
+      return value;
+    },
+  })
+  .argument("<to>", "To-URL", {
+    validator: (value) => {
+      // If it's not external, it has to go to a valid document
+      if (value.includes("://")) {
+        // If this throws, conveniently the validator will do its job.
+        const url = new URL(value);
+        if (url.protocol !== "https:") {
+          throw new Error("We only redirect to https://");
+        }
+      } else {
+        // Check that it's a valid document URL
+        const locale = value.split("/")[1];
+        if (!locale || value.split("/")[2] !== "docs") {
+          throw new Error("The from-URL is expected to be /$locale/docs/");
+        }
+        const validValues = [...VALID_LOCALES.values()];
+        if (!validValues.includes(locale)) {
+          throw new Error(`'${locale}' not in ${validValues}`);
+        }
+
+        // Can't point to something that redirects to something
+        const resolved = resolve(value);
+        if (resolved !== value) {
+          throw new Error(
+            `${value} is already matched as a redirect (to: '${resolved}')`
+          );
+        }
+        // XXX Commented out because how else are going to be able
+        // redirect to archived documents.
+        // // It has to match a document
+        // const document = Document.findByURL(value);
+        // if (!document) {
+        //   throw new Error(
+        //     `To-URL has to resolve to a file on disk (${document.fileInfo.path})`
+        //   );
+        // }
+      }
+      return value;
+    },
+  })
   .action(({ args }) => {
     const { from, to } = args;
-    throw new Error(`not implemented yet ('${from}' → '${to}')`);
+
+    console.warn(chalk.yellow(`not implemented yet ('${from}' → '${to}')`));
   });
 
 program.run();

--- a/redirects/cli.js
+++ b/redirects/cli.js
@@ -2,8 +2,13 @@
 const program = require("@caporal/core").default;
 const chalk = require("chalk");
 
-const { add, resolve, load } = require("../content/redirect");
-const { VALID_LOCALES, Document } = require("../content");
+const {
+  add,
+  resolve,
+  load,
+  validateFromURL,
+  validateToURL,
+} = require("../content/redirect");
 
 program
   .version("0.0.0")
@@ -39,73 +44,21 @@ program
   .command("add", "Add a new redirect")
   .argument("<from>", "From-URL", {
     validator: (value) => {
-      const locale = value.split("/")[1];
-      if (!locale || value.split("/")[2] !== "docs") {
-        throw new Error("The from-URL is expected to be /$locale/docs/");
-      }
-      const validValues = [...VALID_LOCALES.values()];
-      if (!validValues.includes(locale)) {
-        throw new Error(`'${locale}' not in ${validValues}`);
-      }
-      const document = Document.findByURL(value);
-      if (document) {
-        throw new Error(
-          `From-URL resolves to a file on disk (${document.fileInfo.path})`
-        );
-      }
-      const resolved = resolve(value);
-      if (resolved !== value) {
-        throw new Error(
-          `${value} is already matched as a redirect (to: '${resolved}')`
-        );
-      }
+      validateFromURL(value);
       return value;
     },
   })
   .argument("<to>", "To-URL", {
     validator: (value) => {
-      // If it's not external, it has to go to a valid document
-      if (value.includes("://")) {
-        // If this throws, conveniently the validator will do its job.
-        const url = new URL(value);
-        if (url.protocol !== "https:") {
-          throw new Error("We only redirect to https://");
-        }
-      } else {
-        // Check that it's a valid document URL
-        const locale = value.split("/")[1];
-        if (!locale || value.split("/")[2] !== "docs") {
-          throw new Error("The from-URL is expected to be /$locale/docs/");
-        }
-        const validValues = [...VALID_LOCALES.values()];
-        if (!validValues.includes(locale)) {
-          throw new Error(`'${locale}' not in ${validValues}`);
-        }
-
-        // Can't point to something that redirects to something
-        const resolved = resolve(value);
-        if (resolved !== value) {
-          throw new Error(
-            `${value} is already matched as a redirect (to: '${resolved}')`
-          );
-        }
-        // XXX Commented out because how else are going to be able
-        // redirect to archived documents.
-        // // It has to match a document
-        // const document = Document.findByURL(value);
-        // if (!document) {
-        //   throw new Error(
-        //     `To-URL has to resolve to a file on disk (${document.fileInfo.path})`
-        //   );
-        // }
-      }
+      validateToURL(value);
       return value;
     },
   })
-  .action(({ args }) => {
+  .action(({ args, logger }) => {
     const { from, to } = args;
-
-    console.warn(chalk.yellow(`not implemented yet ('${from}' → '${to}')`));
+    const locale = from.split("/")[1];
+    add(locale, from, to);
+    logger.info(chalk.green(`Saved '${from}' → '${to}'`));
   });
 
 program.run();


### PR DESCRIPTION
@fiji-flo I'm deliberately pushing this to the `mdn` repo so you can take over. 

Part of #1418

I think I'm off to a good start here :) 
But it's not working yet. 

I think it's a noble goal that you can add redirects to the `_redirects.txt` file *either* from a CLI or some web form we build into the Toolbar (todo) which means it'll be executed via the `server`. I.e. CLI or server should just be wrappers to these core functions. 
But also, the eventual goal is a tool (CLI or web form) that helps you *move* documents. That'll build on the underlying functions for adding redirects. In fact, that's filed specifically as: https://github.com/mdn/yari/issues/1379

Can you please take over this branch and complete it? Or, we finish it here first and then you can start afresh on the `move` part tool. If you want to discard my work and start afresh I'm totally fine with that. Otherwise, feel free to keep pushing to this branch but be aware that if we eventually "Squash and merge" it will all be committed under *my* name despite your hard work. 

Here's what's currently missing from this humble start:

1. The `git diff` on mdn/content `files/en-us/_redirects.txt` is weird. I think it's because I don't understand how the transitivePairs are supposed to work. 
2. There are no end-to-end tests at all of this stuff. I'm not sure they need to be comprehensive but it would be cool to have a couple of lines that run `yarn redirects add A B` in a bash script maybe. 
