### PR TITLE
 make it work in old browsers

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -31,7 +31,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
     <script>
-      // Only include the fat polyfill for browsers that seem to not have
+      // Only include the polyfill for browsers that seem to not have
       // certain JS features. E.g. Firefox 58.
       if (!Array.prototype.flat || !Array.prototype.includes) {
         document.write(

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -33,14 +33,10 @@
     <script>
       // Only include the fat polyfill for browsers that seem to not have
       // certain JS features. E.g. Firefox 58.
-      (Array.prototype.includes && Array.prototype.flat) ||
+      if (!Array.prototype.flat || !Array.prototype.includes) {
         document.write(
-          '<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"><\/script>'
+          '<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.flat%2Ces6"><\/script>'
         );
-      if (Array.prototype.includes && Array.prototype.flat) {
-        console.log("NO NEED TO INCLUDE POLYFILLS");
-      } else {
-        console.log("DOWNLOAD POLYFILLS PLEASE");
       }
     </script>
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -29,6 +29,21 @@
     <meta name="theme-color" content="#ffffff" />
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+
+    <script>
+      // Only include the fat polyfill for browsers that seem to not have
+      // certain JS features. E.g. Firefox 58.
+      (Array.prototype.includes && Array.prototype.flat) ||
+        document.write(
+          '<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"><\/script>'
+        );
+      if (Array.prototype.includes && Array.prototype.flat) {
+        console.log("NO NEED TO INCLUDE POLYFILLS");
+      } else {
+        console.log("DOWNLOAD POLYFILLS PLEASE");
+      }
+    </script>
+
     <title>MDN Web Docs</title>
     <meta
       name="description"

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -54,22 +54,9 @@ if (!isServer && CRUD_MODE && !NO_WATCHER) {
 app = <React.StrictMode>{app}</React.StrictMode>;
 
 if (container.firstElementChild) {
-  // console.log(`SUPPORT FOR Array.prototype.flat: ${Array.prototype.flat}`);
-
-  if (
-    window.origin !== "https://translate.googleusercontent.com" &&
-    Array.prototype.includes &&
-    Array.prototype.flat &&
-    false
-  ) {
-    console.log("HYDRATE!");
+  if (window.origin !== "https://translate.googleusercontent.com") {
     ReactDOM.hydrate(app, container);
-  } else {
-    console.log("DON'T HYDRATE");
   }
-  // if (window.origin !== "https://translate.googleusercontent.com") {
-  //   ReactDOM.hydrate(app, container);
-  // }
 } else {
   ReactDOM.render(app, container);
 }

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -54,9 +54,22 @@ if (!isServer && CRUD_MODE && !NO_WATCHER) {
 app = <React.StrictMode>{app}</React.StrictMode>;
 
 if (container.firstElementChild) {
-  if (window.origin !== "https://translate.googleusercontent.com") {
+  // console.log(`SUPPORT FOR Array.prototype.flat: ${Array.prototype.flat}`);
+
+  if (
+    window.origin !== "https://translate.googleusercontent.com" &&
+    Array.prototype.includes &&
+    Array.prototype.flat &&
+    false
+  ) {
+    console.log("HYDRATE!");
     ReactDOM.hydrate(app, container);
+  } else {
+    console.log("DON'T HYDRATE");
   }
+  // if (window.origin !== "https://translate.googleusercontent.com") {
+  //   ReactDOM.hydrate(app, container);
+  // }
 } else {
   ReactDOM.render(app, container);
 }


### PR DESCRIPTION
Fixes #2353
Fixes #2367
Fixes #1547
Fixes #2344

This way, it works in Firefox 58, IE11, MS Edge 80 to name a few. 
I opted for a polyfill because it's only 19KB (gzipped, 83KB uncompressed) and it makes the nav work. 

What was curious was that for Firefox 58, it wasn't enough to download the `es6` polyfill, but when I explicitly added `Array.protoype.flat` to it, it started to work. 

Now the top nav works, i.e. clicking to open "Technologies" and the BCD table works. 
I did get some errors with the BCD table and the interactive examples in IE11 but not enough to care. 