### PR TITLE
fix: add style for links to pages that do not yet exists

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -101,7 +101,10 @@
     margin-bottom: $base-spacing * 2;
   }
 
-  .page-not-created {
+  /* page-not-created is the preferred class name, `new` is
+     here for backwards compatibility */
+  .page-not-created,
+  .new {
     color: $red-300;
     cursor: not-allowed;
   }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -101,6 +101,11 @@
     margin-bottom: $base-spacing * 2;
   }
 
+  .page-not-created {
+    color: $red-300;
+    cursor: not-allowed;
+  }
+
   /* readonly inline badges needs a slightly darker background color in general article content  */
   .inline {
     &.optional,

--- a/kumascript/src/api/web.js
+++ b/kumascript/src/api/web.js
@@ -68,7 +68,7 @@ module.exports = {
       L10N_COMMON_STRINGS,
       "summary"
     );
-    return `<a class="new" title="${titleWhenMissing}"${flawAttribute}>${content}</a>`;
+    return `<a class="page-not-created" title="${titleWhenMissing}"${flawAttribute}>${content}</a>`;
   },
 
   // Try calling "decodeURIComponent", but if there's an error, just

--- a/kumascript/tests/index.test.js
+++ b/kumascript/tests/index.test.js
@@ -107,7 +107,7 @@ describe("testing the main render() function", () => {
     );
     const $ = cheerio.load(result);
     const brokenLink = $(
-      'a.new[title^="The documentation about this has not yet been written"]'
+      'a.page-not-created[title^="The documentation about this has not yet been written"]'
     );
     expect(brokenLink.length).toBe(3);
     expect(brokenLink.html()).toBe("<code>bigfoot</code>");

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -416,7 +416,7 @@ test("content built bar page", () => {
   const $ = cheerio.load(html);
   expect($("a[data-flaw-src]").length).toEqual(12);
 
-  const brokenLinks = $("a.new");
+  const brokenLinks = $("a.page-not-created");
   expect(brokenLinks.length).toEqual(4);
   expect(brokenLinks.eq(0).data("flaw-src")).toBe('{{CSSxRef("bigfoot")}}');
   expect(brokenLinks.eq(0).text()).toBe("bigfoot");


### PR DESCRIPTION
Change the class name used for links to pages that do not yet exist from `new` to `page-not-created` and add relevant styling.

![Screenshot 2021-01-14 at 16 28 23](https://user-images.githubusercontent.com/10350960/104604624-37ff0b80-5686-11eb-88cb-9166b445d93f.png)


fix #2065
