### PR TITLE
Update margins for star-icon in bc tables to provide better alignment

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
@@ -10,7 +10,8 @@
     display: inline-block;
     height: $base-unit * 3;
     line-height: 1;
-    margin-left: $base-unit;
+    margin-left: $base-unit / 1.2;
+    margin-right: $base-unit / 1.5;
     width: $base-unit * 3;
   }
 }


### PR DESCRIPTION
Fixes #2630

Brings 6px down to 5px for `margin-left` and introduces a `margin-right` of 4px. This seems to provide a much more centered alignment when the star icon wraps to the next line in bc tables, while maintaining space between value and icon when side-by-side.