### PR TITLE
Don't lazy-load the banners at all

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -7,8 +7,7 @@ import { Document } from "./document";
 import Footer from "./footer";
 import Header from "./header";
 import { NoMatch } from "./routing";
-
-const ActiveBanner = lazy(() => import("./banners/active-banner"));
+import { ActiveBanner } from "./banners/active-banner";
 
 const AllFlaws = lazy(() => import("./flaws"));
 const DocumentEdit = lazy(() => import("./document/forms/edit"));
@@ -21,11 +20,7 @@ function Layout({ children }) {
     <>
       <Header />
       <section className="section">{children}</section>
-      {!isServer && (
-        <Suspense fallback={null}>
-          <ActiveBanner />
-        </Suspense>
-      )}
+      {!isServer && <ActiveBanner />}
       <Footer />
     </>
   );

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -1,21 +1,4 @@
-/**
- * This file defines a React Banner component that renders a
- * call-to-action banner fixed to the bottom of the screen. The props
- * of the Banner component allow customization of the title,
- * description and button call-to-action text of the banner, as well
- * as the URL of the page that clicking on the call-to-action button
- * takes the user to. The Banner component is not exported,
- * however. Instead, we export an ActiveBanner component that pages should
- * use. It loops through an array of banner IDs for the first banner that is enabled by
- * Waffle and has not been dismissed by the user. If it finds such a
- * banner, it displays it with a <Banner>. Otherwise, if none of the
- * specified banners is enabled, or if all enabled banners have been
- * recently dismissed, then it displays nothing.
- *
- * @flow
- */
-import * as React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import CloseIcon from "../kumastyles/general/close.svg";
 import { CATEGORY_MONTHLY_PAYMENTS, useGA } from "../ga-context";
@@ -200,8 +183,10 @@ function SubscriptionBanner() {
   );
 }
 
-export default function ActiveBanner() {
+export function ActiveBanner() {
   const userData = useUserData();
+
+  console.log("ActiveBanner", userData);
 
   if (!userData) {
     return null;


### PR DESCRIPTION
Fixes #1484

This way, you don't lazy load the .css and .js exclusively for banners at on-load. 
Perhaps it would make more sense to always load the CSS but lazy-load the JS. 