### PR TITLE
Move _githistory.json files next to index.html / fixes #1990

### DIFF
--- a/tool/cli.js
+++ b/tool/cli.js
@@ -298,15 +298,22 @@ program
         historyPerLocale[locale][relPath] = value;
       }
       for (const [locale, history] of Object.entries(historyPerLocale)) {
-        const outputFile = path.join(root, locale, "_githistory.json");
-        fs.writeFileSync(outputFile, JSON.stringify(history, null, 2), "utf-8");
-        console.log(
-          chalk.green(
-            `Wrote '${locale}' ${Object.keys(
-              history
-            ).length.toLocaleString()} paths into ${outputFile}`
-          )
-        );
+        const outputFileDir = path.resolve(path.join(root, locale), "..");
+        const outputFile = path.join(outputFileDir, "_githistory.json");
+        if (fs.existsSync(outputFileDir)) {
+          fs.writeFileSync(
+            outputFile,
+            JSON.stringify(history, null, 2),
+            "utf-8"
+          );
+          console.log(
+            chalk.green(
+              `Wrote '${locale}' ${Object.keys(
+                history
+              ).length.toLocaleString()} paths into ${outputFile}`
+            )
+          );
+        }
       }
       fs.writeFileSync(
         saveHistory,


### PR DESCRIPTION
As I was setting up my environment today (to fiddle on another issue), I had errors which are described under #1990.
I was able to reproduce several times on a "fresh" environment.

2 things needed to be addressed (if I understood correctly):

- a check needed to be added in order to verify if the directory actually exists (which is not the case for documents for which the last git revision is a deletion)
- at least on my filesystem, it's not possible to have a file which is also a directory (in other words `index.html/_githistory.json` was not possible) so I moved the location of the `_githistory.json` files next to their index.html counterparts.

As written in the issue, I'm not really familiar with the codebase so let me know if there are things to address/adapt.🙇‍♂️