### PR TITLE
fix: update style for inline optional badge

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -102,8 +102,11 @@
   }
 
   /* readonly inline badges needs a slightly darker background color in general article content  */
-  .inline.readonly {
-    background-color: $neutral-550;
+  .inline {
+    &.optional,
+    &.readonly {
+      background-color: $neutral-550;
+    }
   }
 
   /* 


### PR DESCRIPTION
Update the style for inline optional badges to give them a darker shade of grey

## Before

![Screenshot 2020-12-13 at 05 03 14](https://user-images.githubusercontent.com/10350960/102002058-8de83880-3d01-11eb-8cd5-24f85f8e4f16.png)

## After

![Screenshot 2020-12-13 at 05 03 24](https://user-images.githubusercontent.com/10350960/102002061-8fb1fc00-3d01-11eb-8fae-9e147ebf7390.png)

fix #1936
