### PR TITLE
fake ks macros in regex summaries

### DIFF
--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -202,10 +202,14 @@ const info = {
           );
           for (const match of matches) {
             // A lot of times, the first paragrah is just a (or two) call to
-            // a KS macro. E.g. `<p>{{AddonSidebar}}</p>`.
-            // In these cases, ignore those. Note, if it's `<p>{{SomeSidebar()}}</p>`
-            // it will be left alone because if presence of the bracket characters.
-            const summary = match[1].replace(/{{\w+}}/g, "").trim();
+            // a KS macro. E.g. `<p>{{AddonSidebar}}</p>` or
+            // spelled `<p>{{AddonSidebar()}}</p>`.
+            // In these cases, ignore those.
+            // This essentially means we're keeping all macro calls that
+            // has arguments. E.g. `{{Glossary("foo", "bar")}}`.
+            const summary = match[1]
+              .replace(/{{[^\(]+}}|{{[\w-]+\(\)}}/g, "")
+              .trim();
             if (summary) {
               return postProcessSummaryHTMLSnippet(summary);
             }

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -220,10 +220,11 @@ const info = {
           $ = cheerio.load(document.rawHTML);
           $("span.seoSummary, .summary").each((i, element) => {
             if (!summary) {
-              summary = postProcessSummaryHTMLSnippet(
-                $(element).text(),
-                document
-              );
+              const html = $(element)
+                .html()
+                .replace(/&quot;/g, '"')
+                .replace(/&apos;/g, "'");
+              summary = postProcessSummaryHTMLSnippet(html, document);
             }
           });
           if (!summary) {
@@ -232,10 +233,11 @@ const info = {
             $("div.blockIndicator, div.note").remove();
             $("p").each((i, element) => {
               if (!summary) {
-                summary = postProcessSummaryHTMLSnippet(
-                  $(element).text(),
-                  document
-                );
+                const html = $(element)
+                  .html()
+                  .replace(/&quot;/g, '"')
+                  .replace(/&apos;/g, "'");
+                summary = postProcessSummaryHTMLSnippet(html, document);
               }
             });
           }

--- a/kumascript/src/render.js
+++ b/kumascript/src/render.js
@@ -40,7 +40,6 @@
  *
  * @prettier
  */
-const fs = require("fs");
 
 const Parser = require("./parser.js");
 const Templates = require("./templates.js");


### PR DESCRIPTION
Fixes #1570

I started down the rabbit hole of using `renderMacros()` instead and constructing the environment from within there in the `getPage`. We'd have to track back in every macro where the `.summary` is used and turn that into an async call. 
Also, I got myself into a circular require loop in Node. 
The basic solution (presented here in this PR) seems to work wonderfully on all the pages I tested on. 

The index pages, that use these kinds of macros, are not a high priority itself. 

Suppose that we could figure out how to make a full KS macro render, it still leaves us at risk of going into an infinite loop akin to the chicken-and-egg problem. 

I seem to be able to build EVERYTHING now with `Cheerio`. I edited a couple of corrupt and broken ones on wiki.developer.mozilla.org so they'll fade away. 

