### PR TITLE
only preload the Bold woff2 font

### DIFF
--- a/ssr/render.js
+++ b/ssr/render.js
@@ -101,7 +101,10 @@ const extractWebFontURLs = lazy(() => {
       path.join(clientBuildRoot, entrypoint),
       "utf-8"
     );
-    const generator = extractCSSURLs(css, (url) => url.endsWith(".woff2"));
+    const generator = extractCSSURLs(
+      css,
+      (url) => url.endsWith(".woff2") && /Bold/i.test(url)
+    );
     urls.push(...generator);
   }
   return urls;


### PR DESCRIPTION
Fixes #1954

It seems that for mobile sometimes you need the Zilla Slab Regular. But mobile is only 15%. 
As of this change, we cover most users and the preloading-in-vain problem goes away. 