### PR TITLE
fix: stacking order of main menu and toc

### DIFF
--- a/client/src/ui/organisms/header/index.scss
+++ b/client/src/ui/organisms/header/index.scss
@@ -52,7 +52,7 @@
   position: absolute;
   top: 90px;
   width: 100%;
-  z-index: $top-layer;
+  z-index: $bring-to-front;
 
   @media #{$mq-tablet-and-up} {
     display: block;


### PR DESCRIPTION
Fix stacking order of TOC drop-down and main menu on mobile to ensure the main menu covers the TOC if both are expanded at the same time.

## Updated display

![Screenshot of table of contents drop-down and main menu on mobile expanded showing correct stacking order](https://user-images.githubusercontent.com/10350960/104850225-7c90de00-58f6-11eb-8e44-aec7484d925e.png)


fix #1747
