### PR TITLE
fix redirects for prefixes

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -13,8 +13,11 @@ function redirect(pattern, template, options = {}) {
     if (typeof template === "string") {
       return { url: template, status };
     }
-    const { groups } = match;
-    return { url: template({ ...groups }), status };
+    const { [0]: subString, index, groups } = match;
+    const before = path.substring(0, index);
+    const after = path.substring(index + subString.length);
+    const to = template({ ...groups });
+    return { url: `${before}${to}${after}`, status };
   };
 }
 

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1,6 +1,6 @@
 const { VALID_LOCALES, LOCALE_ALIASES } = require("../constants");
 
-const startRe = /^\^\/?/;
+const startRe = /^\^?\/?/;
 const startTemplate = /^\//;
 
 function redirect(pattern, template, options = {}) {

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -766,14 +766,14 @@ const SCL3_REDIRECT_PATTERNS = [
   // All other Demo Studio and Dev Derby paths (bug 1238037)
   // RewriteRule ^(\w{2,3}(?:-\w{2})?/)?demos
   // /$1docs/Web/Demos_of_open_web_technologies? [R=301,L]
-  localeRedirect(/^demos/i, "/docs/Web/Demos_of_open_web_technologies", {
+  localeRedirect(/^demos.*/i, "/docs/Web/Demos_of_open_web_technologies", {
     permanent: true,
   }),
   // Legacy off-site redirects (bug 1362438)
   // RewriteRule ^contests/ http://www.mozillalabs.com/ [R=302,L]
-  redirect(/^contests/i, "http://www.mozillalabs.com/", { permanent: false }),
+  redirect(/^contests.*/i, "http://www.mozillalabs.com/", { permanent: false }),
   // RewriteRule ^es4 http://www.ecma-international.org/memento/TC39.htm [R=302,L]
-  redirect(/^es4/i, "http://www.ecma-international.org/memento/TC39.htm", {
+  redirect(/^es4.*/i, "http://www.ecma-international.org/memento/TC39.htm", {
     permanent: false,
   }),
 ];
@@ -1156,7 +1156,7 @@ const REDIRECT_PATTERNS = [].concat(
   FIREFOX_SOURCE_DOCS_REDIRECT_PATTERNS,
   [
     localeRedirect(
-      /^fellowship/i,
+      /^fellowship.*/i,
       "/docs/Archive/2015_MDN_Fellowship_Program",
       {
         permanent: true,

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -196,6 +196,7 @@ SCL3_REDIRECT_URLS = list(
             url_test("/en-US/learn/css", "/en-US/docs/Learn/CSS"),
             url_test("/en/learn/css", "/en/docs/Learn/CSS"),
             url_test("/en-US/learn/javascript", "/en-US/docs/Learn/JavaScript"),
+            url_test("/en-US/Learn/JavaScript/First_steps", "/en-US/docs/Learn/JavaScript/First_steps"),
             url_test("/en/learn/javascript", "/en/docs/Learn/JavaScript"),
             url_test("/en-US/learn", "/en-US/docs/Learn"),
             url_test("/en/learn", "/en/docs/Learn"),

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -217,6 +217,10 @@ const SCL3_REDIRECT_URLS = [].concat(
   url_test("/en-US/learn/css", "/en-US/docs/Learn/CSS"),
   url_test("/en/learn/css", "/en/docs/Learn/CSS"),
   url_test("/en-US/learn/javascript", "/en-US/docs/Learn/JavaScript"),
+  url_test(
+    "/en-US/Learn/JavaScript/First_steps",
+    "/en-US/docs/Learn/JavaScript/First_steps"
+  ),
   url_test("/en/learn/javascript", "/en/docs/Learn/JavaScript"),
   url_test("/en-US/learn", "/en-US/docs/Learn"),
   url_test("/en/learn", "/en/docs/Learn"),


### PR DESCRIPTION
Kuma supports to just replace the matching parts, yari should too.

```
curl -I  https://developer.allizom.org/en-US/Learn/JavaScript/First_steps → /en-US/docs/Learn/JavaScript
curl -I  https://developer.mozilla.org/en-US/Learn/JavaScript/First_steps → /en-US/docs/Learn/JavaScript/First_steps
```