### PR TITLE
do not manually manage jest dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "fuzzysearch": "1.0.3",
     "history": "5.0.0",
     "husky": "4.3.0",
-    "jest": "^24.0.0",
     "jest-environment-jsdom-sixteen": "^1.0.3",
     "jest-junit-reporter": "^1.1.0",
     "jest-puppeteer": "4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10951,7 +10951,7 @@ jest-worker@^26.2.1:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@24.9.0, jest@^24.0.0:
+jest@24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest/-/jest-24.9.0.tgz#987d290c05a08b52c56188c1002e368edb007171"
   integrity sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==


### PR DESCRIPTION
Let CRA take care of managing Jest as a dependency.

fix #1659