### PR TITLE
404 page should not cache

### DIFF
--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -22,6 +22,7 @@ from .utils import StopWatch, fmt_size, iterdir, log
 S3_MULTIPART_THRESHOLD = S3TransferConfig().multipart_threshold
 S3_MULTIPART_CHUNKSIZE = S3TransferConfig().multipart_chunksize
 
+NO_CACHE_VALUE = "no-store, must-revalidate"
 
 hashed_filename_regex = re.compile(r"\.[a-f0-9]{8,32}\.")
 
@@ -177,11 +178,15 @@ class UploadFileTask(UploadTask):
 
     @property
     def cache_control(self):
+
         if self.file_path.name == "service-worker.js":
-            return "no-cache"
+            return NO_CACHE_VALUE
+
+        if self.file_path.name == "404.html":
+            return NO_CACHE_VALUE
 
         if self.file_path.parent.name == "_whatsdeployed":
-            return "no-cache"
+            return NO_CACHE_VALUE
 
         if self.is_hashed:
             cache_control_seconds = HASHED_CACHE_CONTROL


### PR DESCRIPTION
Fixes #2037

The S3 key to check, once this has landed and made it into the next build is: https://s3.console.aws.amazon.com/s3/object/mdn-content-stage?region=us-west-2&prefix=main/en-us/_spas/404.html
But it reminds me, if we don't delete that key from S3 before the next build, our uploader might think the file hasn't changed (only its metadata is different)
So as a reminder ourselves, we need to go back and check that it get set correctly. Or we delete the S3 key right before a build finishes. 