### PR TITLE
GroupData - update Barcode Detection API

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -27,8 +27,8 @@
       "properties": ["Navigator.battery"],
       "events": []
     },
-    "Barcode Detector API": {
-      "overview": ["Barcode Detector API"],
+    "Barcode Detection API": {
+      "overview": ["Barcode Detection API"],
       "guides": [],
       "interfaces": ["BarcodeDetector"],
       "methods": [


### PR DESCRIPTION
The API was renamed to [Barcode_Detection_API](https://developer.mozilla.org/en-US/docs/Web/API/Barcode_Detection_API). There is a redirect from *Barcode Detector API* but it isn't working in all cases.

When this goes in I can go back and fix up the new name for the macro. That's easy now we're in github