### PR TITLE
fix: Allow uppercase names for InterWiki

### DIFF
--- a/kumascript/macros/Interwiki.ejs
+++ b/kumascript/macros/Interwiki.ejs
@@ -13,7 +13,7 @@ var title = $2 || path;
 path = (path.charAt(0).toUpperCase() + path.slice(1)).replace(/ /g, "_");
 
 var lang = env.locale.substr(0, 2);
-var prefix = $0;
+var prefix = $0.toLowerCase();
 
 switch(prefix) {
     case 'wikipedia':


### PR DESCRIPTION
Only ran across this in one doc in mdn/content for `glossary/node.js`, but it seemed better to allow `Wikipedia` in addition to other possible incorrect casing. Figured there may be others in the translated or archived content