### PR TITLE
Fix broken links to in-page sections (#2383)

### DIFF
--- a/kumascript/macros/anch.ejs
+++ b/kumascript/macros/anch.ejs
@@ -11,6 +11,6 @@
 //  {{anch("Another section name", "the information elsewhere in this article.")}}
 
 var text = $1 || $0;
-var anchor = '#' + string.replace($0, " ", "_");
+var anchor = '#' + string.replace(string.toLower($0), " ", "_");
 
 %><a href="<%- anchor %>"><%- text %></a>


### PR DESCRIPTION
Fixes #2383.

When being rendered, the header IDs are converted to lowercase, whereas the [anchor macro] does not convert its argument to lowercase. This causes in-page links to be broken on pages that pass IDs containing capital letters to the anchor macro. This commit fixes it by converting the argument of the anchor macro to lowercase, with the help of [string.toLower function].

[anchor macro]: kumascript/macros/anch.ejs
[string.toLower function]: kumascript/src/api/string.js