### PR TITLE
Removes the Doc_status links from MDNSidebar macro

### DIFF
--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -536,14 +536,5 @@ const text = mdn.localStringMap({
           </ol>
       </details>
     </li>
-    <li class="toggle">
-      <details>
-          <summary><%=text['Doc_status_by_topic']%></summary>
-          <ol>
-            <li><a href="<%=baseURL%>Doc_status"><%=text['Doc_status_by_topic']%></a></li>
-            <li><a href="<%=baseURL%>Doc_status/Overview"><%=text['Are_we_documented_yet']%></a></li>
-          </ol>
-      </details>
-    </li>
   </ol>
 </section>


### PR DESCRIPTION
Fixes #1800 