### PR TITLE
Fix: gather-git-history now works on Windows

### DIFF
--- a/build/git-history.js
+++ b/build/git-history.js
@@ -48,7 +48,9 @@ function getFromGit(contentRoot = CONTENT_ROOT) {
       hash = data[0];
       date = new Date(data[1]);
     } else if (line) {
-      const relPath = path.relative(realContentRoot, path.join(repoRoot, line));
+      let relPath = path.relative(realContentRoot, path.join(repoRoot, line));
+      // Normalize the relative path on Windows, which uses \ as a path separator.
+      if (path.sep === "\\") relPath = relPath.replace(/\\/g, "/");
       map.set(relPath, { date, hash });
     }
   }

--- a/content/document.js
+++ b/content/document.js
@@ -240,9 +240,10 @@ const read = memoize((folder) => {
 
   // The last-modified is always coming from the git logs. Independent of
   // which root it is.
-  const gitHistory = getGitHistories(root, locale).get(
-    path.relative(root, filePath)
-  );
+  let gitHistoryKey = path.relative(root, filePath);
+  // Normalize the relative path on Windows, which uses \ as a path separator.
+  if (path.sep === "\\") gitHistoryKey = gitHistoryKey.replace(/\\/g, "/");
+  const gitHistory = getGitHistories(root, locale).get(gitHistoryKey);
   let modified = (gitHistory && gitHistory.modified) || null;
   const hash = (gitHistory && gitHistory.hash) || null;
   // Use the wiki histories for a list of legacy contributors.


### PR DESCRIPTION
Better version of #2663.