### PR TITLE
Make CSS_Ref by default include experimental too

### DIFF
--- a/kumascript/macros/CSS_Ref.ejs
+++ b/kumascript/macros/CSS_Ref.ejs
@@ -10,14 +10,14 @@
        (valid values: 'alphabetically', 'no'; defaults to 'alphabetically')
   $2 - Array of strings used to filter the items by their status
        (valid values: 'standard', 'experimental', "nonstandard', 'obsolete';
-       defaults to ['standard'])
+       defaults to ['standard', 'experimental'])
 */
 
 var data = require('mdn-data/css');
 var types = ["properties", "selectors", "types", "syntaxes", "at-rules",
              "descriptors", "units"];
 var groupingType = "alphabetically";
-var outputStatuses = ["standard"];
+var outputStatuses = ["standard", "experimental"];
 
 if ($0) {
     types = JSON.parse($0);


### PR DESCRIPTION
This change makes the CSS_Ref macro by default also output features marked as status:experimental.

Otherwise, without this change, CSS_Ref by default only output features marked as status:standard.

Related: https://github.com/mdn/content/issues/903
Related: https://github.com/mdn/sprints/issues/2068