### PR TITLE
Allow colon+space separator in DOMxRef macro

### DIFF
--- a/kumascript/macros/DOMxRef.ejs
+++ b/kumascript/macros/DOMxRef.ejs
@@ -20,7 +20,8 @@ let api = $0;
 let str = $1 || $0;
 let rtlLocales = ['ar', 'he', 'fa'];
 
-api = api.replace(/ /g, '_')
+api = api.replace(/: /g, '/')
+    .replace(/ /g, '_')
     .replace(/\(\)/g, '')
     .replace(/\.prototype\./g, '.')
     .replace(/\./g, '/');


### PR DESCRIPTION
This change allows `: ` — a colon followed by a (required) space — to be used as a path separator in `DOMxRef` macro calls, as an alternative to the `.` (dot) separator the `DOMxRef` macro currently expects. For example, this change allows the following syntax:

> This is done using the `{{domxref("ReadableStream: getReader()")}}` method.

...rather than requiring `{{domxref("ReadableStream.getReader()")}}`.

cc @chrisdavidmills @Elchi3

---

We could consider allowing the space to be omitted; for example: `{{domxref("ReadableStream:getReader()")}}` — but IMHO, for consistent reader/user experience, it’s better if we require the space.

Similarly, we could consider allowing multiple spaces after the colon — which wouldn’t have any effect on how it’s rendered — but IMHO it’s better for consistency (internal code-maintenance consistency) to disallow multiple spaces.