### PR TITLE
Chore: add eslint one-var rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,9 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2019,
   },
-  rules: {},
+  rules: {
+    "one-var": ["error", "never"],
+  },
   settings: {
     node: {
       allowModules: ["expect-puppeteer"],

--- a/build/git-history.js
+++ b/build/git-history.js
@@ -36,8 +36,8 @@ function getFromGit(contentRoot = CONTENT_ROOT) {
   );
 
   const map = new Map();
-  let date = null,
-    hash = null;
+  let date = null;
+  let hash = null;
   // Even if we specified the `-z` option to `git log ...` above, sometimes
   // it seems `git log` prefers to use a newline character.
   // At least as of git version 2.28.0 (Dec 2020). So let's split on both

--- a/kumascript/src/api/wiki.js
+++ b/kumascript/src/api/wiki.js
@@ -130,12 +130,12 @@ module.exports = {
     return process_array(null, pages, depth, ordered != 0, this.env.locale);
 
     function chunkify(t) {
-      var tz = [],
-        x = 0,
-        y = -1,
-        n = 0,
-        i,
-        j;
+      var tz = [];
+      var x = 0;
+      var y = -1;
+      var n = 0;
+      var i;
+      var j;
 
       while ((i = (j = t.charAt(x++)).charCodeAt(0))) {
         var m = i == 46 || (i >= 48 && i <= 57);
@@ -154,8 +154,8 @@ module.exports = {
 
       for (let x = 0; aa[x] && bb[x]; x++) {
         if (aa[x] !== bb[x]) {
-          var c = Number(aa[x]),
-            d = Number(bb[x]);
+          var c = Number(aa[x]);
+          var d = Number(bb[x]);
           if (c == aa[x] && d == bb[x]) {
             return c - d;
           } else return aa[x] > bb[x] ? 1 : -1;
@@ -170,8 +170,8 @@ module.exports = {
 
       for (let x = 0; aa[x] && bb[x]; x++) {
         if (aa[x] !== bb[x]) {
-          var c = Number(aa[x]),
-            d = Number(bb[x]);
+          var c = Number(aa[x]);
+          var d = Number(bb[x]);
           if (c == aa[x] && d == bb[x]) {
             return c - d;
           } else return aa[x] > bb[x] ? 1 : -1;

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -1,10 +1,10 @@
 const { assert, itMacro, describeMacro, lintHTML } = require("./utils");
 
-const fs = require("fs"),
-  path = require("path"),
-  jsdom = require("jsdom"),
-  extend = require("extend"),
-  fixture_dir = path.resolve(__dirname, "fixtures/compat");
+const fs = require("fs");
+const path = require("path");
+const jsdom = require("jsdom");
+const extend = require("extend");
+const fixture_dir = path.resolve(__dirname, "fixtures/compat");
 
 const { JSDOM } = jsdom;
 

--- a/kumascript/tests/macros/jsxref.test.js
+++ b/kumascript/tests/macros/jsxref.test.js
@@ -15,12 +15,12 @@ describeMacro("jsxref", function () {
   itMacro("One argument (simple global object)", function (macro) {
     // Suggested in macro docstring, used on:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime
-    var name = "Date",
-      partial_slug = "Date",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
+    var name = "Date";
+    var partial_slug = "Date";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       if (url === glob_url) {
@@ -40,12 +40,12 @@ describeMacro("jsxref", function () {
   itMacro("One argument (method by title)", function (macro) {
     // Used on:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse
-    var name = "Array.prototype.join()",
-      partial_slug = "Array/join",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
+    var name = "Array.prototype.join()";
+    var partial_slug = "Array/join";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       if (url === glob_url) {
@@ -66,12 +66,12 @@ describeMacro("jsxref", function () {
     // Used on:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
     // {{jsxref("Statements/function", "function statement")}}
-    var name = "function statement",
-      partial_slug = "Statements/function",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
+    var name = "function statement";
+    var partial_slug = "Statements/function";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       if (url === glob_url) {
@@ -92,11 +92,12 @@ describeMacro("jsxref", function () {
     // Used on:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators
     // {{jsxref("Operators/yield", "yield")}}
-    var name = "yield",
-      partial_slug = "Operators/yield",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected = '<a href="' + ref_url + '">' + "<code>" + name + "</code></a>";
+    var name = "yield";
+    var partial_slug = "Operators/yield";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + ref_url + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       if (url === ref_url) {
@@ -117,19 +118,13 @@ describeMacro("jsxref", function () {
     // Used on:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of
     // {{jsxref("Statements/for...in", "array iteration and for...in", "#Array_iteration_and_for...in")}}
-    var name = "array iteration and for...in",
-      partial_slug = "Statements/for...in",
-      anchor = "#Array_iteration_and_for...in",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' +
-        glob_url +
-        anchor +
-        '">' +
-        "<code>" +
-        name +
-        "</code></a>";
+    var name = "array iteration and for...in";
+    var partial_slug = "Statements/for...in";
+    var anchor = "#Array_iteration_and_for...in";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + glob_url + anchor + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       url = getPathname(url);
@@ -157,21 +152,21 @@ describeMacro("jsxref", function () {
       // Used on:
       // https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Array/prototype
       // {{jsxref("Global_Objects/Array", "Array", "массива")}}
-      var name = "Array",
-        partial_slug = "Global_Objects/Array",
-        anchor = "массива",
-        js_ref_ru_url = "/ru/docs/" + js_ref_slug,
-        ref_url = js_ref_ru_url + partial_slug,
-        glob_url = js_ref_ru_url + "Global_Objects/" + partial_slug,
-        expected =
-          '<a href="' +
-          glob_url +
-          "#" +
-          "%D0%BC%D0%B0%D1%81%D1%81%D0%B8%D0%B2%D0%B0" +
-          '">' +
-          "<code>" +
-          name +
-          "</code></a>";
+      var name = "Array";
+      var partial_slug = "Global_Objects/Array";
+      var anchor = "массива";
+      var js_ref_ru_url = "/ru/docs/" + js_ref_slug;
+      var ref_url = js_ref_ru_url + partial_slug;
+      var glob_url = js_ref_ru_url + "Global_Objects/" + partial_slug;
+      var expected =
+        '<a href="' +
+        glob_url +
+        "#" +
+        "%D0%BC%D0%B0%D1%81%D1%81%D0%B8%D0%B2%D0%B0" +
+        '">' +
+        "<code>" +
+        name +
+        "</code></a>";
 
       macro.ctx.env.locale = "ru";
 
@@ -201,11 +196,11 @@ describeMacro("jsxref", function () {
       // Used on:
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
       // {{jsxref("Operators/function", "function expressions", "", 1)}}
-      var name = "function expressions",
-        partial_slug = "Operators/function",
-        ref_url = js_ref_url + partial_slug,
-        glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-        expected = '<a href="' + ref_url + '">' + name + "</a>";
+      var name = "function expressions";
+      var partial_slug = "Operators/function";
+      var ref_url = js_ref_url + partial_slug;
+      var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+      var expected = '<a href="' + ref_url + '">' + name + "</a>";
 
       macro.ctx.info.getPageByURL = jest.fn((url) => {
         if (url === ref_url) {
@@ -230,12 +225,12 @@ describeMacro("jsxref", function () {
     // Double-quotes are replaced with &quot;. Used on:
     // https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/38
     // {{jsxref("Function/name", "name")}}
-    var name = "name",
-      partial_slug = "Function/name",
-      ref_url = js_ref_url + partial_slug,
-      glob_url = js_ref_url + "Global_Objects/" + partial_slug,
-      expected =
-        '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
+    var name = "name";
+    var partial_slug = "Function/name";
+    var ref_url = js_ref_url + partial_slug;
+    var glob_url = js_ref_url + "Global_Objects/" + partial_slug;
+    var expected =
+      '<a href="' + glob_url + '">' + "<code>" + name + "</code></a>";
 
     macro.ctx.info.getPageByURL = jest.fn((url) => {
       if (url === glob_url) {


### PR DESCRIPTION
Recently during a review @peterbe mentioned that MDN avoids multi-variable declarations. (I was not aware of this at the time.) This PR adds [`one-var`](https://eslint.org/docs/rules/one-var) Eslint rule to enforce this convention.

For example, instead of this:
```
let a, b;
```
contributors should write this:
```
let a;
let b;
```

This rule is automatically fixable by Eslint, so it will never cause trouble even for the most novice contributors.

I created this PR just by adding a line to `.eslintrc.js` and running Eslint with `--fix`. Eslint did the rest automatically!