### PR TITLE
fix: underlining for links in row headers not clean

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
@@ -58,6 +58,28 @@
     }
   }
 
+  .bc-table-row-header {
+    padding: ($base-spacing / 2) ($base-spacing / 4);
+
+    code {
+      text-decoration: none;
+    }
+  }
+
+  a.bc-table-row-header {
+    display: block;
+
+    &:link,
+    &:visited {
+      text-decoration: none;
+    }
+
+    &:hover,
+    &:focus {
+      background-color: $neutral-500;
+    }
+  }
+
   tbody {
     th,
     td {
@@ -70,6 +92,8 @@
     }
 
     th {
+      padding: 0;
+
       @media #{$mq-small-desktop-and-up} {
         border-right: 2px solid $neutral-100;
         display: table-cell;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -410,23 +410,33 @@ export const FeatureRow = React.memo(
 
     if (compat.bad_url && compat.mdn_url) {
       titleNode = (
-        <abbr className="new" title={`${compat.mdn_url} does not exist`}>
-          {title}
-        </abbr>
+        <div className="bc-table-row-header">
+          <abbr className="new" title={`${compat.mdn_url} does not exist`}>
+            {title}
+          </abbr>
+          {compat.status && <StatusIcons status={compat.status} />}
+        </div>
       );
     } else if (compat.mdn_url && !isRoot) {
-      titleNode = <Link to={compat.mdn_url}>{title}</Link>;
+      titleNode = (
+        <Link to={compat.mdn_url} className="bc-table-row-header">
+          {title}
+          {compat.status && <StatusIcons status={compat.status} />}
+        </Link>
+      );
     } else {
-      titleNode = title;
+      titleNode = (
+        <div className="bc-table-row-header">
+          {title}
+          {compat.status && <StatusIcons status={compat.status} />}
+        </div>
+      );
     }
 
     return (
       <>
         <tr>
-          <th scope="row">
-            {titleNode}
-            {compat.status && <StatusIcons status={compat.status} />}
-          </th>
+          <th scope="row">{titleNode}</th>
           {browsers.map((browser, i) => (
             <CompatCell
               key={browser}


### PR DESCRIPTION
All text in the row headers is now displayed without using any text decoration.
When a user hovers over an entry that is a link

1. The little pointer icon will show and,
2. The background color of the cell will change

## Normal

![Screenshot 2020-11-29 at 17 27 44](https://user-images.githubusercontent.com/10350960/100546229-e0891580-3268-11eb-9685-f3edf69d7c4f.png)

## On hover

![Screenshot of the hover/focus state](https://user-images.githubusercontent.com/10350960/100546232-e5e66000-3268-11eb-9d62-66dfe6407190.png)


fix #1610
fix #1694