### PR TITLE
bark on eslint and prettier checks in CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,8 +50,11 @@ jobs:
           ./testing/scripts/yarn-install.sh
           ./testing/scripts/yarn-lockfile-check.sh
 
-      - name: Lint checking
-        run: ./testing/scripts/lint-check.sh
+      - name: Lint prettier
+        run: yarn prettier-check
+
+      - name: Lint ESLint
+        run: yarn eslint
 
       - name: Unit testing build
         run: yarn test:build

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -8,7 +8,8 @@ export const CRUD_MODE = JSON.parse(
 );
 
 export const AUTOCOMPLETE_SEARCH_WIDGET = JSON.parse(
-  process.env.REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET || JSON.stringify(CRUD_MODE));
+  process.env.REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET || JSON.stringify(CRUD_MODE)
+);
 
 export const NO_WATCHER = JSON.parse(
   process.env.REACT_APP_NO_WATCHER || "false"

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -77,7 +77,12 @@ function LazyBrowserCompatibilityTableInner({
   if (!data.data) {
     return (
       <p>
-        No compatibility data found for <code>{query}</code>. Check the spelling or contribute data to <a href="https://github.com/mdn/browser-compat-data">mdn/browser-compat-data</a>.
+        No compatibility data found for <code>{query}</code>. Check the spelling
+        or contribute data to{" "}
+        <a href="https://github.com/mdn/browser-compat-data">
+          mdn/browser-compat-data
+        </a>
+        .
       </p>
     );
   }

--- a/kumascript/tests/macros/EmbedInteractiveExample.test.js
+++ b/kumascript/tests/macros/EmbedInteractiveExample.test.js
@@ -28,19 +28,20 @@ ${extraHiddenTag}`
 ${extraHiddenTag}`
     );
   });
-  itMacro("Trailing slash in setting and leading slash in argument", function (
-    macro
-  ) {
-    macro.ctx.env.interactive_examples = {
-      base_url: "https://interactive-examples.mdn.mozilla.net/",
-    };
-    return assert.eventually.equal(
-      macro.call("/pages/css/animation.html"),
-      `<iframe class="interactive" width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/css/animation.html" title="MDN Web Docs Interactive Example"></iframe>
+  itMacro(
+    "Trailing slash in setting and leading slash in argument",
+    function (macro) {
+      macro.ctx.env.interactive_examples = {
+        base_url: "https://interactive-examples.mdn.mozilla.net/",
+      };
+      return assert.eventually.equal(
+        macro.call("/pages/css/animation.html"),
+        `<iframe class="interactive" width="100%" height="250" frameborder="0" src="https://interactive-examples.mdn.mozilla.net/pages/css/animation.html" title="MDN Web Docs Interactive Example"></iframe>
 
 ${extraHiddenTag}`
-    );
-  });
+      );
+    }
+  );
   itMacro("Javascript pages get an extra class by default", function (macro) {
     macro.ctx.env.interactive_examples = {
       base_url: "https://interactive-examples.mdn.mozilla.net",

--- a/kumascript/tests/macros/EmbedLiveSample.test.js
+++ b/kumascript/tests/macros/EmbedLiveSample.test.js
@@ -167,31 +167,32 @@ describeMacro("EmbedLiveSample", function () {
         "</iframe></td></tr></tbody></table>"
     );
   });
-  itMacro("Four arguments: ID, width, height, XSS attempt (failed)", function (
-    macro
-  ) {
-    macro.ctx.env.url = "/en-US/docs/Web/SVG/Tutorial/Gradients";
-    return assert.eventually.equal(
-      macro.call(
-        "SVGLinearGradient",
-        "120",
-        "240",
-        '"><script>alert("XSS");</script>'
-      ),
-      '<table class="sample-code-table"><thead><tr>' +
-        '<th scope="col" style="text-align: center;">Screenshot</th>' +
-        '<th scope="col" style="text-align: center;">Live sample</th>' +
-        "</tr></thead>" +
-        "<tbody><tr><td>" +
-        '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" />' +
-        "</td><td>" +
-        '<iframe class="live-sample-frame sample-code-frame" ' +
-        'id="frame_SVGLinearGradient" frameborder="0"' +
-        ' width="120" height="240"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Tutorial/Gradients/_samples_/SVGLinearGradient">' +
-        "</iframe></td></tr></tbody></table>"
-    );
-  });
+  itMacro(
+    "Four arguments: ID, width, height, XSS attempt (failed)",
+    function (macro) {
+      macro.ctx.env.url = "/en-US/docs/Web/SVG/Tutorial/Gradients";
+      return assert.eventually.equal(
+        macro.call(
+          "SVGLinearGradient",
+          "120",
+          "240",
+          '"><script>alert("XSS");</script>'
+        ),
+        '<table class="sample-code-table"><thead><tr>' +
+          '<th scope="col" style="text-align: center;">Screenshot</th>' +
+          '<th scope="col" style="text-align: center;">Live sample</th>' +
+          "</tr></thead>" +
+          "<tbody><tr><td>" +
+          '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" />' +
+          "</td><td>" +
+          '<iframe class="live-sample-frame sample-code-frame" ' +
+          'id="frame_SVGLinearGradient" frameborder="0"' +
+          ' width="120" height="240"' +
+          ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Tutorial/Gradients/_samples_/SVGLinearGradient">' +
+          "</iframe></td></tr></tbody></table>"
+      );
+    }
+  );
   const same_slug_iframe =
     '<iframe class="live-sample-frame sample-code-frame"' +
     ' id="frame_Examples" frameborder="0"' +
@@ -238,24 +239,25 @@ describeMacro("EmbedLiveSample", function () {
       );
     }
   );
-  itMacro('Five arguments: ID, "", "", "", XSS Attempt (failed)', function (
-    macro
-  ) {
-    macro.ctx.env.url = "/en-US/docs/Web/Events/focus";
-    return assert.eventually.equal(
-      macro.call(
-        "Event_delegation",
-        "",
-        "",
-        "",
-        '"><script>alert("XSS");</script>'
-      ),
-      '<iframe class="live-sample-frame sample-code-frame"' +
-        ' id="frame_Event_delegation" frameborder="0"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E/_samples_/Event_delegation">' +
-        "</iframe>"
-    );
-  });
+  itMacro(
+    'Five arguments: ID, "", "", "", XSS Attempt (failed)',
+    function (macro) {
+      macro.ctx.env.url = "/en-US/docs/Web/Events/focus";
+      return assert.eventually.equal(
+        macro.call(
+          "Event_delegation",
+          "",
+          "",
+          "",
+          '"><script>alert("XSS");</script>'
+        ),
+        '<iframe class="live-sample-frame sample-code-frame"' +
+          ' id="frame_Event_delegation" frameborder="0"' +
+          ' src="https://mdn.mozillademos.org/en-US/docs/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E/_samples_/Event_delegation">' +
+          "</iframe>"
+      );
+    }
+  );
   itMacro('Six arguments: ID, width, height, "", "", class', function (macro) {
     macro.ctx.env.url = "/en-US/docs/Web/CSS/-moz-appearance";
     return assert.eventually.equal(
@@ -288,28 +290,29 @@ describeMacro("EmbedLiveSample", function () {
       );
     }
   );
-  itMacro('Seven arguments: ID, width, height, "", "", "", features', function (
-    macro
-  ) {
-    macro.ctx.env.url = "/en-US/docs/Web/API/Media_Streams_API/Constraints";
-    return assert.eventually.equal(
-      macro.call(
-        "Example_Constraint_exerciser",
-        650,
-        800,
-        "",
-        "",
-        "",
-        "video; microphone"
-      ),
-      '<iframe class="live-sample-frame sample-code-frame"' +
-        ' id="frame_Example_Constraint_exerciser" frameborder="0"' +
-        ' width="650" height="800"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints/_samples_/Example_Constraint_exerciser"' +
-        ' allow="video; microphone">' +
-        "</iframe>"
-    );
-  });
+  itMacro(
+    'Seven arguments: ID, width, height, "", "", "", features',
+    function (macro) {
+      macro.ctx.env.url = "/en-US/docs/Web/API/Media_Streams_API/Constraints";
+      return assert.eventually.equal(
+        macro.call(
+          "Example_Constraint_exerciser",
+          650,
+          800,
+          "",
+          "",
+          "",
+          "video; microphone"
+        ),
+        '<iframe class="live-sample-frame sample-code-frame"' +
+          ' id="frame_Example_Constraint_exerciser" frameborder="0"' +
+          ' width="650" height="800"' +
+          ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints/_samples_/Example_Constraint_exerciser"' +
+          ' allow="video; microphone">' +
+          "</iframe>"
+      );
+    }
+  );
   itMacro(
     'Seven arguments: ID, width, height, "", "", "", XSS Attempt (failed)',
     function (macro) {

--- a/kumascript/tests/macros/jsxref.test.js
+++ b/kumascript/tests/macros/jsxref.test.js
@@ -150,49 +150,50 @@ describeMacro("jsxref", function () {
     );
   });
 
-  itMacro("Three arguments (slug, name, anchor without hash) [ru]", function (
-    macro
-  ) {
-    // When the # is omitted in the anchor, it is automatically added
-    // Used on:
-    // https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype
-    // {{jsxref("Global_Objects/Array", "Array", "массива")}}
-    var name = "Array",
-      partial_slug = "Global_Objects/Array",
-      anchor = "массива",
-      js_ref_ru_url = "/ru/docs/" + js_ref_slug,
-      ref_url = js_ref_ru_url + partial_slug,
-      glob_url = js_ref_ru_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' +
-        glob_url +
-        "#" +
-        "%D0%BC%D0%B0%D1%81%D1%81%D0%B8%D0%B2%D0%B0" +
-        '">' +
-        "<code>" +
-        name +
-        "</code></a>";
+  itMacro(
+    "Three arguments (slug, name, anchor without hash) [ru]",
+    function (macro) {
+      // When the # is omitted in the anchor, it is automatically added
+      // Used on:
+      // https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype
+      // {{jsxref("Global_Objects/Array", "Array", "массива")}}
+      var name = "Array",
+        partial_slug = "Global_Objects/Array",
+        anchor = "массива",
+        js_ref_ru_url = "/ru/docs/" + js_ref_slug,
+        ref_url = js_ref_ru_url + partial_slug,
+        glob_url = js_ref_ru_url + "Global_Objects/" + partial_slug,
+        expected =
+          '<a href="' +
+          glob_url +
+          "#" +
+          "%D0%BC%D0%B0%D1%81%D1%81%D0%B8%D0%B2%D0%B0" +
+          '">' +
+          "<code>" +
+          name +
+          "</code></a>";
 
-    macro.ctx.env.locale = "ru";
+      macro.ctx.env.locale = "ru";
 
-    macro.ctx.info.getPageByURL = jest.fn((url) => {
-      url = getPathname(url);
-      if (url === glob_url) {
-        return {
-          url: glob_url,
-          slug: js_ref_slug + partial_slug,
-        };
-      } else if (url === ref_url) {
-        return {};
-      }
-    });
-    macro.ctx.info.getPathname = getPathname;
+      macro.ctx.info.getPageByURL = jest.fn((url) => {
+        url = getPathname(url);
+        if (url === glob_url) {
+          return {
+            url: glob_url,
+            slug: js_ref_slug + partial_slug,
+          };
+        } else if (url === ref_url) {
+          return {};
+        }
+      });
+      macro.ctx.info.getPathname = getPathname;
 
-    return assert.eventually.equal(
-      macro.call(partial_slug, name, anchor),
-      expected
-    );
-  });
+      return assert.eventually.equal(
+        macro.call(partial_slug, name, anchor),
+        expected
+      );
+    }
+  );
 
   itMacro(
     "Four arguments (slug, name, empty anchor, omit code wrap)",

--- a/testing/scripts/lint-check.sh
+++ b/testing/scripts/lint-check.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-yarn prettier-check
-yarn eslint


### PR DESCRIPTION
In https://github.com/mdn/yari/pull/2157 @nschonni discovered a bug in that our prettier and eslint checks never correctly broke the CI, when it should. I'm just "cherry-picking" that diff from until we figure out all the hard discussions around yarn packaging and more advanced eslint config. 