### PR TITLE
unbreak npm publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,6 +50,14 @@ jobs:
           # whoami endpoint.
           export REACT_APP_DISABLE_AUTH=true
 
+          # The 'yarn prepare-build' command is going to try to build up a
+          # file for the git history so it can have an index of each files.
+          # This makes sense in most of the cases where you have a CONTENT_ROOT
+          # which you'll want to build. But the CONTENT_ROOT can't be empty
+          # so you have to set it to something. So let's (ab)use the content
+          # we use for the end-to-end testing.
+          export CONTENT_ROOT=testing/content/files
+
           yarn prepare-build
 
       - name: Dry-run publish to see which files are included

--- a/tool/cli.js
+++ b/tool/cli.js
@@ -263,7 +263,6 @@ program
   .action(
     tryOrExit(async ({ options }) => {
       const { root, saveHistory, loadHistory } = options;
-      console.log({ root });
       if (fs.existsSync(loadHistory)) {
         console.log(
           chalk.yellow(`Reusing exising history from ${loadHistory}`)

--- a/tool/cli.js
+++ b/tool/cli.js
@@ -263,6 +263,7 @@ program
   .action(
     tryOrExit(async ({ options }) => {
       const { root, saveHistory, loadHistory } = options;
+      console.log({ root });
       if (fs.existsSync(loadHistory)) {
         console.log(
           chalk.yellow(`Reusing exising history from ${loadHistory}`)


### PR DESCRIPTION
I knew the new git history stuff would come to bite us. I don't think we've fully perfected how we're going to store the git log history which we dig up from the `git clone` to a file on disk. Anyway. One battle at a time. 

What's happening in https://github.com/mdn/yari/runs/1488979842?check_suite_focus=true for example is that the `yarn prepare-build` command is failing hard because there is no `CONTENT_ROOT` set in the NPM publishing Workflow. 

You can simulate this error easily by doing:
```
cd /tmp
git clone git@github.com:mdn/yari.git && cd yari
yarn --frozen-lockfile
yarn prepare-build
```
And you just run:
```
export CONTENT_ROOT=testing/content/files
```
and try `yarn prepare-build` again, it solves world hunger. 

It's a bit weird that `yarn prepare-build` does so much but it's short and convenient and I'd rather keep it like that. 