### PR TITLE
noIndexing should be reflected in robots meta tag

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -158,11 +158,6 @@ async function buildDocuments(files = null) {
       fs.copyFileSync(filePath, path.join(outPath, path.basename(filePath)));
     }
 
-    // Decide whether it should be indexed (sitemaps, robots meta tag, search-index)
-    document.noIndexing =
-      (document.isArchive && !document.isTranslated) ||
-      document.metadata.slug === "MDN/Kitchensink";
-
     // Collect non-archived documents' slugs to be used in sitemap building and
     // search index building.
     if (!document.noIndexing) {

--- a/build/index.js
+++ b/build/index.js
@@ -461,6 +461,10 @@ async function buildDocument(document, documentOptions = {}) {
 
   doc.pageTitle = getPageTitle(doc);
 
+  // Decide whether it should be indexed (sitemaps, robots meta tag, search-index)
+  doc.noIndexing =
+    (doc.isArchive && !doc.isTranslated) || metadata.slug === "MDN/Kitchensink";
+
   return { doc, liveSamples, fileAttachments, bcdData };
 }
 


### PR DESCRIPTION
Fixes #2766

At first I realized I just need to move those lines `document.noIndexing = ...` so that they appear any time *before* the `renderDocHTML()` which does the actual React SSR part. But then I realized that the stuff in `buildDocuments()` is basically just a wrapper around `buildDocument()` but with the act of writing files to disk. 
By moving it inside the `buildDocument()` function instead, it means that this stuff works when testing from the server. 
Now view-source:http://localhost:5000/en-us/docs/mdn/kitchensink works as expected. 