### PR TITLE
min height in EmbedLiveSample iframes

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -24,6 +24,19 @@ var allowedFeatures = $6;
 
 var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
 
+var MIN_HEIGHT = 60;
+// Forcibly make sure the height is at least `MIN_HEIGHT` pixels.
+// In old MDN, there was less padding in the live samples so it was then OK
+// to have a iframe height of 30px. This is too cramped and it's easier
+// and safer to make sure the height is at least 60px to make sure it
+// looks presently "uncramped" within our design system.
+// Note that if the 'height' is a string like '100%' it won't be a
+// problem because `parseInt('100%') := 100` which is more than `MIN_HEIGHT`
+// assuming it's value is less than 100.
+if (height && parseInt(height) < MIN_HEIGHT) {
+  height = MIN_HEIGHT;
+}
+
 var sampleUrl = "";
 if (sampleSlug) {
     sampleUrl = `/${env.locale}/docs`;

--- a/kumascript/tests/macros/EmbedLiveSample.test.js
+++ b/kumascript/tests/macros/EmbedLiveSample.test.js
@@ -3,6 +3,10 @@
  */
 const { assert, itMacro, describeMacro, beforeEachMacro } = require("./utils");
 
+// This needs to match what the equivalent is inside the EmbedLiveSample.ejs file.
+// Duplicating it here to avoid hardcoding its number in multiple places.
+const MIN_HEIGHT = 60;
+
 describeMacro("EmbedLiveSample", function () {
   beforeEachMacro(function (macro) {
     macro.ctx.env.live_samples = {
@@ -139,7 +143,7 @@ describeMacro("EmbedLiveSample", function () {
       macro.call("Adding_quotation_marks", "500", "50", ""),
       '<iframe class="live-sample-frame sample-code-frame"' +
         ' id="frame_Adding_quotation_marks" frameborder="0"' +
-        ' width="500" height="50"' +
+        ` width="500" height="${MIN_HEIGHT}"` +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/::before/_samples_/Adding_quotation_marks">' +
         "</iframe>"
     );
@@ -264,7 +268,7 @@ describeMacro("EmbedLiveSample", function () {
       macro.call("sampleNone", 100, 50, "", "", "nobutton"),
       '<iframe class="live-sample-frame nobutton"' +
         ' id="frame_sampleNone" frameborder="0"' +
-        ' width="100" height="50"' +
+        ` width="100" height="${MIN_HEIGHT}"` +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance/_samples_/sampleNone">' +
         "</iframe>"
     );
@@ -284,7 +288,7 @@ describeMacro("EmbedLiveSample", function () {
         ),
         '<iframe class="live-sample-frame &#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
           ' id="frame_sampleNone" frameborder="0"' +
-          ' width="100" height="50"' +
+          ` width="100" height="${MIN_HEIGHT}"` +
           ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance/_samples_/sampleNone">' +
           "</iframe>"
       );


### PR DESCRIPTION
Fixes #2683

This depends on https://github.com/mdn/mdn-minimalist/pull/479
To test this PR in Yari you can simply open `node_modules/@mdn/minimalist/sass/atoms/_examples.scss` and remove the `height` line and visit a bunch of pages that used `EmbedLiveSample`. I think they all look sane now. 