### PR TITLE
chore: Ignore mdn folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ function.zip
 testing/content/files/en-us/_githistory.json
 # eslintcache
 client/.eslintcache
+
+# cloned content repos
+mdn/


### PR DESCRIPTION
This folder is used during the production/staging build for the various
content repos