### PR TITLE
flaw when CSSSyntax macro finds nothing in mdn-data

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -446,6 +446,8 @@ if (name === "preview-wiki-content") {
     formattedSyntax += await formatTypesSyntax(formattedSyntax, []);
 }
 
-var result = formattedSyntax || s_missing;
+if (!formattedSyntax) {
+    throw new Error(`No syntax found in DB for '${name}'`);
+}
 
-%><%- result %>
+%><%- formattedSyntax %>


### PR DESCRIPTION
Fixes #2096

You can test on http://localhost:3000/en-US/docs/Web/CSS/::-webkit-scrollbar#_flaws

<img width="1315" alt="Screen Shot 2021-01-12 at 2 29 12 PM" src="https://user-images.githubusercontent.com/26739/104363013-95f2ee00-54e2-11eb-9721-9f491bb3f607.png">

I ran this on all of `web/css/` and it stumbled across 14 of these. 