### PR TITLE
fix: toc and sidebar font size

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -22,7 +22,7 @@ import { Breadcrumbs } from "../ui/molecules/breadcrumbs";
 import LanguageMenu from "../ui/molecules/language-menu";
 import { OnGitHubLink } from "./on-github";
 import { Titlebar } from "../ui/molecules/titlebar";
-import { TOC } from "../ui/molecules/toc";
+import { TOC } from "./organisms/toc";
 import { RenderSideBar } from "./organisms/sidebar";
 
 import "./index.scss";

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -3,9 +3,12 @@
 @import "~@mdn/minimalist/sass/mixins/utils";
 
 .sidebar {
+  font-size: $default-font-size;
   padding: $base-spacing;
 
   h4 {
+    font-family: $heading-font-family;
+    font-size: $medium-font-size;
     margin-bottom: $base-spacing;
   }
 
@@ -16,14 +19,14 @@
     ol,
     ul {
       @media #{$mq-tablet-and-up} {
-        padding-left: $base-unit * 3;
+        padding-left: $base-spacing / 2;
       }
     }
   }
 
   summary,
   li {
-    margin-bottom: $base-unit * 3;
+    margin-bottom: $base-spacing / 2;
   }
 
   a {

--- a/client/src/document/organisms/toc/index.scss
+++ b/client/src/document/organisms/toc/index.scss
@@ -3,6 +3,7 @@
 @import "~@mdn/minimalist/sass/vars/typography";
 
 .document-toc {
+  font-size: $default-font-size;
   padding: ($base-spacing / 2) $base-spacing;
   position: relative;
 

--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { useGA } from "../../../ga-context";
 
-import { Toc } from "../../../document/types";
+import { Toc } from "../../types";
 
 import "./index.scss";
 

--- a/client/src/stories/organisms/page-header.stories.js
+++ b/client/src/stories/organisms/page-header.stories.js
@@ -5,7 +5,7 @@ import { Breadcrumbs } from "../../ui/molecules/breadcrumbs";
 import { Header } from "../../ui/organisms/header";
 import LanguageMenu from "../../ui/molecules/language-menu";
 import { Titlebar } from "../../ui/molecules/titlebar";
-import { TOC } from "../../ui/molecules/toc";
+import { TOC } from "../../document/organisms/toc";
 
 import { breadcrumbParents } from "../mocks/breadcrumbs";
 import { languageMenuData } from "../mocks/language-menu";


### PR DESCRIPTION
Reduce the font-size of the sidebar and toc:

1. It is too large
2. It bleeds too much into the content and makes the UI feel cluttered

## From

![Screenshot 2020-11-09 at 13 30 19](https://user-images.githubusercontent.com/10350960/98536349-56184c00-2290-11eb-8105-990bb03a3150.png)

## To

![Screenshot 2020-11-09 at 13 30 31](https://user-images.githubusercontent.com/10350960/98536365-5fa1b400-2290-11eb-9bb8-b60ac2e4fd03.png)

fix #1605