### PR TITLE
close "Jump to section" on click

### DIFF
--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -47,7 +47,14 @@ export function TOC({ toc }: { toc: Toc[] }) {
         <ul id="toc-entries" className={showTOC ? "show-toc" : undefined}>
           {toc.map((item) => (
             <li key={item.id}>
-              <a href={`#${item.id.toLowerCase()}`}>{item.text}</a>
+              <a
+                href={`#${item.id.toLowerCase()}`}
+                onClick={() => {
+                  setShowTOC(false);
+                }}
+              >
+                {item.text}
+              </a>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
Part of #1747

All this does is that it closes the "Jump to section" if you click on any of its links. 
You still get z-index overlay problem. But, this is an incremental improvement. 

I wish the "Jump to section" thing was more like a modal window. That any click outside it should close it. 