### PR TITLE
Add flaw check for innerHTML

### DIFF
--- a/build/constants.js
+++ b/build/constants.js
@@ -29,6 +29,7 @@ const VALID_FLAW_CHECKS = new Set([
   "images",
   "image_widths",
   "pre_with_html",
+  "pre_with_js_innerhtml",
   "sectioning",
 ]);
 

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -17,6 +17,7 @@ import {
   GenericFlaw,
   BadBCDQueryFlaw,
   PreWithHTMLFlaw,
+  PreWithJSinnerHTMLFlaw,
   SectioningFlaw,
 } from "../types";
 import "./flaws.scss";
@@ -220,6 +221,13 @@ function Flaws({ doc, flaws }: { doc: Doc; flaws: FlawCount[] }) {
                 key="pre_with_html"
                 sourceFolder={doc.source.folder}
                 flaws={doc.flaws.pre_with_html}
+              />
+            );
+          case "pre_with_js_innerhtml":
+            return (
+              <PreWithJSinnerHTML
+                key="pre_with_js_innerhtml"
+                flaws={doc.flaws.pre_with_js_innerhtml}
               />
             );
           case "macros":
@@ -475,6 +483,39 @@ function Sectioning({ flaws }: { flaws: SectioningFlaw[] }) {
               Usually this means there's something in the raw content that makes
               it hard to split up the rendered HTML. Perhaps delete unnecessary
               empty divs.
+            </small>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PreWithJSinnerHTML({ flaws }: { flaws: PreWithJSinnerHTMLFlaw[] }) {
+  const { focus } = useAnnotations(flaws);
+  return (
+    <div className="flaw flaw__pre_with_js_innerhtml">
+      <h3>{humanizeFlawName("pre_with_js_innerhtml")}</h3>
+      <ul>
+        {flaws.map((flaw) => (
+          <li key={flaw.id}>
+            Avoid <code>innerHTML</code>
+            <span
+              role="img"
+              aria-label="Click to scroll to the JS example"
+              title="Click to scroll to the JS example"
+              style={{ cursor: "zoom-in" }}
+              onClick={() => {
+                focus(flaw.id);
+              }}
+            >
+              👀
+            </span>{" "}
+            <br />
+            <small>
+              <a href="/en-US/docs/MDN/Guidelines/Code_guidelines/JavaScript#Use_textContent_not_innerHTML">
+                Consider using <code>textContent</code> instead.
+              </a>
             </small>
           </li>
         ))}

--- a/client/src/document/types.tsx
+++ b/client/src/document/types.tsx
@@ -46,6 +46,8 @@ export interface PreWithHTMLFlaw extends GenericFlaw {
   column?: number;
 }
 
+export interface PreWithJSinnerHTMLFlaw extends GenericFlaw {}
+
 export interface MacroErrorMessage extends GenericFlaw {
   name: string;
   error: {
@@ -69,6 +71,7 @@ type Flaws = {
   bad_bcd_links: BadBCDLinkFlaw[];
   images: ImageReferenceFlaw[];
   pre_with_html: PreWithHTMLFlaw[];
+  pre_with_js_innerhtml: PreWithJSinnerHTMLFlaw[];
   sectioning: SectioningFlaw[];
   image_widths: ImageWidthFlaw[];
 };

--- a/client/src/flaw-utils.js
+++ b/client/src/flaw-utils.js
@@ -11,6 +11,7 @@ export function humanizeFlawName(name) {
     bad_bcd_queries: "Bad BCD queries",
     bad_bcd_links: "Bad BCD links",
     pre_with_html: "<pre> with HTML",
+    pre_with_js_innerhtml: "<pre> with JS innerHTML",
   };
   function fallback() {
     return name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, " ");


### PR DESCRIPTION
MDN code guidelines [recommend](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Code_guidelines/JavaScript#Use_textContent_not_innerHTML) to "use `textContent`, not `innerHTML`".

This PR introduces a flaw check for this guideline to quantify the number of pages which utilize `innerHTML`.

Specifically it:
 - finds all `<pre>` tags with class `brush` that contain string `innerHTML`
 - ignores all content within a node with class `hidden` because it's not visible to reader.