### PR TITLE
Adding the missing CSSRule interfaces

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -168,12 +168,60 @@
       "inh": "Event",
       "impl": []
     },
+    "CSSConditionRule": {
+      "inh": "CSSGroupingRule",
+      "impl": []
+    },
     "CSSCounterStyleRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSFontFaceRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSFontFeatureValuesRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSFontPaletteValuesRule": {
       "inh": "CSSRule",
       "impl": []
     },
     "CSSFontFaceLoadEvent": {
       "inh": "Event",
+      "impl": []
+    },
+    "CSSGroupingRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSImportRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSKeyframeRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSKeyframesRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSMarginRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSMediaRule": {
+      "inh": "CSSConditionRule",
+      "impl": []
+    },
+    "CSSNamespaceRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
+    "CSSPageRule": {
+      "inh": "CSSRule",
       "impl": []
     },
     "CSSPrimitiveValue": {
@@ -184,16 +232,32 @@
       "inh": "EventTarget",
       "impl": []
     },
+    "CSSRule": {
+      "inh": "",
+      "impl": []
+    },
     "CSSStyleDeclaration": {
       "inh": "",
+      "impl": []
+    },
+    "CSSStyleRule": {
+      "inh": "CSSRule",
       "impl": []
     },
     "CSSStyleSheet": {
       "inh": "StyleSheet",
       "impl": []
     },
+    "CSSSupportsRule": {
+      "inh": "CSSConditionRule",
+      "impl": []
+    },
     "CSSValueList": {
       "inh": "CSSValue",
+      "impl": []
+    },
+    "CSSViewportRule": {
+      "inh": "CSSRule",
       "impl": []
     },
     "CallEvent": {

--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -228,6 +228,10 @@
       "inh": "CSSValue",
       "impl": []
     },
+    "CSSPropertyRule": {
+      "inh": "CSSRule",
+      "impl": []
+    },
     "CSSPseudoElement": {
       "inh": "EventTarget",
       "impl": []


### PR DESCRIPTION
I'm working on documenting a bunch of missing CSSRule interface pages. This PR adds the data to InterfaceData.