### PR TITLE
Make Core_JavaScript_1.5 a fundamental redirect

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1147,6 +1147,37 @@ for (const [pattern, path] of [
   );
 }
 
+function simpleRedirect(
+  pattern,
+  replacement,
+  { permanent = true, colonToSlash = false } = {}
+) {
+  return (path) => {
+    const match = pattern.exec(path);
+    if (match === null) {
+      return null;
+    }
+    const status = permanent ? 301 : 302;
+    let url = path.replace(pattern, replacement);
+    if (colonToSlash) {
+      url = url.replace(/:/g, "/");
+    }
+    return { url, status };
+  };
+}
+
+const SIMPLE_REDIRECT_PATTERNS = [
+  simpleRedirect(
+    /\/docs\/Core_JavaScript_1.5_?/,
+    "/docs/Web/JavaScript/",
+    // This will convert :
+    //   /en-US/docs/Core_JavaScript_1.5_Reference:Statements:block
+    // to:
+    //   /en-US/docs/Core_JavaScript_1.5_Reference/Statements/block
+    { colonToSlash: true }
+  ),
+];
+
 const REDIRECT_PATTERNS = [].concat(
   SCL3_REDIRECT_PATTERNS,
   ZONE_REDIRECT_PATTERNS,
@@ -1168,7 +1199,8 @@ const REDIRECT_PATTERNS = [].concat(
       { prependLocale: false, permanent: true }
     ),
   ],
-  LOCALE_PATTERNS
+  LOCALE_PATTERNS,
+  SIMPLE_REDIRECT_PATTERNS
 );
 
 const STARTING_SLASH = /^\//;

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -1077,15 +1077,15 @@ describe("locale alias redirects", () => {
 const CORE_JAVASCRIPT_1_5_URLs = [].concat(
   url_test(
     "/en-US/docs/Core_JavaScript_1.5_Reference/Operators/Special_Operators/typeof_Operator",
-    "en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
+    "/en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
   ),
   url_test(
     "/en-US/docs/Core_JavaScript_1.5_Reference:Operators:Special_Operators:typeof_Operator",
-    "en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
+    "/en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
   ),
   url_test(
     "/en-US/docs/Core_JavaScript_1.5_Guide",
-    "en-US/docs/Web/JavaScript/Guide"
+    "/en-US/docs/Web/JavaScript/Guide"
   )
 );
 

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -1073,3 +1073,24 @@ describe("locale alias redirects", () => {
     it(url, t);
   }
 });
+
+const CORE_JAVASCRIPT_1_5_URLs = [].concat(
+  url_test(
+    "/en-US/docs/Core_JavaScript_1.5_Reference/Operators/Special_Operators/typeof_Operator",
+    "en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
+  ),
+  url_test(
+    "/en-US/docs/Core_JavaScript_1.5_Reference:Operators:Special_Operators:typeof_Operator",
+    "en-US/docs/Web/JavaScript/Reference/Operators/Special_Operators/typeof_Operator"
+  ),
+  url_test(
+    "/en-US/docs/Core_JavaScript_1.5_Guide",
+    "en-US/docs/Web/JavaScript/Guide"
+  )
+);
+
+describe("Core_JavaScript_1.5 redirects", () => {
+  for (const [url, t] of CORE_JAVASCRIPT_1_5_URLs) {
+    it(url, t);
+  }
+});


### PR DESCRIPTION
Part of #2697

@fiji-flo I'm not sure what I'm doing with the fundamental redirects. This is my first ever attempt in there. 
But I'm not looking for perfection here. There are no active links (except those 2 in the obscure Firefox 3.5 release docs) to these so if we get some not perfectly, I'm not that bothered. 
But being able to not have to S3 upload 1,246 redirects every day feels like a win for the planet. 