### PR TITLE
git-history rather fails on symlink CONTENT_ROOT

### DIFF
--- a/build/git-history.js
+++ b/build/git-history.js
@@ -4,15 +4,15 @@ const path = require("path");
 const { CONTENT_ROOT, execGit } = require("../content");
 
 function getFromGit(contentRoot = CONTENT_ROOT) {
-  const repoRoot = execGit(["rev-parse", "--show-toplevel"], {
-    cwd: contentRoot,
-  });
-
   // If `contentRoot` was a symlink, the `repoRoot` won't be. That'll make it
   // impossible to compute the relative path for files within when we get
   // output back from `git log ...`.
   // So, always normalize to the real path.
   const realContentRoot = fs.realpathSync(contentRoot);
+
+  const repoRoot = execGit(["rev-parse", "--show-toplevel"], {
+    cwd: realContentRoot,
+  });
 
   const MARKER = "COMMIT:";
   const output = execGit(
@@ -40,7 +40,7 @@ function getFromGit(contentRoot = CONTENT_ROOT) {
   // it seems `git log` prefers to use a newline character.
   // At least as of git version 2.28.0 (Dec 2020). So let's split on both
   // characters to be safe.
-  for (let line of output.split(/\0|\n/)) {
+  for (const line of output.split(/\0|\n/)) {
     if (line.startsWith(MARKER)) {
       date = new Date(line.replace(MARKER, ""));
     } else if (line) {

--- a/build/git-history.js
+++ b/build/git-history.js
@@ -8,6 +8,12 @@ function getFromGit(contentRoot = CONTENT_ROOT) {
     cwd: contentRoot,
   });
 
+  // If `contentRoot` was a symlink, the `repoRoot` won't be. That'll make it
+  // impossible to compute the relative path for files within when we get
+  // output back from `git log ...`.
+  // So, always normalize to the real path.
+  const realContentRoot = fs.realpathSync(contentRoot);
+
   const MARKER = "COMMIT:";
   const output = execGit(
     [
@@ -30,11 +36,15 @@ function getFromGit(contentRoot = CONTENT_ROOT) {
 
   const map = new Map();
   let date = null;
-  for (let line of output.split("\0")) {
+  // Even if we specified the `-z` option to `git log ...` above, sometimes
+  // it seems `git log` prefers to use a newline character.
+  // At least as of git version 2.28.0 (Dec 2020). So let's split on both
+  // characters to be safe.
+  for (let line of output.split(/\0|\n/)) {
     if (line.startsWith(MARKER)) {
       date = new Date(line.replace(MARKER, ""));
     } else if (line) {
-      const relPath = path.relative(contentRoot, path.join(repoRoot, line));
+      const relPath = path.relative(realContentRoot, path.join(repoRoot, line));
       map.set(relPath, date);
     }
   }


### PR DESCRIPTION
Fixes #1990

Here's how I tested this. I created a folder that was symlinked to the real location of where I keep the content/files. 
E.g.
```
▶ ls -l ~/Downloads/ | rg content
lrwxr-xr-x  1 peterbe  staff         16 Dec  7 10:17 content -> /tmp/mdn/content
▶ export CONTENT_ROOT=/Users/peterbe/Downloads/content/files
```

But for sanity, I had to delete the previous disk-based cache of git histories which is in my (real) temp directory. 
```
▶ rm -fr /var/folders/1x/2hf5hbs902q54g3bgby5bzt40000gn/T/yari-git-history.json
```

Now:
```
▶ node tool/cli.js gather-git-history --verbose
Wrote 'en-us' 11,408 paths into /Users/peterbe/Downloads/content/files/en-us/_githistory.json
Saved 11,408 paths into /var/folders/1x/2hf5hbs902q54g3bgby5bzt40000gn/T/yari-git-history.json

```