### PR TITLE
list BCD sub-rows

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -401,7 +401,9 @@ export const FeatureRow = React.memo(
     const { name, compat, isRoot } = feature;
     const title = compat.description ? (
       <span
-        dangerouslySetInnerHTML={{ __html: `${name}: ${compat.description}` }}
+        dangerouslySetInnerHTML={{
+          __html: `<code>${name.split(".")[0]}</code>: ${compat.description}`,
+        }}
       />
     ) : (
       <code>{name}</code>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -400,7 +400,9 @@ export const FeatureRow = React.memo(
   }) => {
     const { name, compat, isRoot } = feature;
     const title = compat.description ? (
-      <span dangerouslySetInnerHTML={{ __html: compat.description }} />
+      <span
+        dangerouslySetInnerHTML={{ __html: `${name}: ${compat.description}` }}
+      />
     ) : (
       <code>{name}</code>
     );

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -100,7 +100,6 @@ export default function BrowserCompatibilityTable({
 
   const breadcrumbs = query.split(".");
   const category = breadcrumbs[0];
-  const name = breadcrumbs[breadcrumbs.length - 1];
 
   const [platforms, browsers] = gatherPlatformsAndBrowsers(category);
 

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -82,14 +82,10 @@ function FeatureListAccordion({
 }
 
 export default function BrowserCompatibilityTable({
-  id,
-  title,
   query,
   data,
   browsers: browserInfo,
 }: {
-  id: string;
-  title: string;
   query: string;
   data: bcd.Identifier;
   browsers: bcd.Browsers;
@@ -137,7 +133,7 @@ export default function BrowserCompatibilityTable({
           <tbody>
             <FeatureListAccordion
               browsers={browsers}
-              features={listFeatures(data, name)}
+              features={listFeatures(data)}
             />
           </tbody>
         </table>

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -13,21 +13,26 @@ export function isTruthy<T>(t: T | false | undefined | null): t is T {
   return Boolean(t);
 }
 
-export function listFeatures(identifier: bcd.Identifier, name: string = "") {
-  return [
-    identifier.__compat && {
-      name,
-      compat: identifier.__compat,
-      isRoot: true,
-    },
-    ...Object.entries(identifier).map(
-      ([name, subIdentifier]) =>
-        name !== "__compat" &&
-        subIdentifier.__compat && {
-          name,
-          compat: subIdentifier.__compat,
-          isRoot: false,
-        }
-    ),
-  ].filter(isTruthy);
+interface Feature {
+  name: string;
+  compat: bcd.CompatStatement;
+  isRoot: boolean;
+}
+
+export function listFeatures(
+  identifier: bcd.Identifier,
+  parentName: string = ""
+): Feature[] {
+  const features: Feature[] = [];
+  for (const [subName, subIdentifier] of Object.entries(identifier)) {
+    if (subName !== "__compat" && subIdentifier.__compat) {
+      features.push({
+        name: parentName ? `${parentName}.${subName}` : subName,
+        compat: subIdentifier.__compat,
+        isRoot: parentName !== "",
+      });
+      features.push(...listFeatures(subIdentifier, subName));
+    }
+  }
+  return features;
 }


### PR DESCRIPTION
Fixes #1611

To test, look at the BCD table on http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json and compare with https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json

Apart from the styling, it should have the same rows and same stuff in the first column. 