### PR TITLE
how to treat the root index.html file

### DIFF
--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -154,6 +154,15 @@ jobs:
           # would upload the whole content of client/build
           du -sh client/build
 
+          # The root index.html file is never useful. It's not the "home page"
+          # because the home page is actually `/$locale/` since `/` is handled
+          # specifically by the CDN.
+          # The client/build/index.html is actually just a template from
+          # create-react-app, used to server-side render all the other pages.
+          # But we don't want to upload it S3. So, delete it before doing the
+          # deployment step.
+          rm client/build/index.html
+
       - name: Deploy with deployer
         run: |
           # Set the CONTENT_ROOT first

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -154,15 +154,6 @@ jobs:
           # would upload the whole content of client/build
           du -sh client/build
 
-          # The root index.html file is never useful. It's not the "home page"
-          # because the home page is actually `/$locale/` since `/` is handled
-          # specifically by the CDN.
-          # The client/build/index.html is actually just a template from
-          # create-react-app, used to server-side render all the other pages.
-          # But we don't want to upload it S3. So, delete it before doing the
-          # deployment step.
-          rm client/build/index.html
-
       - name: Deploy with deployer
         run: |
           # Set the CONTENT_ROOT first

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -282,15 +282,35 @@ class BucketManager:
         return result
 
     def iter_file_tasks(self, build_directory, for_counting_only=False):
+        # Prepare a computation of what the root /index.html file would be
+        # called as a S3 key. Do this once so it becomes a quicker operation
+        # later when we compare *each* generated key to see if it matches this.
+        root_index_html_as_key = self.get_key(
+            build_directory, build_directory / "index.html"
+        )
+
         # Walk the build_directory and yield file upload tasks.
         for fp in iterdir(build_directory):
             # Exclude any files that aren't artifacts of the build.
             if fp.name.startswith(".") or fp.name.endswith("~"):
                 continue
-            elif for_counting_only:
+
+            key = self.get_key(build_directory, fp)
+
+            # The root index.html file is never useful. It's not the "home page"
+            # because the home page is actually `/$locale/` since `/` is handled
+            # specifically by the CDN.
+            # The client/build/index.html is actually just a template from
+            # create-react-app, used to server-side render all the other pages.
+            # But we don't want to upload it S3. So, delete it before doing the
+            # deployment step.
+            if root_index_html_as_key == key:
+                continue
+
+            if for_counting_only:
                 yield 1
             else:
-                yield UploadFileTask(fp, self.get_key(build_directory, fp))
+                yield UploadFileTask(fp, key)
 
     def iter_redirect_tasks(self, content_roots, for_counting_only=False):
         # Walk the content roots and yield redirect upload tasks.


### PR DESCRIPTION
Fixes #1529

At the moment, we only use the `client/build/index.html` in the `ssr` component to generate the HTML for each and every document. 
Some day, aka. Yari 2, we're going not just (server-side) generate documents but also other single-page-apps (aka. skeletons) such as the home page, site-search, sign-up, etc. That day, we'll use, just like the server-side rendering of documents, the `client/build/index.html` as the template to generate files like `client/build/en-us/index.html` or `client/build/en-us/search/index.html`. But once the index.html "template file" has been used up, there's no point keep it or ever letting it get into S3. 

