### PR TITLE
chore: Hoist env variables in GitHub Actions

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -117,20 +117,44 @@ jobs:
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix }}"
 
       - name: Build everything
-        run: |
+        env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
 
+          # This basically means that all live-sample iframes run on the same
+          # host as the page that includes the iframe. Not great security but the
+          # context is that this is Dev and it's not connected to a real backend.
+          BUILD_LIVE_SAMPLES_BASE_URL: ""
+
+          # Now is not the time to worry about flaws.
+          BUILD_FLAW_LEVELS: "*:ignore"
+
+          # Uncomment when hacking on this workflow. It means the `yarn build`
+          # finishes much sooner, which can be helpful debugging the other stuff
+          # the workflow needs to do.
+          # BUILD_FOLDERSEARCH: web/html
+
+          # This just makes sure the Google Analytics script gets used even if
+          # it goes nowhere.
+          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-00000000-0
+          # Same with the Speedcurve LUX
+          BUILD_SPEEDCURVE_LUX_ID: 000000000
+
+          # Make sure every built page always has
+          # '<meta name="robots" content="noindex, nofollow">' nomatter what
+          # kind of document it is.
+          BUILD_ALWAYS_NO_ROBOTS: true
+        run: |
           if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -139,31 +163,7 @@ jobs:
           echo "CONTENT_ROOT=$CONTENT_ROOT"
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
-
-          # This basically means that all live-sample iframes run on the same
-          # host as the page that includes the iframe. Not great security but the
-          # context is that this is Dev and it's not connected to a real backend.
-          export BUILD_LIVE_SAMPLES_BASE_URL=
-
-          # Now is not the time to worry about flaws.
-          export BUILD_FLAW_LEVELS="*:ignore"
           yarn prepare-build
-
-          # Uncomment when hacking on this workflow. It means the `yarn build`
-          # finishes much sooner, which can be helpful debugging the other stuff
-          # the workflow needs to do.
-          # export BUILD_FOLDERSEARCH=web/html
-
-          # This just makes sure the Google Analytics script gets used even if
-          # it goes nowhere.
-          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
-          # Same with the Speedcurve LUX
-          export BUILD_SPEEDCURVE_LUX_ID=000000000
-
-          # Make sure every built page always has
-          # '<meta name="robots" content="noindex, nofollow">' nomatter what
-          # kind of document it is.
-          export BUILD_ALWAYS_NO_ROBOTS=true
 
           yarn build
 
@@ -172,19 +172,27 @@ jobs:
           du -sh client/build
 
       - name: Deploy with deployer
-        run: |
+        env:
           # Set the CONTENT_ROOT first
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+
+          DEPLOYER_BUCKET_NAME: mdn-content-dev
+          DEPLOYER_BUCKET_PREFIX: ${{ github.event.inputs.deployment_prefix }}
+          DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD: ${{ github.event.inputs.log_each_successful_upload }}
+
+          AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
+        run: |
 
           if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ github.event.inputs.translated_content }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -198,15 +206,8 @@ jobs:
 
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
-
-          export DEPLOYER_BUCKET_NAME=mdn-content-dev
-          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix }}
-          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload }}
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
-
-          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
 
           poetry run deployer upload ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -44,12 +44,11 @@ jobs:
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Start the dev server
-        run: |
+        env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
-          echo "CONTENT_ROOT=$CONTENT_ROOT"
-
+          CONTENT_ROOT: "${{ github.workspace }}/mdn/content/files"
+        run: |
           yarn prepare-build
           yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
@@ -62,11 +61,11 @@ jobs:
           curl --retry-connrefused --retry 5 --silent http://localhost:3000 > /dev/null
 
       - name: Test viewing the dev server
-        run: |
+        env:
           # This will make sure the tests in `testing/tests/*.test.js` only run
           # if the development server is up and ready to be tested.
-          export TESTING_DEVELOPING=true
-
+          TESTING_DEVELOPING: true
+        run: |
           status=0
           yarn test:testing developing || (
             status=$?

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,15 +40,15 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Build the build
-        run: |
+        env:
           # What this does is it makes sure the built client is made for
           # doing CRUD work (e.g. previewing, toolbar, flaws UI, etc)
-          export REACT_APP_CRUD_MODE=true
+          REACT_APP_CRUD_MODE: true
 
           # This makes sure the auth is disabled. I.e. the "Sign in" link
           # in the header. It also disables any XHR checks to the server's
           # whoami endpoint.
-          export REACT_APP_DISABLE_AUTH=true
+          REACT_APP_DISABLE_AUTH: true
 
           # The 'yarn prepare-build' command is going to try to build up a
           # file for the git history so it can have an index of each files.
@@ -56,8 +56,8 @@ jobs:
           # which you'll want to build. But the CONTENT_ROOT can't be empty
           # so you have to set it to something. So let's (ab)use the content
           # we use for the end-to-end testing.
-          export CONTENT_ROOT=testing/content/files
-
+          CONTENT_ROOT: testing/content/files
+        run: |
           yarn prepare-build
 
       - name: Dry-run publish to see which files are included

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -40,15 +40,15 @@ jobs:
           ./testing/scripts/yarn-install.sh
 
       - name: Build select important pages
-        run: |
+        env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: "${{ github.workspace }}/mdn/content/files"
 
           # Make sure it's set to something so that the build uses the
           # Google Analytics tag which is most realistic.
-          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
-
+          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-00000000-0
+        run: |
           yarn prepare-build
           # BUILD_FOLDERSEARCH=mdn/kitchensink yarn build
           BUILD_FOLDERSEARCH=web/javascript/reference/global_objects/array/foreach yarn build

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -141,20 +141,40 @@ jobs:
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
       - name: Build everything
-        run: |
+        env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
 
+          # The default for this environment variable is geared for writers
+          # (aka. local development). Usually defaults are supposed to be for
+          # secure production but this is an exception and default
+          # is not insecure.
+          BUILD_LIVE_SAMPLES_BASE_URL: https://yari-demos.prod.mdn.mozit.cloud
+
+          # Now is not the time to worry about flaws.
+          BUILD_FLAW_LEVELS: "*:ignore"
+
+          # This is the Google Analytics account ID for developer.mozilla.org
+          # If it's used on other domains (e.g. stage or dev builds), it's OK
+          # because ultimately Google Analytics will filter it out since the
+          # origin domain isn't what that account expects.
+          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-36116321-5
+
+          # See the code for a further explanation for this.
+          # You get the ID from
+          # https://speedcurve.com/mozilla-add-ons/mdn/settings/updated/#lux
+          BUILD_SPEEDCURVE_LUX_ID: 108906238
+        run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -163,27 +183,7 @@ jobs:
           echo "CONTENT_ROOT=$CONTENT_ROOT"
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
-
-          # The default for this environment variable is geared for writers
-          # (aka. local development). Usually defaults are supposed to be for
-          # secure production but this is an exception and default
-          # is not insecure.
-          export BUILD_LIVE_SAMPLES_BASE_URL=https://yari-demos.prod.mdn.mozit.cloud
-
-          # Now is not the time to worry about flaws.
-          export BUILD_FLAW_LEVELS="*:ignore"
           yarn prepare-build
-
-          # This is the Google Analytics account ID for developer.mozilla.org
-          # If it's used on other domains (e.g. stage or dev builds), it's OK
-          # because ultimately Google Analytics will filter it out since the
-          # origin domain isn't what that account expects.
-          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
-
-          # See the code for a further explanation for this.
-          # You get the ID from
-          # https://speedcurve.com/mozilla-add-ons/mdn/settings/updated/#lux
-          export BUILD_SPEEDCURVE_LUX_ID=108906238
 
           yarn build
 
@@ -194,19 +194,33 @@ jobs:
           GITHUB_SHA: ${{ env.GITHUB_SHA }}
           GITHUB_RUN_ID: ${{ env.GITHUB_RUN_ID }}
           GITHUB_ACTION: ${{ env.GITHUB_ACTION }}
-        run: |
-          # Set the CONTENT_ROOT first
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
 
+          # Set the CONTENT_ROOT first
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+
+          DEPLOYER_BUCKET_NAME: mdn-content-prod
+          DEPLOYER_BUCKET_PREFIX: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
+          DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
+
+          AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}
+
+          # Note, command will pick up the site ID and deployment API key
+          # from environment variables and if either of them is falsy, the
+          # command will *not* fail. It will simply not deploy anything.
+          SPEEDCURVE_DEPLOY_API_KEY: ${{ secrets.SPEEDCURVE_DEPLOY_API_KEY }}
+          # Based on https://api.speedcurve.com/#get-all-sites using the API key
+          SPEEDCURVE_DEPLOY_SITE_ID: 85742
+        run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -220,25 +234,11 @@ jobs:
 
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
-
-          export DEPLOYER_BUCKET_NAME=mdn-content-prod
-          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
-          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}
-
           poetry run deployer upload ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
-
-          # Note, command will pick up the site ID and deployment API key
-          # from environment variables and if either of them is falsy, the
-          # command will *not* fail. It will simply not deploy anything.
-          export SPEEDCURVE_DEPLOY_API_KEY=${{ secrets.SPEEDCURVE_DEPLOY_API_KEY }}
-          # Based on https://api.speedcurve.com/#get-all-sites using the API key
-          export SPEEDCURVE_DEPLOY_SITE_ID=85742
           poetry run deployer speedcurve-deploy \
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -141,20 +141,45 @@ jobs:
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
       - name: Build everything
-        run: |
+        env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
 
+          # The default for this environment variable is geared for writers
+          # (aka. local development). Usually defaults are supposed to be for
+          # secure production but this is an exception and default
+          # is not insecure.
+          BUILD_LIVE_SAMPLES_BASE_URL: https://yari-demos.stage.mdn.mozit.cloud
+
+          # Now is not the time to worry about flaws.
+          BUILD_FLAW_LEVELS: "*:ignore"
+
+          # This is the Google Analytics account ID for developer.mozilla.org
+          # If it's used on other domains (e.g. stage or dev builds), it's OK
+          # because ultimately Google Analytics will filter it out since the
+          # origin domain isn't what that account expects.
+          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-36116321-5
+
+          # See the code for a further explanation for this.
+          # You get the ID from
+          # https://speedcurve.com/mozilla-add-ons/mdn/settings/updated/#lux
+          BUILD_SPEEDCURVE_LUX_ID: 108906238
+
+          # Make sure every built page always has
+          # '<meta name="robots" content="noindex, nofollow">' nomatter what
+          # kind of document it is.
+          BUILD_ALWAYS_NO_ROBOTS: true
+        run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -163,32 +188,7 @@ jobs:
           echo "CONTENT_ROOT=$CONTENT_ROOT"
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
-
-          # The default for this environment variable is geared for writers
-          # (aka. local development). Usually defaults are supposed to be for
-          # secure production but this is an exception and default
-          # is not insecure.
-          export BUILD_LIVE_SAMPLES_BASE_URL=https://yari-demos.stage.mdn.mozit.cloud
-
-          # Now is not the time to worry about flaws.
-          export BUILD_FLAW_LEVELS="*:ignore"
           yarn prepare-build
-
-          # This is the Google Analytics account ID for developer.mozilla.org
-          # If it's used on other domains (e.g. stage or dev builds), it's OK
-          # because ultimately Google Analytics will filter it out since the
-          # origin domain isn't what that account expects.
-          export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-36116321-5
-
-          # See the code for a further explanation for this.
-          # You get the ID from
-          # https://speedcurve.com/mozilla-add-ons/mdn/settings/updated/#lux
-          export BUILD_SPEEDCURVE_LUX_ID=108906238
-
-          # Make sure every built page always has
-          # '<meta name="robots" content="noindex, nofollow">' nomatter what
-          # kind of document it is.
-          export BUILD_ALWAYS_NO_ROBOTS=true
 
           yarn build
 
@@ -199,19 +199,34 @@ jobs:
           GITHUB_SHA: ${{ env.GITHUB_SHA }}
           GITHUB_RUN_ID: ${{ env.GITHUB_RUN_ID }}
           GITHUB_ACTION: ${{ env.GITHUB_ACTION }}
-        run: |
+
           # Set the CONTENT_ROOT first
-          export CONTENT_ROOT=$(pwd)/mdn/content/files
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+
+          DEPLOYER_BUCKET_NAME: mdn-content-stage
+          DEPLOYER_BUCKET_PREFIX: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
+          DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD: ${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
+
+          AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
+
+          # Note, command will pick up the site ID and deployment API key
+          # from environment variables and if either of them is falsy, the
+          # command will *not* fail. It will simply not deploy anything.
+          SPEEDCURVE_DEPLOY_API_KEY: ${{ secrets.SPEEDCURVE_DEPLOY_API_KEY }}
+          # Based on https://api.speedcurve.com/#get-all-sites using the API key
+          SPEEDCURVE_DEPLOY_SITE_ID: 354836
+        run: |
 
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"
-            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
+            export CONTENT_ARCHIVED_ROOT=${{ github.workspace }}/mdn/archived-content/files
           else
             echo "Will NOT build mdn/archived-content too"
           fi
           if [ ${{ env.BUILD_TRANSLATED_CONTENT }} == "true" ]; then
             echo "Will build mdn/translated-content too"
-            export CONTENT_TRANSLATED_ROOT=$(pwd)/mdn/translated-content/files
+            export CONTENT_TRANSLATED_ROOT=${{ github.workspace }}/mdn/translated-content/files
           else
             echo "Will NOT build mdn/translated-content too"
           fi
@@ -225,25 +240,11 @@ jobs:
 
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/code.json
           poetry run deployer whatsdeployed --output ../client/build/_whatsdeployed/content.json $CONTENT_ROOT
-
-          export DEPLOYER_BUCKET_NAME=mdn-content-stage
-          export DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}
-          export DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          export AWS_ACCESS_KEY_ID=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
-          export AWS_SECRET_ACCESS_KEY=${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
-
           poetry run deployer upload ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
-
-          # Note, command will pick up the site ID and deployment API key
-          # from environment variables and if either of them is falsy, the
-          # command will *not* fail. It will simply not deploy anything.
-          export SPEEDCURVE_DEPLOY_API_KEY=${{ secrets.SPEEDCURVE_DEPLOY_API_KEY }}
-          # Based on https://api.speedcurve.com/#get-all-sites using the API key
-          export SPEEDCURVE_DEPLOY_SITE_ID=354836
           poetry run deployer speedcurve-deploy \
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -64,17 +64,18 @@ jobs:
 
       - name: Unit testing kumascript
         if: steps.git_diff_kumascript.outputs.diff
+        env:
+          CONTENT_ROOT: testing/content/files
         run: |
-          export CONTENT_ROOT=testing/content/files
           yarn test:kumascript
 
       - name: Functional testing
-        run: |
+        env:
           # Make this env var explicit for GitHub Actions because in local
           # dev/debug you're encouraged to start it yourself in a separate
           # terminal.
-          export TESTING_START_SERVER=true
-
+          TESTING_START_SERVER: true
+        run: |
           # In terms of the --maxWorkers option, it's not yet clear which
           # is best.
           # See https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server


### PR DESCRIPTION
Don't feel strongly about this, but it has the benefit of allowing cross-OS building by allowing the action to set/export as required.

You can see the calculated values in the collapsed section of the steps like https://github.com/mdn/yari/pull/2167/checks?check_run_id=1565822944#step:9:8, so a bunch of the `echo` statements could be removed.

Didn't dig into a way to do the conditional assignments of variables like:
```bash
          if [ ${{ github.event.inputs.archived_content }} == "true" ]; then
            echo "Will build mdn/archived-content too"
            export CONTENT_ARCHIVED_ROOT=$(pwd)/mdn/archived-content/files
          else
            echo "Will NOT build mdn/archived-content too"
          fi
```