### PR TITLE
much longer backoff factor for speedcurve pings

### DIFF
--- a/deployer/src/deployer/speedcurve.py
+++ b/deployer/src/deployer/speedcurve.py
@@ -17,7 +17,7 @@ def deploy_ping(api_key: str, site_id: str, note: str, detail: str):
 
     adapter = HTTPAdapter(
         max_retries=Retry(
-            backoff_factor=1.0,
+            backoff_factor=0.3,
             status_forcelist=[429, 500, 502, 503, 504],
             method_whitelist=["POST"],
         )

--- a/deployer/src/deployer/speedcurve.py
+++ b/deployer/src/deployer/speedcurve.py
@@ -17,7 +17,7 @@ def deploy_ping(api_key: str, site_id: str, note: str, detail: str):
 
     adapter = HTTPAdapter(
         max_retries=Retry(
-            total=3,
+            backoff_factor=1.0,
             status_forcelist=[429, 500, 502, 503, 504],
             method_whitelist=["POST"],
         )


### PR DESCRIPTION
The default `backoff_factor` is 0. That means the `Retry` mechanism will immediately retry `total` times. The default for `total` is 10 from my skimming of `lib/python3.8/site-packages/urllib3/util/retry.py`. 

The formula for `backoff_factor` is documented follows:
```
    :param float backoff_factor:
        A backoff factor to apply between attempts after the second try
        (most errors are resolved immediately by a second try without a
        delay). urllib3 will sleep for::

            {backoff factor} * (2 ** ({number of total retries} - 1))

        seconds. If the backoff_factor is 0.1, then :func:`.sleep` will sleep
        for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer
        than :attr:`Retry.BACKOFF_MAX`.

        By default, backoff is disabled (set to 0).
```

In this PR, I set it to 0.3. With 10 retries it means:
```
>>> for i in range(10):
...   sum += 0.3 * (2 ** i)
...   print(0.3 * (2 ** i), sum)
...
0.3 0.3
0.6 0.8999999999999999
1.2 2.0999999999999996
2.4 4.5
4.8 9.3
9.6 18.9
19.2 38.099999999999994
38.4 76.5
76.8 153.3
153.6 306.9
```
So if Speedcurve is *really* down, it will eventually give up after 306.9 seconds (5 min). That feels fair. 
