### PR TITLE
Deploy redirects from the archived content

### DIFF
--- a/deployer/src/deployer/constants.py
+++ b/deployer/src/deployer/constants.py
@@ -10,6 +10,7 @@ CI = config("CI", default=False, cast=bool)
 
 CONTENT_ROOT = config("CONTENT_ROOT", default=None)
 CONTENT_TRANSLATED_ROOT = config("CONTENT_TRANSLATED_ROOT", default=None)
+CONTENT_ARCHIVED_ROOT = config("CONTENT_ARCHIVED_ROOT", default=None)
 
 DEFAULT_BUCKET_NAME = config("DEPLOYER_BUCKET_NAME", default="mdn-content-dev")
 DEFAULT_BUCKET_PREFIX = config("DEPLOYER_BUCKET_PREFIX", default="main")

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -7,6 +7,7 @@ from .constants import (
     CI,
     CONTENT_ROOT,
     CONTENT_TRANSLATED_ROOT,
+    CONTENT_ARCHIVED_ROOT,
     DEFAULT_BUCKET_NAME,
     DEFAULT_BUCKET_PREFIX,
     DEFAULT_NO_PROGRESSBAR,
@@ -122,6 +123,13 @@ def whatsdeployed(ctx, directory: Path, output: str):
     callback=validate_optional_directory,
 )
 @click.option(
+    "--content-archived-root",
+    help="The path to the root folder of the archived content (defaults to CONTENT_ARCHIVED_ROOT)",
+    default=CONTENT_ARCHIVED_ROOT,
+    show_default=True,
+    callback=validate_optional_directory,
+)
+@click.option(
     "--no-progressbar",
     help="Don't show the progress bar",
     default=DEFAULT_NO_PROGRESSBAR,
@@ -135,6 +143,8 @@ def upload(ctx, directory: Path, **kwargs):
     content_roots = [kwargs["content_root"]]
     if kwargs["content_translated_root"]:
         content_roots.append(kwargs["content_translated_root"])
+    if kwargs["content_archived_root"]:
+        content_roots.append(kwargs["content_archived_root"])
     ctx.obj.update(kwargs)
     upload_content(directory, content_roots, ctx.obj)
 


### PR DESCRIPTION
Fixes #2879

Note that, thankfully, this doesn't even touch the `upload.py` code. Just a matter of that list `content_roots`. I tested it like this:
```
poetry run deployer upload ../client/build --no-progressbar --content-root=/Users/peterbe/dev/MOZILLA/MDN/content/files --content-translated-root=/Users/peterbe/dev/MOZILLA/MDN/translated-content/files --content-archived-root=/Users/peterbe/dev/MOZILLA/MDN/archived-content/files | tee /tmp/output.log
```
But before I ran it I replaced the `bucket_manager.client.upload_file(...` and `bucket_manager.client.put_object(...` with a temporary `pass` just so I can pretend that I actually uploaded. 

The summary said:
```
Total uploaded redirects: 43,989
```

On a regular [Prod build](https://github.com/mdn/yari/runs/1867543782?check_suite_focus=true) it usually prints:
```
Total uploaded redirects: 31,396
```
which matches what I find here:
```
MOZILLA/MDN/archived-content  main ✔
▶ fd _redirects.txt | xargs wc -l
      10 files/ar/_redirects.txt
      10 files/ca/_redirects.txt
      26 files/de/_redirects.txt
       2 files/el/_redirects.txt
    9566 files/en-us/_redirects.txt
     295 files/es/_redirects.txt
       9 files/fa/_redirects.txt
       7 files/fi/_redirects.txt
     915 files/fr/_redirects.txt
       4 files/hu/_redirects.txt
       8 files/id/_redirects.txt
      24 files/it/_redirects.txt
     807 files/ja/_redirects.txt
     107 files/ko/_redirects.txt
       2 files/my/_redirects.txt
       8 files/nl/_redirects.txt
     409 files/pl/_redirects.txt
      26 files/pt-br/_redirects.txt
      41 files/pt-pt/_redirects.txt
      44 files/ru/_redirects.txt
       4 files/th/_redirects.txt
       6 files/tr/_redirects.txt
       7 files/uk/_redirects.txt
       3 files/vi/_redirects.txt
     244 files/zh-cn/_redirects.txt
      34 files/zh-tw/_redirects.txt
   12618 total
```
