### PR TITLE
bad es indexing when with dots

### DIFF
--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -225,13 +225,34 @@ def search_index(ctx, buildroot: Path, **kwargs):
             # The reason we're not throwing an error is to make it super convenient
             # to call this command, from bash, without first having to check and figure
             # out if the relevant environment variables are available.
-            log.warning("DEPLOYER_ELASTICSEARCH_URL or --host not set or empty")
+            log.warning("DEPLOYER_ELASTICSEARCH_URL or --url not set or empty")
             return
-        raise Exception("host not set")
+        raise Exception("url not set")
     search.index(
         buildroot,
         url,
         update=kwargs["update"],
         no_progressbar=kwargs["no_progressbar"],
         priority_prefixes=kwargs["priority_prefix"],
+    )
+
+
+@cli.command()
+@click.option(
+    "--url",
+    help="Elasticsearch URL (if not env var ELASTICSEARCH_URL)",
+    default=ELASTICSEARCH_URL,
+    show_default=False,
+)
+@click.argument("text")
+@click.argument("analyzer")
+@click.pass_context
+def search_analyze(ctx, text, analyzer, **kwargs):
+    url = kwargs["url"]
+    if not url:
+        raise Exception("url not set")
+    search.analyze(
+        url,
+        text,
+        analyzer,
     )

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -244,11 +244,10 @@ def search_index(ctx, buildroot: Path, **kwargs):
     default=ELASTICSEARCH_URL,
     show_default=False,
 )
+@click.option("--analyzer", "-a", default="text_analyzer", show_default=True)
 @click.argument("text")
-@click.argument("analyzer")
 @click.pass_context
-def search_analyze(ctx, text, analyzer, **kwargs):
-    url = kwargs["url"]
+def search_analyze(ctx, text, analyzer, url):
     if not url:
         raise Exception("url not set")
     search.analyze(

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -245,11 +245,20 @@ def analyze(
     text: str,
     analyzer: str,
 ):
-    # We can confidently use a single host here because we're not searching
-    # a cluster.
+    # We can confidently use a single host here because we're not searching a cluster.
     connections.create_connection(hosts=[url])
-    # connection = connections.get_connection()
     index = Document._index
-    print(
-        json.dumps(index.analyze(body={"text": text, "analyzer": analyzer}), indent=2)
-    )
+    analysis = index.analyze(body={"text": text, "analyzer": analyzer})
+    if "tokens" in analysis:
+        keys = None
+        for token in analysis["tokens"]:
+            if keys is None:
+                keys = token.keys()
+            longest_key = max(len(x) for x in keys)
+            print()
+            for key in keys:
+                print(f"{key:{longest_key + 1}} {token[key]!r}")
+
+    else:
+        # Desperate if it's not a list of tokens
+        print(json.dumps(analysis, indent=2))

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -238,3 +238,18 @@ def html_strip(html):
             tag.decompose()
     text = tree.body.text()
     return "\n".join(x.strip() for x in text.splitlines() if x.strip())
+
+
+def analyze(
+    url: str,
+    text: str,
+    analyzer: str,
+):
+    # We can confidently use a single host here because we're not searching
+    # a cluster.
+    connections.create_connection(hosts=[url])
+    # connection = connections.get_connection()
+    index = Document._index
+    print(
+        json.dumps(index.analyze(body={"text": text, "analyzer": analyzer}), indent=2)
+    )

--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -5,6 +5,7 @@ from elasticsearch_dsl import (
     Keyword,
     Text,
     analyzer,
+    token_filter,
 )
 
 """
@@ -27,32 +28,53 @@ code) it won't take effect until you rebuild the index. So you might need to run
 
 """
 
+# This creates a token filter which is a "ruleset" that determines how any
+# token should be expanded. For example, "front-end" becomes "front" and "end".
+# There are many options to pick and each one needs to be carefully considered.
+# To get a complete list of all the options, see the documentation at:
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-word-delimiter-tokenfilter.html
+yari_word_delimiter = token_filter(
+    "yari_word_delimiter",
+    type="word_delimiter",
+    # When it splits on 'Array.prototype.forEach' it first of all becomes
+    # 'array', 'protoype', and 'foreach'. But also, still includes
+    # as a word 'array.prototype.foreach'.
+    # With this configuration we'll get good matches for both
+    # 'array foreach' and if people type the full 'array.prototype.foreach'.
+    preserve_original=True,
+    # Otherwise things like 'WebGL' becomes 'web' and 'gl'.
+    # And 'forEach' becomes 'each' because 'for' is a stopword.
+    split_on_case_change=False,
+    # Otherwise things like '3D' would be a search for '3' || 'D'.
+    split_on_numerics=False,
+)
+
 text_analyzer = analyzer(
     "text_analyzer",
     tokenizer="standard",
     # The "asciifolding" token filter makes it so that
     # typing "bézier" becomes the same as searching for "bezier"
     # https://www.elastic.co/guide/en/elasticsearch/reference/7.9/analysis-asciifolding-tokenfilter.html
-    # The "elison" token filter removes elisons from the text.
-    # For example "l'avion" becomes "avion".
-    # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html
-    filter=["word_delimiter", "elision", "lowercase", "stop", "asciifolding"],
-    # char_filter=["html_strip"],
-)
-
-html_text_analyzer = analyzer(
-    "html_text_analyzer",
-    tokenizer="standard",
-    filter=["elison", "lowercase", "asciifolding", "stop", "snowball"],
-    # It's important that you don't use `char_filter=["html_strip"]`
-    # on the titles. For example, there are titles like `<video>`.
-    # If you do `GET /_analyze` on that with or without the html_strip
-    # char filter is the difference between getting `["video"]` and `[]`.
+    filter=[
+        yari_word_delimiter,
+        # The "elison" token filter removes elisons from the text.
+        # For example "l'avion" becomes "avion".
+        # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html
+        "elision",
+        "lowercase",
+        "stop",
+        # This makes it so you can search for either 'bézier' or 'bezier',
+        # and end up matching to 'Bézier curve'.
+        "asciifolding",
+    ],
+    # Note that we don't use the `html_strip` char_filter.
+    # With that, we'd lose some of the valueable characters like: `<video>` which
+    # is an actual title.
 )
 
 
 class Document(ESDocument):
-    title = Text(required=True, analyzer=html_text_analyzer)
+    title = Text(required=True, analyzer=text_analyzer)
     body = Text(analyzer=text_analyzer)
     summary = Text(analyzer=text_analyzer)
     locale = Keyword()

--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -7,20 +7,43 @@ from elasticsearch_dsl import (
     analyzer,
 )
 
+"""
+A great way to debug analyzers is with the `Document._index.analyze()` API which
+is a convenient abstraction for the Elasticsearch Analyze API
+https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-analyze.html
+
+But you can also use the Deployer CLI tool. For example:
+
+    poetry run deployer search-analyze "l'avion" html_text_analyzer
+
+An important thing to note is that if you change the analyzers (here in the Python
+code) it won't take effect until you rebuild the index. So you might need to run
+
+    # before
+    poetry run deployer search-analyze "l'avion" html_text_analyzer
+    poetry run deployer search-index ../client/build
+    # after
+    poetry run deployer search-analyze "l'avion" html_text_analyzer
+
+"""
+
 text_analyzer = analyzer(
     "text_analyzer",
     tokenizer="standard",
     # The "asciifolding" token filter makes it so that
     # typing "bézier" becomes the same as searching for "bezier"
     # https://www.elastic.co/guide/en/elasticsearch/reference/7.9/analysis-asciifolding-tokenfilter.html
-    filter=["lowercase", "stop", "asciifolding"],
+    # The "elison" token filter removes elisons from the text.
+    # For example "l'avion" becomes "avion".
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-elision-tokenfilter.html
+    filter=["word_delimiter", "elision", "lowercase", "stop", "asciifolding"],
     # char_filter=["html_strip"],
 )
 
 html_text_analyzer = analyzer(
     "html_text_analyzer",
     tokenizer="standard",
-    filter=["lowercase", "asciifolding", "stop", "snowball"],
+    filter=["elison", "lowercase", "asciifolding", "stop", "snowball"],
     # It's important that you don't use `char_filter=["html_strip"]`
     # on the titles. For example, there are titles like `<video>`.
     # If you do `GET /_analyze` on that with or without the html_strip


### PR DESCRIPTION
Fixes #7752

Basically, now http://localhost.org:8000/en-US/search?q=Array+foreach works as expected. And I wrote a little CLI debugging tool to better understand how the token filters end up. For example:

```
▶ DEPLOYER_ELASTICSEARCH_URL=localhost:9200 poetry run deployer search-analyze  'Array.prototype.forEach'

token         'array.prototype.foreach'
start_offset  0
end_offset    23
type          '<ALPHANUM>'
position      0

token         'array'
start_offset  0
end_offset    5
type          '<ALPHANUM>'
position      0

token         'prototype'
start_offset  6
end_offset    15
type          '<ALPHANUM>'
position      1

token         'foreach'
start_offset  16
end_offset    23
type          '<ALPHANUM>'
position      2

```

This now means it'll break up that into:
- `array.prototype.foreach`
- `array`
- `prototype`
- `foreach`

(And without the `split_on_case_change` the `forEach` part would have become `for` and `each` and `WebGL` would become `web` and `gl`)

Words like `3D` become just `3d` instead of `3` and `d`. See http://localhost.org:8000/en-US/search?q=2d
