### PR TITLE
On Flaws dashboard, humanize flaw names

### DIFF
--- a/client/src/flaws/index.tsx
+++ b/client/src/flaws/index.tsx
@@ -753,9 +753,7 @@ function AllFlawCounts({ counts }: { counts: FlawsCounts }) {
           {typesSorted.map(([key, value]) => {
             return (
               <tr key={key}>
-                <td>
-                  <code>{key}</code>
-                </td>
+                <td>{humanizeFlawName(key)}</td>
                 <td>
                   <b>{value.toLocaleString()}</b>
                 </td>


### PR DESCRIPTION
Display human-friendly flaw names on the dashboard in "Breakdown by type" table.

E.g., instead of `bad_bcd_links` show "Bad BCD Links".


<details>

<summary>Images</summary>

## Before

![image](https://user-images.githubusercontent.com/45960703/104128282-b5b9d300-5377-11eb-832f-01681ff86ae4.png)

## After

![image](https://user-images.githubusercontent.com/45960703/104128210-493ed400-5377-11eb-8696-985b510cad51.png)

</details>