### PR TITLE
Revert "Bump typescript from 3.9.7 to 4.1.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "stylelint-prettier": "^1.1.2",
     "stylelint-scss": "^3.18.0",
     "ts-loader": "^8.0.10",
-    "typescript": "^4.1.2",
+    "typescript": "^3.9.7",
     "vnu-jar": "^20.6.30"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17618,10 +17618,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typical@^5.0.0, typical@^5.2.0:
   version "5.2.0"


### PR DESCRIPTION
Reverts mdn/yari#1788

We should not upgrade TypeScript until we upgrade create-react-app. 