### PR TITLE
deps: remove babel-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ yarn-error.log*
 fake-v1-api/
 mdn-yari-*.tgz
 function.zip
+
+# tabnine
+.dccache

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-modal": "^3.10.6",
-    "babel-loader": "^8.1.0",
     "eslint-plugin-node": "11.1.0",
     "extend": "^3.0.2",
     "flexsearch": "0.6.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4560,7 +4560,7 @@ babel-jest@^26.6.0, babel-jest@^26.6.3:
     graceful-fs "^4.2.4"
     slash "^3.0.0"
 
-babel-loader@8.1.0, babel-loader@^8.0.6, babel-loader@^8.1.0:
+babel-loader@8.1.0, babel-loader@^8.0.6:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
   integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==


### PR DESCRIPTION
CRA manages the version and updates for `babel-loader` so we should not.

fix #1847