### PR TITLE
force a slight wait after site-search form submission

### DIFF
--- a/testing/tests/sitesearch.test.js
+++ b/testing/tests/sitesearch.test.js
@@ -9,6 +9,8 @@ describe("Site search", () => {
     await page.goto(testURL("/"));
     await expect(page).toFill(SEARCH_SELECTOR, "foo");
     await page.$eval('form[role="search"]', (form) => form.submit());
+    // Force a wait for the lazy-loading
+    await page.waitForNavigation({ waitUntil: "networkidle2" });
     expect(page.url()).toBe(testURL("/en-US/search/?q=foo"));
   });
 


### PR DESCRIPTION
The sitesearch headless tests are fragile as they depend on the timing of the lazy-loaded assets. 
As soon as the [site-search PR](https://github.com/mdn/yari/pull/1473) had been merged, it [failed in CI on `master`](https://github.com/mdn/yari/runs/1863028438?check_suite_focus=true)
This PR fixes the only places where it too prematurely checks that the page URL had changed. 