### PR TITLE
unbreak 'deployer' test suite

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -124,6 +124,8 @@ jobs:
       - name: Lint Python code
         if: env.GIT_DIFF
         run: |
+          ls -la
+          ls -la deployer
           source .venv/bin/activate
           flake8 deployer
           black --check deployer

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install Python poetry
         if: env.GIT_DIFF
-        uses: dschep/install-poetry-action@v1.3
+        uses: snok/install-poetry@v1.1.1
 
       - name: Install deployer
         if: env.GIT_DIFF

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -125,11 +125,9 @@ jobs:
       - name: Lint Python code
         if: env.GIT_DIFF
         run: |
-          ls -la
-          ls -la deployer
           source deployer/.venv/bin/activate
-          flake8 deployer
-          black --check deployer
+          flake8 deployer/src
+          black --check deployer/src
 
       - name: Basic run of deployer
         if: env.GIT_DIFF

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Lint Python code
         if: env.GIT_DIFF
         run: |
+          pwd
+          ls
+          poetry run
           flake8 deployer
           black --check deployer
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -98,12 +98,22 @@ jobs:
       - name: Install Python poetry
         if: env.GIT_DIFF
         uses: snok/install-poetry@v1.1.1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install deployer
-        if: env.GIT_DIFF
         run: |
           cd deployer
           poetry install
+        if: env.GIT_DIFF && steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
       - name: Display Python & Poetry version
         if: env.GIT_DIFF
@@ -114,9 +124,7 @@ jobs:
       - name: Lint Python code
         if: env.GIT_DIFF
         run: |
-          pwd
-          ls
-          poetry run
+          source .venv/bin/activate
           flake8 deployer
           black --check deployer
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -107,7 +107,7 @@ jobs:
         id: cached-poetry-dependencies
         uses: actions/cache@v2
         with:
-          path: .venv
+          path: deployer/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install deployer

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -103,6 +103,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Load cached venv
+        if: env.GIT_DIFF
         id: cached-poetry-dependencies
         uses: actions/cache@v2
         with:
@@ -126,7 +127,7 @@ jobs:
         run: |
           ls -la
           ls -la deployer
-          source .venv/bin/activate
+          source deployer/.venv/bin/activate
           flake8 deployer
           black --check deployer
 

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -149,5 +149,3 @@ And to check that all files are formatted according to `black` run:
 ```sh
 black --check deployer
 ```
-
-.TEST CHANGE. Delete me.

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -149,3 +149,5 @@ And to check that all files are formatted according to `black` run:
 ```sh
 black --check deployer
 ```
+
+.TEST CHANGE. Delete me.

--- a/deployer/src/deployer/constants.py
+++ b/deployer/src/deployer/constants.py
@@ -13,8 +13,8 @@ DEFAULT_BUCKET_NAME = config("DEPLOYER_BUCKET_NAME", default="mdn-content-dev")
 DEFAULT_BUCKET_PREFIX = config("DEPLOYER_BUCKET_PREFIX", default="main")
 
 # When uploading a bunch of files, the work is done in a thread pool.
-# If you use too many "workers" it might saturate your network meaning it's
-# slower.
+# If you use too many "workers" it might saturate your network, meaning it's
+# ultimately slower.
 MAX_WORKERS_PARALLEL_UPLOADS = config(
     "DEPLOYER_MAX_WORKERS_PARALLEL_UPLOADS", default=50, cast=int
 )

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -12,8 +12,8 @@ from .constants import (
 )
 from .update_lambda_functions import update_all
 from .upload import upload_content
-from .whatsdeployed import dump as dump_whatsdeployed
 from .utils import log
+from .whatsdeployed import dump as dump_whatsdeployed
 
 
 def validate_directory(ctx, param, value):


### PR DESCRIPTION
Following the directions on https://github.com/snok/install-poetry#testing

The problem was that when I did https://github.com/mdn/yari/pull/1755 I forgot to fix the `testing.yml` too. But we didn't notice because the `get-diff-action` prevented anything to even attempt to run there. 

What's cool now is that we're now caching the whole `virtualenv` it creates (cached by the `deployer/poetry.lock` file). So not just caching the HTTP downloads that `poetry` would have to done to PyPI but the whole `deployer/.venv` directory. Here's an example of that awesomeness:
<img width="1162" alt="Screen Shot 2020-11-18 at 9 25 54 PM" src="https://user-images.githubusercontent.com/26739/99612988-b7ed5a00-29e4-11eb-84fb-188946ec9dcd.png">
**1s to install all the Python code**

I also desperately made some irrelevant edits to some files just to trigger changes between commits, to bypass the `get-diff-action` stuff. Sorry. 