### PR TITLE
optimize the ssr bundling

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 server: yarn start:dev-server
 type-check: cd client && tsc --noEmit --watch
 web: yarn start:client
+ssr: yarn watch:ssr

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier-format": "prettier --write \"**/*.{js,ts,tsx,json,scss,html}\"",
     "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -d client/build/en-us/_spas || yarn build --spas-only) && nf -j Procfile.start start",
     "start:client": "cd client && cross-env BROWSER=none PORT=3000 react-scripts start",
-    "start:dev-server": "nodemon server --watch server --watch build --watch content --watch kumascript --ext js",
+    "start:dev-server": "nodemon server --watch server --watch build --watch content --watch kumascript --ext js --watch ssr/dist",
     "start:server": "node server",
     "start:static-server": "cross-env ENV_FILE=testing/.env node server/static.js",
     "test": "yarn prettier-check && yarn test:client && yarn test:kumascript && yarn test:build && yarn test:testing",
@@ -26,7 +26,8 @@
     "test:client": "cd client && tsc --noEmit && react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:kumascript": "jest kumascript",
     "test:testing": "cd testing && jest",
-    "tool": "node tool/cli.js"
+    "tool": "node tool/cli.js",
+    "watch:ssr": "cd ssr && webpack --config webpack.config.js --mode=production --watch"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cross-env NODE_ENV=production node build/cli.js",
     "build:client": "cd client && cross-env INLINE_RUNTIME_CHUNK=false react-scripts build",
-    "build:ssr": "cd ssr && webpack --config webpack.config.js --mode=production",
+    "build:ssr": "cd ssr && webpack --mode=production",
     "dev": "yarn prepare-build && nf -j Procfile.dev start",
     "eslint": "eslint .",
     "filecheck": "cd filecheck && node cli.js",
@@ -27,7 +27,7 @@
     "test:kumascript": "jest kumascript",
     "test:testing": "cd testing && jest",
     "tool": "node tool/cli.js",
-    "watch:ssr": "cd ssr && webpack --config webpack.config.js --mode=production --watch"
+    "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "braces": "^3.0.2",
-    "clean-webpack-plugin": "^3.0.0",
     "cross-env": "^7.0.3",
     "diff": "^5.0.0",
     "downshift": "^6.1.0",

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -232,7 +232,6 @@ export default function render(
     }
   }
 
-  $("title").text(pageTitle);
   const $title = $("title");
   $title.text(pageTitle);
 

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -1,8 +1,7 @@
 const path = require("path");
 
 const nodeExternals = require("webpack-node-externals");
-const { CleanWebpackPlugin } = require("clean-webpack-plugin");
-// const webpack = require("webpack");
+const webpack = require("webpack");
 
 module.exports = {
   context: path.resolve(__dirname, "."),
@@ -48,11 +47,18 @@ module.exports = {
         test: /\.(png|svg|jpg|gif)$/,
         use: ["file-loader?outputPath=/distimages/"],
       },
-      // { test: /\.css$/, loader: "style-loader!css-loader" }
       { test: /\.(css|scss)$/, loader: "ignore-loader" },
     ],
   },
   externals: nodeExternals(),
   devtool: "source-map",
-  plugins: [new CleanWebpackPlugin()],
+  plugins: [
+    // This makes is so that there is only one `ssr/dist/main.js` (and
+    // `ssr/dis/main.js.map`) file. There's no point in code splitting the
+    // code that is run by Node. Code splitting is something that we do to benefit
+    // users who consume our code through a browser.
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ],
 };

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -17,6 +17,9 @@ module.exports = {
     __dirname: false,
     __filename: false,
   },
+  // See all options here:
+  // https://webpack.js.org/configuration/stats/
+  stats: "errors-warnings",
   resolve: {
     modules: ["node_modules", "src"],
     extensions: ["*", ".js", ".json", ".ts", ".tsx"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,18 +3613,6 @@
     "@types/source-list-map" "*"
     source-map "^0.7.3"
 
-"@types/webpack@^4.4.31":
-  version "4.41.26"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
-  integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
-  dependencies:
-    "@types/anymatch" "*"
-    "@types/node" "*"
-    "@types/tapable" "*"
-    "@types/uglify-js" "*"
-    "@types/webpack-sources" "*"
-    source-map "^0.6.0"
-
 "@types/webpack@^4.41.13", "@types/webpack@^4.41.8":
   version "4.41.21"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.21.tgz#cc685b332c33f153bb2f5fc1fa3ac8adeb592dee"
@@ -5783,14 +5771,6 @@ clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-clean-webpack-plugin@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz#a99d8ec34c1c628a4541567aa7b457446460c62b"
-  integrity sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==
-  dependencies:
-    "@types/webpack" "^4.4.31"
-    del "^4.1.1"
 
 cli-boxes@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
**UPDATE**
I've sneakily added something that makes sense now. This way, as part of running `yarn dev` it will also start `yarn watch:ssr` and I've added `ssr/dist/` to the list of things that `nodeman` watches over for doing Express restarts. 
The net effect is simply; you make a change in `ssr/index.js` or `ssr/render.js` and now the effect takes place simply by reloading the browsers at localhost:5000. Before, it used to be that you kill it and run `yarn dev` all over again for every little change to the `ssr/*.js` files. 


Before:
<img width="745" alt="Screen Shot 2021-01-29 at 9 02 07 AM" src="https://user-images.githubusercontent.com/26739/106284682-83cabc80-6211-11eb-9e13-1958ad982220.png">

After:
<img width="743" alt="Screen Shot 2021-01-29 at 9 01 57 AM" src="https://user-images.githubusercontent.com/26739/106284712-8a593400-6211-11eb-8cdd-72c9dd60860d.png">

This also removes the need for the `CleanWebpackPlugin` plugin because there's virtually no chance of that directory filling up with junk. 