### PR TITLE
feat: Bump js-yaml to v4

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -81,7 +81,7 @@ function saveHTMLFile(
     // MySQL to disk. Once we're over that period we can delete this if-statement.
     metadata.translation_of_original = translation_of_original;
   }
-  const combined = `---\n${yaml.safeDump(metadata)}---\n${rawHTML.trim()}\n`;
+  const combined = `---\n${yaml.dump(metadata)}---\n${rawHTML.trim()}\n`;
   fs.writeFileSync(filePath, combined);
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "resolutions": {
     "fstream": ">=1.0.12",
     "handlebars": ">=4.5.3",
-    "js-yaml": ">=3.13.1",
     "lodash": ">=4.17.15",
     "mixin-deep": ">=1.3.2",
     "set-value": ">=2.0.1",
@@ -76,7 +75,7 @@
     "imagemin-svgo": "8.0.0",
     "include-media": "1.4.9",
     "is-svg": "4.2.1",
-    "js-yaml": "3.14.1",
+    "js-yaml": "4.0.0",
     "jsesc": "3.0.2",
     "mdn-data": "2.0.15",
     "open": "^7.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4230,6 +4230,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -11637,7 +11642,14 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.14.1, js-yaml@>=3.13.1, js-yaml@^3.13.1:
+js-yaml@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
+js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==


### PR DESCRIPTION
The "safe*" methods no longer are prefixed https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md
Fixes #2315