### PR TITLE
rel=alternate links

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -62,8 +62,9 @@ async function buildDocuments() {
         translationsOf.set(translation_of, []);
       }
       translationsOf.get(translation_of).push({
-        slug: document.metadata.slug,
+        url: document.url,
         locale: document.metadata.locale,
+        title: document.metadata.title,
       });
       // This is a shortcoming. If this is a translated document, we don't have a
       // complete mapping of all other translations. So, the best we can do is

--- a/build/index.js
+++ b/build/index.js
@@ -301,7 +301,17 @@ async function buildDocument(document, documentOptions = {}) {
     // If built just-in-time, we won't have a record of all the other translations
     // available. But if the current document has a translation_of, we can
     // at least use that.
-    otherTranslations.push({ locale: "en-US", slug: metadata.translation_of });
+    const translationOf = Document.findByURL(
+      `/en-US/docs/${metadata.translation_of}`
+    );
+    if (translationOf) {
+      otherTranslations.push({
+        locale: "en-US",
+        // slug: translationOf.metadata.slug,
+        url: translationOf.url,
+        title: translationOf.metadata.title,
+      });
+    }
   }
 
   if (otherTranslations.length) {

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -10,6 +10,39 @@ import {
   GOOGLE_ANALYTICS_DEBUG,
 } from "../build/constants";
 
+// When there are multiple options for a given language, this gives the
+// preferred locale for that language (language => preferred locale).
+const PREFERRED_LOCALE = {
+  pt: "pt-PT",
+  zh: "zh-CN",
+};
+
+function getHrefLang(locale, otherLocales) {
+  // In most cases, just return the language code, removing the country
+  // code if present (so, for example, 'en-US' becomes 'en').
+  let hreflang = locale.split("-")[0];
+
+  // Suppose the locale is one that is ambiguous, we need to fall back on a
+  // a preferred one. For example, if the document is available in 'zh-CN' and
+  // in 'zh-TW', we need to output something like this:
+  //   <link rel=alternate hreflang=zh href=...>
+  //   <link rel=alternate hreflang=zh-TW href=...>
+  //
+  // But other bother if both ambigious locale-to-hreflang are present.
+  const preferred = PREFERRED_LOCALE[hreflang];
+  if (preferred) {
+    // e.g. `preferred===zh-CN` if hreflang was `zh`
+    if (locale !== preferred) {
+      // e.g. `locale===zh-TW`
+      if (otherLocales.includes(preferred)) {
+        // If the more preferred one was there, use the locale + region format.
+        return locale;
+      }
+    }
+  }
+  return hreflang;
+}
+
 const lazy = (creator) => {
   let res;
   let processed = false;
@@ -114,6 +147,20 @@ export default function render(renderApp, doc) {
       doc
     )});</script>`;
     $("#root").after(documentDataTag);
+
+    if (doc.other_translations) {
+      const allOtherLocales = doc.other_translations.map((t) => t.locale);
+      for (const translation of doc.other_translations) {
+        // The locale used in `<link rel="alternate">` needs to be the ISO-639-1
+        // code. For example, it's "en", not "en-US". And it's "sv" not "sv-SE".
+        // See https://developers.google.com/search/docs/advanced/crawling/localized-versions?hl=en&visit_id=637411409912568511-3980844248&rd=1#language-codes
+        $('<link rel="alternate">')
+          .attr("title", translation.title)
+          .attr("href", `https://developer.mozilla.org${translation.url}`)
+          .attr("hreflang", getHrefLang(translation.locale, allOtherLocales))
+          .insertAfter("title");
+      }
+    }
   }
 
   if (pageDescription) {


### PR DESCRIPTION
Fixes #1603

I know this is very hard to test but I know it works. 
You need to have the `translated-content` repo, which only I have on my laptop 🙃. But you can generate one with the importer. 
Or, we can just land this and see how it goes once we enable the translated content in the stage builds. 

Basically, what it does is almost exactly what Kuma does. 
When I open view-source:http://localhost:5000/en-US/docs/Web/HTML/Element/a/ I get: https://gist.github.com/peterbe/f0dd4e116f163e2cda59c3f871ac0adc (pretty printed)
Note that it uses 
```html
  <link
    rel="alternate"
    title="&lt;a&gt;"
    href="https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/a"
    hreflang="zh"
  />
```
for the "Chinese" alternate URL. 
But because the document is available in Traditional Chinese too, it does include:
```html
  <link
    rel="alternate"
    title="&lt;a&gt;"
    href="https://developer.mozilla.org/zh-TW/docs/Web/HTML/Element/a"
    hreflang="zh-TW"
  />
```
...additionally. 

[This is exactly how Kuma works, as far as I understand.](https://github.com/mdn/kuma/blob/1c80ecae7a05c5bf4552495e211f142359ee955a/kuma/wiki/models.py#L1499-L1528)

