### PR TITLE
fix: consistent border color

### DIFF
--- a/client/src/document/organisms/toc/index.scss
+++ b/client/src/document/organisms/toc/index.scss
@@ -18,7 +18,7 @@
 
   .toc-trigger-mobile {
     border: 0;
-    border-bottom: 2px solid $primary-100;
+    border-bottom: 2px solid $primary-50;
     color: $link-color;
     font-weight: normal;
     padding: ($base-spacing / 2);


### PR DESCRIPTION
Update the border color for the TOC button on mobile.

Part of #1918
