### PR TITLE
fix: add tabindex=-1 to main element

### DIFF
--- a/client/src/ui/atoms/page-content/index.tsx
+++ b/client/src/ui/atoms/page-content/index.tsx
@@ -15,6 +15,10 @@ export function MainContentContainer({
       id="content"
       className={className}
       role="main"
+      // This is added to ensure that the main element is
+      // focusable. https://github.com/mdn/yari/issues/2755
+      // TypeScript expects this value to be a number
+      tabIndex={-1}
     >
       {children}
     </main>


### PR DESCRIPTION
Add `tabindex=-1` to `main` element to make it focusable for our skip link

fix #2755
