### PR TITLE
Browser release dates not being shown

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -130,7 +130,19 @@ async function buildDocuments(files = null) {
     for (const { url, data } of bcdData) {
       fs.writeFileSync(
         path.join(outPath, path.basename(url)),
-        JSON.stringify(data)
+        JSON.stringify(data, (key, value) => {
+          // The BCD data object contains a bunch of data we don't need in the
+          // React component that loads the `bcd.json` file and displays it.
+          // The `.releases` block contains information about browsers (e.g
+          // release dates) and that part has already been extracted and put
+          // next to each version number where appropriate.
+          if (key === "releases") {
+            return undefined;
+          }
+          // TODO: Instead of serializing with a exclusion, instead explicitly
+          // serialize exactly only the data that is needed.
+          return value;
+        })
       );
     }
 

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -273,14 +273,6 @@ function _addSingleSectionBCD($) {
     browserReleaseData.set(name, releaseData);
   }
 
-  // We never need this data, after the release info has been extracted
-  // for each 'version_added'.
-  Object.values(browsers).forEach((browser) => {
-    // Remove because it's added weight which we don't need in the
-    // state data sent to the client eventually.
-    delete browser.releases;
-  });
-
   for (const [key, compat] of Object.entries(data)) {
     let block;
     if (key === "__compat") {


### PR DESCRIPTION
Fixes #2308

How to test this:

```
yarn prepare-build
BUILD_FOLDERSEARCH=web/css yarn build 
cat client/build/en-us/docs/web/css/writing-mode/bcd.json | jq
```

The bug only shows itself when the builder comes across the same object from `@mdn/browser-compat-data`. Whoever is the first object that touched the object would mutate it too destructively so when the next page builds, it would lack information. 

For the record, the serialized and dumped `bcd.json` becomes about 113KB if you don't disregard that chunk of data. If you do the exclusion serialization it becomes about 5KB. So there's value in the optimization.
