### PR TITLE
removing contribute link from learn sidebar

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -267,7 +267,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'How the Web works',
       'Tools_and_setup': 'Tools and setup',
       'Design_and_accessibility': 'Design and accessibility',
-    'How_to_contribute': 'How to contribute'
   },
   'de': {
     'Complete_beginners': 'Anfänger starten hier!',
@@ -521,7 +520,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'Wie das Internet funktioniert',
       'Tools_and_setup': 'Werkzeuge und Arbeitsumgebungen',
       'Design_and_accessibility': 'Design und Zugänglichkeit',
-    'How_to_contribute': 'Wie kannst Du zu MDN beitragen?'
   },
   'pt-BR': {
     'Complete_beginners': 'Completos iniciantes, comecem por aqui!',
@@ -777,7 +775,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'Como a Internet funciona',
       'Tools_and_setup': 'Ferramentas e configuração',
       'Design_and_accessibility': 'Projeto e acessibilidade',
-    'How_to_contribute': 'Como contribuir'
   },
   'ru': {
     'Complete_beginners': 'Новички начинают здесь!',
@@ -1004,7 +1001,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'Как работает Веб',
       'Tools_and_setup': 'Инструменты и установка',
       'Design_and_accessibility': 'Дизайн и доступность',
-    'How_to_contribute': 'Как помочь?'
   },
   'zh-CN': {
     'Complete_beginners': '新手请从这开始！',
@@ -1258,7 +1254,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'Web 是如何运作的',
       'Tools_and_setup': '工具与安装',
       'Design_and_accessibility': '设计与可访问性',
-    'How_to_contribute': '如何贡献'
   },
   'zh-TW': {
     'Complete_beginners': '全新手請從這開始！',
@@ -1485,7 +1480,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'Web 的運作方式',
       'Tools_and_setup': '工具與設定',
       'Design_and_accessibility': '設計與親合度',
-    'How_to_contribute': '如何貢獻'
   },
   'fr': {
     'Complete_beginners': 'Bienvenue aux débutants !',
@@ -1766,7 +1760,6 @@ var text = mdn.localStringMap({
       'How_the_Web_works': 'How the Web works',
       'Tools_and_setup': 'Tools and setup',
       'Design_and_accessibility': 'Design and accessibility',
-    'How_to_contribute': 'How to contribute'
   }
 });
 %>
@@ -2206,7 +2199,6 @@ var text = mdn.localStringMap({
         </ol>
     </details>
   </li>
-  <li data-default-state="<%=currentPageIsUnder('How_to_contribute')%>"><a href="<%=baseURL%>How_to_contribute"><%=text['How_to_contribute']%></a></li>
 </ol>
 
 </section>


### PR DESCRIPTION
The page linked to is https://developer.mozilla.org/en-US/docs/Learn/How_to_contribute

I've removed this page from the content, and want to remove the corresponding link to it from the learn sidebar.

This page was ineffective, hardly ever looked at, and out of date.