### PR TITLE
deployer sets wrong URL on external URL redirects

### DIFF
--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -274,7 +274,7 @@ class BucketManager:
     def get_redirect_keys(self, from_url, to_url):
         return (
             f"{self.key_prefix}{from_url.strip('/').lower()}",
-            f"/{to_url.strip('/')}",
+            f"/{to_url.strip('/')}" if to_url.startswith("/") else to_url,
         )
 
     def get_bucket_objects(self):


### PR DESCRIPTION
Fixes #350

I tested it by building the whole site and then running `poetry run upload ../client/build` but before I did that I had it just print to a file what it WOULD have done. It worked :)