### PR TITLE
Different deployment strategies for prod, stage, and dev

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,31 +1,30 @@
-name: Production Build
+name: Dev Build
 
-env:
-  DEFAULT_DEPLOYMENT_PREFIX: "main"
-  DEFAULT_NOTES: ""
-  DEFAULT_ARCHIVED_CONTENT: "false"
-  DEFAULT_TRANSLATED_CONTENT: "false"
-  DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
+# NOTE! This is the *DEV* workflow.
+# Keep in mind that much of the configuration is repeated in `prod-build.yml`
+# and `stage-build.yml`
+#
+# For a complete picture of all environments, see:
+#
+#  https://docs.google.com/spreadsheets/d/1VnnEl-iTtKYmlyN02FiEXygxZCgE4o_ZO8wSleebne4/edit?usp=sharing
+#
 
+# NOTE! Unlike prod and stage, this work only works on manual dispatch
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 */24 * * *"
-
   workflow_dispatch:
     inputs:
       notes:
         description: "Notes"
         required: false
-        default: ${DEFAULT_NOTES}
+        default: ""
       archived_content:
         description: "Build archived content"
         required: false
-        default: ${DEFAULT_ARCHIVED_CONTENT}
+        default: "false"
       translated_content:
         description: "Build translated content"
         required: false
-        default: ${DEFAULT_TRANSLATED_CONTENT}
+        default: "false"
 
       # This is very useful when combined with the "Use workflow from"
       # feature that is built into the "Run workflow" button on
@@ -36,12 +35,12 @@ on:
       deployment_prefix:
         description: "Deployment prefix"
         required: false
-        default: ${DEFAULT_DEPLOYMENT_PREFIX}
+        default: "main"
 
       log_each_successful_upload:
         description: "Deployer logs each success"
         required: false
-        default: ${DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD}
+        default: "false"
 
 jobs:
   build:
@@ -56,13 +55,13 @@ jobs:
           path: mdn/content
 
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT, 'true')"
+        if: "contains(github.event.inputs.archived_content, 'true')"
         with:
           repository: mdn/archived-content
           path: mdn/archived-content
 
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')"
+        if: "contains(github.event.inputs.translated_content, 'true')"
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
@@ -106,11 +105,11 @@ jobs:
 
       - name: Print information about build
         run: |
-          echo "notes: ${{ github.event.inputs.notes || env.DEFAULT_NOTES }}"
-          echo "archived_content: ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }}"
-          echo "translated_content: ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}"
-          echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}"
-          echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
+          echo "notes: ${{ github.event.inputs.notes }}"
+          echo "archived_content: ${{ github.event.inputs.archived_content }}"
+          echo "translated_content: ${{ github.event.inputs.translated_content }}"
+          echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload }}"
+          echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix }}"
 
       - name: Build everything
         run: |
@@ -118,13 +117,13 @@ jobs:
           # sub-folder called "mdn/content"
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else
@@ -136,14 +135,9 @@ jobs:
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
 
-          # The default for this environment variable is geared for writers
-          # (aka. local development). Usually defaults are supposed to be for
-          # secure production but this is an exception and default
-          # is not insecure.
-          #export BUILD_LIVE_SAMPLES_BASE_URL=https://mdn.mozillademos.org
-          # WARNING: The following is temporary, only because, for now, we're
-          #          deploying to the mdn-content-dev S3 bucket. Remove once
-          #          we start deploying to the mdn-content-prod S3 bucket!
+          # This basically means that all live-sample iframes run on the same
+          # host as the page that includes the iframe. Not great security but the
+          # context is that this is Dev and it's not connected to a real backend.
           export BUILD_LIVE_SAMPLES_BASE_URL=
 
           # Now is not the time to worry about flaws.
@@ -155,11 +149,9 @@ jobs:
           # the workflow needs to do.
           # export BUILD_FOLDERSEARCH=web/html
 
-          # This is the Google Analytics account ID for developer.mozilla.org
-          # If it's used on other domains (e.g. stage or dev builds), it's OK
-          # because ultimately Google Analytics will filter it out since the
-          # origin domain isn't what that account expects.
-          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
+          # This just makes sure the Google Analytics script gets used even if
+          # it goes nowhere.
+          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
 
           yarn build
 
@@ -172,13 +164,13 @@ jobs:
           # Set the CONTENT_ROOT first
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else
@@ -196,13 +188,20 @@ jobs:
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
 
           export DEPLOYER_BUCKET_NAME=mdn-content-dev
-          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
-          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
+          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix }}
+          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload }}
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_AWS_SECRET_ACCESS_KEY }}
+          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
 
           poetry run deployer upload ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
+          # TODO
+          # Execute command to tell the Dev CloudFront distribution to use the
+          # latest and greatest *version* of the updated lambda functions.
+          # (Or, make it an optional flag to the `update-lambda-functions` command)
+
+          # TODO
+          # Execute command to publish built content to Elasticsearch

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -1,0 +1,209 @@
+name: Prod Build
+
+# NOTE! This is the *PROD* workflow.
+# Keep in mind that much of the configuration is repeated in `stage-build.yml`
+# and `dev-build.yml`
+#
+# For a complete picture of all environments, see:
+#
+#  https://docs.google.com/spreadsheets/d/1VnnEl-iTtKYmlyN02FiEXygxZCgE4o_ZO8wSleebne4/edit?usp=sharing
+#
+
+env:
+  DEFAULT_DEPLOYMENT_PREFIX: "main"
+  DEFAULT_NOTES: ""
+  DEFAULT_ARCHIVED_CONTENT: "false"
+  DEFAULT_TRANSLATED_CONTENT: "false"
+  DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 */24 * * *"
+
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Notes"
+        required: false
+        default: ${DEFAULT_NOTES}
+      archived_content:
+        description: "Build archived content"
+        required: false
+        default: ${DEFAULT_ARCHIVED_CONTENT}
+      translated_content:
+        description: "Build translated content"
+        required: false
+        default: ${DEFAULT_TRANSLATED_CONTENT}
+
+      # This is very useful when combined with the "Use workflow from"
+      # feature that is built into the "Run workflow" button on
+      # https://github.com/mdn/yari/actions?query=workflow%3A%22Production+Build%22
+      # If you override the deployment prefix to something like the name
+      # of the branch, you can deploy that entire branch to its own prefix
+      # in S3 which means that it can be fully hosted as its own site.
+      deployment_prefix:
+        description: "Deployment prefix"
+        required: false
+        default: ${DEFAULT_DEPLOYMENT_PREFIX}
+
+      log_each_successful_upload:
+        description: "Deployer logs each success"
+        required: false
+        default: ${DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: mdn/content
+          path: mdn/content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT, 'true')"
+        with:
+          repository: mdn/archived-content
+          path: mdn/archived-content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')"
+        with:
+          repository: mdn/translated-content
+          path: mdn/translated-content
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "12"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Python poetry
+        uses: dschep/install-poetry-action@v1.3
+
+      - name: Install deployer
+        run: |
+          cd deployer
+          poetry install
+
+      - name: Display Python & Poetry version
+        run: |
+          python --version
+          poetry --version
+
+      - name: Print information about build
+        run: |
+          echo "notes: ${{ github.event.inputs.notes || env.DEFAULT_NOTES }}"
+          echo "archived_content: ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }}"
+          echo "translated_content: ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}"
+          echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}"
+          echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
+
+      - name: Build everything
+        run: |
+          # Remember, the mdn/content repo got cloned into `pwd` into a
+          # sub-folder called "mdn/content"
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          # The default for this environment variable is geared for writers
+          # (aka. local development). Usually defaults are supposed to be for
+          # secure production but this is an exception and default
+          # is not insecure.
+          export BUILD_LIVE_SAMPLES_BASE_URL=https://yari-demos.prod.mdn.mozit.cloud
+
+          # Now is not the time to worry about flaws.
+          export BUILD_FLAW_LEVELS="*:ignore"
+          yarn prepare-build
+
+          # This is the Google Analytics account ID for developer.mozilla.org
+          # If it's used on other domains (e.g. stage or dev builds), it's OK
+          # because ultimately Google Analytics will filter it out since the
+          # origin domain isn't what that account expects.
+          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
+
+          yarn build
+
+          du -sh client/build
+
+      - name: Deploy with deployer
+        run: |
+          # Set the CONTENT_ROOT first
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          cd deployer
+
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
+
+          export DEPLOYER_BUCKET_NAME=mdn-content-prod
+          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
+          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
+          # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
+          echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
+
+          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}
+
+          poetry run deployer upload ../client/build
+          poetry run deployer update-lambda-functions ./aws-lambda
+
+          # TODO
+          # Execute command to publish built content to Elasticsearch

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -1,0 +1,209 @@
+name: Stage Build
+
+# NOTE! This is the *STAGE* workflow.
+# Keep in mind that much of the configuration is repeated in `prod-build.yml`
+# and `dev-build.yml`
+#
+# For a complete picture of all environments, see:
+#
+#  https://docs.google.com/spreadsheets/d/1VnnEl-iTtKYmlyN02FiEXygxZCgE4o_ZO8wSleebne4/edit?usp=sharing
+#
+
+env:
+  DEFAULT_DEPLOYMENT_PREFIX: "main"
+  DEFAULT_NOTES: ""
+  DEFAULT_ARCHIVED_CONTENT: "false"
+  DEFAULT_TRANSLATED_CONTENT: "false"
+  DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 */12 * * *"
+
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Notes"
+        required: false
+        default: ${DEFAULT_NOTES}
+      archived_content:
+        description: "Build archived content"
+        required: false
+        default: ${DEFAULT_ARCHIVED_CONTENT}
+      translated_content:
+        description: "Build translated content"
+        required: false
+        default: ${DEFAULT_TRANSLATED_CONTENT}
+
+      # This is very useful when combined with the "Use workflow from"
+      # feature that is built into the "Run workflow" button on
+      # https://github.com/mdn/yari/actions?query=workflow%3A%22Production+Build%22
+      # If you override the deployment prefix to something like the name
+      # of the branch, you can deploy that entire branch to its own prefix
+      # in S3 which means that it can be fully hosted as its own site.
+      deployment_prefix:
+        description: "Deployment prefix"
+        required: false
+        default: ${DEFAULT_DEPLOYMENT_PREFIX}
+
+      log_each_successful_upload:
+        description: "Deployer logs each success"
+        required: false
+        default: ${DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/checkout@v2
+        with:
+          repository: mdn/content
+          path: mdn/content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT, 'true')"
+        with:
+          repository: mdn/archived-content
+          path: mdn/archived-content
+
+      - uses: actions/checkout@v2
+        if: "contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')"
+        with:
+          repository: mdn/translated-content
+          path: mdn/translated-content
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: "12"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2.1.3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install all yarn packages
+        run: yarn --frozen-lockfile
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Python poetry
+        uses: dschep/install-poetry-action@v1.3
+
+      - name: Install deployer
+        run: |
+          cd deployer
+          poetry install
+
+      - name: Display Python & Poetry version
+        run: |
+          python --version
+          poetry --version
+
+      - name: Print information about build
+        run: |
+          echo "notes: ${{ github.event.inputs.notes || env.DEFAULT_NOTES }}"
+          echo "archived_content: ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }}"
+          echo "translated_content: ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}"
+          echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}"
+          echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
+
+      - name: Build everything
+        run: |
+          # Remember, the mdn/content repo got cloned into `pwd` into a
+          # sub-folder called "mdn/content"
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          # The default for this environment variable is geared for writers
+          # (aka. local development). Usually defaults are supposed to be for
+          # secure production but this is an exception and default
+          # is not insecure.
+          export BUILD_LIVE_SAMPLES_BASE_URL=https://yari-demos.stage.mdn.mozit.cloud
+
+          # Now is not the time to worry about flaws.
+          export BUILD_FLAW_LEVELS="*:ignore"
+          yarn prepare-build
+
+          # This is the Google Analytics account ID for developer.mozilla.org
+          # If it's used on other domains (e.g. stage or dev builds), it's OK
+          # because ultimately Google Analytics will filter it out since the
+          # origin domain isn't what that account expects.
+          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
+
+          yarn build
+
+          du -sh client/build
+
+      - name: Deploy with deployer
+        run: |
+          # Set the CONTENT_ROOT first
+          export CONTENT_ROOT=$(pwd)/mdn/content/files
+
+          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/archived-content too"
+            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+          else
+            echo "Will NOT build mdn/archived-content too"
+          fi
+          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+            echo "Will build mdn/translated-content too"
+            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+          else
+            echo "Will NOT build mdn/translated-content too"
+          fi
+
+          # Info about which CONTENT_* environment variables were set and to what.
+          echo "CONTENT_ROOT=$CONTENT_ROOT"
+          echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
+          echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
+
+          cd deployer
+
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
+          poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
+
+          export DEPLOYER_BUCKET_NAME=mdn-content-stage
+          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
+          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
+          # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
+          echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
+
+          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
+
+          poetry run deployer upload ../client/build
+          poetry run deployer update-lambda-functions ./aws-lambda
+
+          # TODO
+          # Execute command to publish built content to Elasticsearch

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -13,7 +13,7 @@ Prod and stage are supposed to be as similar as possible.
 All environments are as separate from each other as possible.
 
 You can manually trigger a build for any environment (using the GitHub UI)
-but only prod and stage are building on a cron job.
+but only prod and stage build on a cron job.
 
 ## The details
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,0 +1,73 @@
+# Deployment Environments
+
+## There are 3 environments
+
+1. Prod - developer.mozilla.org
+2. Stage - developer.allizom.org
+3. Dev(s) - [main].content.dev.mdn.mozit.cloud
+
+## Ground rules
+
+Prod and stage are supposed to be as similar as possible.
+
+All environments are as separate from each other as possible.
+
+You can manually trigger a build for any environment (using the GitHub UI)
+but only prod and stage are building on a cron job.
+
+## The details
+
+We will try to commit to maintaining the (public) details for each environment in
+[this spreadsheet](https://docs.google.com/spreadsheets/d/1VnnEl-iTtKYmlyN02FiEXygxZCgE4o_ZO8wSleebne4/edit?usp=sharing).
+
+But the best source of details are in viewing the 3 GitHub Action workflows:
+
+1. `prod-build.yml`
+1. `stage-build.yml`
+1. `dev-build.yml`
+
+Note! Yes, these files are very similar in various tricks and techniques are
+blatantly repeated across all three files. But the benefit is that it keeps things
+simple for the benefit of security.
+
+## Stage is for testing
+
+The stage environment is updated most frequently. Use it for quality assurance
+testing.
+
+Unlike dev, the stage environment is actually connected to a real database
+(the Kuma stage environment).
+
+## Dev is for experimenting
+
+Use this environment when you can't wait for the cron schedule for stage,
+or if you want to try out a specific (git) branch.
+
+The default deployment prefix is `main` which is the first word in the domain name:
+`main.content.dev.mdn.mozit.cloud`. But you can deploy to the dev environment
+with a custom prefix. E.g. `web-perf-experiment123` and then the URL becomes:
+`web-perf-experiment123.content.dev.mdn.mozit.cloud`.
+
+## With or without Kuma
+
+The biggest difference between dev compared to prod & stage, is that the
+backend API is faked in dev. This includes the ability to sign in.
+Also, in prod & stage, the CDN (AWS CloudFront) is configured to fall back to
+Kuma to render what can't be rendered as a static asset.
+
+## Tracking Whatsdeployed
+
+### Prod
+
+- [Code](INSERT-URL-WHEN-WE-HAVE-IT)
+- [Content](INSERT-URL-WHEN-WE-HAVE-IT)
+
+### Stage
+
+- [Code](INSERT-URL-WHEN-WE-HAVE-IT)
+- [Content](INSERT-URL-WHEN-WE-HAVE-IT)
+
+### Dev (`main`)
+
+- [Code](https://whatsdeployed.io/s/Rzl/mdn/yari)
+- [Content](https://whatsdeployed.io/s/DLi/mdn/content)


### PR DESCRIPTION
Part of #1713

@escattone I'm starting to get writers-block. I can't think of anything else to include now. 
I wanted to jot down some key points in that markdown documentation file, but I deliberately tried to be brief to not overcommit to too many technical details. 

I quite like the look of this! It's never pretty to have to see all those little bash tricks repeated so heavily, but I quite like the idea that you can put on your Stage environment hat and work exclusively on that without having to worry about breaking something in prod or dev, for example. 