### PR TITLE
feat: enable lazy loading of images

### DIFF
--- a/client/src/stories/molecules/dropdown.stories.js
+++ b/client/src/stories/molecules/dropdown.stories.js
@@ -10,7 +10,7 @@ export default {
 export const dropdown = () => {
   const label = (
     <>
-      <img src={avatarImage} className="avatar" alt="username" />
+      <img src={avatarImage} className="avatar" alt="username" loading="lazy" />
       <span className="avatar-username">username</span>
     </>
   );

--- a/client/src/ui/molecules/login/index.tsx
+++ b/client/src/ui/molecules/login/index.tsx
@@ -51,6 +51,7 @@ function LoginInner() {
         src={userData.avatarUrl || avatarImage}
         className="avatar"
         alt={userData.username}
+        loading="lazy"
       />
       <span className="avatar-username">{userData.username}</span>
     </>

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -45,7 +45,7 @@ if (hasScreenshot) {
   %><tbody><%
     %><tr><%
       %><td><%
-        %><img alt="" class="internal" src="<%= screenshotUrl %>" /><%
+        %><img alt="" class="internal" src="<%= screenshotUrl %>" loading="lazy" /><%
       %></td><%
       %><td><%
 } // end hasScreenshot

--- a/kumascript/macros/HTMLRefTable.ejs
+++ b/kumascript/macros/HTMLRefTable.ejs
@@ -202,7 +202,7 @@ if (withBadges) {
     badge = HTMLTags[i].deprecated   ? '<span title="' + l10n.deprecated   + '">' + await template("FontAwesomeIcon", ["icon-thumbs-down-alt"]) + '<span>'
           : HTMLTags[i].experimental ? '<span title="' + l10n.experimental + '">' + await template("FontAwesomeIcon", ["icon-beaker"]) + '<span>'
           : HTMLTags[i].component    ? '<span title="' + l10n.components   + '">' + await template("FontAwesomeIcon", ["icon-cogs"]) + '<span>'
-          : HTMLTags[i].html5        ? '<a href="/' + env.locale + '/docs/HTML/HTML5"><img alt="HTML5" title="' + l10n.html5 + '" src="/files/3843/HTML5_Badge_32.png" width="16" height="16"></a>'
+          : HTMLTags[i].html5        ? '<a href="/' + env.locale + '/docs/HTML/HTML5"><img alt="HTML5" title="' + l10n.html5 + '" src="/files/3843/HTML5_Badge_32.png" width="16" height="16" loading="lazy" ></a>'
           : '&nbsp;';
 %>
    <td style="vertical-align: top;"><%- badge %></td>

--- a/kumascript/tests/macros/EmbedLiveSample.test.js
+++ b/kumascript/tests/macros/EmbedLiveSample.test.js
@@ -158,7 +158,7 @@ describeMacro("EmbedLiveSample", function () {
         '<th scope="col" style="text-align: center;">Live sample</th>' +
         "</tr></thead>" +
         "<tbody><tr><td>" +
-        '<img alt="" class="internal" src="/files/722/SVG_Linear_Gradient_Example.png" />' +
+        '<img alt="" class="internal" src="/files/722/SVG_Linear_Gradient_Example.png" loading="lazy" />' +
         "</td><td>" +
         '<iframe class="live-sample-frame sample-code-frame" ' +
         'id="frame_SVGLinearGradient" frameborder="0"' +
@@ -183,7 +183,7 @@ describeMacro("EmbedLiveSample", function () {
         '<th scope="col" style="text-align: center;">Live sample</th>' +
         "</tr></thead>" +
         "<tbody><tr><td>" +
-        '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" />' +
+        '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" loading="lazy" />' +
         "</td><td>" +
         '<iframe class="live-sample-frame sample-code-frame" ' +
         'id="frame_SVGLinearGradient" frameborder="0"' +

--- a/testing/content/files/en-us/web/fixable_flaws/images/index.html
+++ b/testing/content/files/en-us/web/fixable_flaws/images/index.html
@@ -4,7 +4,7 @@ slug: Web/Fixable_Flaws/Images
 ---
 
 <p>Fixable...</p>
-<img src="/en-US/docs/Web/Fixable_Flaws/Images/Fixable.png">
+<img src="/en-US/docs/Web/Fixable_Flaws/Images/Fixable.png" loading="lazy" alt="Fixable image">
 
 <p>Hopeless...</p>
-<img src="./doesntexist.jpeg">
+<img src="./doesntexist.jpeg" loading="lazy" alt="Image not found">

--- a/testing/content/files/en-us/web/foo/index.html
+++ b/testing/content/files/en-us/web/foo/index.html
@@ -18,6 +18,6 @@ tags:
 <div>{{page("web/fixable_flaws")}}</div>
 
 <figure>
-  <img src="screenshot.png" alt="Screenshot of colors">
+  <img src="screenshot.png" alt="Screenshot of colors" loading="lazy" >
   <figcaption>A perfectly normal image</figcaption>
 </figure>

--- a/testing/content/files/en-us/web/images/index.html
+++ b/testing/content/files/en-us/web/images/index.html
@@ -6,22 +6,22 @@ slug: Web/Images
 <h3>No flaws</h3>
 
 <figure>
-  <img src="florian.png" alt="Mugshot picture">
+  <img src="florian.png" alt="Mugshot picture" loading="lazy" >
   <figcaption>A perfectly good picture using <code>florian.png</code></figcaption>
 </figure>
 
 <figure>
-  <img src="./florian.png" alt="Mugshot picture">
+  <img src="./florian.png" alt="Mugshot picture" loading="lazy" >
   <figcaption>A perfectly good picture using <code>./florian.png</code></figcaption>
 </figure>
 
 <figure>
-  <img src="https://www.peterbe.com/static/images/howsmywifi-scr.png" alt="Screenshot of an app">
+  <img src="https://www.peterbe.com/static/images/howsmywifi-scr.png" alt="Screenshot of an app" loading="lazy" >
   <figcaption>A remote URL with <code>https://</code></figcaption>
 </figure>
 
 <figure>
-  <img src="../foo/screenshot.png" alt="Screenshot from sibling document">
+  <img src="../foo/screenshot.png" alt="Screenshot from sibling document" loading="lazy" >
   <figcaption>An image in a sibling document using <code>../foo/screenshot.png</code></figcaption>
 </figure>
 
@@ -31,36 +31,36 @@ slug: Web/Images
 <h3>Flaws all over the shop</h3>
 
 <figure>
-  <img src="idontexist.png" alt="Deliberately not working image">
+  <img src="idontexist.png" alt="Deliberately not working image" loading="lazy" >
   <figcaption>An image reference that doesn't exist on disk</figcaption>
 </figure>
 
 <figure>
-  <img src="/en-US/docs/Web/Images/florian.png" alt="Mugshot picture">
+  <img src="/en-US/docs/Web/Images/florian.png" alt="Mugshot picture" loading="lazy" >
   <figcaption>An overly verbose reference to image using <code>/en-US/docs/Web/Images/florian.png</code></figcaption>
 </figure>
 
 <figure>
-  <img src="Florian.PNG" alt="Mugshot picture">
+  <img src="Florian.PNG" alt="Mugshot picture" loading="lazy" >
   <figcaption>Valid picture reference but wrong cASe <code>Florian.PNG</code></figcaption>
 </figure>
 
 <figure>
-  <img src="http://www.peterbe.com/static/images/favicon-32.png" alt="Tiny mugshot favicon">
+  <img src="http://www.peterbe.com/static/images/favicon-32.png" alt="Tiny mugshot favicon" loading="lazy" >
   <figcaption>An external image with a <code>http://</code> protocol</figcaption>
 </figure>
 
 <figure>
-  <img src="https://developer.mozilla.org/en-US/docs/Web/Images/screenshot.png" alt="Devedition logo">
+  <img src="https://developer.mozilla.org/en-US/docs/Web/Images/screenshot.png" alt="Devedition logo" loading="lazy" >
   <figcaption>An external image with the <code>https://developer.mozilla.org</code> prefix</figcaption>
 </figure>
 
 <figure>
-  <img src="/en-US/docs/Web/Foo/screenshot.png" alt="Screenshot from sibling document">
+  <img src="/en-US/docs/Web/Foo/screenshot.png" alt="Screenshot from sibling document" loading="lazy" >
   <figcaption>An image in a sibling document unnecessarily verbose</figcaption>
 </figure>
 
 <figure>
-  <img src="../Foo/nonexistent.png" alt="Screenshot from sibling document">
+  <img src="../Foo/nonexistent.png" alt="Screenshot from sibling document" loading="lazy" >
   <figcaption>An image in a sibling document that doesn't exist</figcaption>
 </figure>


### PR DESCRIPTION
Enable browser-level lazy-loading by adding `loading="lazy"` on each img element.

Also updated [Content](https://github.com/mdn/content/pull/66)

Ref: https://github.com/mdn/yari/issues/1540