### PR TITLE
Exclude pages called Index in the Index macro

### DIFF
--- a/kumascript/macros/Index.ejs
+++ b/kumascript/macros/Index.ejs
@@ -51,6 +51,12 @@ function getPages(pageList) {
             if (urlsSeen.has(page.url)) {
                 continue;
             }
+            // Never include a page that is called "Index" because it's usually
+            // pointless since it's clearly the page you're already on.
+            // See https://github.com/mdn/yari/issues/1468
+            if (section + '/Index' === page.url) {
+                continue;
+            }
             urlsSeen.add(page.url);
             result.push({
                 title: page.title.replace(/</g,'&lt;').replace(/>/g,'&gt;'),


### PR DESCRIPTION
Fixes #1468

The page to test it on is http://localhost:3000/en-US/docs/WebAssembly/Index which makes it easy to see the before-and-after with `master`. 
Also, I think *this* will be easier to review once https://github.com/mdn/yari/pull/1469 is merged (and this branch is updated).