### PR TITLE
Revise compat table issue reporting link

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -128,7 +128,7 @@ export default function BrowserCompatibilityTable({
           rel="noopener noreferrer"
           title="Report an issue with this compatibility data"
         >
-          Report problems with this data on GitHub
+          Report problems with this compatibility data on GitHub
         </a>
         <table key="bc-table" className="bc-table bc-table-web">
           <Headers {...{ platforms, browsers }} />


### PR DESCRIPTION
This changes the compat table's issue link to mention "compatibility" explicitly, in the hopes of reducing confusion about what the link covers.

Fixes #2183.