### PR TITLE
improvement to the ssr dist bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -13,9 +13,6 @@ kumascript/node_modules/
 content/node_modules/
 server/node_modules/
 
-# This won't be relevant or needed once the content is gone.
-/content/files/en-us/
-
 /deployer
 kumascript/tests
 testing/
@@ -26,7 +23,6 @@ import/
 README.md
 client/search-experimentation.js
 yarn-error.log
-content/files/
 
 # Since we ship the built stuff, we actually no longer need any of the source
 client/src/

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -2,7 +2,7 @@ const path = require("path");
 
 const nodeExternals = require("webpack-node-externals");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-// const webpack = require("webpack");
+const webpack = require("webpack");
 
 module.exports = {
   context: path.resolve(__dirname, "."),
@@ -38,21 +38,26 @@ module.exports = {
           {
             loader: "@svgr/webpack",
             options: {
-              svgo: true,
+              svgo: false,
               titleProp: true,
             },
           },
         ],
       },
       {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: ["file-loader?outputPath=/distimages/"],
+        test: /\.svg$/,
+        use: ["file-loader?outputPath=/dev/null"],
       },
-      // { test: /\.css$/, loader: "style-loader!css-loader" }
+      { test: /\.(png|jpe?g|gif)$/, loader: "ignore-loader" },
       { test: /\.(css|scss)$/, loader: "ignore-loader" },
     ],
   },
   externals: nodeExternals(),
   devtool: "source-map",
-  plugins: [new CleanWebpackPlugin()],
+  plugins: [
+    new CleanWebpackPlugin(),
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ],
 };


### PR DESCRIPTION
1. "Disable" code splitting of the Webpack compiled bundle. Because it doesn't make sense to have it in Node. 
2. Dump all svg files that the Webpack build finds into `/dev/null`. 

@schalkneethling We don't need the `ssr/dist/distimages/*` images. They are not used to generate the HTML. 
But I couldn't use the `ignore-loader` because when I do that, I get errors that don't yet make sense to me. Perhaps you have a better idea. 