### PR TITLE
fix: Vertically align the > with the anchors

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -14,6 +14,9 @@
   }
 
   a {
+    display: flex;
+    align-items: center;
+
     &:active {
       @include highlighted-link-state();
 
@@ -29,7 +32,7 @@
   }
 
   li {
-    display: inline;
+    display: inline-flex;
     hyphens: auto;
 
     .breadcrumb,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28865023/100771348-584f6f80-3424-11eb-9d99-d837a0412b0e.png)


Fixes #1866 