### PR TITLE
Safari column missing in Yari

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -13,7 +13,7 @@ export const PLATFORM_BROWSERS: { [key: string]: bcd.BrowserNames[] } = {
     "samsunginternet_android",
   ],
   server: ["nodejs"],
-  "webextensions-desktop": ["chrome", "edge", "firefox", "opera"],
+  "webextensions-desktop": ["chrome", "edge", "firefox", "opera", "safari"],
   "webextensions-mobile": ["firefox_android"],
 };
 

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -34,7 +34,9 @@ const NEW_ISSUE_TEMPLATE = `
 </details>
 `;
 
-function gatherPlatformsAndBrowsers(category): [string[], bcd.BrowserNames[]] {
+function gatherPlatformsAndBrowsers(
+  category: string
+): [string[], bcd.BrowserNames[]] {
   let platforms = ["desktop", "mobile"];
   if (category === "javascript") {
     platforms.push("server");

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -48,7 +48,7 @@ const browsers = {
   "desktop": ['chrome', 'edge', 'firefox', 'ie', 'opera', 'safari'],
   "mobile": ['webview_android', 'chrome_android', 'firefox_android', 'opera_android', 'safari_ios', 'samsunginternet_android'],
   "server": ['nodejs'],
-  "webextensions-desktop": ['chrome', 'edge', 'firefox', 'opera'],
+  "webextensions-desktop": ['chrome', 'edge', 'firefox', 'opera', 'safari'],
   "webextensions-mobile": ['firefox_android']
 };
 

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -135,7 +135,7 @@ describeMacro("Compat", function () {
           Array.from(dom.querySelector(".bc-table").classList),
           "bc-table-ext"
         );
-        assert.equal(dom.querySelector(".bc-platform-desktop").colSpan, 4);
+        assert.equal(dom.querySelector(".bc-platform-desktop").colSpan, 5);
         assert.equal(dom.querySelector(".bc-platform-mobile").colSpan, 1);
       });
     }


### PR DESCRIPTION
Fixes #1676

What happened was that [`safari` was added to the list of `webextension-desktop`](https://github.com/mdn/kumascript/commit/56bb32e064b62252d6e7a069960724abef631366). 
The original PR was here: https://github.com/mdn/kumascript/pull/1396

I don't know exactly when we forked Compat.ejs into Yari, but clearly this is a case of a macro that was edit since *after* the fork point. 