### PR TITLE
Update instructions for `CONTENT_ROOT` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ After that, run these commands in your bash:
     yarn dev
     open http://localhost:3000
 
-Make sure you point to the `/files` folder inside your clone of the content repo. Instead of having to type `export CONTENT_ROOT=/path/to/mdn/content/files`
+Make sure you point to the `/files` folder inside your clone of the content
+repo. Instead of having to type `export CONTENT_ROOT=/path/to/mdn/content/files`
 for `yarn dev` every time, you can put into `.env` file:
 
     CONTENT_ROOT=/path/to/mdn/content/files

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ After that, run these commands in your bash:
     yarn dev
     open http://localhost:3000
 
-Instead of having to type `export CONTENT_ROOT=/path/to/mdn/content/files`
+Make sure you point to the `/files` folder inside your clone of the content repo. Instead of having to type `export CONTENT_ROOT=/path/to/mdn/content/files`
 for `yarn dev` every time, you can put into `.env` file:
 
     CONTENT_ROOT=/path/to/mdn/content/files


### PR DESCRIPTION
Updated instructions to make it more obvious to point to files directory inside content repo

I had trouble to get started running this repo. I don't think it's very clear to point to the files folder inside the clone of the content repo. I think this change will help people get started quicker.