### PR TITLE
cope with old locale prefixes

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -2,7 +2,6 @@ const VALID_LOCALES = new Map(
   [
     "ar",
     "bg",
-    "bm",
     "bn",
     "ca",
     "de",
@@ -39,7 +38,18 @@ const VALID_LOCALES = new Map(
 
 const DEFAULT_LOCALE = "en-US";
 
+const LOCALE_ALIASES = new Map([
+  // Case is not important on either the keys or the values.
+  ["en", "en-us"],
+  ["bn-bd", "bn"],
+  ["ja-jp", "ja"],
+  ["pt", "pt-PT"], // Note! Portugal Portugese is the default
+  ["cn", "zh-cn"],
+  ["zh", "zh-tw"],
+]);
+
 module.exports = {
   VALID_LOCALES,
   DEFAULT_LOCALE,
+  LOCALE_ALIASES,
 };

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -41,11 +41,11 @@ const DEFAULT_LOCALE = "en-US";
 const LOCALE_ALIASES = new Map([
   // Case is not important on either the keys or the values.
   ["en", "en-us"],
-  ["bn-bd", "bn"],
-  ["ja-jp", "ja"],
   ["pt", "pt-PT"], // Note! Portugal Portugese is the default
   ["cn", "zh-cn"],
-  ["zh", "zh-tw"],
+  ["zh", "zh-cn"],
+  ["zh-hans", "zh-cn"],
+  ["zh-hant", "zh-tw"],
 ]);
 
 module.exports = {

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1163,8 +1163,8 @@ const REDIRECT_PATTERNS = [].concat(
       ({ subPath }) => `https://wiki.mozilla.org/docs/ServerJS${subPath}`,
       { prependLocale: false, permanent: true }
     ),
-  ]
-  // LOCALE_PATTERNS
+  ],
+  LOCALE_PATTERNS
 );
 
 const STARTING_SLASH = /^\//;

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -53,8 +53,8 @@ for (const locale of VALID_LOCALES.keys()) {
     // E.g. `en-US` becomes alias `en_US`
     fixableLocales.set(locale.replace("-", "_").toLowerCase(), locale);
   } else {
-    // E.g. `fr` becomes alias `fr-fr`
-    fixableLocales.set(`${locale}-${locale}`.toLowerCase(), locale);
+    // E.g. `fr` becomes alias `fr-XX`
+    fixableLocales.set(`${locale}-\\w{2}`.toLowerCase(), locale);
   }
 }
 
@@ -73,9 +73,15 @@ const LOCALE_PATTERNS = [
       "i"
     ),
     ({ locale, suffix }) => {
-      return `/${VALID_LOCALES.get(
-        fixableLocales.get(locale.toLowerCase()).toLowerCase()
-      )}/${suffix}`;
+      if (fixableLocales.has(locale.toLowerCase())) {
+        // E.g. it was something like `en_Us`
+        return `/${VALID_LOCALES.get(
+          fixableLocales.get(locale.toLowerCase()).toLowerCase()
+        )}/${suffix}`;
+      }
+      // E.g. it was something like `Fr-sW` (Swiss French)
+      locale = locale.split("-")[0];
+      return `/${VALID_LOCALES.get(locale.toLowerCase())}/${suffix}`;
     },
     { permanent: true }
   ),

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -69,19 +69,20 @@ const LOCALE_PATTERNS = [
     new RegExp(
       `^(?<locale>${Array.from(fixableLocales.keys()).join(
         "|"
-      )})/(?<suffix>.*)`,
+      )})(/(?<suffix>.*)|$)`,
       "i"
     ),
     ({ locale, suffix }) => {
-      if (fixableLocales.has(locale.toLowerCase())) {
+      locale = locale.toLowerCase();
+      if (fixableLocales.has(locale)) {
         // E.g. it was something like `en_Us`
-        return `/${VALID_LOCALES.get(
-          fixableLocales.get(locale.toLowerCase()).toLowerCase()
-        )}/${suffix}`;
+        locale = VALID_LOCALES.get(fixableLocales.get(locale).toLowerCase());
+      } else {
+        // E.g. it was something like `Fr-sW` (Swiss French)
+        locale = locale.split("-")[0];
+        locale = VALID_LOCALES.get(locale);
       }
-      // E.g. it was something like `Fr-sW` (Swiss French)
-      locale = locale.split("-")[0];
-      return `/${VALID_LOCALES.get(locale.toLowerCase())}/${suffix}`;
+      return `/${locale}/${suffix || ""}`;
     },
     { permanent: true }
   ),

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1144,7 +1144,6 @@ for (const [pattern, path] of [
 }
 
 const REDIRECT_PATTERNS = [].concat(
-  LOCALE_PATTERNS,
   SCL3_REDIRECT_PATTERNS,
   ZONE_REDIRECT_PATTERNS,
   MARIONETTE_REDIRECT_PATTERNS,
@@ -1165,6 +1164,7 @@ const REDIRECT_PATTERNS = [].concat(
       { prependLocale: false, permanent: true }
     ),
   ]
+  // LOCALE_PATTERNS
 );
 
 const STARTING_SLASH = /^\//;

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -967,6 +967,28 @@ const FIREFOX_SOURCE_DOCS_URLS = [].concat(
   )
 );
 
+const LOCALE_ALIAS_URLS = [].concat(
+  url_test("/en-US/docs/Foo/bar", null, { statusCode: 404 }),
+  url_test("/eN-uS/docs/Foo/bar", null, { statusCode: 404 }),
+  url_test("/en-au/docs/Foo/bar", null, { statusCode: 404 }),
+  url_test("/en-gb/docs/Foo/bar", null, { statusCode: 404 }),
+  url_test("/en_gb/docs/Foo/bar", null, { statusCode: 404 }),
+
+  url_test("/PT-PT/docs/Foo/bar", null, { statusCode: 404 }),
+  url_test("/XY-PQ/docs/Foo/bar", null, { statusCode: 404 }),
+
+  url_test("/en/docs/Foo/bar", "/en-US/docs/Foo/bar"),
+  url_test("/En_uS/docs/Foo/bar", "/en-US/docs/Foo/bar"),
+  url_test("/pt/docs/Foo/bar", "/pt-PT/docs/Foo/bar"),
+  url_test("/Fr-FR/docs/Foo/bar", "/fr/docs/Foo/bar"),
+  url_test("/JA-JP/docs/Foo/bar", "/ja/docs/Foo/bar"),
+  url_test("/JA-JA/docs/Foo/bar", "/ja/docs/Foo/bar"),
+  url_test("/JA-JX/docs/Foo/bar", "/ja/docs/Foo/bar"),
+  url_test("/fR-SW/docs/Foo/bar", "/fr/docs/Foo/bar"),
+  url_test("/zh-HAnt/docs/Foo/bar", "/zh-TW/docs/Foo/bar"),
+  url_test("/zH-HAns/docs/Foo/bar", "/zh-CN/docs/Foo/bar")
+);
+
 describe("scl3 redirects", () => {
   for (const [url, t] of SCL3_REDIRECT_URLS) {
     it(url, t);
@@ -1029,6 +1051,12 @@ describe("firefox accounts redirects", () => {
 
 describe("firefox src docs redirects", () => {
   for (const [url, t] of FIREFOX_SOURCE_DOCS_URLS) {
+    it(url, t);
+  }
+});
+
+describe("locale alias redirects", () => {
+  for (const [url, t] of LOCALE_ALIAS_URLS) {
     it(url, t);
   }
 });

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -986,7 +986,16 @@ const LOCALE_ALIAS_URLS = [].concat(
   url_test("/JA-JX/docs/Foo/bar", "/ja/docs/Foo/bar"),
   url_test("/fR-SW/docs/Foo/bar", "/fr/docs/Foo/bar"),
   url_test("/zh-HAnt/docs/Foo/bar", "/zh-TW/docs/Foo/bar"),
-  url_test("/zH-HAns/docs/Foo/bar", "/zh-CN/docs/Foo/bar")
+  url_test("/zH-HAns/docs/Foo/bar", "/zh-CN/docs/Foo/bar"),
+  url_test("/zh/docs/Foo/bar", "/zh-CN/docs/Foo/bar"),
+  url_test("/cn/docs/Foo/bar", "/zh-CN/docs/Foo/bar"),
+
+  // No suffix
+  url_test("/en", "/en-US/"),
+  url_test("/en/", "/en-US/"),
+  url_test("/En_uS", "/en-US/"),
+  url_test("/Fr-FR", "/fr/"),
+  url_test("/zh", "/zh-CN/")
 );
 
 describe("scl3 redirects", () => {


### PR DESCRIPTION
Part of #1345

Here's how I tested it manually:
```javascript
const { resolveFundamental } = require("./libs/fundamental-redirects");

console.log(resolveFundamental("/en/docs/Foo/bar"));
console.log(resolveFundamental("/En_uS/docs/Foo/bar"));
console.log(resolveFundamental("/pt/docs/Foo/bar"));
console.log(resolveFundamental("/fr-FR/docs/Foo/bar"));
console.log('-');
console.log(resolveFundamental("/en-US/docs/Foo/bar"));
console.log(resolveFundamental("/en-us/docs/Foo/bar"));
```
Outputs:
```
{ url: '/en-US/docs/Foo/bar', status: 301 }
{ url: '/en-US/docs/Foo/bar', status: 301 }
{ url: '/pt-PT/docs/Foo/bar', status: 301 }
{ url: '/fr/docs/Foo/bar', status: 301 }
-
{}
{}
```

So the key here is that there is exactly 1 single Map object we need to maintain to control all legacy locale redirects. The `LOCALE_ALIASES` map. It's quite possible I forgot something but apart from `el-gr` this solution addresses all links we have within the built pages, based on [this research](https://github.com/mdn/yari/issues/1345#issuecomment-729799323).

Now, I'm not familiar with URLs like `/zh-HANT/docs/Web` or `/zh-hans/docs/Web` but if you believe these are still coming in to our CDN, from external links, then we can simply add those the `LOCALE_ALIASES` map. 

The reason this PR isn't saying "Fixes" is because we chatted on Slack about discussing this a bit more in person. So I never added the extra tests. 