### PR TITLE
Make Interwiki macro replace spaces & uppercase first letter of path

### DIFF
--- a/kumascript/macros/Interwiki.ejs
+++ b/kumascript/macros/Interwiki.ejs
@@ -9,6 +9,9 @@
 var path = $1;
 var title = $2 || path;
 
+// Uppercase first character in path, replace all spaces with underscores.
+path = ($1.charAt(0).toUpperCase() + $1.slice(1)).replace(/ /g, "_");
+
 var lang = env.locale.substr(0, 2);
 var prefix = $0;
 

--- a/kumascript/macros/Interwiki.ejs
+++ b/kumascript/macros/Interwiki.ejs
@@ -10,7 +10,7 @@ var path = $1;
 var title = $2 || path;
 
 // Uppercase first character in path, replace all spaces with underscores.
-path = ($1.charAt(0).toUpperCase() + $1.slice(1)).replace(/ /g, "_");
+path = (path.charAt(0).toUpperCase() + path.slice(1)).replace(/ /g, "_");
 
 var lang = env.locale.substr(0, 2);
 var prefix = $0;


### PR DESCRIPTION
This change makes the `Interwiki` macro construct the path value for wiki URLs by replacing any spaces in the article title with underscores, and uppercasing the first letter of the path.

Otherwise, without this change, the macro constructs wiki URLs that contain spaces — which results in MDN having more than 100 URLs with spaces; and because the URL spec disallows spaces in URLs, all the MDN articles with those space-containing URLs are invalid.

Moreover, given a URL with spaces, MediaWiki anyway redirects that to the corresponding URL which has the spaces replaced by underscores. So this change also prevents an unnecessary/wasteful redirect.

Further, given a URL with a path that begins with a lowercase letter, MediaWiki redirects that to the corresponding URL which has the first letter of the path in uppercase.

And MDN has 190 Interwiki macro calls with values that don’t begin with an uppercase letter, so without the part of this change which uppercases the first letter of the path, the result is that we have 190 links that cause unnecessary/wasteful redirects each time anyone follows them.