### PR TITLE
trigger GA pageview send event

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -13,6 +13,7 @@ import { Footer } from "./ui/organisms/footer";
 import { Header } from "./ui/organisms/header";
 import { PageNotFound } from "./page-not-found";
 import { Banner } from "./banners";
+import { useDebugGA } from "./ga-context";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const DocumentEdit = React.lazy(() => import("./document/forms/edit"));
@@ -75,6 +76,8 @@ function DocumentOrPageNotFound(props) {
 }
 
 export function App(appProps) {
+  useDebugGA();
+
   const routes = (
     <Routes>
       {/*

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -14,3 +14,7 @@ export const AUTOCOMPLETE_SEARCH_WIDGET = JSON.parse(
 export const NO_WATCHER = JSON.parse(
   process.env.REACT_APP_NO_WATCHER || "false"
 );
+
+export const DEBUG_GOOGLE_ANALYTICS = JSON.parse(
+  process.env.REACT_APP_DEBUG_GOOGLE_ANALYTICS || "false"
+);

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { useContext, useEffect, useState } from "react";
 
+import { DEBUG_GOOGLE_ANALYTICS } from "./constants";
+
 export type GAFunction = (...any) => void;
 
 export const CATEGORY_MONTHLY_PAYMENTS = "monthly payments";
@@ -95,6 +97,27 @@ export function useClientId() {
   }, [ga]);
 
   return clientId;
+}
+
+// This only really exists so you can debug Google Analytics when running the
+// debug server (localhost:3000) otherwise you won't get useful logging in
+// the Web Console when your code does things like `ga("send", ...)`.
+// See the REACT_APP_DEBUG_GOOGLE_ANALYTICS in docs/envvars.md for more info.
+export function useDebugGA() {
+  useEffect(() => {
+    if (DEBUG_GOOGLE_ANALYTICS) {
+      const internalScript = document.createElement("script");
+      internalScript.textContent = `
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', 'UA-00000000-0', 'mozilla.org');`.trim();
+      document.head.appendChild(internalScript);
+      const externalScript = document.createElement("script");
+      externalScript.src =
+        "https://www.google-analytics.com/analytics_debug.js";
+      externalScript.async = true;
+      document.head.appendChild(externalScript);
+    }
+  }, []);
 }
 
 export function useGA() {

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -154,7 +154,7 @@ By default it's disabled (empty string).
 
 If true, and when `BUILD_GOOGLE_ANALYTICS_ACCOUNT` is truthy, when it injects
 the Google Analytics script tag it will use
-`<script src="https://www.google-analytics.com/anaytics_debug.js"></script>`
+`<script src="https://www.google-analytics.com/analytics_debug.js"></script>`
 instead which triggers additional console logging which is useful for developers.
 
 ### `BUILD_SPEEDCURVE_LUX_ID`
@@ -278,3 +278,13 @@ dev server.
 
 Disable file watching and hot reloading on content change.
 Also disables search index updates.
+
+### `REACT_APP_DEBUG_GOOGLE_ANALYTICS`
+
+**Default: `false`**
+
+When you use the `create-react-app` server on `localhost:3000` it can't
+inject the Google Analytics script like you can when you server-side
+render (see `ssr/render.js`). By setting this to `true` it will forcibly
+inject a `<script async src="https://www.google-analytics.com/analytics_debug.js"></script>`
+tag and the necessary code to activate it.

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -226,7 +226,7 @@ export default function render(
       $("<script>").text(`\n${googleAnalyticsJS}\n`).appendTo($("head"));
       $(
         `<script async src="https://www.google-analytics.com/${
-          GOOGLE_ANALYTICS_DEBUG ? "anaytics_debug" : "analytics"
+          GOOGLE_ANALYTICS_DEBUG ? "analytics_debug" : "analytics"
         }.js"></script>`
       ).appendTo($("head"));
     }


### PR DESCRIPTION
Fixes #2355

**How to test this...**
Best way to test this is to use `localhost:5000` which is a whole lot more realistic than using `localhost:3000` because, this way, the initial HTML is always server-side rendered (on-the-fly by Express instead of statically built in S3). 
But to be able to even do that add the following to your `.env` first:
```
BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
BUILD_GOOGLE_ANALYTICS_DEBUG=true
```
Use a browser that doesn't block or "mess" with Google Analytics so that you know that it's not tracking protection refusing things. I use my stable Chrome. 
Load a page like: http://localhost:5000/en-US/docs/Web/HTML/Element/video
Open the web console, and what you should see is something like this:
<img width="798" alt="Screen Shot 2021-01-06 at 3 03 27 PM" src="https://user-images.githubusercontent.com/26739/103814835-62224f00-5030-11eb-91bd-02df5fecac7f.png">

Things to observe:
* It doesn't set `dimension19`
* The `location` (`dl`) is accurate
* The `title` (`dt`) is accurate
* It ran! And only once.

Now, click a link in the breadcrumb to trigger a client-side navigation. Here's what you should see:
<img width="793" alt="Screen Shot 2021-01-06 at 3 05 38 PM" src="https://user-images.githubusercontent.com/26739/103814986-a4e42700-5030-11eb-9b96-fd97ac748f23.png">
Things to observe:
* It does set `dimension19`
* The `location` (`dl`) is accurate
* The `title` (`dt`) is accurate
* It ran! And only "once" (technically the second time if you include that previous initial load).


During the course of working on this, I've unravelled two things:

* It's hard to debug Google Analytics when you use the `webpackage` server (from `create-react-app` in `localhost:3000`). So I added a little shim to make it possible to enable Google Analytics even when you're on `http://localhost:3000`.
* The way Kuma did this (sending the `pageview` event) makes it impossible to incorporate client-side navigation. It would send it as the `/api/v1/whoami` XHR has finished loading. That only happens once if the user does trigger client-side navigation. Granted, Kuma probably implemented it like this to be able to include that the pageview was done as a signed in user. There's value in knowing how many pageviews where made my signed in users. But think this pattern is incorrect because it's not how MDN works. In MDN, you *always* load the page anonymously. Then, the `whoami` XHR mutates later and you might end up to be logged in (or some other interesting waffle flag). But that should be a separate event. So I'm breaking things a little bit here but nobody actively looking at this. And if they do, we should have a dedicated event that sends to GA that the user was logged in. 

Also, if you wait for `/api/v1/whoami` to finish, we miss pageview counts if that XHR request gets stuck (because Kuma) or if the user loads a page, but clicks away faster than the XHR request can complete. 