### PR TITLE
support -v in tools/cli

### DIFF
--- a/tool/cli.js
+++ b/tool/cli.js
@@ -26,7 +26,7 @@ function tryOrExit(f) {
     try {
       await f({ options, ...args });
     } catch (error) {
-      if (options.verbose) {
+      if (options.verbose || options.v) {
         console.error(chalk.red(error.stack));
       }
       throw error;


### PR DESCRIPTION
When I was reviewing https://github.com/mdn/yari/pull/2545 I stumbled into a bug. That's fine, but to see the full traceback I needed to go into "verbose" mode. I thought I could just add `-v` but that didn't do anything. 
If I had used `--verbose` it worked and I would get the stacktrace printed out. 

<img width="653" alt="Screen Shot 2021-01-20 at 3 32 15 PM" src="https://user-images.githubusercontent.com/26739/105231322-ae8f8380-5b34-11eb-917b-2f7b1ff2b4a1.png">

As of this change, it's now the same effect to type:
```
yarn tool fix-redirects -v
```
...as:
```
yarn tool fix-redirects --verbose
```
