### PR TITLE
Run Lighthouse in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -42,31 +42,51 @@ jobs:
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
           yarn prepare-build
-          BUILD_FOLDERSEARCH=mdn/kitchensink yarn build
+          # BUILD_FOLDERSEARCH=mdn/kitchensink yarn build
           BUILD_FOLDERSEARCH=web/javascript/reference/global_objects/array/foreach yarn build
 
-      - name: Install and run lhci
+      # - name: Start static server
+      #   run: |
+
+      # #         yarn serve-ssr & npx wait-on http://localhost:3000/ping && lhci autorun \
+      # # --upload.target=temporary-public-storage \
+      # # --collect.url="http://localhost:3000/" \
+      # # --collect.numberOfRuns=3
+
+      - name: Serve and lhci
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         run: |
-          # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
-          # for other things you can set.
-          # The reason this file gets created on-the-fly here in the workflow instead
-          # of checked into the project is because right here is the only place
-          # where it's needed so there's little point is cluttering up the
-          # repo root.
-          cat > lighthouserc.js <<CONFIGURATION
-          module.exports = {
-            ci: {
-              collect: {
-                staticDistDir: 'client/build',
-              },
-              upload: {
-                target: 'temporary-public-storage',
-              },
-            },
-          };
-          CONFIGURATION
+          yarn start:static-server &
+          sleep 1
+          curl --retry-connrefused --retry 5 \
+            http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/ > /dev/null
 
-          npm install -g @lhci/cli@next
-          lhci autorun
+          # # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
+          # # for other things you can set.
+          # # The reason this file gets created on-the-fly here in the workflow instead
+          # # of checked into the project is because right here is the only place
+          # # where it's needed so there's little point is cluttering up the
+          # # repo root.
+          # cat > lighthouserc.js <<CONFIGURATION
+          # module.exports = {
+          #   ci: {
+          #     collect: {
+          #       staticDistDir: 'client/build',
+          #     },
+          #     upload: {
+          #       target: 'temporary-public-storage',
+          #     },
+          #   },
+          # };
+          # CONFIGURATION
+
+          # npm install -g @lhci/cli@next
+          # lhci autorun
+
+          # Note, we can supply multiple `--collect.url=...` to have lhci test
+          # a variety of URLs and then assume a average (or median?) across them.
+          lhci autorun \
+            --upload.target=temporary-public-storage \
+            --collect.url="http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/" \
+            --collect.numberOfRuns=3

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,70 @@
+name: Performance
+
+on:
+  pull_request:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: mdn/content
+          path: mdn/content
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "12"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install all yarn packages
+        run: |
+          ./testing/scripts/yarn-install.sh
+
+      - name: Build select important pages
+        run: |
+          # Remember, the mdn/content repo got cloned into `pwd` into a
+          # sub-folder called "mdn/content"
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          yarn prepare-build
+          BUILD_FOLDERSEARCH=mdn/kitchensink yarn build
+          BUILD_FOLDERSEARCH=web/javascript/reference/global_objects/array/foreach yarn build
+
+      - name: Install and run lhci
+        run: |
+          # Temp debugging
+          ls -lR client/build/
+
+          cat > lighthouserc.js <<CONFIGURATION
+          module.exports = {
+            ci: {
+              collect: {
+                staticDistDir: 'client/build',
+              },
+              upload: {
+                target: 'temporary-public-storage',
+              },
+            },
+          };
+          CONFIGURATION
+
+
+          # XXX Why can't this be `@next`?
+
+          npm install -g @lhci/cli@0.5.x
+          lhci autorun

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -46,6 +46,8 @@ jobs:
           BUILD_FOLDERSEARCH=web/javascript/reference/global_objects/array/foreach yarn build
 
       - name: Install and run lhci
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         run: |
           # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
           # for other things you can set.

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -45,14 +45,6 @@ jobs:
           # BUILD_FOLDERSEARCH=mdn/kitchensink yarn build
           BUILD_FOLDERSEARCH=web/javascript/reference/global_objects/array/foreach yarn build
 
-      # - name: Start static server
-      #   run: |
-
-      # #         yarn serve-ssr & npx wait-on http://localhost:3000/ping && lhci autorun \
-      # # --upload.target=temporary-public-storage \
-      # # --collect.url="http://localhost:3000/" \
-      # # --collect.numberOfRuns=3
-
       - name: Serve and lhci
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
@@ -84,9 +76,14 @@ jobs:
           # npm install -g @lhci/cli@next
           # lhci autorun
 
+          npm install -g @lhci/cli@next
+
           # Note, we can supply multiple `--collect.url=...` to have lhci test
           # a variety of URLs and then assume a average (or median?) across them.
+
+          # All options for "collect" here:
+          # https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
+
           lhci autorun \
             --upload.target=temporary-public-storage \
-            --collect.url="http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/" \
-            --collect.numberOfRuns=3
+            --collect.url="http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/"

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -47,9 +47,6 @@ jobs:
 
       - name: Install and run lhci
         run: |
-          # Temp debugging
-          ls -lR client/build/
-
           cat > lighthouserc.js <<CONFIGURATION
           module.exports = {
             ci: {
@@ -63,8 +60,5 @@ jobs:
           };
           CONFIGURATION
 
-
-          # XXX Why can't this be `@next`?
-
-          npm install -g @lhci/cli@0.5.x
+          npm install -g @lhci/cli@next
           lhci autorun

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -47,6 +47,12 @@ jobs:
 
       - name: Install and run lhci
         run: |
+          # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
+          # for other things you can set.
+          # The reason this file gets created on-the-fly here in the workflow instead
+          # of checked into the project is because right here is the only place
+          # where it's needed so there's little point is cluttering up the
+          # repo root.
           cat > lighthouserc.js <<CONFIGURATION
           module.exports = {
             ci: {

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          # Needed because of
+          # https://github.com/GoogleChrome/lighthouse-ci/issues/172
           ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/checkout@v2
@@ -56,28 +58,6 @@ jobs:
           curl --retry-connrefused --retry 5 \
             http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/ > /dev/null
 
-          # # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#collect
-          # # for other things you can set.
-          # # The reason this file gets created on-the-fly here in the workflow instead
-          # # of checked into the project is because right here is the only place
-          # # where it's needed so there's little point is cluttering up the
-          # # repo root.
-          # cat > lighthouserc.js <<CONFIGURATION
-          # module.exports = {
-          #   ci: {
-          #     collect: {
-          #       staticDistDir: 'client/build',
-          #     },
-          #     upload: {
-          #       target: 'temporary-public-storage',
-          #     },
-          #   },
-          # };
-          # CONFIGURATION
-
-          # npm install -g @lhci/cli@next
-          # lhci autorun
-
           npm install -g @lhci/cli@next
 
           # Note, we can supply multiple `--collect.url=...` to have lhci test
@@ -89,3 +69,8 @@ jobs:
           lhci autorun \
             --upload.target=temporary-public-storage \
             --collect.url="http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach/"
+
+          # TODO (as of Oct 2020)
+          # Once our Lighthouse score starts to not be so terrible, we can start
+          # adding assertions here.
+          # See https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/configuration.md#categories

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@caporal/core": "2.0.2",
     "@mdn/browser-compat-data": "2.0.3",
-    "@yari-internal/fundamental-redirects": "file:./libs/fundamental-redirects",
     "@yari-internal/constants": "file:./libs/constants",
+    "@yari-internal/fundamental-redirects": "file:./libs/fundamental-redirects",
     "braces": "^3.0.2",
     "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.3",

--- a/server/static.js
+++ b/server/static.js
@@ -3,12 +3,14 @@
  */
 
 const express = require("express");
+var compression = require("compression");
 
 const { staticMiddlewares } = require("./middlewares");
 const { resolveFundamental } = require("../content");
 
 const app = express();
 app.use(express.json());
+app.use(compression());
 
 app.use((req, res, next) => {
   // If we have a fundamental redirect mimic out Lambda@Edge and redirect.

--- a/server/static.js
+++ b/server/static.js
@@ -21,5 +21,10 @@ app.use((req, res, next) => {
 
 app.use(staticMiddlewares);
 
+// Used by CI to make sure the server is up and running
+app.get("/_ping", (req, res) => {
+  res.send("pong\n");
+});
+
 const PORT = parseInt(process.env.SERVER_PORT || "5000");
 app.listen(PORT, () => console.log(`Listening on port ${PORT}`));

--- a/server/static.js
+++ b/server/static.js
@@ -3,7 +3,7 @@
  */
 
 const express = require("express");
-var compression = require("compression");
+const compression = require("compression");
 
 const { staticMiddlewares } = require("./middlewares");
 const { resolveFundamental } = require("../content");
@@ -22,11 +22,6 @@ app.use((req, res, next) => {
 });
 
 app.use(staticMiddlewares);
-
-// Used by CI to make sure the server is up and running
-app.get("/_ping", (req, res) => {
-  res.send("pong\n");
-});
 
 const PORT = parseInt(process.env.SERVER_PORT || "5000");
 app.listen(PORT, () => console.log(`Listening on port ${PORT}`));


### PR DESCRIPTION
Fixes #274

Moved from https://github.com/mdn/yari/pull/1487
Because I need to run it from the `mdn` repo otherwise the `LHCI_GITHUB_APP_TOKEN` can't be used.