### PR TITLE
Allow full pathname for "yarn content preview"

### DIFF
--- a/tool/cli.js
+++ b/tool/cli.js
@@ -242,16 +242,24 @@ program
     })
   )
 
-  .command("preview", "Open a preview of a slug")
-  .argument("<slug>", "Slug of the document in question")
+  .command("preview", "Open a preview, given a slug or pathname or URL")
+  .argument(
+    "<slugOrPathnameOrUrl>",
+    "Slug or pathname or URL of the document in question"
+  )
   .argument("[locale]", "Locale", {
     default: DEFAULT_LOCALE,
     validator: [...VALID_LOCALES.values()],
   })
   .action(
     tryOrExit(async ({ args }) => {
-      const { slug, locale } = args;
+      const { slugOrPathnameOrUrl, locale } = args;
+      const slug = slugOrPathnameOrUrl.replace(
+        /(https:\/\/([^/]+\/en-US(\/docs)?\/)|files\/en-us\/)?(.+?)(\/index.html)?/g,
+        "$4"
+      );
       const url = `http://localhost:${PORT}${buildURL(locale, slug)}`;
+      console.log(`Previewing files/en-us/${slug}/index.html`.toLowerCase());
       await open(url);
     })
   )


### PR DESCRIPTION
This change allows you to give "yarn content preview" an MDN URL or local pathname (with or without the "index.html" part):

    yarn content preview files/en-us/web/api/idbindex
    yarn content preview files/en-us/web/api/idbindex/index.html
    yarn content preview https://developer.mozilla.org/en-US/docs/Web/API/IDBIndex
    yarn content preview https://developer.mozilla.org/docs/Web/API/IDBIndex

The local-pathname support allows you to yari-view a given article by using the tab key and your shell’s pathname-completion mechanism to complete a local directory path in your mdn/content clone.

It also facilitates using the complete paths copied from, for example, the "Files changed" tab of the GitHub pull-request UI, or from the output of "git log --name-only" or "git diff --name-only" — all of which show the file pathnames in the form:

    files/en-us/web/javascript/reference/global_objects/date/index.html

This change allows you to paste that full pathname as-is into your shell as the argument for "yarn content preview".

The URL support allows you to preview the local equivalent of whatever production https://developer.mozilla.org URL you give.