### PR TITLE
unbreak poetry install in GHA

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -91,7 +91,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install Python poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install deployer
         run: |

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install Python poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install deployer
         run: |

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -101,7 +101,7 @@ jobs:
           python-version: "3.8"
 
       - name: Install Python poetry
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install deployer
         run: |


### PR DESCRIPTION
I'll be honest, I started reading the error messages and the documentation and I just got half lost and half bored. 
The lines that broke are these: https://github.com/mdn/yari/blob/12e461062567ab8e0db6e4c659e1ba562a2b0572/.github/workflows/dev-build.yml#L93-L94


So I went to [their repo](https://github.com/dschep/install-poetry-action) to see if there are any issues/PRs. 
But then I see that repo is archived and it recommends to use: [`snok/install-poetry`](https://github.com/snok/install-poetry) instead. 
So I changed to that and suddenly, [it can now build set up `poetry` again](https://github.com/mdn/yari/runs/1414185250?check_suite_focus=true).


