### PR TITLE
Highlight h3 tags and make them a clickable link

### DIFF
--- a/build/heading-highlight.js
+++ b/build/heading-highlight.js
@@ -1,0 +1,72 @@
+/**
+ * Uses a regular expression to replace spaces with an underscore.
+ *
+ * @param {String} id The string to generate an ID from.
+ * @returns {String} The unique ID string.
+ */
+function uniqueH3ID(id) {
+  return id.replace(/\s+/gm, "_");
+}
+
+/**
+ * Mutate the $ instance by looking for <h3> tags that can
+ * be converted into direct links.
+ *
+ * @param {Object} $ The cheerio object to be mutated.
+ * @param {Object} doc The document data.
+ * @returns {HTMLElement} The sub heading with a direct link added.
+ *
+ */
+function headingHighlight($, doc) {
+  $("h3").each((i, header) => {
+    const $header = $(header);
+    let textContent = $header.text();
+    let fallbackID = uniqueH3ID($header.attr("id"));
+
+    if (!$header) {
+      console.warn(
+        `Found ${i} <h3> tags on the document, unable to highlight page: ${doc.mdn_url}`
+      );
+      return; // bail
+    }
+
+    // if first character of an ID doesn't start
+    // with [a-zA-Z] inject an underscore
+    const regExp = new RegExp(/^[^a-zA-Z]+/, "g");
+    if (regExp.test(textContent)) {
+      let id = uniqueH3ID(textContent);
+      $header.attr("id", `_${id}`);
+    } else if (regExp.test($header.attr("id"))) {
+      let id = $header.attr("id");
+      $header.attr("id", `_${id}`);
+    }
+
+    // if id exists use it for anchors href
+    if ($header.attr("id")) {
+      let id = $header.attr("id");
+      let link = $(`<a href='#${id}'>${textContent}</a>`);
+      $header.attr("id", `${id}`);
+      $header.prepend(link);
+      $header.text("");
+    } else {
+      let id = uniqueH3ID(textContent);
+      let link = $(`<a href='#${id}'>${textContent}</a>`);
+
+      // if duplicate ID, append duplicate number to the end
+      // of the string.. more than 2 duplicates things go wrong
+      // since I'm using j=1 (i counts h3 tags in the .each loop)
+      let duplicate = $(`h3:contains('${textContent}')`).eq(1);
+      let j = 1;
+      duplicate.attr("id", `${id}_${j + 1}`);
+      $header.attr("id", `${id}`);
+      $header.prepend(link);
+      $header.text("");
+    }
+    return $header.prepend(`<a href='#${fallbackID}'>${textContent}</a>`);
+  });
+}
+
+module.exports = {
+  headingHighlight,
+  uniqueH3ID,
+};

--- a/build/index.js
+++ b/build/index.js
@@ -21,6 +21,7 @@ const { normalizeBCDURLs, extractBCDData } = require("./bcd-urls");
 const { checkImageReferences } = require("./check-images");
 const { getPageTitle } = require("./page-title");
 const { syntaxHighlight } = require("./syntax-highlight");
+const { headingHighlight } = require("./heading-highlight");
 const cheerio = require("./monkeypatched-cheerio");
 const buildOptions = require("./build-options");
 const { renderCache: renderKumascriptCache } = require("../kumascript");
@@ -276,6 +277,9 @@ async function buildDocument(document, documentOptions = {}) {
 
   // Apply syntax highlighting all <pre> tags.
   syntaxHighlight($, doc);
+
+  // Apply direct permalinks to all <h3> tags.
+  headingHighlight($, doc);
 
   // Post process HTML so that the right elements gets tagged so they
   // *don't* get translated by tools like Google Translate.

--- a/testing/content/files/en-us/web/headinghighlight/index.html
+++ b/testing/content/files/en-us/web/headinghighlight/index.html
@@ -1,0 +1,17 @@
+---
+title: Document with sub headings that need direct permalinks
+slug: Web/HeadingHighlight
+summary: A test page to check the headingHighlight utility.
+---
+
+<h3>Some Heading</h3>
+<p>vanilla heading</p>
+
+<h3 id="content_categories">Content Categories</h3>
+<p>sub heading with preset id</p>
+
+<h3>3 Methods</h3>
+<p>heading starts with number</p>
+
+<h3>Some Heading</h3>
+<p>duplicate heading</p>

--- a/testing/tests/heading-highlight.test.js
+++ b/testing/tests/heading-highlight.test.js
@@ -1,0 +1,132 @@
+/* eslint-disable no-undef */
+const fs = require("fs");
+const path = require("path");
+const cheerio = require("cheerio");
+const { uniqueH3ID } = require("../../build/heading-highlight");
+
+const buildRoot = path.join("..", "client", "build");
+
+// Main Tests - Heading Highlight to add permalinks
+// issues here where, "error wile building documents" so I haven't been able to test thoroughly yet
+test("content successfully built to test heading highlight utility", () => {
+  expect(fs.existsSync(buildRoot)).toBeTruthy();
+
+  // Creates '../client/build/en-us/docs/web/headinghighlight/' URI
+  const builtFolder = path.join(
+    buildRoot,
+    "en-US",
+    "docs",
+    "web",
+    "headinghighlight"
+  );
+  expect(fs.existsSync(builtFolder)).toBeTruthy(); // unexpected errors with jest here
+
+  const jsonFile = path.join(builtFolder, "index.json");
+  expect(fs.existsSync(jsonFile)).toBeTruthy();
+
+  // should be able to read doc and keys from YAML inside document separators from index.html
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.title).toBe(
+    "Document with sub headings that need direct permalinks"
+  );
+  expect(doc.mdn_url).toBe("en-US/docs/Web/HeadingHighlight");
+  expect(doc.summary).toBe(
+    "A test page to check the headingHighlight utility."
+  );
+
+  // html content '/headinghighlight/index.html'
+  const htmlFile = path.join(builtFolder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+
+  // cheerio object
+  const $ = cheerio.load(html);
+
+  // test the .each loop
+  $("h3").each((i, header) => {
+    const $header = $(header);
+    let textContent = $header.text();
+    let fallbackID = uniqueH3ID($header.attr("id"));
+
+    // maybe useless but should probably bail if no <h3> tags are present
+    if (!$header) {
+      console.warn(
+        `Found ${i} <h3> tags on the document, unable to highlight page: ${doc.mdn_url}`
+      );
+      return; // bail
+    }
+
+    // if first character of an ID doesn't start
+    // with [a-zA-Z] then inject an underscore
+    const regExp = new RegExp(/^[^a-zA-Z]+/, "g");
+
+    if (regExp.test(textContent)) {
+      let id = uniqueH3ID(textContent);
+      $header.attr("id", `_${id}`);
+    } else if (regExp.test($header.attr("id"))) {
+      let id = $header.attr("id");
+      $header.attr("id", `_${id}`);
+      expect($header.attr("id")).toBe(`_${id}`);
+    }
+
+    // if id exists use it for anchors href
+    if ($header.attr("id")) {
+      expect($header.attr("id")).toBeTruthy();
+      let id = $header.attr("id").toLowerCase();
+
+      let link = $(`<a href='#${id}'>${textContent}</a>`);
+      // make sure links are set properly
+      expect(link.attr("id")).toBe(`#${id}`);
+      expect(link.text()).toBe($header.text());
+
+      $header.attr("id", id);
+      $header.prepend(link);
+      $header.text("");
+      expect(textContent).toBe("");
+    } else {
+      let id = uniqueH3ID(textContent);
+      let link = $(`<a href='#${id}'>${textContent}</a>`);
+      let duplicate = $(`h3:contains('${$header.text()}')`).eq(1);
+      let j = 1;
+
+      duplicate.attr("id", `${id}_${j + 1}`);
+      $header.attr("id", `${id}`);
+      $header.prepend(link);
+      $header.text("");
+    }
+    return $header.prepend(`<a href='#${fallbackID}'>${textContent}</a>`);
+  });
+});
+
+// Small Tests for Unique ID generator - (All passing)
+test("test heading text with more than one word title cased", () => {
+  expect(uniqueH3ID("Content Categories bla")).toBe("Content_Categories_bla");
+});
+
+// if some words have hyphen keep it, treat it as any other character
+test("hyphenated heading", () => {
+  expect(uniqueH3ID("Some-heading text")).toBe("Some-heading_text");
+});
+
+// when commas are in heading text remove them within the ID/permalink (manually set ID behavior)
+// if we keep them it would look like this (Rest,_default,_and_destructured)
+// I can update my regex to remove replace commas with white space but for now
+// uniqueH3ID only matches white space characters and replaces them with an underscore
+test("heading text with comma separated words", () => {
+  expect(uniqueH3ID("Rest, default, and destructured parameters")).toBe(
+    "Rest,_default,_and_destructured_parameters"
+  );
+});
+
+// when heading text ends with a question mark,
+// dont include it in ID (this is manually set ID behavior)
+// my regex /\s+/ is only matching white space characters
+test("heading text that ends with a ?", () => {
+  expect(uniqueH3ID("What will your website look like?")).toBe(
+    "What_will_your_website_look_like?"
+  );
+});
+
+// I think manually set ID's have all non-word characters /\W+/ removed
+test("heading text that ends with non-words", () => {
+  expect(uniqueH3ID("Another one...")).toBe("Another_one...");
+});


### PR DESCRIPTION
This PR is part of #1427 

I created a `headingHighlight` function to highlight `<h3>` tags on the document and add a permalink to make the sub headings a clickable link. I tested each page on my local system and couldn't find any issues, all of the `<h3>` tags were highlighted and turned into clickable permalinks as intended. 

I did run into issues when trying to create tests in `heading-hightlight.tests.js`. I kept receiving an `ENOENT: no such file or directory` when trying to test a `index.njk` template page to more thoroughly check the `headingHighlight` function. I tested the `uniqueH3ID` function for most cases we discussed but I wasn't able to correctly test the actual `headingHighlight` utility other than by manually looking through each pages sub headings and clicking the link to make sure it worked correctly. 

I need to clean up some of my messy code and remove the comments (sorry I wrote a lot of them) and then I think this should be good to go. Thanks for all the help along the way!