### PR TITLE
page title is too large on mobile

### DIFF
--- a/client/src/ui/molecules/titlebar/index.scss
+++ b/client/src/ui/molecules/titlebar/index.scss
@@ -1,3 +1,4 @@
+@import "~@mdn/minimalist/sass/vars/typography";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 
@@ -13,11 +14,13 @@
 
   h1 {
     word-break: break-word;
+    font-size: $large-font-size-mobile;
 
     @media #{$mq-tablet-and-up} {
       margin: 0 auto;
       max-width: $max-width-default;
       padding: $base-spacing;
+      font-size: $xl-font-size;
     }
   }
 }


### PR DESCRIPTION
Fixes #1805

BEFORE
<img width="537" alt="Screen Shot 2020-12-07 at 11 05 54 AM" src="https://user-images.githubusercontent.com/26739/101374476-361e7d00-387c-11eb-901e-ad1aac883bef.png">

AFTER
<img width="757" alt="Screen Shot 2020-12-07 at 11 02 48 AM" src="https://user-images.githubusercontent.com/26739/101374503-3c145e00-387c-11eb-8ab3-913307bfa748.png">

And on my iOS Safari
![IMG_87C5B2C71E3F-1](https://user-images.githubusercontent.com/26739/101374564-50585b00-387c-11eb-816f-428ecb4be54d.jpeg)
