### PR TITLE
Adding Element Timing spec

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -1365,6 +1365,10 @@
       "inh": "",
       "impl": []
     },
+    "PerformanceElementTiming": {
+      "inh": "PerformanceEntry",
+      "impl": []
+    },
     "PerformanceLongTaskTiming": {
       "inh": "PerformanceEntry",
       "impl": []

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -729,6 +729,11 @@
     "url": "https://www.w3.org/TR/dom/",
     "status": "Obsolete"
   },
+  "Element Timing API": {
+    "name": "Element Timing",
+    "url": "https://wicg.github.io/element-timing/",
+    "status": "ED"
+  },
   "Element Traversal": {
     "name": "Element Traversal Specification",
     "url": "https://www.w3.org/TR/ElementTraversal/",


### PR DESCRIPTION
Adds: https://wicg.github.io/element-timing and the inheritance data for the `PerformanceElementTiming` interface.