### PR TITLE
fix: change reference-page to document-page

### DIFF
--- a/client/.storybook/preview.scss
+++ b/client/.storybook/preview.scss
@@ -26,7 +26,7 @@ body {
 
 /* Grids */
 .docs {
-  .reference-page {
+  .document-page {
     .page-header,
     .titlebar-container,
     .breadcrumb-container,

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -41,7 +41,7 @@ function StandardLayout({ children }) {
   return <Layout pageType="standard-page">{children}</Layout>;
 }
 function DocumentLayout({ children }) {
-  return <Layout pageType="reference-page">{children}</Layout>;
+  return <Layout pageType="document-page">{children}</Layout>;
 }
 
 export function App(appProps) {

--- a/client/src/stories/grid/reference-page-grid.stories.mdx
+++ b/client/src/stories/grid/reference-page-grid.stories.mdx
@@ -5,7 +5,7 @@ import { Meta } from "@storybook/addon-docs/blocks";
 # Reference Page Grid
 
 <div class="docs">
-  <div class="page-wrapper reference-page">
+  <div class="page-wrapper document-page">
     <header class="page-header">
       <h1>Header</h1>
     </header>

--- a/client/src/stories/organisms/page-header.stories.js
+++ b/client/src/stories/organisms/page-header.stories.js
@@ -20,7 +20,7 @@ export default defaults;
 export const pageHeader = () => (
   <>
     <Router>
-      <div className={`page-wrapper reference-page`}>
+      <div className={`page-wrapper document-page`}>
         <Header />
 
         <Titlebar docTitle="Type selectors" />


### PR DESCRIPTION
Change the `reference-page` class name to `document-page`

fix #1998
