### PR TITLE
Make it possible to control translated-content from manual builds

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -69,14 +69,26 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
 
+      # Our usecase is a bit complicated. When the cron schedule runs this workflow,
+      # we rely on the env vars defined at the top of the file. But if it's a manual
+      # trigger we rely on the inputs and only the inputs. That way, the user can
+      # opt to type in 'false'.
+      # It's not possible to express this with GitHub Workflow syntax, so we
+      # have a dedicate set that conveniently sets these as env vars which we
+      # can refer to later in `if: ....` lines or in bash with the `run: ...` blocks.
+      - name: Figure out what we'll need to build
+        run: |
+          echo "BUILD_TRANSLATED_CONTENT=${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}" >> $GITHUB_ENV
+          echo "BUILD_ARCHIVED_CONTENT=${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT, 'true')"
+        if: "contains(env.BUILD_ARCHIVED_CONTENT, 'true')"
         with:
           repository: mdn/archived-content
           path: mdn/archived-content
 
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')"
+        if: "contains(env.BUILD_TRANSLATED_CONTENT, 'true')"
         with:
           repository: mdn/translated-content-rendered
           path: mdn/translated-content
@@ -125,6 +137,8 @@ jobs:
           echo "translated_content: ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}"
           echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}"
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
+          echo "BUILD_TRANSLATED_CONTENT: ${{ env.BUILD_TRANSLATED_CONTENT }}"
+          echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
       - name: Build everything
         run: |
@@ -132,13 +146,13 @@ jobs:
           # sub-folder called "mdn/content"
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else
@@ -175,13 +189,13 @@ jobs:
           # Set the CONTENT_ROOT first
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -69,14 +69,26 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
 
+      # Our usecase is a bit complicated. When the cron schedule runs this workflow,
+      # we rely on the env vars defined at the top of the file. But if it's a manual
+      # trigger we rely on the inputs and only the inputs. That way, the user can
+      # opt to type in 'false'.
+      # It's not possible to express this with GitHub Workflow syntax, so we
+      # have a dedicate set that conveniently sets these as env vars which we
+      # can refer to later in `if: ....` lines or in bash with the `run: ...` blocks.
+      - name: Figure out what we'll need to build
+        run: |
+          echo "BUILD_TRANSLATED_CONTENT=${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}" >> $GITHUB_ENV
+          echo "BUILD_ARCHIVED_CONTENT=${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT, 'true')"
+        if: "contains(env.BUILD_ARCHIVED_CONTENT, 'true')"
         with:
           repository: mdn/archived-content
           path: mdn/archived-content
 
       - uses: actions/checkout@v2
-        if: "contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')"
+        if: "contains(env.BUILD_TRANSLATED_CONTENT, 'true')"
         with:
           repository: mdn/translated-content-rendered
           path: mdn/translated-content
@@ -125,6 +137,8 @@ jobs:
           echo "translated_content: ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }}"
           echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}"
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
+          echo "BUILD_TRANSLATED_CONTENT: ${{ env.BUILD_TRANSLATED_CONTENT }}"
+          echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
       - name: Build everything
         run: |
@@ -132,13 +146,13 @@ jobs:
           # sub-folder called "mdn/content"
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else
@@ -180,13 +194,13 @@ jobs:
           # Set the CONTENT_ROOT first
           export CONTENT_ROOT=$(pwd)/mdn/content/files
 
-          if [ ${{ github.event.inputs.archived_content || env.DEFAULT_ARCHIVED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
             export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
-          if [ ${{ github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT }} == "true" ]; then
+          if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
             export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
           else


### PR DESCRIPTION
Fixes #2036

Wow what a timesink!! Turns out you can't use
```
contains(github.event.inputs.translated_content || env.DEFAULT_TRANSLATED_CONTENT, 'true')
```
because it becomes falsy if `github.event.inputs.translated_content` *and* `env.DEFAULT_TRANSLATED_CONTENT` is set. Or something. 
This PR might look small and neat but I went through 10+ commits and equally many builds to test this carefully. 
Now, we should be getting the best of both worlds:

1. If it's a `cron` schedule, the default env vars rule the decision. 
2. If it's a manual trigger, the inputs decide. That means it's possible to type in `false` and have it NOT build the translated content.
3. The inputs, if you use that, get *their* default from the env vars. 

Yikes! That got complicated. 