### PR TITLE
Provide support for `summary` and `raw` query options (#2161)

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation, useSearchParams } from "react-router-dom";
 
 // we include our base SASS here to ensure it is loaded
 // and applied before any component specific style
@@ -56,6 +56,8 @@ function DocumentOrPageNotFound(props) {
   // It's true by default if the SSR rendering says so.
   const [notFound, setNotFound] = React.useState<boolean>(!!props.pageNotFound);
   const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
+  const rawContent = searchParams.get("raw") === "" || searchParams.get("raw");
   const initialPathname = React.useRef(pathname);
   React.useEffect(() => {
     if (initialPathname.current && initialPathname.current !== pathname) {
@@ -63,7 +65,13 @@ function DocumentOrPageNotFound(props) {
     }
   }, [pathname]);
 
-  return notFound ? (
+  return rawContent ? (
+    notFound ? (
+      <PageNotFound />
+    ) : (
+      <Document {...props} />
+    )
+  ) : notFound ? (
     <StandardLayout>
       <PageNotFound />
     </StandardLayout>

--- a/client/src/document/ingredients/summary.tsx
+++ b/client/src/document/ingredients/summary.tsx
@@ -1,0 +1,10 @@
+export function Summary({ section }) {
+  return (
+    <div dangerouslySetInnerHTML={{ __html: buildSummary(section.content) }} />
+  );
+}
+
+function buildSummary(content: string) {
+  // We should strip any embedded examples from the summary
+  return content.replace(/<iframe.*<\/iframe>/gm, "");
+}

--- a/content/document.js
+++ b/content/document.js
@@ -293,12 +293,14 @@ function update(url, rawHTML, metadata) {
 }
 
 function findByURL(url, ...args) {
-  const [bareURL, hash = ""] = url.split("#", 2);
+  const [queryWithoutHash, hash = ""] = url.split("#", 2);
+  const [bareURL, query = ""] = queryWithoutHash.split("?", 2);
   const doc = read(urlToFolderPath(bareURL), ...args);
-  if (doc && hash) {
-    return { ...doc, url: `${doc.url}#${hash}` };
-  }
-  return doc;
+  if (!doc) return doc;
+  return {
+    ...doc,
+    url: doc.url + (query ? `?${query}` : "") + (hash ? `#${hash}` : ""),
+  };
 }
 
 function findAll(


### PR DESCRIPTION
This PR restores support for `summary` and `raw` query params supported in previous iteration of the documentation portal. The feature allows 3-rd party to query for raw documentation and/or just a summary without a need to crawl the web page. It not only makes it easier for others to consume the documentation, but reduces unnecessary transfer and render costs to minimum on the portal side.