### PR TITLE
make printing documents suck a bit less

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -27,10 +27,7 @@
       color="#5bbad5"
     />
     <meta name="theme-color" content="#ffffff" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
+
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>MDN Web Docs</title>
     <meta
@@ -38,6 +35,24 @@
       content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."
     />
     <link rel="canonical" href="https://developer.mozilla.org" />
+    <style media="print">
+      .breadcrumbs-locale-container,
+      .document-toc-container,
+      .on-github,
+      nav.sidebar,
+      .page-header-main,
+      .page-footer,
+      ul.prev-next {
+        display: none !important;
+      }
+      .article,
+      .article pre {
+        padding: 2px;
+      }
+      .article pre {
+        border-left-width: 2px;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -28,6 +28,7 @@ import { Metadata } from "./organisms/metadata";
 import { ReactComponent as Dino } from "../assets/dino.svg";
 
 import "./index.scss";
+// import "./document-print.scss";
 
 // Lazy sub-components
 const Toolbar = React.lazy(() => import("./toolbar"));

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -28,7 +28,6 @@ import { Metadata } from "./organisms/metadata";
 import { ReactComponent as Dino } from "../assets/dino.svg";
 
 import "./index.scss";
-// import "./document-print.scss";
 
 // Lazy sub-components
 const Toolbar = React.lazy(() => import("./toolbar"));


### PR DESCRIPTION
Fixes #2054

Before:
<img width="1149" alt="Screen Shot 2020-12-15 at 1 33 01 PM" src="https://user-images.githubusercontent.com/26739/102257221-7a43fa00-3eda-11eb-8e9f-1d325d24df9f.png">

After:
<img width="1073" alt="Screen Shot 2020-12-15 at 1 35 35 PM" src="https://user-images.githubusercontent.com/26739/102257253-80d27180-3eda-11eb-9d48-201f32b15949.png">

Print stylesheets is a matter of "how long is a rope?". There's probably, even more, we could do. But printing isn't a huge priority so it doesn't yet deserve a huge investment. 
Here are a couple of cheap fixes that, I believe, carry a lot of punch. I haven't actually printed them out on actual paper but I've been using the PDF print which is potentially what a lot of people will use when they "print". 