### PR TITLE
Downloading images (fixable flaws) should also compress

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -16,6 +16,7 @@ const { BUILD_OUT_ROOT } = require("./constants");
 const { makeSitemapXML, makeSitemapIndexXML } = require("./sitemaps");
 const { CONTENT_TRANSLATED_ROOT } = require("../content/constants");
 const { uniqifyTranslationsOf } = require("./translationsof");
+const { humanFileSize } = require("./utils");
 
 async function buildDocuments(files = null) {
   // If a list of files was set, it came from the CLI.
@@ -230,15 +231,6 @@ async function buildOtherSPAs() {
 
   // XXX Here, build things like the home page, site-search etc.
   // ...
-}
-
-function humanFileSize(size) {
-  if (size < 1024) return size + " B";
-  let i = Math.floor(Math.log(size) / Math.log(1024));
-  let num = size / Math.pow(1024, i);
-  let round = Math.round(num);
-  num = round < 10 ? num.toFixed(2) : round < 100 ? num.toFixed(1) : round;
-  return `${num} ${"KMGTPEZY"[i - 1]}B`;
 }
 
 function formatTotalFlaws(flawsCountMap, header = "Total_Flaws_Count") {

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -3,6 +3,11 @@ const path = require("path");
 
 const chalk = require("chalk");
 const got = require("got");
+const imagemin = require("imagemin");
+const imageminPngquant = require("imagemin-pngquant");
+const imageminMozjpeg = require("imagemin-mozjpeg");
+const imageminGifsicle = require("imagemin-gifsicle");
+const imageminSvgo = require("imagemin-svgo");
 
 const { Document, Redirect } = require("../content");
 const { FLAW_LEVELS } = require("./constants");
@@ -11,6 +16,7 @@ const {
   findMatchesInText,
   replaceMatchesInText,
 } = require("./matches-in-text");
+const { humanFileSize } = require("./utils");
 
 function injectFlaws(doc, $, options, { rawContent }) {
   if (doc.isArchive) return;
@@ -431,7 +437,22 @@ async function fixFixableFlaws(doc, options, document) {
             .replace(/\s+/g, "_")
             .toLowerCase()
         );
-        fs.writeFileSync(destination, imageBuffer);
+        // Before writing to disk, run it through the same imagemin
+        // compression we do in the filecheck CLI.
+        const compressedImageBuffer = await imagemin.buffer(imageBuffer, {
+          plugins: [getImageminPlugin(url.pathname)],
+        });
+        if (compressedImageBuffer.length < imageBuffer.length) {
+          console.log(
+            `Raw image size: ${humanFileSize(
+              imageBuffer.length
+            )} Compressed: ${humanFileSize(compressedImageBuffer.length)}`
+          );
+          fs.writeFileSync(destination, compressedImageBuffer);
+        } else {
+          console.log(`Raw image size: ${humanFileSize(imageBuffer.length)}`);
+          fs.writeFileSync(destination, imageBuffer);
+        }
         console.log(`Downloaded ${flaw.src} to ${destination}`);
         newSrc = path.basename(destination);
       } catch (error) {
@@ -483,6 +504,23 @@ async function fixFixableFlaws(doc, options, document) {
       }
     }
   }
+}
+
+function getImageminPlugin(fileName) {
+  const extension = path.extname(fileName);
+  if ((extension === ".jpg") | (extension === ".jpeg")) {
+    return imageminMozjpeg();
+  }
+  if (extension === ".png") {
+    return imageminPngquant();
+  }
+  if (extension === ".gif") {
+    return imageminGifsicle();
+  }
+  if (extension === ".svg") {
+    return imageminSvgo();
+  }
+  throw new Error(`No imagemin plugin for ${extension}`);
 }
 
 module.exports = { injectFlaws, injectSectionFlaws, fixFixableFlaws };

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -508,7 +508,7 @@ async function fixFixableFlaws(doc, options, document) {
 
 function getImageminPlugin(fileName) {
   const extension = path.extname(fileName);
-  if ((extension === ".jpg") | (extension === ".jpeg")) {
+  if (extension === ".jpg" || extension === ".jpeg") {
     return imageminMozjpeg();
   }
   if (extension === ".png") {

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,0 +1,10 @@
+function humanFileSize(size) {
+  if (size < 1024) return size + " B";
+  let i = Math.floor(Math.log(size) / Math.log(1024));
+  let num = size / Math.pow(1024, i);
+  let round = Math.round(num);
+  num = round < 10 ? num.toFixed(2) : round < 100 ? num.toFixed(1) : round;
+  return `${num} ${"KMGTPEZY"[i - 1]}B`;
+}
+
+module.exports = { humanFileSize };


### PR DESCRIPTION
Fixes #2164

How I tested it was that I grepped around for a page that has external images and when viewing it with the toolbar it should say "Fix fixable flaws". If you look at the `stdout` it should say something like:
```
12:49:13 PM server.1    |  Raw image size: 33.5 KB Compressed: 13.6 KB
12:49:13 PM server.1    |  Downloaded https://mdn.mozillademos.org/files/11403/matrix-composition.jpg to /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/webgl_api/matrix_math_for_the_web/matrix-composition.jpg
12:49:13 PM server.1    |  Fixed (image4) image https://mdn.mozillademos.org/files/11403/matrix-composition.jpg to matrix-composition.jpg
```
And if the file was already small, it should say something like:
```
12:46:05 PM server.1    |  Raw image size: 38.5 KB
12:46:05 PM server.1    |  Downloaded https://mdn.mozillademos.org/files/15123/Capture2.png to /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/webvr_api/using_the_webvr_api/capture2.png
12:46:05 PM server.1    |  Fixed (image2) image https://mdn.mozillademos.org/files/15123/Capture2.png to capture2.png
```

I didn't want to get too smart with making the `filecheck/cheker.js` code share utility functions with `build/flaws.js` because they're sufficiently far away from each other than they do things differently anyway. The only thing the two have in common is that they figure out which plugins to use depending on the filename. 
Also, in a matter of weeks or so, we'll have no more need for the flaw that looks for external images and downloads them because we'll have processed all existing ones and that day we can remove `got()` and just throw a hard error that you're not supposed to use external images in the first place. 