### PR TITLE
Download external images with the extension that it really is

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -506,16 +506,22 @@ async function fixFixableFlaws(doc, options, document) {
             `No file type could be extracted from ${flaw.src} at all. Probably not going to be a valid image file.`
           );
         }
-        if (!VALID_MIME_TYPES.has(fileType.mime)) {
+        const isSVG =
+          fileType.mime === "application/xml" &&
+          flaw.src.toLowerCase().endsWith(".svg");
+
+        if (!(VALID_MIME_TYPES.has(fileType.mime) || isSVG)) {
           throw new Error(
             `${flaw.src} has an unrecognized mime type: ${fileType.mime}`
           );
         }
+        // Otherwise FileType would make it `.xml`
+        const imageExtension = isSVG ? "svg" : fileType.ext;
         const imageBasename = sanitizeFilename(
           `${path.basename(
             decodeURI(url.pathname),
             path.extname(decodeURI(url.pathname))
-          )}.${fileType.ext}`
+          )}.${imageExtension}`
         );
         const destination = path.join(
           Document.getFolderPath(document.metadata),

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -517,11 +517,10 @@ async function fixFixableFlaws(doc, options, document) {
         }
         // Otherwise FileType would make it `.xml`
         const imageExtension = isSVG ? "svg" : fileType.ext;
+        const decodedPathname = decodeURI(url.pathname).replace(/\s+/g, "_");
         const imageBasename = sanitizeFilename(
-          `${path.basename(
-            decodeURI(url.pathname).replace(/\s+/g, "_"),
-            path.extname(decodeURI(url.pathname))
-          )}.${imageExtension}`
+          `${path.basename(decodedPathname, path.extname(decodedPathname))
+          }.${imageExtension}`
         );
         const destination = path.join(
           Document.getFolderPath(document.metadata),

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -519,7 +519,7 @@ async function fixFixableFlaws(doc, options, document) {
         const imageExtension = isSVG ? "svg" : fileType.ext;
         const imageBasename = sanitizeFilename(
           `${path.basename(
-            decodeURI(url.pathname),
+            decodeURI(url.pathname).replace(/\s+/g, "_"),
             path.extname(decodeURI(url.pathname))
           )}.${imageExtension}`
         );

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -519,8 +519,10 @@ async function fixFixableFlaws(doc, options, document) {
         const imageExtension = isSVG ? "svg" : fileType.ext;
         const decodedPathname = decodeURI(url.pathname).replace(/\s+/g, "_");
         const imageBasename = sanitizeFilename(
-          `${path.basename(decodedPathname, path.extname(decodedPathname))
-          }.${imageExtension}`
+          `${path.basename(
+            decodedPathname,
+            path.extname(decodedPathname)
+          )}.${imageExtension}`
         );
         const destination = path.join(
           Document.getFolderPath(document.metadata),

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -9,6 +9,7 @@ const imageminPngquant = require("imagemin-pngquant");
 const imageminMozjpeg = require("imagemin-mozjpeg");
 const imageminGifsicle = require("imagemin-gifsicle");
 const imageminSvgo = require("imagemin-svgo");
+const sanitizeFilename = require("sanitize-filename");
 
 const { Document, Redirect, Image } = require("../content");
 const { FLAW_LEVELS } = require("./constants");
@@ -510,10 +511,12 @@ async function fixFixableFlaws(doc, options, document) {
             `${flaw.src} has an unrecognized mime type: ${fileType.mime}`
           );
         }
-        const imageBasename = `${path.basename(
-          decodeURI(url.pathname),
-          path.extname(decodeURI(url.pathname))
-        )}.${fileType.ext}`;
+        const imageBasename = sanitizeFilename(
+          `${path.basename(
+            decodeURI(url.pathname),
+            path.extname(decodeURI(url.pathname))
+          )}.${fileType.ext}`
+        );
         const destination = path.join(
           Document.getFolderPath(document.metadata),
           path


### PR DESCRIPTION
Fixes #2659
Fixes #2643


The time it took me to tinker with the problem in https://github.com/mdn/content/pull/1587 was enough to have a bunch of code that is worth keeping. 
Now, it will download the image with the **correct file extension** independent of the URL. 
But also, there's an interesting chance here to validate the image before downloading it. If it's not going to work, it's good to elevate that explicitly. This will prevent you from thinking the fixable flaw thing worked, just to eventually fail in the PR CI. 

I copied the HTML from the above-mentioned PR and confirmed that it's a fixable flaw:
<img width="1075" alt="Screen Shot 2021-01-22 at 1 24 46 PM" src="https://user-images.githubusercontent.com/26739/105530426-c6424580-5cb5-11eb-83be-2870887320e0.png">

(pun intended that I used the `Glossary/PNG` page)

After running the fixable flaws:

<img width="1057" alt="Screen Shot 2021-01-22 at 1 25 28 PM" src="https://user-images.githubusercontent.com/26739/105530491-dfe38d00-5cb5-11eb-87a1-45dd4c05e4f5.png">
