### PR TITLE
Feat: add tags to document editor

### DIFF
--- a/client/src/document/forms/form.tsx
+++ b/client/src/document/forms/form.tsx
@@ -7,7 +7,7 @@ import useSWR from "swr";
 
 type DocumentFormData = {
   rawHTML: string;
-  metadata: { slug: string; title: string };
+  metadata: { slug: string; title: string; tags: Array<string> };
 };
 
 // Same as DocumentFormData but metadata also includes the locale
@@ -35,6 +35,7 @@ export function DocumentForm({
   );
   const [title, setTitle] = useState(doc ? doc.metadata.title : "");
   const [rawHTML, setRawHtml] = useState(doc ? doc.rawHTML : "");
+  const [tags, setTags] = useState(doc ? doc.metadata.tags : []);
 
   const [autosaveEnabled, setAutoSaveEnabled] = useLocalStorage(
     "autosaveEdit",
@@ -71,6 +72,21 @@ export function DocumentForm({
     setAutoSaveEnabled(!autosaveEnabled);
   }
 
+  function removeTag(tag: string) {
+    setTags(tags.filter((elem) => elem !== tag));
+  }
+
+  function addTag() {
+    const input: any = document.getElementById("newTag");
+    const newTag: string = input.value;
+    if (tags.includes(newTag)) {
+      console.log("This tag is already there:", newTag);
+    } else {
+      setTags([...tags, newTag]);
+    }
+    input.value = "";
+  }
+
   const { callback: debounceCallback } = useDebouncedCallback(onSave, 1000);
 
   useEffect(() => {
@@ -78,7 +94,7 @@ export function DocumentForm({
       debounceCallback(
         {
           rawHTML,
-          metadata: { slug, title, locale },
+          metadata: { slug, title, locale, tags },
         },
         didSlugChange
       );
@@ -87,6 +103,7 @@ export function DocumentForm({
     willAutosave,
     debounceCallback,
     slug,
+    tags,
     title,
     rawHTML,
     didSlugChange,
@@ -101,7 +118,7 @@ export function DocumentForm({
         onSave(
           {
             rawHTML,
-            metadata: { slug, title, locale },
+            metadata: { slug, title, locale, tags },
           },
           didSlugChange
         );
@@ -149,6 +166,43 @@ export function DocumentForm({
           />
         </label>
       </p>
+
+      <div>
+        <label>Tags</label>
+        <ul>
+          {tags.map((tag) => (
+            <li key={tag}>
+              {tag}
+              <button
+                style={{ marginLeft: "10px" }}
+                onClick={() => removeTag(tag)}
+              >
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+        <div style={{ marginBottom: "5px" }}>
+          <input
+            id="newTag"
+            disabled={disableInputs}
+            type="text"
+            placeholder="New tag"
+            defaultValue=""
+          />
+          <button
+            type="submit"
+            disabled={disableInputs}
+            style={{ marginLeft: "10px" }}
+            onClick={(event) => {
+              event.preventDefault();
+              addTag();
+            }}
+          >
+            Add tag
+          </button>
+        </div>
+      </div>
 
       <textarea
         disabled={disableInputs}

--- a/content/document.js
+++ b/content/document.js
@@ -247,7 +247,8 @@ function update(url, rawHTML, metadata) {
   if (
     isNewSlug ||
     document.rawHTML !== rawHTML ||
-    document.metadata.title !== metadata.title
+    document.metadata.title !== metadata.title ||
+    JSON.stringify(document.metadata.tags) !== JSON.stringify(metadata.tags)
   ) {
     saveHTMLFile(indexPath, rawHTML, {
       ...document.metadata,


### PR DESCRIPTION
This PR extends "Edit view" with the ability to see, add, and remove document tags. It's very basic in its style and functionality (does not validate tags, does not sort tags). Suggestions are welcome.

## Preview
The new section is in the red box.
![image](https://user-images.githubusercontent.com/45960703/104845196-249dab80-58e5-11eb-9f87-92a782d79524.png)