### PR TITLE
add GHA workflow for stage builds

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,178 @@
+name: Production Build
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 */24 * * *"
+
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Notes"
+        required: false
+        default: ""
+      archived_content:
+        description: "Build archived content"
+        required: false
+        default: "false"
+      translated_content:
+        description: "Build translated content"
+        required: false
+        default: "false"
+      log_each_successful_upload:
+        description: "Deployer logs each success"
+        required: false
+        default: "false"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: mdn/content
+          path: mdn/content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.archived_content, 'true')"
+        with:
+          repository: mdn/archived-content
+          path: mdn/archived-content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.translated_content, 'true')"
+        with:
+          repository: mdn/translated-content
+          path: mdn/translated-content
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "12"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Python poetry
+        uses: dschep/install-poetry-action@v1.3
+
+      - name: Install deployer
+        run: |
+          cd deployer
+          poetry install
+
+      - name: Display Python & Poetry version
+        run: |
+          python --version
+          poetry --version
+
+      - name: Print information about build
+        run: |
+          echo "Trigger notes: ${{ github.event.inputs.notes }}"
+          echo "Trigger archived-content: ${{ github.event.inputs.archived_content }}"
+          echo "Trigger translated-content: ${{ github.event.inputs.translated_content }}"
+          echo "Trigger log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload }}"
+
+      - name: Build everything
+        run: |
+          # Remember, the mdn/content repo got cloned into `pwd` into a
+          # sub-folder called "mdn/content"
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          export BUILD_LIVE_SAMPLES_BASE_URL=https://yari-demos.stage.mdn.mozit.cloud
+
+          # Now is not the time to worry about flaws.
+          export BUILD_FLAW_LEVELS="*:ignore"
+          yarn prepare-build
+
+          # Uncomment when hacking on this workflow. It means the `yarn build`
+          # finishes much sooner, which can be helpful debugging the other stuff
+          # the workflow needs to do.
+          # export BUILD_FOLDERSEARCH=web/html
+
+          # This is the Google Analytics account ID for developer.mozilla.org
+          # If it's used on other domains (e.g. stage or dev builds), it's OK
+          # because ultimately Google Analytics will filter it out since the
+          # origin domain isn't what that account expects.
+          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
+
+          yarn build
+
+          # TODO: When the deployer is available this is where we
+          # would upload the whole content of client/build
+          du -sh client/build
+
+      - name: Deploy with deployer
+        run: |
+          # Set the CONTENT_ROOT first
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          cd deployer
+
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
+
+          export DEPLOYER_BUCKET_NAME=mdn-content-stage
+          export DEPLOYER_BUCKET_PREFIX=main
+          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload }}
+
+          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_AWS_SECRET_ACCESS_KEY }}
+
+          poetry run deployer upload ../client/build
+          poetry run deployer update-lambda-functions ./aws-lambda


### PR DESCRIPTION
Here's the GHA workflow for stage. Do we want to run this on a cron schedule? Until we launch Yari, I think this workflow is the one we want to run regularly, and perhaps we temporarily disable the `cron` schedule on the `production-build.yml` and only run that one manually for special branches?