### PR TITLE
stich live samples together with whitespace

### DIFF
--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -202,7 +202,12 @@ class HTMLTool {
     for (const part of LIVE_SAMPLE_PARTS) {
       const src = $(
         `.${part},pre[class*="brush:${part}"],pre[class*="${part};"]`
-      ).text();
+      )
+        .map((i, element) => {
+          return $(element).text();
+        })
+        .get()
+        .join("\n");
       // The string replacements below have been carried forward from Kuma:
       //   * Bugzilla 819999: &nbsp; gets decoded to \xa0, which trips up CSS.
       //   * Bugzilla 1284781: &nbsp; is incorrectly parsed on embed sample.


### PR DESCRIPTION
Fixes #1585

This is how they describe doing the `.map` in the documentation: https://cheerio.js.org/
How we joined the array of strings is up to us. It's not clear if kuma is using `\n` or ` ` but I think a newline feels more solid. 