### PR TITLE
Enable navigation to image URLs in port 3000 Yari

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -74,7 +74,16 @@ function DocumentOrPageNotFound(props) {
   );
 }
 
+function Content({ pathname, appProps }) {
+  if (/\.(png|webp|gif|jpeg|svg)$/.test(pathname)) {
+    return <img src={pathname} alt={pathname} />;
+  } else {
+    return <DocumentOrPageNotFound {...appProps} />;
+  }
+}
+
 export function App(appProps) {
+  const { pathname } = useLocation();
   const routes = (
     <Routes>
       {/*
@@ -161,7 +170,7 @@ export function App(appProps) {
             />
             <Route
               path="/docs/*"
-              element={<DocumentOrPageNotFound {...appProps} />}
+              element={<Content pathname={pathname} appProps={appProps} />}
             />
             <Route
               path="*"

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -75,7 +75,7 @@ function DocumentOrPageNotFound(props) {
 }
 
 function Content({ pathname, appProps }) {
-  if (/\.(png|webp|gif|jpeg|svg)$/.test(pathname)) {
+  if (/\.(png|webp|gif|jpe?g|svg)$/.test(pathname)) {
     return <img src={pathname} alt={pathname} />;
   } else {
     return <DocumentOrPageNotFound {...appProps} />;


### PR DESCRIPTION
For contributors running a full local Yari dev environment, with a port 3000 front-end dev server, this change makes it possible for them to navigate in a web browser to image URLs and to actually view the images.

Otherwise, without this change, if a contributor tries to view, e.g., http://localhost:3000/en-US/docs/Web/HTML/Applying_color/paletton3.png in a browser, they’ll get a “Loading Error” page, with the following message:

> Error: 404 on /en-US/docs/Web/HTML/Applying_color/paletton3.png/index.json: Page not found