### PR TITLE
Make Yari handle .jpg files (not just .jpeg)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -144,7 +144,7 @@ app.get("/*", async (req, res) => {
 
   // TODO: Would be nice to have a list of all supported file extensions
   // in a constants file.
-  if (/\.(png|webp|gif|jpeg|svg)$/.test(req.url)) {
+  if (/\.(png|webp|gif|jpe?g|svg)$/.test(req.url)) {
     // Remember, Image.findByURL() will return the absolute file path
     // iff it exists on disk.
     const filePath = Image.findByURL(req.url);


### PR DESCRIPTION
This change makes the Yari backend correctly handle `.jpg` files.

Otherwise, without this change, the Yari (Express) backend responds with a 404 to any requests for `.jpg` resources; for example: http://localhost:5000/en-US/docs/Web/API/Window/devicePixelRatio/devicepixelration_diff.jpg

Files with `.jpeg` extensions are already correctly handled, even without this change; so the patch here is a minor change to update an existing regex pattern in the code to make it match "`.jpg`" as well as "`.jpeg`".

---

I noticed this problem when testing https://github.com/mdn/content/pull/676 — which I guess is the first mdn/content change to add any `.jpg` files to the repo (there are no other existing `.jpg` files in the entire tree)