### PR TITLE
don't index pages that don't have a translation_of

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -161,7 +161,9 @@ async function buildDocuments(files = null) {
     // Decide whether it should be indexed (sitemaps, robots meta tag, search-index)
     document.noIndexing =
       (document.isArchive && !document.isTranslated) ||
-      document.metadata.slug === "MDN/Kitchensink";
+      document.metadata.slug === "MDN/Kitchensink" ||
+      (document.metadata.locale !== "en-US" &&
+        document.translations.length === 0);
 
     // Collect non-archived documents' slugs to be used in sitemap building and
     // search index building.


### PR DESCRIPTION
When a translation doesn't even have a working `translation_of` (with or without redirects and/or englishifying slugs) I don't think we should index them. We can argue that we shouldn't even build them, but I wouldn't mind parking that aside until we figure out how to get rid of them.

With this PR, pages like 
https://developer.mozilla.org/es/docs/Web/CSS/Primeros_pasos or https://developer.mozilla.org/ko/docs/MDN/About/MDN_services would still get built, but not included in the `/sitemaps/$locale/sitemap.xml.gz`. 

