### PR TITLE
A better loading screen for client-side navigation transitions

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -7,6 +7,11 @@
 
 @import "./prism-overrides";
 
+.loading-document-placeholder article {
+  // Any huge margin bottom to keep the footer away when loading
+  margin-bottom: 1200px;
+}
+
 .article {
   padding: $base-spacing;
 

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -76,7 +76,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
   }, [doc]);
 
   if (!doc && !error) {
-    return <p>Loading...</p>;
+    return <LoadingDocumentPlaceholder />;
   }
 
   if (error) {
@@ -150,6 +150,32 @@ export function Document(props /* TODO: define a TS interface for this */) {
         </main>
 
         {doc.sidebarHTML && <RenderSideBar doc={doc} />}
+      </div>
+    </>
+  );
+}
+
+function LoadingDocumentPlaceholder() {
+  return (
+    <>
+      <Titlebar docTitle={"Loading…"} />
+
+      <div className="breadcrumbs-locale-container">
+        <div className="breadcrumb-container">
+          <p>&nbsp;</p>
+        </div>
+      </div>
+      <div className="page-content-container loading-document-placeholder">
+        <main className="main-content" role="main">
+          <article className="article">
+            <p>
+              <span role="img" aria-label="Hourglass">
+                ⏳
+              </span>{" "}
+              Loading…
+            </p>
+          </article>
+        </main>
       </div>
     </>
   );


### PR DESCRIPTION
Part of #1587

I'm not falling in love with how it looks but it certainly works and it's certainly a huge deal better than what we had before at a pretty cheap cost. 

Here's a screencast where I use Chrome and the "Fast 3G" network speed:
![Screen-Recording-2020-10-30-at-12 51 44-PM](https://user-images.githubusercontent.com/26739/97735501-cc5ac880-1ab0-11eb-9538-953df8a35052.gif)
