### PR TITLE
fix: indexes lacks multi column display

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -102,4 +102,12 @@
       }
     }
   }
+
+  /*
+   * multi-column layout on pages with an index such as
+   * https://developer.mozilla.org/en-US/docs/Web/API#Specifications
+  */
+  .index {
+    columns: 300px;
+  }
 }


### PR DESCRIPTION
Use `columns` to display indexes in a multi column layout

fix #1609