### PR TITLE
Use last part of the title page in WebExtAPISidebar

### DIFF
--- a/kumascript/macros/WebExtAPISidebar.ejs
+++ b/kumascript/macros/WebExtAPISidebar.ejs
@@ -41,7 +41,7 @@ function buildSublist(pages, title, ignoreBadges) {
     var apiComponentName = title;
     var titlePieces = title.split(".");
     if (titlePieces.length > 1) {
-      apiComponentName = titlePieces[1];
+      apiComponentName = titlePieces[titlePieces.length - 1];
     }
 
     var translated = false;


### PR DESCRIPTION
E.g. display `create()` for page devtools.panel.create()

Fix #2189

---

Quoting from my first comment on #2189:

> I tried to make a PR but changing the `WebExtAPISidebar.ejs` didn’t seem to affect the rendered page. I noticed that `nodemon` didn’t listen for ejs files but even after relaunching `yarn dev` it still gave me the wrong results.

I tried again and it still doesn’t work. When using `yarn start`, and I try to visit the `devtools.panels` page, I get a “`Error: 404 on /en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/create/index.json: Page not found`”. The only way I get to make yari work is to launch `yarn start` in my local clone of `mdn/content` first, which I believe builds file with its own version of yari. `yarn build` also failed:

<details><summary>output</summary>

```
yarn run v1.22.10
$ cross-env NODE_ENV=production node build/cli.js

Building SPAs...
Wrote /home/ariasuni/projets/divers/yari/client/build/en-us/_spas/404.html

Building Documents...
Building roots: [ '/home/ariasuni/projets/divers/mdn_content/' ]
Error: Unable to figure out locale from files/en-us/developer_guide/editor_configuration with files
    at extractLocale (/home/ariasuni/projets/divers/yari/content/document.js:54:11)
    at /home/ariasuni/projets/divers/yari/content/document.js:200:18
    at /home/ariasuni/projets/divers/yari/content/utils.js:70:19
    at Object.iter (/home/ariasuni/projets/divers/yari/content/document.js:366:15)
    at iter.next (<anonymous>)
    at buildDocuments (/home/ariasuni/projets/divers/yari/build/cli.js:60:14)
    at Se._action (/home/ariasuni/projets/divers/yari/build/cli.js:271:66)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
    at async Se.run (/home/ariasuni/projets/divers/yari/node_modules/@caporal/core/dist/index.js:1:27579)
    at async Te._run (/home/ariasuni/projets/divers/yari/node_modules/@caporal/core/dist/index.js:1:32257)

error: Unable to figure out locale from files/en-us/developer_guide/editor_configuration with files
```
</details>

So I couldn’t test the change and hopefully it works.