### PR TITLE
fix: Format MacroInvocationError for problem matcher

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -236,11 +236,9 @@ async function buildDocument(document, documentOptions = {}) {
         // message.
         error.updateFileInfo(document.fileInfo);
         throw new Error(
-          `MacroInvocationError trying to parse ${error.filepath}, line ${error.line} column ${error.column} (${error.error.message})`
+          `${error.filepath}:${error.line}:${error.column}: error: MacroInvocationError - ${error.error.message}`
         );
       }
-
-      // Any other unexpected error re-thrown.
       throw error;
     }
 


### PR DESCRIPTION
Hit one of these in https://github.com/mdn/content/runs/1794076830?check_suite_focus=true#step:7:102 and though that if this format is adopted, then a problem matcher like https://github.com/mdn/content/pull/1206/files#diff-25c661e20a38ae8e4610534138256b0595a4703ee1a06430bc22add458e56b8dR7 could be added.
This also format also allows linking to a location from the terminal in VS Code (and others?) https://code.visualstudio.com/Docs/editor/tasks#_defining-a-problem-matcher

Doesn't look like any other errors follow this format right now, but it could be a nice to have for some of the others later down the road so individual lines get a comment via a problem matcher on GitHub PRs