### PR TITLE
fix: ARIA practices entries in SpecData

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -24,19 +24,19 @@
     "url": "https://www.w3.org/TR/wai-aria-1.2/",
     "status": "WD"
   },
-  "ARIA Authoring Practices": {
+  "ARIA Authoring Practices 1.1": {
     "name": "WAI-ARIA Authoring Practices 1.1",
-    "url": "https://w3c.github.io/aria-practices/",
-    "status": "Draft"
+    "url": "https://www.w3.org/TR/wai-aria-practices-1.1/",
+    "status": "NOTE"
+  },
+  "ARIA Authoring Practices 1.2": {
+    "name": "WAI-ARIA Authoring Practices 1.2",
+    "url": "https://www.w3.org/TR/wai-aria-practices-1.2/",
+    "status": "WD"
   },
   "ARIA in HTML": {
     "name": "ARIA in HTML",
     "url": "https://w3c.github.io/html-aria/",
-    "status": "WD"
-  },
-  "ARIA Authoring Practices": {
-    "name": "WAI-ARIA Authoring Practices",
-    "url": "https://www.w3.org/TR/wai-aria-practices-1.1/",
     "status": "WD"
   },
   "Async Function": {

--- a/kumascript/tests/macros/specdata.test.js
+++ b/kumascript/tests/macros/specdata.test.js
@@ -18,6 +18,7 @@ const specStatusValues = [
   "Draft",
   "Obsolete",
   "LC",
+  "NOTE",
 ];
 
 /*


### PR DESCRIPTION
1.1 published version is marked as a "NOTE", added versions to the names