### PR TITLE
be smarter about indexing 'archived' in ES

### DIFF
--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -162,7 +162,43 @@ def to_search(file):
     return Document(
         _id=doc["mdn_url"],
         title=doc["title"],
-        archived=doc.get("isArchive") or False,
+        # This is confusing. But it's worth hacking around for now until
+        # localizations are uplifted (and unfrozen maybe).
+        # A document that is definitely archived E.g. /en-us/docs/Thunderbird/XUL
+        # will look like this:
+        #
+        #       "isArchive": true,
+        #       "isTranslated": false,
+        #       "locale": "en-US",
+        #
+        # A document that is a translation and is definitely archived
+        # E.g. /fr/docs/Mozilla/Gecko/Gecko_Embedding_Basics
+        # will look like this:
+        #
+        #       "isArchive": true,
+        #       "isTranslated": false,
+        #       "locale": "fr",
+        #
+        # Now, the really confusing one is translated documents that are
+        # not archived. E.g. /fr/docs/CSS/Premiers_pas/Fonctionnement_de_CSS
+        # will look like this:
+        #
+        #       "isArchive": true,
+        #       "isTranslated": true,
+        #       "locale": "fr",
+        #
+        # Which actually makes sense because in Yari, here "isArchive" is (ab)used
+        # to do things like deciding not to show the Toolbar.
+        # And for the record, here's what a perfectly maintained en-US document looks
+        # like. E.g. /en-US/docs/Web/CSS
+        #
+        #       "isArchive": true,
+        #       "isTranslated": false,
+        #       "locale": "en-US",
+        #
+        # When searching though, we don't necessary want to think of all (for example)
+        # French documents to be archived. Hence the following logic.
+        archived=(doc.get("isArchive") and not doc.get("isTranslated")) or False,
         body=html_strip(
             "\n".join(
                 x["value"]["content"]


### PR DESCRIPTION
With this change, I can, in my `kuma` branche search the ES index for non-en-us content and be able to distinguish between actually archived and not actually archived. 