### PR TITLE
make findByURL smarter with hashes

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -249,7 +249,14 @@ function del(folder) {
   updateWikiHistory(path.join(CONTENT_ROOT, metadata.locale), metadata.slug);
 }
 
-const findByURL = (url, ...args) => read(urlToFolderPath(url), ...args);
+function findByURL(url, ...args) {
+  const [bareURL, hash = ""] = url.split("#", 2);
+  const doc = read(urlToFolderPath(bareURL), ...args);
+  if (doc && hash) {
+    doc.url = `${doc.url}#${hash}`;
+  }
+  return doc;
+}
 
 function findAll(
   { files, folderSearch } = { files: new Set(), folderSearch: null }


### PR DESCRIPTION
Fixes #1383

This is my backward way of reviewing https://github.com/mdn/yari/pull/1449
My first instinct was that it's weird that a *folder* has a hash in it. It's not weird that a URL has a hash in it.
I think it makes sense for the call of `Document.findByURL('/en-us/docs/foo#bar')` but that's also the only time it makes sense. In your PR, you replaced every `read()` with `readWithHash` which felt like a solution to a problem that didn't exist. 

Also, there's a breakage of logic here:
```javascript
  const doc = read(folder);
  if (hash) {
    doc.url = `${doc.url}#${hash}`;
```
because `read(folder)` can return `undefined`. See: https://github.com/mdn/yari/blob/ed215461b28b24607160074113964cfd4855ae67/content/document.js#L150-L151
In my hack, I only reattach the `hash` back if the `read()` did indeed return a `Document` instance object thingy.