### PR TITLE
fix: social links in footer lack discernable names

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -78,7 +78,7 @@ export function Footer() {
                 href="https://twitter.com/mozdevnet"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="Follow MDN on Twitter"
+                aria-label="Twitter"
               >
                 <TwitterIcon />
               </a>
@@ -88,7 +88,7 @@ export function Footer() {
                 href="https://github.com/mdn/"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="Contribute on Github"
+                aria-label="Github"
               >
                 <GithubIcon />
               </a>
@@ -104,7 +104,7 @@ export function Footer() {
                 href="https://twitter.com/mozilla"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="Follow Mozilla on Twitter"
+                aria-label="Twitter"
               >
                 <TwitterIcon />
               </a>
@@ -114,7 +114,7 @@ export function Footer() {
                 href="https://www.instagram.com/mozillagram/"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="Follow Mozilla on Instagram"
+                aria-label="Instagram"
               >
                 <InstagramIcon />
               </a>

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -78,6 +78,7 @@ export function Footer() {
                 href="https://twitter.com/mozdevnet"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Follow MDN on Twitter"
               >
                 <TwitterIcon />
               </a>
@@ -87,6 +88,7 @@ export function Footer() {
                 href="https://github.com/mdn/"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Contribute on Github"
               >
                 <GithubIcon />
               </a>
@@ -102,6 +104,7 @@ export function Footer() {
                 href="https://twitter.com/mozilla"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Follow Mozilla on Twitter"
               >
                 <TwitterIcon />
               </a>
@@ -111,6 +114,7 @@ export function Footer() {
                 href="https://www.instagram.com/mozillagram/"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Follow Mozilla on Instagram"
               >
                 <InstagramIcon />
               </a>


### PR DESCRIPTION
Add `aria-label` to ensure social links in footer have discernable names

fix #1978
