### PR TITLE
fix: overflow items in search results dropdown

### DIFF
--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -62,7 +62,7 @@
     box-shadow: 0 2px 8px 0 $neutral-500;
     left: 0;
     position: absolute;
-    top: 45px;
+    top: 42px;
     width: 100%;
     z-index: $top-layer;
 
@@ -70,9 +70,10 @@
       color: $yellow-100;
     }
 
-    div {
+    .result-item {
       border-bottom: 1px solid $neutral-550;
       padding: $base-unit;
+      word-break: break-word;
     }
 
     .result-item:hover,


### PR DESCRIPTION
Prevent long titles from extending beyond the search result drop-down container

## Before

![Screenshot 2020-12-02 at 14 45 04](https://user-images.githubusercontent.com/10350960/100874848-d73cba80-34ad-11eb-936b-efb5a863862a.png)

## After

![Screenshot 2020-12-02 at 14 45 30](https://user-images.githubusercontent.com/10350960/100874860-dd329b80-34ad-11eb-9ec3-c8e0116be655.png)

fix #1680