### PR TITLE
fix: correct sequential heading order

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -134,7 +134,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
             <div className="metadata">
               <section className="document-meta">
                 <header className="visually-hidden">
-                  <h4>Metadata</h4>
+                  <h3>Metadata</h3>
                 </header>
                 <ul>
                   <li className="last-modified">


### PR DESCRIPTION
Even though visually hidden, the Metadata heading should be marked up as an `h3` as opposed to an `h4`

fix #1969