### PR TITLE
fix: active state of breadcrumb items to remove background color from >

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -15,11 +15,8 @@
 
   a {
     &:active {
-      @include highlighted-link-state();
-
-      &::after {
-        /* a hack in modern browsers to change the icon to white */
-        filter: invert(100%);
+      span {
+        @include highlighted-link-state();
       }
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28865023/100894448-82fffd80-34e2-11eb-9485-069063a367ef.png)

Fixes #1865 