### PR TITLE
Cope with .PNG file extension

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -507,7 +507,7 @@ async function fixFixableFlaws(doc, options, document) {
 }
 
 function getImageminPlugin(fileName) {
-  const extension = path.extname(fileName);
+  const extension = path.extname(fileName).toLowerCase();
   if (extension === ".jpg" || extension === ".jpeg") {
     return imageminMozjpeg();
   }

--- a/filecheck/checker.js
+++ b/filecheck/checker.js
@@ -112,7 +112,7 @@ async function checkFile(filePath, options) {
   }
 
   const tempdir = tempy.directory();
-  const extension = path.extname(filePath);
+  const extension = path.extname(filePath).toLowerCase();
   try {
     const plugins = [];
     if ((extension === ".jpg") | (extension === ".jpeg")) {

--- a/server/index.js
+++ b/server/index.js
@@ -144,7 +144,7 @@ app.get("/*", async (req, res) => {
 
   // TODO: Would be nice to have a list of all supported file extensions
   // in a constants file.
-  if (/\.(png|webp|gif|jpeg|svg)$/.test(req.url)) {
+  if (/\.(png|webp|gif|jpe?g|svg)$/.test(req.url)) {
     // Remember, Image.findByURL() will return the absolute file path
     // iff it exists on disk.
     const filePath = Image.findByURL(req.url);


### PR DESCRIPTION
Fixes #2262

Thanks for these fixes I was able to make https://github.com/mdn/content/pull/584
It uncovered two problems. First, if you download a `foo.PNG` file, it couldn't find the right `imagemin` plugin. 
But also, requesting `curl -I http://localhost:5000/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose/mongodb_atlas_-_createcluster.jpg` failed because the server was only aware of `.jpeg` file extensions. 