### PR TITLE
Add correct german page for Memory Management

### DIFF
--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -267,7 +267,7 @@ var text = mdn.localStringMap({
     'Inheritance': 'Vererbung und Prototypenkette',
     'Strict_mode': 'Strict Modus',
     'Typed_arrays': 'JavaScript Typed-Arrays',
-    'Memory_Management': 'Memory Management',
+    'Memory_Management': 'Speicherverwaltung',
     'Event_Loop': 'Laufzeitmodell und Event-Loop',
     'Reference': 'Referenzen:',
     'Global_Objects': 'Standardobjekte',


### PR DESCRIPTION
In the german JS Sidebar the link for Memory Management is linked to a non existent page leading to a 404 page not found.

![page-not-found-memory-management](https://user-images.githubusercontent.com/16798723/102979553-80ebf600-4506-11eb-8119-210fc450a96d.png)

But there actually exists a german page for this and it is correctly linked in the content of other pages.
The page is called "Speicherverwaltung"
Here's the link to the german page: https://developer.mozilla.org/de/docs/Web/JavaScript/Speicherverwaltung