### PR TITLE
crash early on zero width space characters in folder names

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -179,6 +179,11 @@ const read = memoize((folder) => {
   if (filePath.includes(" ")) {
     throw new Error("Folder contains whitespace which is not allowed.");
   }
+  if (filePath.includes("\u200b")) {
+    throw new Error(
+      `Folder contains zero width whitespace which is not allowed (${filePath})`
+    );
+  }
   const isTranslated =
     CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT);
   const isArchive =


### PR DESCRIPTION
Fixes #2171

Once this goes into `master` it's going to break the cron jobs that build. But we can now already go and fix it in `mdn/content` so *this* PR can be merged without breaking things. 

Here's how I tested it by the way:
```
BUILD_FOLDERSEARCH=web/api/paintworklet yarn build
```