### PR TITLE
link to English equivalent from 404 page

### DIFF
--- a/client/src/page-not-found/index.tsx
+++ b/client/src/page-not-found/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import useSWR from "swr";
 
 import LANGUAGES_RAW from "../languages.json";
@@ -128,11 +128,11 @@ function FallbackLink({ url }: { url: string }) {
           <b>English</b>
         </p>
         <p className="fallback-link">
-          <Link to={document.mdn_url}>
+          <a href={document.mdn_url}>
             <b>{document.title}</b>
             <br />
             <small>{document.mdn_url}</small>
-          </Link>
+          </a>
         </p>
       </div>
     );


### PR DESCRIPTION
Fixes #2007

First of all, switching from `<Link to>` to `<a href>` within the `PageNotFound` component solves the problem of it might not scroll to the top when you click it. This can equally be solved with [scroll restoration](https://reactrouter.com/web/guides/scroll-restoration) but I suspect it needs a little bit more work. 

Secondly, I appreciate that it's hard to test this now! But when we enable the auto-complete search widget, a click on a search result there will mutate the page and want to try to load a document. 

Complicated challenges like this is another feather in the hat of abandoning client-side navigation for the production site. :)
