### PR TITLE
Update securecontext macro: Fix link to browser compatibility

### DIFF
--- a/kumascript/macros/secureContextGeneric.ejs
+++ b/kumascript/macros/secureContextGeneric.ejs
@@ -23,10 +23,10 @@ var str_tooltip = mdn.localString({
 });
 
 var str_desc = mdn.localString({
-  "en-US": "This feature is available only in <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>secure contexts</a> (HTTPS), in some or all <a href='#Browser_compatibility'>supporting browsers</a>.",
-  "fr"   : "Cette fonctionnalité est uniquement disponible dans des <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>contextes sécurisés</a> (HTTPS), pour certains <a href='#Compatibilité_des_navigateurs'>navigateurs qui la prennent en charge</a>.",
-  "ja"   : "この機能は一部またはすべての<a href='#Browser_compatibility'>対応しているブラウザー</a>において、<a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>安全なコンテキスト</a> (HTTPS) でのみ利用できます。",
-  "zh-CN": "此项功能仅在<a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>安全上下文</a>(HTTPS), 一些 <a href='#Browser_compatibility'>支持的浏览器</a>."
+  "en-US": "This feature is available only in <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>secure contexts</a> (HTTPS), in some or all <a href='#browser_compatibility'>supporting browsers</a>.",
+  "fr"   : "Cette fonctionnalité est uniquement disponible dans des <a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>contextes sécurisés</a> (HTTPS), pour certains <a href='#compatibilité_des_navigateurs'>navigateurs qui la prennent en charge</a>.",
+  "ja"   : "この機能は一部またはすべての<a href='#browser_compatibility'>対応しているブラウザー</a>において、<a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>安全なコンテキスト</a> (HTTPS) でのみ利用できます。",
+  "zh-CN": "此项功能仅在<a href='/" + lang + "/docs/Web/Security/Secure_Contexts'>安全上下文</a>(HTTPS), 一些 <a href='#browser_compatibility'>支持的浏览器</a>."
 });
 
 if($0 === 'inline') {


### PR DESCRIPTION
The current link within the securecontext macro directs to #Browser_compatibility when the id is in fact lowercase. 
Example: https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API#Secure_context