### PR TITLE
Fixup .gitignore after PR #1573

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,6 @@ fake-v1-api/
 mdn-yari-*.tgz
 function.zip
 
-<<<<<<< HEAD
 testing/content/files/en-us/_githistory.json
-=======
 # eslintcache
 client/.eslintcache
->>>>>>> master


### PR DESCRIPTION
Looks like during a rebase `.gitignore` got extra lines showing the diff of two branches `<<<<<<< HEAD`, `=======`, `>>>>>>> master`. These probably should be removed.