### PR TITLE
imagemin on filepaths with brackets

### DIFF
--- a/filecheck/checker.js
+++ b/filecheck/checker.js
@@ -129,11 +129,15 @@ async function checkFile(filePath, options) {
     const files = await imagemin([filePath], {
       destination: tempdir,
       plugins,
+      // Needed because otherwise start trying to find files using
+      // `globby()` which chokes on file paths that contain brackets.
+      // E.g. `/web/css/transform-function/rotate3d()/transform.png`
+      // Setting this to false tells imagemin() to just accept what
+      // it's given instead of trying to search for the image.
+      glob: false,
     });
     if (!files.length) {
-      throw new Error(
-        `${filePath} could not be compressed with plugin: ${plugins[0]}`
-      );
+      throw new Error(`${filePath} could not be compressed`);
     }
     const compressed = files[0];
     const sizeBefore = fs.statSync(filePath).size;


### PR DESCRIPTION
Fixes #2562

You can test it against some of the files in https://github.com/mdn/content/pull/1368

Or just navigate to a page that has an external image and whose folder the page is in has the `()` characters in the name. 