### PR TITLE
BCD table crashes shouldn't break the page

### DIFF
--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -4,7 +4,9 @@ const bcd = require("@mdn/browser-compat-data");
 
 function packageBCD(query) {
   let data = query.split(".").reduce((prev, curr) => {
-    return prev && prev.hasOwnProperty(curr) ? prev[curr] : undefined;
+    return prev && Object.prototype.hasOwnProperty.call(prev, "curr")
+      ? prev[curr]
+      : undefined;
   }, bcd);
   return { browsers: bcd.browsers, data };
 }

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -4,7 +4,7 @@ const bcd = require("@mdn/browser-compat-data");
 
 function packageBCD(query) {
   let data = query.split(".").reduce((prev, curr) => {
-    return prev && Object.prototype.hasOwnProperty.call(prev, "curr")
+    return prev && Object.prototype.hasOwnProperty.call(prev, curr)
       ? prev[curr]
       : undefined;
   }, bcd);

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -3,8 +3,8 @@
 const bcd = require("@mdn/browser-compat-data");
 
 function packageBCD(query) {
-  let data = query.split(".").reduce(function (prev, curr) {
-    return prev ? prev[curr] : undefined;
+  let data = query.split(".").reduce((prev, curr) => {
+    return prev && prev.hasOwnProperty(curr) ? prev[curr] : undefined;
   }, bcd);
   return { browsers: bcd.browsers, data };
 }

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -77,8 +77,7 @@ function LazyBrowserCompatibilityTableInner({
   if (!data.data) {
     return (
       <p>
-        Error loading BCD table because there's no known data for{" "}
-        <code>{query}</code>
+        No compatibility data found for <code>{query}</code>. Check the spelling or contribute data to <a href="https://github.com/mdn/browser-compat-data">mdn/browser-compat-data</a>.
       </p>
     );
   }

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -35,12 +35,18 @@ export function LazyBrowserCompatibilityTable({
     <>
       {title && !isH3 && <DisplayH2 id={id} title={title} />}
       {title && isH3 && <DisplayH3 id={id} title={title} />}
-      <LazyBrowserCompatibilityTableInner dataURL={dataURL} />
+      <LazyBrowserCompatibilityTableInner dataURL={dataURL} query={query} />
     </>
   );
 }
 
-function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
+function LazyBrowserCompatibilityTableInner({
+  dataURL,
+  query,
+}: {
+  dataURL: string;
+  query: string;
+}) {
   const [bcdDataURL, setBCDDataURL] = useState("");
 
   const { error, data } = useSWR(
@@ -68,6 +74,15 @@ function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
   if (error) {
     return <p>Error loading BCD data</p>;
   }
+  if (!data.data) {
+    return (
+      <p>
+        Error loading BCD table because there's no known data for{" "}
+        <code>{query}</code>
+      </p>
+    );
+  }
+
   return (
     <Suspense fallback={<Loading />}>
       <BrowserCompatibilityTable {...data} />


### PR DESCRIPTION
Fixes #2020

@ddbeck I can't request a review from you. I added you with `Write` permission to the repo but perhaps it's pending you invitation acceptance. Or perhaps some caching going on in the PR UI. Anyway...

@schalkneethling Can you please review the appears and can you also sanity test my PR. If you open `lazy-bcd-table.tsx` you'll see that there are 3 individual chances of NOT displaying the full BCD table but instead displaying an "error message". 
Can you please have a think about some better styling we can use. Perhaps there's something from minimalist or from the `ui` folder that I can use?

@ddbeck Can you sanity check the implementation and perhaps reflect on the "word smithing" of the error message it self. Here's what it looks like:
<img width="707" alt="Screen Shot 2020-12-09 at 4 40 52 PM" src="https://user-images.githubusercontent.com/26739/101691864-5184b600-3a3d-11eb-8971-237bc32a093b.png">
It crashes hard [in stage](https://github.com/mdn/yari/issues/2020) because the sub-component shouldn't have been even attempted if the data isn't there. When open `node_modules/@mdn/browser-compat-data/api/CSSTransformComponent.json` I can clearly see that there's no entry for `toString`. I'm not judging that really. It's going to happen again sooner or later. And it can equally happen if you'd typed `{{Compat("api.CSSTransformComponent.toMatrixxxxtypo")}}` 

Whilst you guys can take a look at that I'm going to follow-up with a thing so that this is registered as a flaw. The author of that page should be made aware that `api.CSSTransformComponent.toString` doesn't exist in BCD. 