### PR TITLE
fix: use highlighted link state for breadcrumb active

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -7,7 +7,12 @@
   ],
   "plugins": ["stylelint-scss"],
   "rules": {
-    "max-nesting-depth": 3,
+    "max-nesting-depth": [
+      3,
+      {
+        "ignoreAtRules": ["media"]
+      }
+    ],
     "declaration-no-important": true,
     "font-weight-notation": "named-where-possible",
     "selector-no-qualifying-type": [

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -1,4 +1,6 @@
 @import "~@mdn/minimalist/sass/mixins/utils";
+@import "~@mdn/minimalist/sass/mixins/links";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -9,6 +11,17 @@
 
   @media #{$mq-small-desktop-and-up} {
     padding: $base-spacing;
+  }
+
+  a {
+    &:active {
+      @include highlighted-link-state();
+
+      &::after {
+        /* a hack in modern browsers to change the icon to white */
+        filter: invert(100%);
+      }
+    }
   }
 
   ol {
@@ -31,14 +44,14 @@
     .breadcrumb,
     .breadcrumb-penultimate {
       &::after {
-        content: "";
         background: transparent url("~@mdn/dinocons/arrows/chevron.svg") 0 0
           no-repeat;
         background-size: 12px;
-        margin: 0 5px;
-        width: 12px;
+        content: "";
         height: 12px;
+        margin: 0 5px;
         transform: rotate(90deg);
+        width: 12px;
       }
     }
 
@@ -50,15 +63,15 @@
 
     .breadcrumb-penultimate {
       &::before {
-        display: inline-block;
-        content: "";
         background: transparent url("~@mdn/dinocons/arrows/chevron.svg") 0 0
           no-repeat;
         background-size: 12px;
-        margin-right: 5px;
-        width: 12px;
+        content: "";
+        display: inline-block;
         height: 12px;
+        margin-right: $base-spacing / 4;
         transform: rotate(-90deg);
+        width: 12px;
 
         @media #{$mq-small-desktop-and-up} {
           display: none;


### PR DESCRIPTION
Use `highlight-link-state` for the `:active` state of breadcrumb links

## New `:active` state

![screen shot of breadcrumb active state, shows a blue background with white forground](https://user-images.githubusercontent.com/10350960/100451506-340c2f80-30c0-11eb-8b42-acb7cbced100.png)

fix #1594