### PR TITLE
force dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: build
+      prefix-development: chore
+      include: scope

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+    # This forces the Dependabot commit messages to conform to something
+    # our auto-merge workflow can always cope with.
+    # See https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/31#issuecomment-718779806
     commit-message:
       prefix: build
       prefix-development: chore


### PR DESCRIPTION
No issue. This is a bit experimental (but most likely harmless) and uncertain. 

The author of our wonderful [`action-dependabot-auto-merge`](https://github.com/ahmadnassri/action-dependabot-auto-merge) now [claims he's found a solution](https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/31#issuecomment-718779806) to the problem that sometimes Dependabot generates PRs that don't have a "from version" in the title which means the auto-merge workflow can't work. 

It's kinda hard to test this, but let's try if having this means that we cease to get Dependabot PRs (on Actions) that lack the from-version in the title. If this works now, let's do it for `npm` too. 