### PR TITLE
It's not OK to have diff markers in the content

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -93,6 +93,21 @@ async function buildDocuments(files = null) {
       );
     }
 
+    // This is very useful in CI where every page gets built. If there's an
+    // accidentally unresolved git conflict, that's stuck in the content,
+    // bail extra early.
+    if (
+      // If the document itself, is a page that explains and talks about git merge
+      // conflicts, i.e. a false positive, those angled brackets should be escaped
+      /^<<<<<<< HEAD\n/m.test(document.rawContent) &&
+      /^=======\n/m.test(document.rawContent) &&
+      /^>>>>>>>/m.test(document.rawContent)
+    ) {
+      throw new Error(
+        `${document.fileInfo.path} contains git merge conflict markers`
+      );
+    }
+
     const {
       doc: builtDocument,
       liveSamples,

--- a/build/cli.js
+++ b/build/cli.js
@@ -93,21 +93,6 @@ async function buildDocuments(files = null) {
       );
     }
 
-    // This is very useful in CI where every page gets built. If there's an
-    // accidentally unresolved git conflict, that's stuck in the content,
-    // bail extra early.
-    if (
-      // If the document itself, is a page that explains and talks about git merge
-      // conflicts, i.e. a false positive, those angled brackets should be escaped
-      /^<<<<<<< HEAD\n/m.test(document.rawContent) &&
-      /^=======\n/m.test(document.rawContent) &&
-      /^>>>>>>>/m.test(document.rawContent)
-    ) {
-      throw new Error(
-        `${document.fileInfo.path} contains git merge conflict markers`
-      );
-    }
-
     const {
       doc: builtDocument,
       liveSamples,

--- a/content/document.js
+++ b/content/document.js
@@ -191,6 +191,20 @@ const read = memoize((folder) => {
     (CONTENT_ARCHIVED_ROOT && filePath.startsWith(CONTENT_ARCHIVED_ROOT));
 
   const rawContent = fs.readFileSync(filePath, "utf8");
+
+  // This is very useful in CI where every page gets built. If there's an
+  // accidentally unresolved git conflict, that's stuck in the content,
+  // bail extra early.
+  if (
+    // If the document itself, is a page that explains and talks about git merge
+    // conflicts, i.e. a false positive, those angled brackets should be escaped
+    /^<<<<<<< HEAD\n/m.test(rawContent) &&
+    /^=======\n/m.test(rawContent) &&
+    /^>>>>>>>/m.test(rawContent)
+  ) {
+    throw new Error(`${filePath} contains git merge conflict markers`);
+  }
+
   const {
     attributes: metadata,
     body: rawHTML,


### PR DESCRIPTION
Fixes #2591

<img width="1210" alt="Screen Shot 2021-01-19 at 10 23 05 AM" src="https://user-images.githubusercontent.com/26739/105054730-537c6480-5a40-11eb-93dd-356347873965.png">
