### PR TITLE
update youtube embed code

### DIFF
--- a/kumascript/macros/EmbedYouTube.ejs
+++ b/kumascript/macros/EmbedYouTube.ejs
@@ -23,11 +23,12 @@ if (ratio == "16:9") {
     // adding any more ratios must be done in co-operation with style sheet changes
 }
 
-var video = "<div class='intrinsic-wrapper'>";
-video += "<div class='intrinsic-container " + ratio_class + "'>";
-video += "<iframe allowfullscreen src='https://www.youtube.com/embed/" + $0 + "?rel=0&html5=1'></iframe>";
-video +="</div>";
-video +="</div>";
+
+var video = '<iframe width="560" height="315" ' +
+  `src="https://www.youtube-nocookie.com/embed/${$0}" ` +
+  'frameborder="0" ' +
+  'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ' +
+  'allowfullscreen></iframe>';
 
 %>
 

--- a/kumascript/macros/EmbedYouTube.ejs
+++ b/kumascript/macros/EmbedYouTube.ejs
@@ -3,26 +3,6 @@
 //
 // Parameters:
 //  $0  Video ID
-//  $1  Aspect Ratio (optional - will be 16:9 if not specified)
-//
-// If the video URL is https://www.youtube.com/embed/G4FnzvLr_ak, the ID
-// is "G4FnzvLr_ak".
-//
-// We always request HTML5 video, hoping to avoid Flash whenever possible.
-
-
-var ratio = $1 || "16:9";
-var ratio_class = '';
-
-if (ratio == "16:9") {
-    // default, no change needed
-} else if (ratio == "4:3") {
-    ratio_class = "intrinsic-container-4x3";
-} else {
-    // no match, use default
-    // adding any more ratios must be done in co-operation with style sheet changes
-}
-
 
 var video = '<iframe width="560" height="315" ' +
   `src="https://www.youtube-nocookie.com/embed/${$0}" ` +


### PR DESCRIPTION
Fixes #2245
Fixes #2246

This kills two issues with one stone. Sorry, but I think it's justifiable. 

Also, I noticed that the `intrinstic-wrapper` and `intrinsic-container` doesn't do anything. Neither of those terms can be found in use anywhere in `yari` or in `mdn-minimalist`. 

There are quite a few pages that use `EmbedYouTube` but I randomly picked some and checked and it works fine. 
