### PR TITLE
not lowercase anchor links is a flaw

### DIFF
--- a/testing/content/files/en-us/web/not_lowercase_anchors/index.html
+++ b/testing/content/files/en-us/web/not_lowercase_anchors/index.html
@@ -1,0 +1,13 @@
+---
+title: Anchor links that aren't lowercased
+slug: Web/Not_lowercase_anchors
+---
+
+<ul>
+  <li><a href='#Heading1'>Heading1</a></li>
+  <li><a href="/en-US/docs/Web/Foo#Heading2">Heading2</a></li>
+  <li><a href="/en-US/docs/Web/Foo#">Empty anchor</a></li>
+  <li><a href="/en-US/docs/Web/Foo">No anchor</a></li>
+  <li><a href="/en-US/docs/Web/Fuu#Anchor">Pathname broken (fixable) with anchor</a></li>
+  <li><a href="https://www.peterbe.com/#About">External site</a></li>
+</ul>


### PR DESCRIPTION
Fixes #2524

Basically, anything like:
```
<a href="#Foo">
<!-- or -->
<a href="/en-US/docs/Web#Capital">
```
is now considered a flaw. They're always fixable. 

Most easily seen on http://localhost:3000/en-US/docs/web/not_lowercase_anchors#_flaws
<img width="963" alt="Screen Shot 2021-01-19 at 5 51 57 PM" src="https://user-images.githubusercontent.com/26739/105103735-11bede80-5a7f-11eb-8ef4-296b47454228.png">
