### PR TITLE
fix: readonly badge background color

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -85,6 +85,11 @@
     }
   }
 
+  /* readonly inline badges needs a slightly darker background color in general article content  */
+  .inline.readonly {
+    background-color: $neutral-550;
+  }
+
   /* top navigational elements on tutorial pages */
   .prev-next {
     @media #{$mq-tablet-and-up} {


### PR DESCRIPTION
The inline readonly badge needs a slightly darker background color when used in general article content.

### Before

![Screenshot 2020-12-02 at 15 01 02](https://user-images.githubusercontent.com/10350960/100877712-d7d75000-34b1-11eb-9988-16202809fb1d.png)

### After

![Screenshot 2020-12-02 at 15 01 12](https://user-images.githubusercontent.com/10350960/100877735-de65c780-34b1-11eb-9323-09b524d3286d.png)


fix #1883