### PR TITLE
fix: note cards

### DIFF
--- a/kumascript/macros/B2GOnlyHeader2.ejs
+++ b/kumascript/macros/B2GOnlyHeader2.ejs
@@ -67,6 +67,8 @@ var secLevel = $0 && $0.toLowerCase() || 'certified';
 if ( !(secLevel in secString) ) secLevel = 'certified';
 
 
-%><div class="blockIndicator warning">
-    <p style="text-align:center"><%- secString[secLevel] %></p>
+%>
+<div class="notecard warning">
+    <h4>Warning</h4>
+    <p><%- secString[secLevel] %></p>
 </div>

--- a/kumascript/macros/CompatibilityTable.ejs
+++ b/kumascript/macros/CompatibilityTable.ejs
@@ -37,7 +37,7 @@ var cta = mdn.localString({
 
 %>
 
-<div class="blockIndicator warning"><%-cta%></div>
+<div class="notecard note"><%-cta%></div>
 
 <div class="htab">
     <a id="AutoCompatibilityTable" name="AutoCompatibilityTable"></a>

--- a/kumascript/macros/DeprecatedGeneric.ejs
+++ b/kumascript/macros/DeprecatedGeneric.ejs
@@ -132,18 +132,20 @@ var str_desc = mdn.localString({
 
 switch($0) {
     case 'inline':
-        %><span class="inlineIndicator deprecated deprecatedInline" title="<%=(tip)%>"><%-str%></span><%
+        %><span class="notecard inline deprecated" title="<%=(tip)%>"><%-str%></span><%
         break;
     case 'header':
         if (tip.length) { str = str + " " + tip; }
-        %><div class="blockIndicator deprecated deprecatedHeader">
-            <p><strong><%-str%></strong><br/><%-str_desc%></p>
+        %>
+        <div class="notecard deprecated">
+            <h4><%-str%></h4>
+            <p><%-str_desc%></p>
         </div><%
         break;
     case 'method':
         if (tip.length) { str = str + " " + tip; }
         %><div>
-            <span class="indicatorInHeadline deprecated deprecatedMethod"><%-str%></span>
+            <span class="notecard inline deprecated"><%-str%></span>
             <h3><%-($2)%></h3>
         </div><%
         break;

--- a/kumascript/macros/Draft.ejs
+++ b/kumascript/macros/Draft.ejs
@@ -70,8 +70,9 @@ switch (env.locale) {
         s_draft = 'Черновик';
         s_not_complete = 'Эта страница не завершена.';
 }
-%><div class="blockIndicator draft">
-    <p><strong><%=s_draft%></strong><br/>
-    <%=s_not_complete%></p>
+%>
+<div class="notecard draft">
+    <h4><%=s_draft%></h4>
+    <p><%=s_not_complete%></p>
     <%-s_details%>
 </div>

--- a/kumascript/macros/LegacyAddonsNotice.ejs
+++ b/kumascript/macros/LegacyAddonsNotice.ejs
@@ -1,7 +1,7 @@
 <%
 
 var output = mdn.localString({
-    'en-US': '<div class="blockIndicator warning">' +
+    'en-US': '<div class="notecard warning"><h4>Warning</h4>' +
         '<p>Add-ons using the techniques described in this document are considered a legacy technology in Firefox. ' +
         'Don\'t use these techniques to develop new add-ons. Use ' +
         '<a href="/en-US/Add-ons/WebExtensions">WebExtensions</a> instead. ' +
@@ -18,7 +18,7 @@ var output = mdn.localString({
         'resources, migration paths, office hours, and more</a>, '+
         'is available to help developers transition to the new technologies.</p>' +
         '</div>',
-    'zh-CN': '<div class="blockIndicator warning">' +
+    'zh-CN': '<div class="notecard warning">' +
         '<p>我们即将放弃这篇文档中描述的 Firefox 附加组件技术。</p>' +
         '<p>请勿使用下列技术开发新的附加组件。请改用 ' +
         '<a href="/zh-CN/Add-ons/WebExtensions">WebExtension</a> 代替。' +
@@ -30,7 +30,7 @@ var output = mdn.localString({
         'href="/zh-CN/Add-ons/Working_with_multiprocess_Firefox">制作多进程兼容的附加组件</a>的文档，但迁移到 WebExtension 是更加着眼于未来的选择。</p>' +
         '<p>有关的 wiki 页面写有协助开发人员过渡到新技术的<a href="https://wiki.mozilla.org/Add-ons/developer/communication">有关资源、迁移路径、办公时间等信息</a>'+
         '。</div>',
-    'fr': '<div class="blockIndicator warning">' +
+    'fr': '<div class="notecard warning">' +
         '<p>Les modules complémentaires utilisant les techniques décrites dans ce document sont considérés comme une ancienne technologie dans Firefox. ' +
         'N\'utilisez pas ces techniques pour developper de nouveaux modules complémentaires. Utilisez plutôt ' +
         '<a href="/fr/Add-ons/WebExtensions">les WebExtensions</a>. ' +

--- a/kumascript/macros/Non-standardGeneric.ejs
+++ b/kumascript/macros/Non-standardGeneric.ejs
@@ -47,13 +47,15 @@ if (fxosCheck == 0) {
 
 switch($0) {
   case 'inline':
-    %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
+    %><span class="notecard inline warning"><%-str_inline%></span><%
     break;
   case 'header':
-    %><div class="blockIndicator nonStandard nonStandardHeader">
-      <p><strong><%-str_inline%></strong><br/>
-      <%-str_long%></p>
-      </div><%
+    %>
+      <div class="notecard warning">
+        <h4><%-str_inline%></h4>
+        <p><%-str_long%></p>
+      </div>
+    <%
     break;
 }
 
@@ -61,13 +63,15 @@ switch($0) {
 
 switch($0) {
   case 'inline':
-    %><span class="inlineIndicator nonStandard nonStandardInline"><%-str_inline%></span><%
+    %><span class="notecard inline warning"><%-str_inline%></span><%
     break;
   case 'header':
-    %><div class="blockIndicator nonStandard nonStandardHeader">
-      <p><strong><%-str_inline%></strong><br/>
-      <%-str_fxos_long%></p>
-      </div><%
+    %>
+      <div class="notecard warning">
+        <h4><%-str_inline%></h4>
+        <p><%-str_fxos_long%></p>
+      </div>
+    <%
     break;
 }
 

--- a/kumascript/macros/NoteStart.ejs
+++ b/kumascript/macros/NoteStart.ejs
@@ -20,4 +20,4 @@ var note = mdn.localString({
     "zh-TW": "註："
 });
 
-%><div class="blockIndicator note"><strong><%-note%></strong>&nbsp;
+%><div class="notecard note"><h4><%-note%></h4>

--- a/kumascript/macros/ObsoleteGeneric.ejs
+++ b/kumascript/macros/ObsoleteGeneric.ejs
@@ -115,17 +115,24 @@ var str_desc = mdn.localString({
 
 switch($0) {
     case 'inline':
-        %><span title="<%=tip%>" class="inlineIndicator obsolete obsoleteInline"><%-str%></span><%
+        %><span title="<%=tip%>" class="notecard inline obsolete"><%-str%></span><%
         break;
     case 'header':
         if (string.length(tip)) { str = str + " " + tip; }
-        %><div class="blockIndicator obsolete obsoleteHeader"><p><strong><%-str%></strong><br/><%-str_desc%></p></div><%
+        %>
+            <div class="notecard obsolete">
+                <h4><%-str%></h4>
+                <p><%-str_desc%></p>
+            </div>
+        <%
         break;
     case 'method':
         if (string.length(tip)) { str = str + " " + tip; }
-        %><div class="headingWithIndicator">
-        <h3><%- $2 %>()</h3>
-        <span class="indicatorInHeadline obsolete obsoleteMethod"><%- str %></span>
-        </div><%
+        %>
+        <div class="headingWithIndicator">
+            <h4><%- $2 %>()</h4>
+            <span class="notecard inline obsolete"><%- str %></span>
+        </div>
+        <%
         break;
 }%>

--- a/kumascript/macros/SeeCompatTable.ejs
+++ b/kumascript/macros/SeeCompatTable.ejs
@@ -12,6 +12,8 @@ var str = mdn.localString({
     "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#Browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
 });
 
-%><div class="blockIndicator experimental indicator-warning">
+%>
+<div class="notecard experimental">
+    <h4>Experimental</h4>
     <p><%- str %></p>
 </div>

--- a/kumascript/macros/SimpleBanner.ejs
+++ b/kumascript/macros/SimpleBanner.ejs
@@ -6,7 +6,7 @@
         $2 - Additional text to display
 
 */%>
-<div class="blockIndicator <%= $1 %>">
-<div class="bannerHeading"><%- $0 %></div>
-<div class="bannerText"><%- $2 %></div>
+<div class="notecard <%= $1 %>">
+    <h4><%- $0 %></h4>
+    <p><%- $2 %></p>
 </div>

--- a/kumascript/macros/gecko_minversion_note.ejs
+++ b/kumascript/macros/gecko_minversion_note.ejs
@@ -18,8 +18,7 @@ switch(lang) {
     break;
 }
 %>
-
-<div class="blockIndicator geckoMinVer standardNote">
-  <div style="text-align:center; font-weight:bold; padding-bottom: 0.5em;"><%- str %></div>
-  <div><%- $1 %></div>
+<div class="notecard note">
+  <h4><%- str %></h4>
+  <p><%- $1 %></p>
 </div>

--- a/kumascript/macros/jsOverrides.ejs
+++ b/kumascript/macros/jsOverrides.ejs
@@ -1,4 +1,4 @@
-<div class="blockIndicator inheritsbox template-jsOverrides">
+<div class="notecard note">
 <%
 /**
  * Given an object and a list of properties or
@@ -147,6 +147,7 @@ for (var i = 0; i < desiredprototype.length; i++) {
 htmlstring += parts.join(', ');
 
 
-%><div><span style="font-weight:700;"><%- titleString %></span></div>
+%>
+<div><span><%- titleString %></span></div>
 <div><%- htmlstring %></div>
 </div>

--- a/kumascript/macros/jsapi_minversion_header.ejs
+++ b/kumascript/macros/jsapi_minversion_header.ejs
@@ -26,6 +26,7 @@ switch(lang) {
 }
 
 
-%><div class="blockIndicator jsMinVer jsMinVerHeader">
+%><div class="notecard note">
+    <h4>Note</h4>
     <p><%- str %></p>
 </div>

--- a/kumascript/macros/minversionGeneric.ejs
+++ b/kumascript/macros/minversionGeneric.ejs
@@ -79,17 +79,22 @@ switch(lang) {
 
 switch($0) {
     case 'inline':
-        %><span class="inlineIndicator standardNote"><%=newIn%><%- web.link(wiki.uri(link), productVersion) %></span><%
+        %><span class="notecard inline note"><%=newIn%><%- web.link(wiki.uri(link), productVersion) %></span><%
         break;
     case 'header':
-        %><div class="blockIndicator standardNote">
-<p><%-text%></p>
-</div><%
+        %>
+        <div class="notecard note">
+            <h4>Note</h4>
+            <p><%-text%></p>
+        </div>
+    <%
         break;
     case 'note':
-        %><div class="blockIndicator standardNote">
-    <p><%- web.link(wiki.uri(link), note) %></p>
-    <p style="font-weight:400;"><%-$3%></p>
-</div><%
+        %>
+        <div class="notecard note">
+            <h4><%- web.link(wiki.uri(link), note) %></h4>
+            <p><%-$3%></p>
+        </div>
+        <%
         break;
 } %>

--- a/kumascript/macros/secureContextGeneric.ejs
+++ b/kumascript/macros/secureContextGeneric.ejs
@@ -27,9 +27,9 @@ var str_desc = mdn.localString({
 });
 
 if($0 === 'inline') {
-  result = "<span class='inlineIndicator secureContexts' title='" + str_tooltip + "'>" + str_title + "</span>";
+  result = "<span class='notecard inline secure' title='" + str_tooltip + "'>" + str_title + "</span>";
 } else if($0 === 'header') {
-  result = "<div class='blockIndicator secureContexts'><p><strong>" + str_title + "</strong><br/>" + str_desc + "</p></div>";
+  result = "<div class='notecard secure'><h4>" + str_title + "</h4><p>" + str_desc + "</p></div>";
 }
 %>
 

--- a/kumascript/macros/unimplementedGeneric.ejs
+++ b/kumascript/macros/unimplementedGeneric.ejs
@@ -60,17 +60,18 @@ if ($1 && $0 != 'method') {
 
 switch($0) {
   case 'inline':
-    %><span class="inlineIndicator unimplemented unimplementedInline"><%-str%></span><%
+    %><span class="notecard inline warning"><%-str%></span><%
     break;
   case 'header':
-    %><div class="blockIndicator unimplemented unimplementedHeader">
+    %><div class="notecard warning">
+      <h4>Warning</h4>
       <p><%-str%></p>
       </div><%
     break;
   case 'method':
     %><div>
-      <span class="indicatorInHeadline unimplemented unimplementedMethod"><%- str %></span>
-      <h3><%= $2 %>()</h3>
+      <span class="notecard inline warning"><%- str %></span>
+      <h4><%= $2 %>()</h4>
       </div><%
     break;
 }

--- a/kumascript/macros/warning.ejs
+++ b/kumascript/macros/warning.ejs
@@ -15,6 +15,8 @@ var s_warning = mdn.localString({
     "zh-CN": "Warning:"
 });
 
-%><div class="blockIndicator warning">
-    <p><strong><%=s_warning%></strong> <%- $0 %></p>
+%>
+<div class="notecard warning">
+    <h4><%=s_warning%></h4>
+    <p><%- $0 %></p>
 </div>

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -230,7 +230,7 @@ const info = {
           if (!summary) {
             // To avoid <p> tags that are inside things like
             // `<div class="notecard>`, just remove those divs first.
-            $("div.notecard, div.note").remove();
+            $("div.notecard, div.note, div.blockIndicator").remove();
             $("p").each((i, element) => {
               if (!summary) {
                 const html = $(element)

--- a/kumascript/src/info.js
+++ b/kumascript/src/info.js
@@ -229,8 +229,8 @@ const info = {
           });
           if (!summary) {
             // To avoid <p> tags that are inside things like
-            // `<div class="blockIndicator>`, just remove those divs first.
-            $("div.blockIndicator, div.note").remove();
+            // `<div class="notecard>`, just remove those divs first.
+            $("div.notecard, div.note").remove();
             $("p").each((i, element) => {
               if (!summary) {
                 const html = $(element)

--- a/kumascript/tests/macros/Deprecated.test.js
+++ b/kumascript/tests/macros/Deprecated.test.js
@@ -20,50 +20,50 @@ describeMacro("Deprecated_Inline", function () {
   itMacro('"semver" string only (en-US)', function (macro) {
     return assert.eventually.equal(
       macro.call("1.9.2"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)">Deprecated since Gecko 1.9.2</span>`
+      `<span class="notecard inline deprecated" title="(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)">Deprecated since Gecko 1.9.2</span>`
     );
   });
   itMacro("Numeric version only (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(45),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
+      `<span class="notecard inline deprecated" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
     );
   });
   itMacro("Gecko-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("gecko45"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
+      `<span class="notecard inline deprecated" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
     );
   });
   itMacro("HTML-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("html4"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/HTML">HTML4</a></span>`
+      `<span class="notecard inline deprecated" title="">Deprecated since <a href="/en-US/docs/HTML">HTML4</a></span>`
     );
   });
   itMacro("JS-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("js1.7"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since <a href="/en-US/docs/JavaScript/New_in_JavaScript/1.7">JavaScript 1.7</a></span>`
+      `<span class="notecard inline deprecated" title="">Deprecated since <a href="/en-US/docs/JavaScript/New_in_JavaScript/1.7">JavaScript 1.7</a></span>`
     );
   });
   itMacro("CSS-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("css2"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated since CSS 2</span>`
+      `<span class="notecard inline deprecated" title="">Deprecated since CSS 2</span>`
     );
   });
   itMacro("CSS-prefixed version (ja)", function (macro) {
     macro.ctx.env.locale = "ja";
     return assert.eventually.equal(
       macro.call("css2"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="">非推奨 CSS 2</span>`
+      `<span class="notecard inline deprecated" title="">非推奨 CSS 2</span>`
     );
   });
   itMacro("Nonsense-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("foobar13"),
-      `<span class="inlineIndicator deprecated deprecatedInline" title="">Deprecated</span>`
+      `<span class="notecard inline deprecated" title="">Deprecated</span>`
     );
   });
 });

--- a/kumascript/tests/macros/Draft.test.js
+++ b/kumascript/tests/macros/Draft.test.js
@@ -8,7 +8,7 @@ describeMacro("Draft", () => {
   itMacro("No arguments (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Draft</h4>\n    <p>This page is not complete.</p>\n    \n</div>`
     );
   });
 
@@ -16,7 +16,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "es";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Borrador</h4>\n    <p>Esta página no está completa.</p>\n    \n</div>`
     );
   });
 
@@ -24,7 +24,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "fr";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Brouillon</h4>\n    <p>Cette page n&#39;est pas terminée.</p>\n    \n</div>`
     );
   });
 
@@ -32,7 +32,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ja";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>草案</h4>\n    <p>このページは完成していません。</p>\n    \n</div>`
     );
   });
 
@@ -40,7 +40,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ko";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>초안</h4>\n    <p>이 문서는 작성중입니다.</p>\n    \n</div>`
     );
   });
 
@@ -48,7 +48,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pl";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Szkic</h4>\n    <p>Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
     );
   });
 
@@ -56,7 +56,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "zh-CN";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>草案</h4>\n    <p>本页尚未完工.</p>\n    \n</div>`
     );
   });
 
@@ -64,7 +64,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "zh-TW";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>編撰中</h4>\n    <p>本頁仍未完成</p>\n    \n</div>`
     );
   });
 
@@ -72,7 +72,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pt-PT";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Esboço</h4>\n    <p>Esta página está incompleta.</p>\n    \n</div>`
     );
   });
 
@@ -80,7 +80,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pt-BR";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Rascunho</h4>\n    <p>Esta página está incompleta.</p>\n    \n</div>`
     );
   });
 
@@ -88,14 +88,14 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ru";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="notecard draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <h4>Черновик</h4>\n    <p>Эта страница не завершена.</p>\n    \n</div>`
     );
   });
 
   itMacro("One argument (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("The reason is shrouded in mystery (escattone)."),
-      `<div class="notecard draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
+      `<div class="notecard draft">\n    <h4>Draft</h4>\n    <p>This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
     );
   });
 
@@ -116,7 +116,7 @@ describeMacro("Draft", () => {
             "Root element is a 'draft'"
           );
 
-          let header = dom.querySelector("strong");
+          let header = dom.querySelector("h4");
           // Block indicator has a header
           expect(header).toEqual(expect.anything());
           assert.equal(header.textContent.trim(), "Draft");
@@ -151,7 +151,7 @@ describeMacro("Draft", () => {
             "Root element is a 'draft'"
           );
 
-          let header = dom.querySelector("strong");
+          let header = dom.querySelector("h4");
           // Block indicator has a header
           expect(header).toEqual(expect.anything());
           assert.equal(header.textContent.trim(), "Draft");
@@ -184,7 +184,7 @@ describeMacro("Draft", () => {
           "Root element is a 'draft'"
         );
 
-        let header = dom.querySelector("strong");
+        let header = dom.querySelector("h4");
         // Block indicator has a header
         expect(header).toEqual(expect.anything());
         assert.equal(header.textContent.trim(), "Draft");

--- a/kumascript/tests/macros/Draft.test.js
+++ b/kumascript/tests/macros/Draft.test.js
@@ -8,7 +8,7 @@ describeMacro("Draft", () => {
   itMacro("No arguments (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    \n</div>`
     );
   });
 
@@ -16,7 +16,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "es";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Borrador</strong><br/>\n    Esta página no está completa.</p>\n    \n</div>`
     );
   });
 
@@ -24,7 +24,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "fr";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Brouillon</strong><br/>\n    Cette page n&#39;est pas terminée.</p>\n    \n</div>`
     );
   });
 
@@ -32,7 +32,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ja";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>草案</strong><br/>\n    このページは完成していません。</p>\n    \n</div>`
     );
   });
 
@@ -40,7 +40,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ko";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>초안</strong><br/>\n    이 문서는 작성중입니다.</p>\n    \n</div>`
     );
   });
 
@@ -48,7 +48,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pl";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Szkic</strong><br/>\n    Strona ta nie jest jeszcze ukończona.</p>\n    \n</div>`
     );
   });
 
@@ -56,7 +56,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "zh-CN";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>草案</strong><br/>\n    本页尚未完工.</p>\n    \n</div>`
     );
   });
 
@@ -64,7 +64,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "zh-TW";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>編撰中</strong><br/>\n    本頁仍未完成</p>\n    \n</div>`
     );
   });
 
@@ -72,7 +72,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pt-PT";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Esboço</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
     );
   });
 
@@ -80,7 +80,7 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "pt-BR";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Rascunho</strong><br/>\n    Esta página está incompleta.</p>\n    \n</div>`
     );
   });
 
@@ -88,14 +88,14 @@ describeMacro("Draft", () => {
     macro.ctx.env.locale = "ru";
     return assert.eventually.equal(
       macro.call(),
-      `<div class="blockIndicator draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
+      `<div class="notecard draft">\n    <p><strong>Черновик</strong><br/>\n    Эта страница не завершена.</p>\n    \n</div>`
     );
   });
 
   itMacro("One argument (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("The reason is shrouded in mystery (escattone)."),
-      `<div class="blockIndicator draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
+      `<div class="notecard draft">\n    <p><strong>Draft</strong><br/>\n    This page is not complete.</p>\n    <em>The reason is shrouded in mystery (escattone).</em>\n</div>`
     );
   });
 
@@ -108,8 +108,8 @@ describeMacro("Draft", () => {
           let dom = JSDOM.fragment(result);
           expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
           assert(
-            dom.firstElementChild.classList.contains("blockIndicator"),
-            "Root element is a 'blockIndicator'"
+            dom.firstElementChild.classList.contains("notecard"),
+            "Root element is a 'notecard'"
           );
           assert(
             dom.firstElementChild.classList.contains("draft"),
@@ -143,8 +143,8 @@ describeMacro("Draft", () => {
           let dom = JSDOM.fragment(result);
           expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
           assert(
-            dom.firstElementChild.classList.contains("blockIndicator"),
-            "Root element is a 'blockIndicator'"
+            dom.firstElementChild.classList.contains("notecard"),
+            "Root element is a 'notecard'"
           );
           assert(
             dom.firstElementChild.classList.contains("draft"),
@@ -176,8 +176,8 @@ describeMacro("Draft", () => {
         let dom = JSDOM.fragment(result);
         expect(dom.childElementCount).toBeGreaterThanOrEqual(1);
         assert(
-          dom.firstElementChild.classList.contains("blockIndicator"),
-          "Root element is a 'blockIndicator'"
+          dom.firstElementChild.classList.contains("notecard"),
+          "Root element is a 'notecard'"
         );
         assert(
           dom.firstElementChild.classList.contains("draft"),


### PR DESCRIPTION
Update kumascript macros in preparation for the changes from minimalist release 0.2.6

## Before

![Screenshot 2020-11-11 at 17 56 55](https://user-images.githubusercontent.com/10350960/98834276-ad145180-2447-11eb-82ba-e609f5433abe.png)

## After

![Screenshot 2020-11-11 at 17 49 43](https://user-images.githubusercontent.com/10350960/98834309-b7cee680-2447-11eb-9bcc-eae74c238341.png)

Test page: http://localhost.org:3000/en-US/docs/Web/API/Window/applicationCache

### These are some macros we should probably consider deprecating:

- /yari/kumascript/macros/B2GOnlyHeader2.ejs
- /yari/kumascript/macros/Draft.ejs
- /yari/kumascript/macros/gecko_minversion_note.ejs
- /yari/kumascript/macros/jsOverrides.ejs
- /yari/kumascript/macros/LegacyAddonsNotice.ejs
- /yari/kumascript/macros/NoteStart.ejs
- /yari/kumascript/macros/SimpleBanner.ejs
- /yari/kumascript/macros/warning.ejs

part of #1133