### PR TITLE
fix: browser-compat legend layout

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
@@ -1,26 +1,40 @@
 .bc-legend {
-  margin-bottom: $base-spacing;
-  margin-top: $base-spacing;
+  margin: ($base-spacing * 2) 0;
 
-  dl {
+  dl.bc-legend-items-container {
     align-items: center;
-    display: grid;
-    grid-template-columns: 40px 1fr;
+    display: flex;
+    flex-wrap: wrap;
+    gap: $base-spacing * 2;
     line-height: 1.2;
+    max-width: inherit;
 
-    dt {
-      margin: ($base-spacing / 2) 0;
+    .bc-legend-item {
+      flex-basis: 100%;
+
+      @media #{$mq-tablet-and-up} {
+        flex-basis: 45%;
+      }
     }
 
+    dt,
     dd {
-      margin: ($base-spacing / 2);
+      display: inline-block;
+      margin: 0;
+      max-width: 275px;
+      min-height: 30px;
+      min-width: 30px;
+    }
+
+    dt {
+      margin-right: $base-spacing / 2;
+      vertical-align: middle;
     }
   }
 
   abbr {
     cursor: help;
     display: inline-block;
-    padding: $base-spacing / 2;
   }
 
   .bc-supports {

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -80,10 +80,10 @@ export function Legend({ compat }: { compat: bcd.Identifier }) {
       <h3 className="visually-hidden" id="Legend">
         Legend
       </h3>
-      <dl>
+      <dl className="bc-legend-items-container">
         {getActiveLegendItems(compat).map(([key, label]) =>
           ["yes", "partial", "no", "unknown"].includes(key) ? (
-            <React.Fragment key={key}>
+            <div className="bc-legend-item" key={key}>
               <dt key={key}>
                 <span className={`bc-supports-${key} bc-supports`}>
                   <abbr
@@ -95,17 +95,17 @@ export function Legend({ compat }: { compat: bcd.Identifier }) {
                 </span>
               </dt>
               <dd>{label}</dd>
-            </React.Fragment>
+            </div>
           ) : (
-            <React.Fragment key={key}>
+            <div className="bc-legend-item" key={key}>
               <dt>
-                <abbr className="only-icon" title={label}>
-                  <span>{label}</span>
-                  <i className={`legend-icons ic-${key}`} />
-                </abbr>
+                <abbr
+                  className={`only-icon legend-icons ic-${key}`}
+                  title={label}
+                ></abbr>
               </dt>
               <dd>{label}</dd>
-            </React.Fragment>
+            </div>
           )
         )}
       </dl>


### PR DESCRIPTION
Fix browser compat table legend layout across viewports

![Screenshot of browser compat table legend](https://user-images.githubusercontent.com/10350960/100518477-60947a00-319a-11eb-81d8-ab69bbd8dede.png)

fix #1612