### PR TITLE
Don't say "Nothing found" when you haven't typed anything

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -312,6 +312,7 @@ function InnerSearchNavigateWidget() {
             ) : (
               resultItems.length === 0 &&
               inputValue &&
+              inputValue !== "/" &&
               searchIndex && <div className="nothing-found">nothing found</div>
             )}
             {resultItems.map((item, i) => (

--- a/testing/tests/search.test.js
+++ b/testing/tests/search.test.js
@@ -17,7 +17,7 @@ describe("Site search", () => {
     await expect(page).toMatch("<foo>: A test tag");
   });
 
-  test("find Foo page", async () => {
+  test("find Foo page by title search", async () => {
     await page.goto(testURL("/"));
     await expect(page).toFill(SEARCH_SELECTOR, "foo");
     await expect(page).toMatch("<foo>: A test tag");
@@ -28,6 +28,35 @@ describe("Site search", () => {
     // on the line above because expect-puppeteer doesn't have a wait to
     // properly wait for the (pushState) URL to have changed.
     expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+  });
+
+  test("find nothing by title search", async () => {
+    await page.goto(testURL("/"));
+    await expect(page).toFill(SEARCH_SELECTOR, "gooblyg00k");
+    await expect(page).toMatchElement(".nothing-found", {
+      text: "nothing found",
+    });
+  });
+
+  test("find Foo page by fuzzy-search", async () => {
+    await page.goto(testURL("/"));
+    await expect(page).toFill(SEARCH_SELECTOR, "/");
+    await expect(page).toMatch("Fuzzy searching by URI");
+    await expect(page).not.toMatchElement(".nothing-found", {
+      text: "nothing found",
+    });
+    await expect(page).toFill(SEARCH_SELECTOR, "/wboo");
+    await expect(page).toMatch("<foo>: A test tag");
+    await expect(page).toClick('[aria-selected="true"]');
+    await expect(page).toMatchElement("h1", { text: "<foo>: A test tag" });
+  });
+
+  test("find nothing by fuzzy-search", async () => {
+    await page.goto(testURL("/"));
+    await expect(page).toFill(SEARCH_SELECTOR, "/gooblygook");
+    await expect(page).toMatchElement(".nothing-found", {
+      text: "nothing found",
+    });
   });
 
   test("input placeholder changes when focused", async () => {


### PR DESCRIPTION
Fixes #1696

Much better!
<img width="411" alt="Screen Shot 2020-11-10 at 8 28 16 PM" src="https://user-images.githubusercontent.com/26739/98754315-6b769e80-2394-11eb-88b0-4abb07c778ef.png">

Also, I cheekily added some more end-to-end headless tests to the search that finds (and not finds) things by fuzzy-search. 