### PR TITLE
correct BCD platform icons

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -21,15 +21,19 @@ function PlatformHeaders({ platforms }) {
   return (
     <tr className="bc-platforms">
       <td />
-      {platforms.map((platform) => (
-        <th
-          key={platform}
-          className={`bc-platform-${platform}`}
-          colSpan={Object.keys(PLATFORM_BROWSERS[platform]).length}
-        >
-          <span>{platform}</span>
-        </th>
-      ))}
+      {platforms.map((platform) => {
+        const platformCount = Object.keys(PLATFORM_BROWSERS[platform]).length;
+        const platformId = platform.replace("webextensions-", "");
+        return (
+          <th
+            key={platform}
+            className={`bc-platform-${platformId}`}
+            colSpan={platformCount}
+          >
+            <span>{platform}</span>
+          </th>
+        );
+      })}
     </tr>
   );
 }


### PR DESCRIPTION
Fixes #1595

Proof that it works:
<img width="1265" alt="Screen Shot 2020-11-10 at 1 41 23 PM" src="https://user-images.githubusercontent.com/26739/98717064-9217e380-235a-11eb-9b94-a59459249c2e.png">
