### PR TITLE
fix: padding on notes in bcd table

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
@@ -37,10 +37,7 @@
 
 .bc-history-mobile {
   display: block;
-
-  dl {
-    padding: 10px;
-  }
+  padding: $base-spacing / 2;
 
   @media #{$mq-small-desktop-and-up} {
     display: none;


### PR DESCRIPTION
Updates the padding for the notes inside BCD tables

note: @peterbe 
