### PR TITLE
chore: Ignore ESLint/Webpack dependabots

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      # Need manual updates with "resolutions" in package.json
+      # to property hoist versions from react-scripts
+      - dependency-name: "webpack"
+      - dependency-name: "eslint"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Related docs https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#ignore