### PR TITLE
fix: archived content banner

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -111,3 +111,20 @@
     columns: 300px;
   }
 }
+
+/*
+ * style for archived content banner
+ * http://localhost:3000/en-us/docs/BrowserID/Specify_an_Email_Address
+ */
+.archived {
+  background-color: $yellow-400;
+  padding: $base-spacing / 4;
+  position: fixed;
+  text-align: center;
+  top: 0;
+  width: 100%;
+
+  p {
+    margin: 0;
+  }
+}

--- a/client/src/ui/organisms/header/index.scss
+++ b/client/src/ui/organisms/header/index.scss
@@ -30,7 +30,7 @@
 .page-header {
   margin: 0 auto;
   max-width: $max-width-default;
-  padding: $base-spacing;
+  padding: ($base-unit * 6) $base-spacing $base-spacing;
   position: relative;
   width: 100%;
 


### PR DESCRIPTION
Add a fixed banner on archived content pages.

### At the top

![Screenshot 2020-12-01 at 17 03 13](https://user-images.githubusercontent.com/10350960/100759207-080ee800-33f9-11eb-823f-58f655bf1f53.png)

### When scrolled

![Screenshot 2020-12-01 at 17 04 05](https://user-images.githubusercontent.com/10350960/100759234-10672300-33f9-11eb-84fc-9b4d40cc3943.png)

fix #1312