### PR TITLE
Fix handling for /*/contributors.txt routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -99,7 +99,7 @@ app.get("/*/contributors.txt", async (req, res) => {
   if (!document) {
     return res.status(404).send(`Document not found by URL (${url})`);
   }
-  const [builtDocument] = await buildDocument(document);
+  const { doc: builtDocument } = await buildDocument(document);
   if (document.metadata.contributors || !document.isArchive) {
     res.send(
       renderContributorsTxt(


### PR DESCRIPTION
This change fixes a problem that causes Yari to crash for requests to `/*/contributors.txt` routes. The existing code expects a call to `await buildDocument(document)` to return an array. when in fact it returns an object.

Without this change, requests for `/*/contributors.txt` routes cause Yari to crash with this log output:

```
node_modules/@mdn/yari/server/index.js:102
  const [builtDocument] = await buildDocument(document);
                          ^
TypeError: (intermediate value) is not iterable
    at node_modules/@mdn/yari/server/index.js:102:27
error Command failed with exit code 1.
```