### PR TITLE
add .notecard on div.warning divs

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -94,6 +94,17 @@ function injectNoTranslate($) {
 }
 
 /**
+ * Find all `<div class="warning">` and turn them into `<div class="warning notecard">`
+ * and keep in mind that if it was already been manually fixed so, you
+ * won't end up with `<div class="warning notecard notecard">`.
+ *
+ * @param {Cheerio document instance} $
+ */
+function injectNotecardOnWarnings($) {
+  $("div.warning").addClass("notecard");
+}
+
+/**
  * Return the full URL directly to the file in GitHub based on this folder.
  * @param {String} folder - the current folder we're processing.
  */
@@ -269,6 +280,14 @@ async function buildDocument(document, documentOptions = {}) {
   // Post process HTML so that the right elements gets tagged so they
   // *don't* get translated by tools like Google Translate.
   injectNoTranslate($);
+
+  // All content that uses `<div class="warning">` needs to become
+  // `<div class="warning notecard">` instead.
+  // Some day, we can hopefully do a mass search-and-replace so we never
+  // need to do this code here.
+  // We might want to delete this injection in 2021 some time when all content's
+  // raw HTML has been fixed to always have it in there already.
+  injectNotecardOnWarnings($);
 
   // Turn the $ instance into an array of section blocks. Most of the
   // section blocks are of type "prose" and their value is a string blob

--- a/testing/content/files/en-us/web/donttranslatethese/index.html
+++ b/testing/content/files/en-us/web/donttranslatethese/index.html
@@ -4,6 +4,10 @@ slug: Web/DontTranslateThese
 ---
 <p>Here's a <code>pre</code> tag without any class set in the HTML</p>
 
+<div class="warning">
+  <p><strong>Warning:</strong> Bla bla</p>
+</div>
+
 <pre>
 h1 { color: pink; }
 </pre>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -205,6 +205,20 @@ test("the 'notranslate' class is correctly inserted", () => {
   expect($("pre.notranslate").length).toEqual($("pre").length);
 });
 
+test("the 'notecard' class is correctly inserted", () => {
+  const folder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "donttranslatethese"
+  );
+  const htmlFile = path.join(folder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+  const $ = cheerio.load(html);
+  expect($("div.warning.notecard").length).toEqual($("div.warning").length);
+});
+
 test("content with non-ascii characters in the slug", () => {
   const builtFolder = path.join(
     buildRoot,


### PR DESCRIPTION
Part of #1795

I still think we should, someday in 2021, go in and do a mass edit of all ~400 files. 

Also, there's something rather strange about the display now. 
<img width="929" alt="Screen Shot 2020-11-20 at 11 47 47 AM" src="https://user-images.githubusercontent.com/26739/99826328-37367700-2b26-11eb-86df-030b00e7c4ca.png">
The fact that in the red warning box you have 
```
[ICON] [HEADING]
[text]
```
whereas on the yellow one, it's 
```
[ICON]
[HEADING]
[text]
```