### PR TITLE
fix: ESlint no-unreachable-loop

### DIFF
--- a/kumascript/tests/macros/utils.js
+++ b/kumascript/tests/macros/utils.js
@@ -180,12 +180,13 @@ function lintHTML(html) {
   if (report.valid) {
     return null;
   }
+  let result = "";
   for (const messages of report.results.map((result) => result.messages)) {
     for (const message of messages) {
-      // console.log(message);
-      return message.message;
+      result += message.message;
     }
   }
+  return result;
 }
 
 // ### Exported public API


### PR DESCRIPTION
Changed behaviour to match comment block. Since it's for testing the "first" result might be enough and just suppressed though