### PR TITLE
fix: wrap long titles on mobile

### DIFF
--- a/client/src/ui/molecules/titlebar/index.scss
+++ b/client/src/ui/molecules/titlebar/index.scss
@@ -9,8 +9,12 @@
 
   @media #{$mq-tablet-and-up} {
     padding: 0;
+  }
 
-    h1 {
+  h1 {
+    word-break: break-all;
+
+    @media #{$mq-tablet-and-up} {
       margin: 0 auto;
       max-width: $max-width-default;
       padding: $base-spacing;


### PR DESCRIPTION
Wrap long titles on mobile.

## Before

![Screenshot 2020-11-09 at 19 40 56](https://user-images.githubusercontent.com/10350960/98576871-d4daac80-22c3-11eb-9c62-b2495d581944.png)

## After

![Screenshot 2020-11-09 at 19 41 06](https://user-images.githubusercontent.com/10350960/98576879-d86e3380-22c3-11eb-9044-9c0b70b6e96e.png)

fix #1674