### PR TITLE
make weird actually external images fixable

### DIFF
--- a/build/check-images.js
+++ b/build/check-images.js
@@ -74,7 +74,8 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
     // Make a special exception for the legacy images that start with `/@api/deki...`
     // If you just pretend their existing URL is static external domain, it
     // will be recognized as an external image (which is fixable).
-    const absoluteURL = src.startsWith("/@api/deki")
+    // Also any `<img src="/files/1234/foo.png">` should match.
+    const absoluteURL = /^\/(@api\/deki\/|files\/\d+)/.test(src)
       ? `https://mdn.mozillademos.org${src}`
       : new URL(src, baseURL);
 

--- a/build/check-images.js
+++ b/build/check-images.js
@@ -71,7 +71,12 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
 
     // These two lines is to simulate what a browser would do.
     const baseURL = `http://yari.placeholder${url}/`;
-    const absoluteURL = new URL(src, baseURL);
+    // Make a special exception for the legacy images that start with `/@api/deki...`
+    // If you just pretend their existing URL is static external domain, it
+    // will be recognized as an external image (which is fixable).
+    const absoluteURL = src.startsWith("/@api/deki")
+      ? `https://mdn.mozillademos.org${src}`
+      : new URL(src, baseURL);
 
     // NOTE: Checking for lacking 'alt' text is to be done as part
     // of https://github.com/mdn/yari/issues/1018 which would need

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -432,7 +432,6 @@ async function fixFixableFlaws(doc, options, document) {
     let newSrc;
     if (flaw.externalImage) {
       // Sanity check that it's an external image
-      console.log({ src: flaw.src, forced: forceExternalURL(flaw.src) });
       const url = new URL(forceExternalURL(flaw.src));
       if (url.protocol !== "https:") {
         throw new Error(`Insecure image URL ${flaw.src}`);

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -412,6 +412,7 @@ async function fixFixableFlaws(doc, options, document) {
   // These get logged as external images by the flaw detection, but to actually
   // be able to process them and fix the problem we need to "temporarily"
   // pretend they were hosted on a remote working full domain.
+  // See https://github.com/mdn/yari/issues/1103
   function forceExternalURL(url) {
     if (url.startsWith("/")) {
       return `https://mdn.mozillademos.org${url}`;

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -407,6 +407,18 @@ async function fixFixableFlaws(doc, options, document) {
     }
   }
 
+  // We have a lot of images that *should* be external, at least for the sake
+  // of cleaning up, but aren't. E.g. `/@api/deki/files/247/=HTMLBlinkElement.gif`
+  // These get logged as external images by the flaw detection, but to actually
+  // be able to process them and fix the problem we need to "temporarily"
+  // pretend they were hosted on a remote working full domain.
+  function forceExternalURL(url) {
+    if (url.startsWith("/")) {
+      return `https://mdn.mozillademos.org${url}`;
+    }
+    return url;
+  }
+
   // Any 'images' flaws with a suggestion or external image...
   for (const flaw of doc.flaws.images || []) {
     if (!(flaw.suggestion || flaw.externalImage)) {
@@ -419,12 +431,13 @@ async function fixFixableFlaws(doc, options, document) {
     let newSrc;
     if (flaw.externalImage) {
       // Sanity check that it's an external image
-      const url = new URL(flaw.src);
+      console.log({ src: flaw.src, forced: forceExternalURL(flaw.src) });
+      const url = new URL(forceExternalURL(flaw.src));
       if (url.protocol !== "https:") {
         throw new Error(`Insecure image URL ${flaw.src}`);
       }
       try {
-        const imageBuffer = await got(flaw.src, {
+        const imageBuffer = await got(forceExternalURL(flaw.src), {
           responseType: "buffer",
           resolveBodyOnly: true,
           timeout: 10000,
@@ -435,6 +448,10 @@ async function fixFixableFlaws(doc, options, document) {
           path
             .basename(decodeURI(url.pathname))
             .replace(/\s+/g, "_")
+            // From legacy we have a lot of images that are named like
+            // `/@api/deki/files/247/=HTMLBlinkElement.gif` for example.
+            // Take this opportunity to clean that odd looking leading `=`.
+            .replace(/^=/, "")
             .toLowerCase()
         );
         // Before writing to disk, run it through the same imagemin


### PR DESCRIPTION
Part of #1103

This takes care of the first 2 checkboxes on https://github.com/mdn/yari/issues/1103

Using this patch, I was able to create:

* https://github.com/mdn/content/pull/933
* https://github.com/mdn/content/pull/934

...simply by pressing the "Fix fixable flaws" button. 