### PR TITLE
Unexpected build errors in CI doesn't reveal which file caused it

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -195,7 +195,27 @@ async function buildDocument(document, documentOptions = {}) {
     if (options.clearKumascriptRenderCache) {
       renderKumascriptCache.clear();
     }
-    [renderedHtml, flaws] = await kumascript.render(document.url);
+    try {
+      [renderedHtml, flaws] = await kumascript.render(document.url);
+    } catch (error) {
+      if (error.name === "MacroInvocationError") {
+        // The source HTML couldn't even be parsed! There's no point allowing
+        // anything else move on.
+        // But considering that this might just be one of many documents you're
+        // building, let's at least help by setting a more user-friendly error
+        // message.
+        throw new Error(
+          `MacroInvocationError trying to parse ${
+            document.fileInfo.path
+          }, line ${error.line + document.fileInfo.frontMatterOffset} column ${
+            error.column
+          } (${error.error.message})`
+        );
+      }
+
+      // Any other unexpected error re-thrown.
+      throw error;
+    }
 
     const sampleIds = kumascript.getLiveSampleIDs(
       document.metadata.slug,

--- a/build/index.js
+++ b/build/index.js
@@ -204,12 +204,9 @@ async function buildDocument(document, documentOptions = {}) {
         // But considering that this might just be one of many documents you're
         // building, let's at least help by setting a more user-friendly error
         // message.
+        error.updateFileInfo(document.fileInfo);
         throw new Error(
-          `MacroInvocationError trying to parse ${
-            document.fileInfo.path
-          }, line ${error.line + document.fileInfo.frontMatterOffset} column ${
-            error.column
-          } (${error.error.message})`
+          `MacroInvocationError trying to parse ${error.filepath}, line ${error.line} column ${error.column} (${error.error.message})`
         );
       }
 

--- a/kumascript/src/render.js
+++ b/kumascript/src/render.js
@@ -67,17 +67,16 @@ async function render(
   renderPrerequisiteFromURL,
   { templates = null } = {}
 ) {
-  // Parse the source document.
   let tokens;
   try {
     tokens = Parser.parse(source);
   } catch (e) {
     // If there are any parsing errors in the input document
-    // we can't process any of the macros, and just return the
-    // source document unmodified, along with the error.
+    // we can't process any of the macros. Return early with a MacroInvocationError
+    // which contains useful information to the caller.
     // Note that rendering errors in the macros are different;
     // we handle these individually below.
-    return [source, [new MacroInvocationError(e, source)]];
+    throw new MacroInvocationError(e, source);
   }
 
   // The default templates are only overridden during testing.

--- a/kumascript/tests/render.test.js
+++ b/kumascript/tests/render.test.js
@@ -102,16 +102,17 @@ describe("render() function", () => {
   it.each(syntaxCases)("handles syntax errors: %s", async (fn) => {
     let input = get(fn);
     // null templates since we expect errors before we render any
-    let [result, errors] = await render(input, {}, renderPrerequisiteFromURL, {
-      templates: null,
-    });
-    expect(result).toEqual(input);
-    expect(Array.isArray(errors)).toBe(true);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toBeInstanceOf(MacroInvocationError);
-    expect(errors[0].name).toBe("MacroInvocationError");
-    expect(errors[0]).toHaveProperty("line");
-    expect(errors[0]).toHaveProperty("column");
+    expect.assertions(4);
+    try {
+      await render(input, {}, renderPrerequisiteFromURL, {
+        templates: null,
+      });
+    } catch (e) {
+      expect(e).toBeInstanceOf(MacroInvocationError);
+      expect(e.name).toBe("MacroInvocationError");
+      expect(e).toHaveProperty("line");
+      expect(e).toHaveProperty("column");
+    }
   });
 
   it("handles undefined templates", async () => {


### PR DESCRIPTION
Fixes #2169
Fixes #2168

Here's what you'd see in `localhost:3000` if you accidentally introduce something to the raw (KS) HTML that can't even be parsed:
<img width="1453" alt="Screen Shot 2020-12-16 at 4 03 29 PM" src="https://user-images.githubusercontent.com/26739/102406471-9d44db80-3fb8-11eb-8fa7-5d5618f92c0d.png">

It's not gorgeous but it's sufficiently informative and that's what matters. 

This is what you'd see if you use `yarn build` (which is what we use the PR Build in CI on the mdn/content repo):
```
▶ yarn build /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/csspropertyrule/index.html
yarn run v1.22.10
$ cross-env NODE_ENV=production node build/cli.js /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/csspropertyrule/index.html

Building SPAs...
Wrote /Users/peterbe/dev/MOZILLA/MDN/yari/client/build/en-us/_spas/404.html

Building Documents...
Building roots: [ '/Users/peterbe/dev/MOZILLA/MDN/content/files' ]
Error: MacroInvocationError trying to parse /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/csspropertyrule/index.html, line 36 column 62 (Expected [ \t\n\r;] or [^(} ] but "(" found.)
    at buildDocument (/Users/peterbe/dev/MOZILLA/MDN/yari/build/index.js:207:15)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
    at async buildDocuments (/Users/peterbe/dev/MOZILLA/MDN/yari/build/cli.js:100:9)
    at async Se._action (/Users/peterbe/dev/MOZILLA/MDN/yari/build/cli.js:279:60)
    at async Se.run (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/@caporal/core/dist/index.js:1:27579)
    at async Te._run (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/@caporal/core/dist/index.js:1:32257)

error: MacroInvocationError trying to parse /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/web/api/csspropertyrule/index.html, line 36 column 62 (Expected [ \t\n\r;] or [^(} ] but "(" found.)

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

That should be enough to raise awareness of the problem. 
