### PR TITLE
break out CI workflows (docs)

### DIFF
--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -1,0 +1,22 @@
+name: Markdown Docs files
+
+on:
+  pull_request:
+    paths:
+      - docs/**/*.md
+      - .github/workflows/pr-docs.yml
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: "12"
+
+      - name: Lint markdown files
+        run: |
+          npx markdownlint-cli docs/**/*.md

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -141,29 +141,3 @@ jobs:
         run: |
           cd deployer
           poetry run deployer --help
-
-  docs:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: technote-space/get-diff-action@v4
-        with:
-          PATTERNS: docs/**/*.md
-          FILES: |
-            README.md
-
-      - name: Setup Node.js environment
-        if: env.GIT_DIFF
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: "12"
-
-      - name: Lint markdown files
-        if: env.GIT_DIFF
-        run: |
-          echo "GIT DIFF:"
-          echo "${{ env.GIT_DIFF }}"
-          echo ""
-          npx markdownlint-cli ${{ env.GIT_DIFF }}


### PR DESCRIPTION
This way, GitHub Actions doesn't even need to start a container if that `on.pull_request.paths` don't match. 
And it doesn't hurt to run `markdownlint-cli` on every single `docs/**/*.md` file we have because there are so few. 