### PR TITLE
fix /sitemaps.xml

### DIFF
--- a/build/sitemaps.js
+++ b/build/sitemaps.js
@@ -20,11 +20,15 @@ function makeSitemapIndexXML(pathnames) {
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    "<sitemap>",
     ...pathnames.map((pathname) => {
-      return `<loc>https://developer.mozilla.org${pathname}</loc>`;
+      const lastMod = new Date().toString().split("T")[0];
+      return (
+        "<sitemap>" +
+        `<loc>https://developer.mozilla.org${pathname}</loc>` +
+        `<lastmod>${lastMod}</lastmod>` +
+        "</sitemap>"
+      );
     }),
-    "</sitemap>",
     "</sitemapindex>",
   ].join("\n");
 }

--- a/build/sitemaps.js
+++ b/build/sitemaps.js
@@ -21,11 +21,10 @@ function makeSitemapIndexXML(pathnames) {
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     ...pathnames.map((pathname) => {
-      const lastMod = new Date().toString().split("T")[0];
       return (
         "<sitemap>" +
         `<loc>https://developer.mozilla.org${pathname}</loc>` +
-        `<lastmod>${lastMod}</lastmod>` +
+        `<lastmod>${new Date().toISOString().split("T")[0]}</lastmod>` +
         "</sitemap>"
       );
     }),


### PR DESCRIPTION
Fixes #2199

Running
```
BUILD_FOLDERSEARCH=web/html/element/v yarn build
```

Produces
```
▶ cat client/build/sitemap.xml
<?xml version="1.0" encoding="UTF-8"?>
<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<sitemap><loc>https://developer.mozilla.org/sitemaps/ca/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/de/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/fr/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/ja/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/ko/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/pl/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/pt-br/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/ru/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/zh-cn/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
<sitemap><loc>https://developer.mozilla.org/sitemaps/en-us/sitemap.xml.gz</loc><lastmod>2020-12-18</lastmod></sitemap>
</sitemapindex>%
```