### PR TITLE
fix ks unit tests for mdn-fiori branch

### DIFF
--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -41,7 +41,7 @@ var titleAttrValue = mdn.localString({
     "en-US": "This API has not been standardized."
 });
 %>
-<svg class="icon experimental" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
+<svg class="icon nonStandard" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
     role="img">
     <title><%=titleAttrValue%></title>
     <path

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -41,7 +41,7 @@ var titleAttrValue = mdn.localString({
     "en-US": "This API has not been standardized."
 });
 %>
-<svg class="icon nonStandard" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
+<svg class="icon non-standard" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"
     role="img">
     <title><%=titleAttrValue%></title>
     <path

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -41,9 +41,10 @@ const expectedHTML = `<div class="index">
         <li>
             <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
-                <span title="This is an experimental API that should not be used in production code." class="icon-only-inline">
-                    <i class="icon-beaker"></i>
-                </span>
+              <svg class="icon experimental" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img">
+                <title>This is an experimental API that should not be used in production code.</title>
+                <path d="M90.72 82.34c4.4 7 1.29 12.66-7 12.66H16.25C8 95 4.88 89.31 9.28 82.34l29.47-46.46V12.5H35A3.75 3.75 0 0135 5h30a3.75 3.75 0 010 7.5h-3.75v23.38zM45.08 39.86L29.14 65h41.72L54.92 39.86l-1.17-1.81V12.5h-7.5v25.55z" />
+              </svg
             </span>
         </li>
         <li>
@@ -74,7 +75,7 @@ function compareNode(actual, expected) {
     actual.nodeName === "A" ||
     (actual.nodeName === "SPAN" && expected.textContent.trim())
   ) {
-    expect(actual.textContent).toEqual(expected.textContent);
+    expect(actual.textContent.trim()).toEqual(expected.textContent.trim());
   }
 }
 

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -101,14 +101,14 @@ const expectedMethods = {
         "The MyTestMethod1 property of the TestInterface interface is experimental.",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "MyTestMethod2",
       target: "/en-US/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      badges: ["experimental", "deprecated", "non-standard", "obsolete"],
       text: "MyTestMethod3",
       target: "/en-US/docs/Web/API/TestInterface/TestMethod3",
       title:
@@ -124,14 +124,14 @@ const expectedMethods = {
         "The MyTestMethod1 property of the TestInterface interface is experimental.",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "MyTestMethod2 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      badges: ["experimental", "deprecated", "non-standard", "obsolete"],
       text: "MyTestMethod3 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestMethod3",
       title:
@@ -147,14 +147,14 @@ const expectedMethods = {
         "The MyTestMethod1 property of the TestInterface interface is experimental (ja translation).",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "MyTestMethod2",
       target: "/ja/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
     },
     {
-      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      badges: ["experimental", "deprecated", "non-standard", "obsolete"],
       text: "MyTestMethod3",
       target: "/ja/docs/Web/API/TestInterface/TestMethod3",
       title:
@@ -173,7 +173,7 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges.",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "TestEvent2",
       target: "/en-US/docs/Web/API/TestInterface/TestEvent2",
       title:
@@ -196,7 +196,7 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges.",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "TestEvent2 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestEvent2",
       title:
@@ -219,7 +219,7 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges (ja translation).",
     },
     {
-      badges: ["deprecated", "nonStandard"],
+      badges: ["deprecated", "non-standard"],
       text: "TestEvent2",
       target: "/ja/docs/Web/API/TestInterface/TestEvent2",
       title:

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -94,27 +94,22 @@ const expectedProperties = {
 const expectedMethods = {
   "en-US": [
     {
-      badges: ["icon-beaker"],
-      text: " MyTestMethod1",
+      badges: ["experimental"],
+      text: "MyTestMethod1",
       target: "/en-US/docs/Web/API/TestInterface/TestMethod1",
       title:
         "The MyTestMethod1 property of the TestInterface interface is experimental.",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  MyTestMethod2",
+      badges: ["deprecated", "nonStandard"],
+      text: "MyTestMethod2",
       target: "/en-US/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-beaker",
-        "icon-thumbs-down-alt",
-        "icon-warning-sign",
-        "icon-trash",
-      ],
-      text: "    MyTestMethod3",
+      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      text: "MyTestMethod3",
       target: "/en-US/docs/Web/API/TestInterface/TestMethod3",
       title:
         "The MyTestMethod3 property of the TestInterface interface has all the badges.",
@@ -122,27 +117,22 @@ const expectedMethods = {
   ],
   fr: [
     {
-      badges: ["icon-beaker"],
-      text: " MyTestMethod1 [Traduire]",
+      badges: ["experimental"],
+      text: "MyTestMethod1 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestMethod1",
       title:
         "The MyTestMethod1 property of the TestInterface interface is experimental.",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  MyTestMethod2 [Traduire]",
+      badges: ["deprecated", "nonStandard"],
+      text: "MyTestMethod2 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-beaker",
-        "icon-thumbs-down-alt",
-        "icon-warning-sign",
-        "icon-trash",
-      ],
-      text: "    MyTestMethod3 [Traduire]",
+      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      text: "MyTestMethod3 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestMethod3",
       title:
         "The MyTestMethod3 property of the TestInterface interface has all the badges.",
@@ -150,27 +140,22 @@ const expectedMethods = {
   ],
   ja: [
     {
-      badges: ["icon-beaker"],
-      text: " MyTestMethod1",
+      badges: ["experimental"],
+      text: "MyTestMethod1",
       target: "/ja/docs/Web/API/TestInterface/TestMethod1",
       title:
         "The MyTestMethod1 property of the TestInterface interface is experimental (ja translation).",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  MyTestMethod2",
+      badges: ["deprecated", "nonStandard"],
+      text: "MyTestMethod2",
       target: "/ja/docs/Web/API/TestInterface/TestMethod2",
       title:
         "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
     },
     {
-      badges: [
-        "icon-beaker",
-        "icon-thumbs-down-alt",
-        "icon-warning-sign",
-        "icon-trash",
-      ],
-      text: "    MyTestMethod3",
+      badges: ["experimental", "deprecated", "nonStandard", "obsolete"],
+      text: "MyTestMethod3",
       target: "/ja/docs/Web/API/TestInterface/TestMethod3",
       title:
         "The MyTestMethod3 property of the TestInterface interface has all the badges (ja translation).",
@@ -188,8 +173,8 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges.",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  TestEvent2",
+      badges: ["deprecated", "nonStandard"],
+      text: "TestEvent2",
       target: "/en-US/docs/Web/API/TestInterface/TestEvent2",
       title:
         "The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard.",
@@ -211,8 +196,8 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges.",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  TestEvent2 [Traduire]",
+      badges: ["deprecated", "nonStandard"],
+      text: "TestEvent2 [Traduire]",
       target: "/fr/docs/Web/API/TestInterface/TestEvent2",
       title:
         "The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard.",
@@ -234,8 +219,8 @@ const expectedEvents = {
         "The MyTestEvent1 event of the TestInterface interface has no badges (ja translation).",
     },
     {
-      badges: ["icon-thumbs-down-alt", "icon-warning-sign"],
-      text: "  TestEvent2",
+      badges: ["deprecated", "nonStandard"],
+      text: "TestEvent2",
       target: "/ja/docs/Web/API/TestInterface/TestEvent2",
       title:
         "The MyTestEvent2 event of the TestInterface interface is deprecated and non-standard (ja translation).",
@@ -328,7 +313,7 @@ function checkInterfaceItem(actual, expected, config) {
     // If we are not on this page, the item contains a link
     // and the text contents includes a CTA if one should be present
     // (CTA is specified in the test data in the cases where it is expected)
-    expect(actual.textContent).toEqual(expected.text);
+    expect(actual.textContent).toContain(expected.text);
     const methodLink = actual.querySelector("a");
     expect(methodLink.href).toEqual(expected.target);
   } else {
@@ -336,15 +321,19 @@ function checkInterfaceItem(actual, expected, config) {
     // and the text contents omits the CTA
     const methodLink = actual.querySelector("a");
     expect(methodLink).toBeNull();
-    const methodName = actual.querySelector("i");
+    const methodName = actual.querySelector("svg");
     expect(actual.textContent).toContain(methodName.textContent);
   }
 
   // Test that the badges are what we expect
-  const badgeClasses = actual.querySelectorAll("i");
+  const badgeClasses = actual.querySelectorAll("svg");
   expect(badgeClasses.length).toEqual(expected.badges.length);
   for (let badgeClass of badgeClasses) {
-    expect(expected.badges).toContain(badgeClass.getAttribute("class"));
+    badgeClass.classList.forEach((value) => {
+      if (value !== "icon") {
+        expect(expected.badges).toContain(value);
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Fixes #1519 

@schalkneethling As part of fixing the unit tests, I noticed that the `NonStandardBadge.ejs` macro uses the `experimental` CSS class, but I suspect that should be something else. I changed it to use `nonStandard` instead (which my kumascript unit test changes assume as well), but let me know if that's incorrect.