### PR TITLE
glob in Windows breaks document-watch

### DIFF
--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -20,7 +20,7 @@ function postDocumentInfo(filePath, changeType) {
   // notation and use `\` characters.
   // Now, when we use it, it'll work as if `glob.sync()` and returned paths
   // in a fashion that is expected in the OS.
-  filePath = path.split(filePath).join(path.sep);
+  filePath = filePath.split("/").join(path.sep);
 
   try {
     const document = Document.read(

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -14,6 +14,14 @@ function postEvent(type, data = {}) {
 }
 
 function postDocumentInfo(filePath, changeType) {
+  // Note! On Windows, `glob.sync()` will return URLs that always use
+  // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
+  // But the `Document.urlToFolderPath()` function will respect Windows
+  // notation and use `\` characters.
+  // Now, when we use it, it'll work as if `glob.sync()` and returned paths
+  // in a fashion that is expected in the OS.
+  filePath = path.split(filePath).join(path.sep);
+
   try {
     const document = Document.read(
       path.dirname(path.relative(CONTENT_ROOT, filePath))
@@ -26,15 +34,7 @@ function postDocumentInfo(filePath, changeType) {
     // matches the filePath by using `Document.urlToFolderPath`.
     // This would prevent the document from being added in the first place
     // if the filePath doesn't map correctly to the URL, but in reverse.
-    // Note! On Windows, `glob.sync()` will return URLs that always use
-    // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
-    // But the `Document.urlToFolderPath()` function will respect Windows
-    // notation and use `\` characters.
-    if (
-      !filePath.includes(
-        Document.urlToFolderPath(document.url).replace(/\\/g, "/")
-      )
-    ) {
+    if (!filePath.includes(Document.urlToFolderPath(document.url))) {
       console.warn(
         `The slug of ${filePath} doesn't match the folder is located in.`
       );

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -14,14 +14,6 @@ function postEvent(type, data = {}) {
 }
 
 function postDocumentInfo(filePath, changeType) {
-  // Note! On Windows, `glob.sync()` will return URLs that always use
-  // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
-  // But the `Document.urlToFolderPath()` function will respect Windows
-  // notation and use `\` characters.
-  // Now, when we use it, it'll work as if `glob.sync()` and returned paths
-  // in a fashion that is expected in the OS.
-  filePath = filePath.split("/").join(path.sep);
-
   try {
     const document = Document.read(
       path.dirname(path.relative(CONTENT_ROOT, filePath))
@@ -53,7 +45,13 @@ const label = "Populate search-index with glob";
 console.time(label);
 let count = 0;
 glob.sync(SEARCH_PATTERN).forEach((filePath) => {
-  postDocumentInfo(filePath, "added");
+  // Note! On Windows, `glob.sync()` will return URLs that always use
+  // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
+  // But the `Document.urlToFolderPath()` function will respect Windows
+  // notation and use `\` characters.
+  // Now, when we use it, it'll work as if `glob.sync()` and returned paths
+  // in a fashion that is expected in the OS.
+  postDocumentInfo(filePath.split("/").join(path.sep), "added");
   count++;
 });
 postEvent("ready");

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -26,7 +26,15 @@ function postDocumentInfo(filePath, changeType) {
     // matches the filePath by using `Document.urlToFolderPath`.
     // This would prevent the document from being added in the first place
     // if the filePath doesn't map correctly to the URL, but in reverse.
-    if (!filePath.includes(Document.urlToFolderPath(document.url))) {
+    // Note! On Windows, `glob.sync()` will return URLs that always use
+    // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
+    // But the `Document.urlToFolderPath()` function will respect Windows
+    // notation and use `\` characters.
+    if (
+      !filePath.includes(
+        Document.urlToFolderPath(document.url).replace(/\\/g, "/")
+      )
+    ) {
       console.warn(
         `The slug of ${filePath} doesn't match the folder is located in.`
       );


### PR DESCRIPTION
Fixes #2733
Fixes #2732

@hamishwillee If you have the time, do you think you can test this?
You'd have to have a git checkout of this branch of mine of the `yari` repo. You can't test this from the `mdn/content` repo yet. 

I don't have access to Windows to test, but I'm fairly confident it will work. But your functional test-blessing would be great. 