### PR TITLE
fixing the templatelink macro, as it was pointing links to the wrong place

### DIFF
--- a/kumascript/macros/TemplateLink.ejs
+++ b/kumascript/macros/TemplateLink.ejs
@@ -6,15 +6,15 @@
  * code for reference.
  *
  * Note that GitHub URLs are case-sensitve.
- * e.g. {{TemplateLink("Page")}} leads to 404, but {{TemplateLink("page")}} works
- * as the file is named "page.ejs".
+ * e.g. If the file is named "page.ejs", {{TemplateLink("Page")}} leads to 404
+ * but {{TemplateLink("page")}} works
  *
  * Parameters:
  *
  * $0 - Name of the template to link to.
  */
 
-let dest = "https://github.com/mdn/kumascript/tree/master/macros/" + $0 + ".ejs";
+let dest = "https://github.com/mdn/yari/tree/master/kumascript/macros/" + $0 + ".ejs";
 let text = $0;
 %>
 <code class="templateLink"><a href="<%-dest%>"><%=text%></a></code>

--- a/kumascript/tests/macros/TemplateLink.test.js
+++ b/kumascript/tests/macros/TemplateLink.test.js
@@ -8,7 +8,7 @@ describeMacro("TemplateLink", () => {
     return assert.eventually.equal(
       macro.call("TemplateLink"),
       '<code class="templateLink">' +
-        '<a href="https://github.com/mdn/kumascript/tree/master/macros/TemplateLink.ejs">' +
+        '<a href="https://github.com/mdn/yari/tree/master/kumascript/macros/TemplateLink.ejs">' +
         "TemplateLink" +
         "</a></code>"
     );


### PR DESCRIPTION
The generated links were still pointing to the old kuma repo, so I've updated the base URL to point correctly to the macros directory inside the yari repo.

I also tweaked the explanatory wording a bit.