### PR TITLE
remove @include highlighted-link-state()

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -16,12 +16,6 @@
   a {
     display: flex;
     align-items: center;
-
-    &:active {
-      span {
-        @include highlighted-link-state();
-      }
-    }
   }
 
   ol {


### PR DESCRIPTION
Part of #2791

I suspect it happened because we're not running `stylelint` in Yari. Only in mdn-minimalist. 