### PR TITLE
fix: use break-wor for titlebar

### DIFF
--- a/client/src/ui/molecules/titlebar/index.scss
+++ b/client/src/ui/molecules/titlebar/index.scss
@@ -12,7 +12,7 @@
   }
 
   h1 {
-    word-break: break-all;
+    word-break: break-word;
 
     @media #{$mq-tablet-and-up} {
       margin: 0 auto;


### PR DESCRIPTION
Switch from `break-all` to using `break-word` for the titlebar

fix #1869