### PR TITLE
Provide a basic style for .callout-box

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -146,6 +146,14 @@
   .index {
     columns: 300px;
   }
+
+  .callout-box {
+    background: #eee;
+    float: right;
+    padding: 20px;
+    text-align: center;
+    width: 30%;
+  }
 }
 
 /*

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -117,8 +117,8 @@
     }
   }
 
-  /* 
-   * top navigational elements on tutorial pages 
+  /*
+   * top navigational elements on tutorial pages
    * prevnext is added for backwards compatibility
    */
   .prevnext,
@@ -148,9 +148,9 @@
   }
 
   .callout-box {
-    background: #eee;
+    background: $neutral-550;
     float: right;
-    padding: 20px;
+    padding: $base-spacing;
     text-align: center;
     width: 30%;
   }


### PR DESCRIPTION
Currently there are no styles for `.callout-box` as discussed in #2158. This PR aims to provide some, possibly temporary, styling to the class that resembles its old style, so that it looks somewhat decent.

Feel free to replace the hardcoded values with variables with an edit.

# Before
<img src="https://i.ibb.co/LCjvwrC/Before.png" alt=".callout-box before changes">

# After
<img src="https://i.ibb.co/QJtp0Ph/After.png" alt=".callout-box after changes">