### PR TITLE
Fix linkifying bug in SVGRef macro

### DIFF
--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -39,7 +39,7 @@ if (found_tag != undefined && found_tag != null && found_tag.length) {
 
     for (aPage in pageList) {
         if (page.hasTag(pageList[aPage], found_tag)) {
-            resultSVG.push(pageList[aPage].title.replace(/[<>]/g, ""));
+            resultSVG.push(pageList[aPage].slug.split("/").pop(-1).toLowerCase());
         }
     }
 }


### PR DESCRIPTION
This commit fixes a bug in the `SVGRef` macro, by changing part of the `SVGRef` macro source to use the same code as the corresponding part in the `HTMLRef` macro source.

Without this change, the macro can cause broken hyperlinks to be generated.

---

See the **Related Topics** sidebar at https://developer.mozilla.org/en-US/docs/Web/SVG/Element/desc. If you View Source or inspect the DOM, you’ll find this:
```html
<a href="/en-US/docs/Web/SVG/Element/title — the SVG accessible name element"><code>&lt;title — the SVG accessible name element&gt;</code></a>
```
