### PR TITLE
fix deployer upload of redirects

### DIFF
--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -261,7 +261,7 @@ class BucketManager:
 
     def get_redirect_keys(self, from_url, to_url):
         return (
-            f"{self.key_prefix}{from_url.strip('/').lower()}/index.html",
+            f"{self.key_prefix}{from_url.strip('/').lower()}",
             f"/{to_url.strip('/')}",
         )
 


### PR DESCRIPTION
Fixes #1569 

It's amazing that neither of us caught this earlier, but when we modified our deployer uploads as well as our Lambda@Edge function to stop using `index.html`, we forgot to do the same for redirects.

This code has already been used to upload to both https://main.content.dev.mdn.mozit.cloud and https://yari.stage.mdn.mozit.cloud, and it works.

Try https://main.content.dev.mdn.mozit.cloud/en-US/docs/SVG. It now correctly redirects to https://main.content.dev.mdn.mozit.cloud/en-US/docs/Web/SVG.