### PR TITLE
Language drop-down is broken

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -18,7 +18,7 @@ import { LazyBrowserCompatibilityTable } from "./lazy-bcd-table";
 // Misc
 // Sub-components
 import { Breadcrumbs } from "../ui/molecules/breadcrumbs";
-import LanguageMenu from "../ui/molecules/language-menu";
+import { LanguageMenu } from "../ui/molecules/language-menu";
 import { OnGitHubLink } from "./on-github";
 import { Titlebar } from "../ui/molecules/titlebar";
 import { TOC } from "./organisms/toc";

--- a/client/src/document/types.tsx
+++ b/client/src/document/types.tsx
@@ -68,7 +68,7 @@ type Flaws = {
 
 export type Translation = {
   locale: string;
-  slug: string;
+  url: string;
 };
 
 export type DocParent = {

--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -12,7 +12,7 @@ const LANGUAGES = new Map(
   })
 );
 
-export default function LanguageMenu({
+export function LanguageMenu({
   locale,
   translations,
 }: {
@@ -65,9 +65,8 @@ export default function LanguageMenu({
         <option value={locale}>{verbose ? verbose.native : locale}</option>
         {translations.map((t) => {
           const verbose = LANGUAGES.get(t.locale.toLowerCase());
-          const url = `/${t.locale}/docs/${t.slug}`;
           return (
-            <option key={url} value={url}>
+            <option key={t.url} value={t.url}>
               {verbose ? verbose.native : t.locale}
             </option>
           );

--- a/testing/.env
+++ b/testing/.env
@@ -7,6 +7,7 @@
 
 CONTENT_ROOT=testing/content/files
 CONTENT_ARCHIVED_ROOT=testing/archived-content/files
+CONTENT_TRANSLATED_ROOT=testing/translated-content/files
 
 # Because you never benefit from the progressbar when doing mass builds in
 # testing environment. And in CI, it's always disabled anyway.

--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -23,6 +23,21 @@ describe("Basic viewing of functional pages", () => {
     await expect(page).toMatchElement(".document-meta time", { visible: true });
   });
 
+  it("open the French /fr/docs/Web/Foo page and navigate to English", async () => {
+    await page.goto(testURL("/fr/docs/Web/Foo"));
+    await expect(page).toMatchElement("h1", {
+      text: "<foo>: Une page de test",
+    });
+    await expect(page).toSelect('select[name="language"]', "English (US)");
+    await expect(page).toClick("button", { text: "Change language" });
+    await expect(page).toMatchElement("h1", { text: "<foo>: A test tag" });
+    // Should have been redirected too...
+    // Note! It's important that this happens *after* the `.toMatchElement`
+    // on the line above because expect-puppeteer doesn't have a wait to
+    // properly wait for the (pushState) URL to have changed.
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+  });
+
   it("open the /en-US/docs/Web/InteractiveExample page", async () => {
     await page.goto(testURL("/en-US/docs/Web/InteractiveExample"), {
       // Be a bit less patient with this particular page because it contains

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -129,6 +129,24 @@ test("content built foo page", () => {
   );
 });
 
+test("content built French foo page", () => {
+  expect(fs.existsSync(buildRoot)).toBeTruthy();
+
+  const builtFolder = path.join(buildRoot, "fr", "docs", "web", "foo");
+  expect(fs.existsSync(builtFolder)).toBeTruthy();
+
+  const jsonFile = path.join(builtFolder, "index.json");
+  expect(fs.existsSync(jsonFile)).toBeTruthy();
+
+  // We should be able to read it and expect certain values
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.title).toBe("<foo>: Une page de test");
+  expect(doc.isTranslated).toBe(true);
+  expect(doc.other_translations[0].locale).toBe("en-US");
+  expect(doc.other_translations[0].url).toBe("/en-US/docs/Web/Foo");
+  expect(doc.other_translations[0].title).toBe("<foo>: A test tag");
+});
+
 test("summary extracted correctly by span class", () => {
   const builtFolder = path.join(
     buildRoot,

--- a/testing/translated-content/files/fr/web/foo/index.html
+++ b/testing/translated-content/files/fr/web/foo/index.html
@@ -1,0 +1,7 @@
+---
+title: "<foo>: Une page de test"
+slug: Web/Foo
+translation_of: Web/Foo
+---
+
+<p>Foë</p>


### PR DESCRIPTION
Fixes #1914

Clearly, we failed ourselves here by not having test coverage. 
So I took the time to introduce a test that tests the translated content. At least at an absolute minimal. 
It literally tests what I described in the issue but it's all automated with headless testing. 
