### PR TITLE
colgroups in BC table

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -132,9 +132,9 @@ export default function BrowserCompatibilityTable({
         </a>
         <table key="bc-table" className="bc-table bc-table-web">
 <colgroup>
-<col>
-<col span="6" class="desktop">
-<col span="6" class="mobile">
+<col span="1" class="feature"></col>
+<col span="6" class="desktop"></col>
+<col span="6" class="mobile"></col>
 </colgroup>
           <Headers {...{ platforms, browsers }} />
           <tbody>

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -131,6 +131,11 @@ export default function BrowserCompatibilityTable({
           Report problems with this compatibility data on GitHub
         </a>
         <table key="bc-table" className="bc-table bc-table-web">
+<colgroup>
+<col>
+<col span="6" class="desktop">
+<col span="6" class="mobile">
+</colgroup>
           <Headers {...{ platforms, browsers }} />
           <tbody>
             <FeatureListAccordion

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -132,9 +132,9 @@ export default function BrowserCompatibilityTable({
         </a>
         <table key="bc-table" className="bc-table bc-table-web">
 <colgroup>
-<col span="1" class="feature"></col>
-<col span="6" class="desktop"></col>
-<col span="6" class="mobile"></col>
+<col span="1" class="feature">
+<col span="6" class="desktop">
+<col span="6" class="mobile">
 </colgroup>
           <Headers {...{ platforms, browsers }} />
           <tbody>


### PR DESCRIPTION
- 1 for first column
- 6 for desktop browsers
- 6 for mobile browsers

Rif
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup