### PR TITLE
optimize breadcrumb data lookups

### DIFF
--- a/build/document-utils.js
+++ b/build/document-utils.js
@@ -5,9 +5,14 @@ const { Document } = require("../content");
  */
 function addBreadcrumbData(url, document) {
   const parents = [];
-  let split = url.split("/");
+  const split = url.split("/");
   let parentURL;
-  while (split.length > 2) {
+  // If the URL was something like `/en-US/docs/Foo/Bar` when you split
+  // that, the array becomes `['', 'en-US', 'docs', 'Foo', 'Bar']`
+  // And as length, that's `[1, 2, 3, 4, 5]`. Therefore, there's never
+  // any point of going for 1, 2, or 3 since that's just the home page
+  // which we don't ever include in the breadcrumb trail.
+  while (split.length > 4) {
     split.pop();
     parentURL = split.join("/");
     // This test makes it possible to "skip" certain URIs that might not


### PR DESCRIPTION
I noticed that if you look carefully at how that `while` loop works, for every document we ultimately end up doing:
```javascript
const parentDoc = Document.findByURL('/en-US/docs');
// and 
const parentDoc = Document.findByURL('/en-US');
```
That will never yield anything. Thankfully, the `Document.findByURL` is backed by `Document.read` which is memoized (in production) but it's still a waste if this fix is so easy. 

A good page to test it on that has a deep breadcrumb trail is: http://localhost:3000/en-US/docs/Games/Techniques/3D_on_the_web/Building_up_a_basic_demo_with_PlayCanvas/editor

Part of #1458