### PR TITLE
BCD table doesn't list main feature

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -400,11 +400,7 @@ export const FeatureRow = React.memo(
   }) => {
     const { name, compat, isRoot } = feature;
     const title = compat.description ? (
-      <span
-        dangerouslySetInnerHTML={{
-          __html: `<code>${name.split(".")[0]}</code>: ${compat.description}`,
-        }}
-      />
+      <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
       <code>{name}</code>
     );

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -100,6 +100,7 @@ export default function BrowserCompatibilityTable({
 
   const breadcrumbs = query.split(".");
   const category = breadcrumbs[0];
+  const name = breadcrumbs[breadcrumbs.length - 1];
 
   const [platforms, browsers] = gatherPlatformsAndBrowsers(category);
 
@@ -132,7 +133,7 @@ export default function BrowserCompatibilityTable({
           <tbody>
             <FeatureListAccordion
               browsers={browsers}
-              features={listFeatures(data)}
+              features={listFeatures(data, "", name)}
             />
           </tbody>
         </table>

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -21,9 +21,18 @@ interface Feature {
 
 export function listFeatures(
   identifier: bcd.Identifier,
-  parentName: string = ""
+  parentName: string = "",
+  rootName: string = ""
 ): Feature[] {
   const features: Feature[] = [];
+  if (rootName && identifier.__compat) {
+    features.push({
+      name: rootName,
+      compat: identifier.__compat,
+      isRoot: true,
+    });
+  }
+
   for (const [subName, subIdentifier] of Object.entries(identifier)) {
     if (subName !== "__compat" && subIdentifier.__compat) {
       features.push({


### PR DESCRIPTION
Fixes #1668

I believe all of these are now matching in parity. Or, are they? My head is a spinning from all the tabs and stuff:

1. http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Browser_compatibility and https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array#Browser_compatibility
2. http://localhost:5000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat/#Browser_compatibility and https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat#Browser_compatibility
3. http://localhost:5000/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json and https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json