### PR TITLE
Error in section types in translated-content

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -259,7 +259,8 @@ function _addSingleSectionBCD($) {
   // prose section :(
   if (!dataQuery) {
     // I wish there was a good place to log this!
-    return _addSectionProse($);
+    const [proseSections] = _addSectionProse($);
+    return proseSections;
   }
   const query = dataQuery.replace(/^bcd:/, "");
   const { browsers, data } = packageBCD(query);

--- a/testing/archived-content/files/en-us/busted_bcd_rendering/index.html
+++ b/testing/archived-content/files/en-us/busted_bcd_rendering/index.html
@@ -1,0 +1,20 @@
+---
+title: Busted BCD rendering
+slug: Busted_BCD_rendering
+---
+
+<div class="bc-data">
+  <p>
+    There was a time when the <i>old</i> <code>Compat</code> macro didn't inject
+    the "BCD query" as an <code>id</code> attribute on the
+    <code>&lt;div class=&quot;bc-data&quot;&gt;</code> tag.<br />
+    This would cause problems in Yari when it tried to break up the page into
+    sections.
+  </p>
+  <p>
+    The whole point of this sample fixture data is to verify the fix for
+    <a href="https://github.com/mdn/yari/issues/2785"
+      >https://github.com/mdn/yari/issues/2785</a
+    >.
+  </p>
+</div>

--- a/testing/archived-content/files/en-us/busted_bcd_rendering/wikihistory.json
+++ b/testing/archived-content/files/en-us/busted_bcd_rendering/wikihistory.json
@@ -1,0 +1,4 @@
+{
+  "modified": "2021-02-03T01:01:01.550Z",
+  "contributors": ["peterbe"]
+}


### PR DESCRIPTION
Fixes #2785

Now http://localhost:3000/ar/docs/web/api/navigator.battery works. It didn't before. This is just the first one that would trip it up. Nothing special about that page. 

The fix took a lot longer than it might appear when looking at the PR diff. 
All of this would have entirely been impossible to even happen if we had proper typing in JS. If we had return types on the functions, something like TS would have caught this immediately. :(
Mixed emotions about that. 

I'm confident this unbreaks the complete builds. I'll add an end-to-end test that makes sure that section of the document extractor gets walked. The tests don't need to assert much but it would be nice to include a fixture page that would have at least broken in CI when I worked on https://github.com/mdn/yari/pull/2752