### PR TITLE
Compat tables aren't rendering prefixes

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
@@ -38,6 +38,10 @@
 .bc-history-mobile {
   display: block;
 
+  dl {
+    padding: 10px;
+  }
+
   @media #{$mq-small-desktop-and-up} {
     display: none;
   }

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -256,11 +256,20 @@ function FlagsNote({
   );
 }
 
-function getNotes(browser: bcd.BrowserNames, support: bcd.SupportStatement) {
+function getNotes(
+  browser: bcd.BrowserNames,
+  support: bcd.SupportStatement,
+  locale: string
+) {
   return asList(support)
     .flatMap((item, i) => {
       const supportNotes = [
-        item.prefix ? { iconName: "prefix", label: "prefix" } : null,
+        item.prefix
+          ? {
+              iconName: "prefix",
+              label: `Implemented with the vendor prefix: ${item.prefix}`,
+            }
+          : null,
         item.notes
           ? (Array.isArray(item.notes)
               ? item.notes
@@ -296,16 +305,18 @@ function getNotes(browser: bcd.BrowserNames, support: bcd.SupportStatement) {
                 <CellText support={item} />
                 <CellIcons support={item} />
               </dt>
-              {supportNotes.map(({ iconName, label }, i) => (
-                <dd key={i}>
-                  <Icon name={iconName} />{" "}
-                  {typeof label === "string" ? (
-                    <span dangerouslySetInnerHTML={{ __html: label }} />
-                  ) : (
-                    label
-                  )}
-                </dd>
-              ))}
+              {supportNotes.map(({ iconName, label }, i) => {
+                return (
+                  <dd key={i}>
+                    <Icon name={iconName} />{" "}
+                    {typeof label === "string" ? (
+                      <span dangerouslySetInnerHTML={{ __html: label }} />
+                    ) : (
+                      label
+                    )}
+                  </dd>
+                );
+              })}
               {!hasNotes && <dd />}
             </div>
           </React.Fragment>
@@ -320,11 +331,13 @@ function CompatCell({
   support,
   showNotes,
   onToggle,
+  locale,
 }: {
   browser: bcd.BrowserNames;
   support: bcd.SupportStatement | undefined;
   showNotes: boolean;
   onToggle: () => void;
+  locale: string;
 }) {
   const supportClassName = getSupportClassName(support);
   const browserReleaseDate = getSupportBrowserReleaseDate(support);
@@ -369,12 +382,12 @@ function CompatCell({
             <i className="ic-history" aria-hidden="true" />
           </button>
         )}
+        {showNotes && (
+          <dl className="bc-history bc-history-mobile">
+            {getNotes(browser, support!, locale)}
+          </dl>
+        )}
       </td>
-      {showNotes && (
-        <section className="bc-history bc-history-mobile">
-          <dl>{getNotes(browser, support!)}</dl>
-        </section>
-      )}
     </>
   );
 }
@@ -386,6 +399,7 @@ export const FeatureRow = React.memo(
     browsers,
     activeCell,
     onToggleCell,
+    locale,
   }: {
     index: number;
     feature: {
@@ -396,6 +410,7 @@ export const FeatureRow = React.memo(
     browsers: bcd.BrowserNames[];
     activeCell: number | null;
     onToggleCell: ([row, column]: [number, number]) => void;
+    locale: string;
   }) => {
     const { name, compat, isRoot } = feature;
     const title = compat.description ? (
@@ -443,13 +458,20 @@ export const FeatureRow = React.memo(
               support={compat.support[browser]}
               showNotes={activeCell === i}
               onToggle={() => onToggleCell([index, i])}
+              locale={locale}
             />
           ))}
         </tr>
         {activeBrowser && (
           <tr className="bc-history">
             <td colSpan={browsers.length + 1}>
-              <dl>{getNotes(activeBrowser, compat.support[activeBrowser]!)}</dl>
+              <dl>
+                {getNotes(
+                  activeBrowser,
+                  compat.support[activeBrowser]!,
+                  locale
+                )}
+              </dl>
             </td>
           </tr>
         )}

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -54,9 +54,11 @@ type CellIndex = [number, number];
 function FeatureListAccordion({
   features,
   browsers,
+  locale,
 }: {
   features: ReturnType<typeof listFeatures>;
   browsers: bcd.BrowserNames[];
+  locale: string;
 }) {
   const [[activeRow, activeColumn], dispatchCellToggle] = useReducer<
     React.Reducer<CellIndex | [null, null], CellIndex>
@@ -76,7 +78,10 @@ function FeatureListAccordion({
           {...{ feature, browsers }}
           index={i}
           activeCell={activeRow === i ? activeColumn : null}
-          onToggleCell={dispatchCellToggle}
+          onToggleCell={([row, column]: [number, number]) => {
+            dispatchCellToggle([row, column]);
+          }}
+          locale={locale}
         />
       ))}
     </>
@@ -87,10 +92,12 @@ export default function BrowserCompatibilityTable({
   query,
   data,
   browsers: browserInfo,
+  locale,
 }: {
   query: string;
   data: bcd.Identifier;
   browsers: bcd.Browsers;
+  locale: string;
 }) {
   const location = useLocation();
 
@@ -136,6 +143,7 @@ export default function BrowserCompatibilityTable({
             <FeatureListAccordion
               browsers={browsers}
               features={listFeatures(data, "", name)}
+              locale={locale}
             />
           </tbody>
         </table>

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -11,6 +11,7 @@ import { DisplayH2, DisplayH3 } from "./ingredients/utils";
 // That means that when the lazy-loading happens, it only needs to lazy-load
 // the JS (and the JSON XHR fetch of course)
 import "./ingredients/browser-compatibility-table/index.scss";
+import { useLocale } from "../hooks";
 
 const BrowserCompatibilityTable = lazy(
   () => import("./ingredients/browser-compatibility-table")
@@ -47,6 +48,7 @@ function LazyBrowserCompatibilityTableInner({
   dataURL: string;
   query: string;
 }) {
+  const locale = useLocale();
   const [bcdDataURL, setBCDDataURL] = useState("");
 
   const { error, data } = useSWR(
@@ -89,7 +91,7 @@ function LazyBrowserCompatibilityTableInner({
 
   return (
     <Suspense fallback={<Loading />}>
-      <BrowserCompatibilityTable {...data} />
+      <BrowserCompatibilityTable locale={locale} {...data} />
     </Suspense>
   );
 }


### PR DESCRIPTION
Fixes #2163

Now it looks like this:
<img width="934" alt="Screen Shot 2021-01-11 at 3 27 34 PM" src="https://user-images.githubusercontent.com/26739/104234547-92e3f900-5421-11eb-8aa1-0c11990c636b.png">

The old `Compat.ejs` used to rely on `L10n-CompatTable.json` to get some of it strings. When Gregor rewrote how the BCD table works (in React with TypeScript) instead of relying on that file, he just copied the English strings over directly into the TypeScript code. Clearly, I missed one. The one that this PR fixes. It was subtle. 

I think the original intent was to move away from having these `.json` files fo chrome localization that Kumascript used and move to something more modern/sane such as `react-fluent`. Either way, the reason it was never fully implemented was because at the time the BCD table was ported to React, we didn't know what was going to happen with localization. So, instead of just waiting (forever) for a firm decision on that, we proceeded with building BCD + Yari in 100% hardcoded English. The chrome localization had to wait. 

In the midst of working on this, I thought I need to use the `L10n-CompatTable.json` so I started introducing the `locale` variable (to come from the URL) so that within the functional components I could use it. Turns out, it's not needed. But I also don't feel like undoing that change because it's not unrealistic that it's useful to, in some deep BCD component, to know the current locale. It'd be needed if/when we move to `react-fluent`. 

Whilst working on this, I noticed something that's never been noticed before. In the way the notes is rendered, it attempts to create invalid HTML with something like this:
```
<table>
  <tr>
    <td>...</td>
    <section>
        <dl>...</dl>
    </section>
  </tr>
</table>
```
When you run React in dev mode, on the `master` branch, you'll see a warning when you visit http://localhost:3000/en-US/docs/Web/API/Notification/Notification and try to expand one of the rows. 
So I had to take care of that too, but it turns out it was actually unrelated. But I think it's worth keeping. 
The only problem now was that the padding is too small when the notes field appears in responsive mode. You'll see that I tried to inject a `padding:10px` for the `dl` but that's not working. I don't know why. Can you figure it out?