### PR TITLE
Support Whatsdeployed

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -154,11 +154,6 @@ jobs:
           # would upload the whole content of client/build
           du -sh client/build
 
-      - name: Dump Whatsdeployed files
-        run: |
-          poetry run deployer whatsdeployed --output client/build/_whatsdeployed-code.json
-          poetry run deployer whatsdeployed --output client/build/_whatsdeployed-content.json $(pwd)/mdn/content/
-
       - name: Deploy with deployer
         run: |
           # Set the CONTENT_ROOT first
@@ -183,6 +178,10 @@ jobs:
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
 
           cd deployer
+
+          poetry run deployer whatsdeployed --output client/build/_whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output client/build/_whatsdeployed/content.json $CONTENT_ROOT
+
           export DEPLOYER_BUCKET_NAME=mdn-content-dev
           export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix }}
           export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload }}

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -156,8 +156,6 @@ jobs:
 
       - name: Dump Whatsdeployed files
         run: |
-          # Set the CONTENT_ROOT first
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
           poetry run deployer whatsdeployed --output client/build/_whatsdeployed-code.json
           poetry run deployer whatsdeployed --output client/build/_whatsdeployed-content.json $(pwd)/mdn/content/
 

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -154,6 +154,13 @@ jobs:
           # would upload the whole content of client/build
           du -sh client/build
 
+      - name: Dump Whatsdeployed files
+        run: |
+          # Set the CONTENT_ROOT first
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          poetry run deployer whatsdeployed --output client/build/_whatsdeployed-code.json
+          poetry run deployer whatsdeployed --output client/build/_whatsdeployed-content.json $(pwd)/mdn/content/
+
       - name: Deploy with deployer
         run: |
           # Set the CONTENT_ROOT first

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -179,8 +179,8 @@ jobs:
 
           cd deployer
 
-          poetry run deployer whatsdeployed --output client/build/_whatsdeployed/code.json
-          poetry run deployer whatsdeployed --output client/build/_whatsdeployed/content.json $CONTENT_ROOT
+          poetry run deployer whatsdeployed --output ../client/build/whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
 
           export DEPLOYER_BUCKET_NAME=mdn-content-dev
           export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix }}

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -179,7 +179,7 @@ jobs:
 
           cd deployer
 
-          poetry run deployer whatsdeployed --output ../client/build/whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
 
           export DEPLOYER_BUCKET_NAME=mdn-content-dev

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -72,7 +72,6 @@ def update_lambda_functions(ctx, directory):
 )
 @click.pass_context
 def whatsdeployed(ctx, directory: Path, output: str):
-    # TODO: `ctx.obj["dry_run"]` can't actually be set. Figure out why.
     dump_whatsdeployed(directory, Path(output), dry_run=ctx.obj["dry_run"])
 
 

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -71,9 +71,9 @@ def update_lambda_functions(ctx, directory):
     "directory", type=click.Path(), callback=validate_directory, default=".",
 )
 @click.pass_context
-def whatsdeployed(ctx, directory: Path, output: Path):
+def whatsdeployed(ctx, directory: Path, output: str):
     # TODO: `ctx.obj["dry_run"]` can't actually be set. Figure out why.
-    dump_whatsdeployed(directory, output, dry_run=ctx.obj["dry_run"])
+    dump_whatsdeployed(directory, Path(output), dry_run=ctx.obj["dry_run"])
 
 
 @cli.command()

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -12,6 +12,7 @@ from .constants import (
 )
 from .update_lambda_functions import update_all
 from .upload import upload_content
+from .whatsdeployed import dump as dump_whatsdeployed
 from .utils import log
 
 
@@ -54,6 +55,25 @@ def cli(ctx, **kwargs):
 def update_lambda_functions(ctx, directory):
     log.info(f"Deployer ({__version__})", bold=True)
     update_all(directory, dry_run=ctx.obj["dry_run"])
+
+
+@cli.command(
+    help="Create a whatsdeployed.json file "
+    "by asking git what the current HEAD sha is and what branch you're on."
+)
+@click.option(
+    "--output",
+    type=click.Path(),
+    help="Name of JSON file to create",
+    default="whatsdeployed.json",
+)
+@click.argument(
+    "directory", type=click.Path(), callback=validate_directory, default=".",
+)
+@click.pass_context
+def whatsdeployed(ctx, directory: Path, output: Path):
+    # TODO: `ctx.obj["dry_run"]` can't actually be set. Figure out why.
+    dump_whatsdeployed(directory, output, dry_run=ctx.obj["dry_run"])
 
 
 @cli.command()

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -59,7 +59,7 @@ def update_lambda_functions(ctx, directory):
 
 @cli.command(
     help="Create a whatsdeployed.json file "
-    "by asking git what the current HEAD sha is and what branch you're on."
+    "by asking git for the date and commit hash of HEAD."
 )
 @click.option(
     "--output",

--- a/deployer/src/deployer/whatsdeployed.py
+++ b/deployer/src/deployer/whatsdeployed.py
@@ -8,8 +8,10 @@ from .utils import log
 
 
 def dump(directory: Path, output: Path, dry_run=False):
+    command = "git log -n 1 --pretty=medium"
+    log.info(f"Executing {command!r} in {directory}")
     subprocess_result = subprocess.run(
-        "git log -n 1 --pretty=medium",
+        command,
         cwd=directory,
         shell=True,
         check=True,
@@ -30,6 +32,7 @@ def dump(directory: Path, output: Path, dry_run=False):
         if dry_run:
             log.info(f"Write {json.dumps(data)!r} to {output}")
         else:
+            output.parent.mkdir(parents=True, exist_ok=True)
             with open(output, "w") as f:
                 json.dump(data, f, indent=2)
             log.info(f"Wrote {json.dumps(data)!r} to {output}")

--- a/deployer/src/deployer/whatsdeployed.py
+++ b/deployer/src/deployer/whatsdeployed.py
@@ -1,0 +1,37 @@
+import json
+import subprocess
+from pathlib import Path
+
+import click
+
+from .utils import log
+
+
+def dump(directory: Path, output: Path, dry_run=False):
+    subprocess_result = subprocess.run(
+        "git log -n 1 --pretty=medium",
+        cwd=directory,
+        shell=True,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    commit: str = None
+    date: str = None
+
+    for line in subprocess_result.stdout.splitlines():
+        if line.startswith("commit "):
+            commit = line.split()[1]
+        elif line.startswith("Date:"):
+            date = line.split("Date:")[1].strip()
+
+    if date and commit:
+        data = {"commit": commit, "date": date}
+        if dry_run:
+            log.info(f"Write {json.dumps(data)!r} to {output}")
+        else:
+            with open(output, "w") as f:
+                json.dump(data, f, indent=2)
+            log.info(f"Wrote {json.dumps(data)!r} to {output}")
+    else:
+        raise click.ClickException("'commit' and 'date' not found in git log output")


### PR DESCRIPTION
Fixes #1527

This creates an S3 key `_whatsdeployed/code.json` and `_whatsdeployed/content.json` based on the git sha of `mdn/yari` and `mdn/content` respectively. 

Next is to go to https://whatsdeployed.io and generate the right URLs and share them somehow. Like we're doing in the README.md on kuma. 
However, we're not in production yet! But we'll have a dev URL at least and Whatsdeployed supports (and encourages) that you have multiple environments that compare against. 