### PR TITLE
fix: top alignment of article with toc

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -24,7 +24,7 @@
 
 /* override rule from reset as it does not work for MDN */
 article > * + * {
-  margin-top: inherit;
+  margin-top: 0;
 }
 
 .article {
@@ -98,6 +98,10 @@ article > * + * {
       background-color: transparent;
       color: $neutral-600;
     }
+  }
+
+  table {
+    margin-bottom: $base-spacing;
   }
 
   /* readonly inline badges needs a slightly darker background color in general article content  */

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -22,21 +22,11 @@
   }
 }
 
-/* override rule from reset as it does not work for MDN */
-article > * + * {
-  margin-top: 0;
-}
-
 .article {
   padding: ($base-spacing / 2) $base-spacing $base-spacing;
 
   @media #{$mq-small-desktop-and-up} {
     margin-bottom: $large-spacing;
-  }
-
-  /* if the article starts with a notecard, remove the top margin */
-  .notecard:first-of-type {
-    margin-top: 0;
   }
 
   p,

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -101,7 +101,7 @@ article > * + * {
   }
 
   table {
-    margin-bottom: $base-spacing;
+    margin-bottom: $base-spacing * 2;
   }
 
   /* readonly inline badges needs a slightly darker background color in general article content  */

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -34,6 +34,11 @@ article > * + * {
     margin-bottom: $large-spacing;
   }
 
+  /* if the article starts with a notecard, remove the top margin */
+  .notecard:first-of-type {
+    margin-top: 0;
+  }
+
   p,
   ul,
   ol,

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -22,8 +22,13 @@
   }
 }
 
+/* override rule from reset as it does not work for MDN */
+article > * + * {
+  margin-top: inherit;
+}
+
 .article {
-  padding: $base-spacing;
+  padding: ($base-spacing / 2) $base-spacing $base-spacing;
 
   @media #{$mq-small-desktop-and-up} {
     margin-bottom: $large-spacing;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -29,6 +29,13 @@
     margin-bottom: $large-spacing;
   }
 
+  h2,
+  h3,
+  h4,
+  h5 {
+    margin-top: 0;
+  }
+
   p,
   ul,
   ol,


### PR DESCRIPTION
Ensure that on desktop viewports the top element in the article lines up with the heading of the "Jump to section" component.

- https://developer.allizom.org/en-US/docs/Web/JavaScript/About_JavaScript
- https://developer.allizom.org/en-US/docs/Web/API/DeviceMotionEventAcceleration

## heading as the first element

![Screenshot 2020-11-30 at 11 02 15](https://user-images.githubusercontent.com/10350960/100589319-9dc44d80-32fb-11eb-940c-42c6acea5f0e.png)


## notecard as the first element

![Screenshot 2020-11-30 at 10 48 09](https://user-images.githubusercontent.com/10350960/100589256-8dac6e00-32fb-11eb-92c6-95ea656bda00.png)

## With interactive element

![Screenshot 2020-11-30 at 11 00 11](https://user-images.githubusercontent.com/10350960/100589306-9a30c680-32fb-11eb-922e-dd06123d1fb1.png)


Note: A lot of pages start with two empty `div` element. Not sure why CKEditor did that but, that is something we will have to clean up post-launch. Those are not a problem visually. Sometimes though, like the two pages linked below, it starts with a `div` that wraps an empty paragraph tag. That is a problem visually as paragraphs have a bottom margin. This again is something we will have to live with until the source is cleaned up.

- https://developer.allizom.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval
- https://developer.allizom.org/en-US/docs/Web/API/Web_Bluetooth_API

Other than these caveats, "normal" cases will now align correctly whether it starts with a heading element or one of the notecards.

fix #1732