### PR TITLE
set a cookie when changing language

### DIFF
--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -12,6 +12,9 @@ const LANGUAGES = new Map(
   })
 );
 
+// This needs to match what's set in 'libs/constants.js' on the server/builder!
+const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
+
 export function LanguageMenu({
   locale,
   translations,
@@ -38,6 +41,13 @@ export function LanguageMenu({
         // The default is the current locale itself. If that's what's chosen,
         // don't bother redirecting.
         if (localeURL !== locale) {
+          for (const translation of translations) {
+            if (translation.url === localeURL) {
+              document.cookie = `${PREFERRED_LOCALE_COOKIE_NAME}=${
+                translation.locale
+              };max-age=${60 * 60 * 24 * 365 * 3};path=/`;
+            }
+          }
           navigate(localeURL);
         }
       }}

--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -43,9 +43,13 @@ export function LanguageMenu({
         if (localeURL !== locale) {
           for (const translation of translations) {
             if (translation.url === localeURL) {
-              document.cookie = `${PREFERRED_LOCALE_COOKIE_NAME}=${
+              let cookieValue = `${PREFERRED_LOCALE_COOKIE_NAME}=${
                 translation.locale
               };max-age=${60 * 60 * 24 * 365 * 3};path=/`;
+              if (document.location.hostname !== "localhost") {
+                cookieValue += ";secure";
+              }
+              document.cookie = cookieValue;
             }
           }
           navigate(localeURL);

--- a/deployer/aws-lambda/content-origin-request/package.json
+++ b/deployer/aws-lambda/content-origin-request/package.json
@@ -7,9 +7,11 @@
     "make-package": "yarn install && zip -r -X function.zip . -i index.js 'node_modules/*'"
   },
   "dependencies": {
-    "@yari-internal/fundamental-redirects": "file:../../../libs/fundamental-redirects",
     "@yari-internal/constants": "file:../../../libs/constants",
+    "@yari-internal/fundamental-redirects": "file:../../../libs/fundamental-redirects",
+    "@yari-internal/get-locale": "file:../../../libs/get-locale",
     "accept-language-parser": "^1.5.0",
+    "cookie": "0.4.1",
     "sanitize-filename": "^1.6.3"
   },
   "engines": {

--- a/deployer/aws-lambda/content-origin-request/yarn.lock
+++ b/deployer/aws-lambda/content-origin-request/yarn.lock
@@ -2,16 +2,24 @@
 # yarn lockfile v1
 
 
+"@yari-internal/constants@file:../../../libs/constants":
+  version "0.0.1"
+
 "@yari-internal/fundamental-redirects@file:../../../libs/fundamental-redirects":
   version "0.0.1"
 
-"@yari-internal/constants@file:../../../libs/constants":
+"@yari-internal/get-locale@file:../../../libs/get-locale":
   version "0.0.1"
 
 accept-language-parser@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"
   integrity sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E=
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 sanitize-filename@^1.6.3:
   version "1.6.3"

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -48,8 +48,11 @@ const LOCALE_ALIASES = new Map([
   ["zh-hant", "zh-tw"],
 ]);
 
+const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
+
 module.exports = {
   VALID_LOCALES,
   DEFAULT_LOCALE,
   LOCALE_ALIASES,
+  PREFERRED_LOCALE_COOKIE_NAME,
 };

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -48,6 +48,8 @@ const LOCALE_ALIASES = new Map([
   ["zh-hant", "zh-tw"],
 ]);
 
+// This must match what we do in `language-menu/index.tsx` where the cookie
+// gets set in the client!
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
 
 module.exports = {

--- a/libs/get-locale/index.js
+++ b/libs/get-locale/index.js
@@ -34,7 +34,7 @@ function getLocale(request, fallback = DEFAULT_LOCALE) {
   const cookieLocale = getCookie(request.headers, PREFERRED_LOCALE_COOKIE_NAME);
   if (cookieLocale) {
     // If it's valid, stick to it.
-    if (VALID_LOCALES.get(cookieLocale.toLowerCase())) {
+    if (VALID_LOCALES.has(cookieLocale.toLowerCase())) {
       return VALID_LOCALES.get(cookieLocale.toLowerCase());
     }
   }

--- a/libs/get-locale/index.js
+++ b/libs/get-locale/index.js
@@ -1,0 +1,53 @@
+const { parse } = require("cookie");
+const acceptLanguageParser = require("accept-language-parser");
+
+const {
+  DEFAULT_LOCALE,
+  VALID_LOCALES,
+  PREFERRED_LOCALE_COOKIE_NAME,
+} = require("../constants");
+const VALID_LOCALES_LIST = [...VALID_LOCALES.values()];
+
+// From https://github.com/aws-samples/cloudfront-authorization-at-edge/blob/01c1bc843d478977005bde86f5834ce76c479eec/src/lambda-edge/shared/shared.ts#L216
+// but rewritten in JavaScript (from TypeScript).
+function extractCookiesFromHeaders(headers) {
+  // Cookies are present in the HTTP header "Cookie" that may be present multiple times.
+  // This utility function parses occurrences  of that header and splits out all the cookies and their values
+  // A simple object is returned that allows easy access by cookie name: e.g. cookies["nonce"]
+  if (!headers["cookie"]) {
+    return {};
+  }
+  const cookies = headers["cookie"].reduce(
+    (reduced, header) => Object.assign(reduced, parse(header.value)),
+    {}
+  );
+
+  return cookies;
+}
+
+function getCookie(headers, cookieKey) {
+  return extractCookiesFromHeaders(headers)[cookieKey];
+}
+
+function getLocale(request, fallback = DEFAULT_LOCALE) {
+  // First try by cookie.
+  const cookieLocale = getCookie(request.headers, PREFERRED_LOCALE_COOKIE_NAME);
+  if (cookieLocale) {
+    // If it's valid, stick to it.
+    if (VALID_LOCALES.get(cookieLocale.toLowerCase())) {
+      return VALID_LOCALES.get(cookieLocale.toLowerCase());
+    }
+  }
+
+  // Each header in request.headers is always a list of objects.
+  const acceptLangHeaders = request.headers["accept-language"];
+  const { value = null } = (acceptLangHeaders && acceptLangHeaders[0]) || {};
+  const locale =
+    value &&
+    acceptLanguageParser.pick(VALID_LOCALES_LIST, value, { loose: true });
+  return locale || fallback;
+}
+
+module.exports = {
+  getLocale,
+};

--- a/libs/get-locale/package.json
+++ b/libs/get-locale/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@yari-internal/get-locale",
+  "license": "MPL-2.0",
+  "private": true,
+  "version": "0.0.1",
+  "main": "index.js"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@caporal/core": "2.0.2",
     "@mdn/browser-compat-data": "2.0.7",
+    "accept-language-parser": "1.5.0",
     "braces": "^3.0.2",
     "chalk": "4.1.0",
     "cheerio": "1.0.0-rc.3",
@@ -40,6 +41,8 @@
     "clean-webpack-plugin": "3.0.0",
     "cli-progress": "^3.8.2",
     "compression": "1.7.4",
+    "cookie": "0.4.1",
+    "cookie-parser": "1.4.5",
     "cross-env": "^7.0.3",
     "cssesc": "^3.0.0",
     "diff": "5.0.0",

--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -15,7 +15,7 @@ const slugRewrite = (req, res, next) => {
 
 /**
  * This function is returns an object with {url:string, status:number}
- * if there's someplace to redirect. Otherwise an empty object.
+ * if there's some place to redirect to, otherwise an empty object.
  */
 const originRequest = (req, res, next) => {
   const { url: fundamentalRedirectUrl, status } = resolveFundamental(req.url);

--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -1,5 +1,7 @@
 const express = require("express");
 
+const { resolveFundamental } = require("../libs/fundamental-redirects");
+const { getLocale } = require("../libs/get-locale");
 const { STATIC_ROOT } = require("./constants");
 
 // Lowercase every request because every possible file we might have
@@ -11,6 +13,41 @@ const slugRewrite = (req, res, next) => {
   next();
 };
 
+/**
+ * This function is returns an object with {url:string, status:number}
+ * if there's someplace to redirect. Otherwise an empty object.
+ */
+const originRequest = (req, res, next) => {
+  const { url: fundamentalRedirectUrl, status } = resolveFundamental(req.url);
+  if (fundamentalRedirectUrl && status) {
+    res.redirect(status, fundamentalRedirectUrl);
+  } else if (req.url === "/" || req.url.startsWith("/docs/")) {
+    // Fake it so it becomes like Lambda@Edge
+    req.headers.cookie = [
+      {
+        // The `req.cookies` comes from cookie-parser
+        value: Object.entries(req.cookies)
+          .map(([key, value]) => `${key}=${value}`)
+          .join(";"),
+      },
+    ];
+    if (req.headers["accept-language"]) {
+      // Lambda@Edge expects it to be an array of objects
+      req.headers["accept-language"] = [
+        { value: req.headers["accept-language"] },
+      ];
+    }
+    const path = req.url.endsWith("/") ? req.url.slice(0, -1) : req.url;
+    const locale = getLocale(req);
+    // The only time we actually want a trailing slash is when the URL is just
+    // the locale. E.g. `/en-US/` (not `/en-US`)
+    res.redirect(302, `/${locale}${path || "/"}`);
+  } else {
+    next();
+  }
+};
+
 module.exports = {
   staticMiddlewares: [slugRewrite, express.static(STATIC_ROOT)],
+  originRequestMiddleware: originRequest,
 };

--- a/testing/tests/developing.test.js
+++ b/testing/tests/developing.test.js
@@ -53,3 +53,82 @@ describe("Testing the kitchensink page", () => {
 
   // XXX Do more advanced tasks that test the server and document "CRUD operations"
 });
+
+// Note, some of these tests cover some of the core code that we use in
+// the Lambda@Edge origin-request handler.
+describe("Testing the Express server", () => {
+  withDeveloping("redirect without any useful headers", async () => {
+    let response = await got(serverURL("/"), { followRedirect: false });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/en-US/");
+
+    response = await got(serverURL("/docs/Web"), {
+      followRedirect: false,
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/en-US/docs/Web");
+
+    // Trailing slashed
+    response = await got(serverURL("/docs/Web/"), {
+      followRedirect: false,
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/en-US/docs/Web");
+  });
+
+  withDeveloping("redirect by preferred locale cookie", async () => {
+    let response = await got(serverURL("/"), {
+      followRedirect: false,
+      headers: {
+        // Note! Case insensitive
+        Cookie: "preferredlocale=zH-cN; foo=bar",
+      },
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/zh-CN/");
+
+    // Some bogus locale we definitely don't recognized
+    response = await got(serverURL("/"), {
+      followRedirect: false,
+      headers: {
+        Cookie: "preferredlocale=xyz; foo=bar",
+      },
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/en-US/");
+  });
+
+  withDeveloping("redirect by 'Accept-Language' header", async () => {
+    let response = await got(serverURL("/"), {
+      followRedirect: false,
+      headers: {
+        // Based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
+        "Accept-language": "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
+      },
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/fr/");
+
+    // Some bogus locale we definitely don't recognized
+    response = await got(serverURL("/"), {
+      followRedirect: false,
+      headers: {
+        "accept-language": "xyz, X;q=0.9, Y;q=0.8, Z;q=0.7, *;q=0.5",
+      },
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/en-US/");
+  });
+
+  withDeveloping("redirect by cookie trumps", async () => {
+    let response = await got(serverURL("/"), {
+      followRedirect: false,
+      headers: {
+        Cookie: "preferredlocale=SV-se",
+        "Accept-language": "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
+      },
+    });
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe("/sv-SE/");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3927,6 +3927,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accept-language-parser@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"
+  integrity sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E=
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -6128,6 +6133,14 @@ convert-source-map@^0.3.3:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
   integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
 
+cookie-parser@1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.5.tgz#3e572d4b7c0c80f9c61daf604e4336831b5d1d49"
+  integrity sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==
+  dependencies:
+    cookie "0.4.0"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
@@ -6137,6 +6150,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-concurrently@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Part of #1889
(The reason I'm not saying "Fixes" is because I don't want the issue to close until we've upgraded and tested the new Lambda function on stage)

This is quite a big and complex PR so I'm hoping for a review from both of you gentlemen. 

To test this, you need to build some translated content. I use:
```
export CONTENT_ROOT=/Users/peterbe/dev/MOZILLA/MDN/yari/testing/content/files
export CONTENT_TRANSLATED_ROOT=testing/translated-content/files
yarn build && yarn start
```
Now you should be able to go to http://localhost:5000/en-US/docs/Web/Foo and note the little language drop-down and you should be able to change to French. Once you've done that, check your browser's cookies. 
Now if you go to http://localhost:5000/ it should redirect to http://localhost:5000/fr/
And if you go to http://localhost:5000/docs/Web/foo/ it redirects to http://localhost:5000/fr/docs/Web/foo/
(the last trailing `/`) won't happen in Lambda@Edge. 

What's I'm uncertain about is that I've done the right tricks with `@yari-internals` in package.json etc. Please take a close look at that @fiji-flo 
If I got it wrong, once it hits Lambda@Edge, we can fail forward accordingly. 

A really cool change as of this PR is that we can now travel through some of the code that happens in `origin-request`. To be able to do that in the `middlewares.js` I did some "monkey patching" of the request object. Hopefully I got it right!

