### PR TITLE
make page-not-found more lazy loading

### DIFF
--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { useLocation, useParams } from "react-router-dom";
+import useSWR from "swr";
+
+import { Doc } from "../document/types";
+import LANGUAGES_RAW from "../languages.json";
+
+const LANGUAGES = new Map(
+  Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
+    return [locale.toLowerCase(), data];
+  })
+);
+
+// TODO IDEA
+// Use https://www.npmjs.com/package/string-similarity
+// to download the /$locale/search-index.json to get a list of all possible
+// URLs and see if we can compare the current URL with one of those
+// for making a great suggestion,
+// like "Did you mean: <a href=$url>$doctitle</a>?"
+
+export default function FallbackLink({ url }: { url: string }) {
+  const { locale } = useParams();
+  const location = useLocation();
+
+  const [fallbackCheckURL, setFallbackCheckURL] = React.useState<null | string>(
+    null
+  );
+
+  const { error, data: document } = useSWR<null | Doc>(
+    fallbackCheckURL,
+    async (url) => {
+      const response = await fetch(url);
+      if (response.ok) {
+        const { doc } = await response.json();
+        return doc;
+      } else if (response.status === 404) {
+        return null;
+      }
+      throw new Error(`${response.status} on ${url}`);
+    },
+    { revalidateOnFocus: false }
+  );
+
+  React.useEffect(() => {
+    if (url && locale.toLowerCase() !== "en-us") {
+      // What if we attempt to see if it would be something there in English?
+      // We'll use the `index.json` version of the URL
+      let enUSURL = url.replace(`/${locale}/`, "/en-US/");
+      // But of the benefit of local development, devs can use `/_404/`
+      // instead of `/docs/` to simulate getting to the Page not found page.
+      // So remove that when constructing the English index.json URL.
+      enUSURL = enUSURL.replace("/_404/", "/docs/");
+
+      // Lastly, because we're going to append `index.json` always make sure
+      // the URL, up to this point, has a trailing /. The "defensiveness" here
+      // is probably only necessary so it works in production and in local development.
+      if (!enUSURL.endsWith("/")) {
+        enUSURL += "/";
+      }
+      enUSURL += "index.json";
+      setFallbackCheckURL(enUSURL);
+    }
+  }, [url, locale, location]);
+
+  if (error) {
+    return (
+      <div className="fallback-document notecard negative">
+        <h4>Oh no!</h4>
+        <p>
+          Unfortunately, when trying to look to see if there was an English
+          fallback, that check failed. This is either because of a temporary
+          network error or because of a bug.
+        </p>
+        <p>
+          The error was: <code>{error.toString()}</code>
+        </p>
+      </div>
+    );
+  } else if (document) {
+    return (
+      <div className="fallback-document notecard success">
+        <h4>Good news!</h4>
+        <p>
+          The page you requested doesn't exist in{" "}
+          <b>{LANGUAGES.get(locale.toLowerCase())?.English}</b> but it exists in{" "}
+          <b>English</b>
+        </p>
+        <p className="fallback-link">
+          <a href={document.mdn_url}>
+            <b>{document.title}</b>
+            <br />
+            <small>{document.mdn_url}</small>
+          </a>
+        </p>
+      </div>
+    );
+  } else if (document === null) {
+    // It means the lookup "worked" in principle, but there wasn't an English
+    // document there. Bummer. But at least we tried.
+    // Should we say something??
+  }
+
+  return null;
+}

--- a/client/src/page-not-found/index.tsx
+++ b/client/src/page-not-found/index.tsx
@@ -1,17 +1,10 @@
-import React, { useEffect, useState } from "react";
-import { useLocation, useParams } from "react-router-dom";
-import useSWR from "swr";
+import React from "react";
+import { useLocation } from "react-router-dom";
 
-import LANGUAGES_RAW from "../languages.json";
-import { Doc } from "../document/types";
 import { PageContentContainer } from "../ui/atoms/page-content";
 import "./index.scss";
 
-const LANGUAGES = new Map(
-  Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
-    return [locale.toLowerCase(), data];
-  })
-);
+const FallbackLink = React.lazy(() => import("./fallback-link"));
 
 // NOTE! To hack on this component, you have to use a trick to even get to this
 // unless you use the Express server on localhost:5000.
@@ -22,23 +15,15 @@ const LANGUAGES = new Map(
 
 export function PageNotFound() {
   const location = useLocation();
-  const [url, setURL] = useState("");
+  const [url, setURL] = React.useState("");
 
-  useEffect(() => {
+  React.useEffect(() => {
     // If we're in a useEffect, this means we're in a client-side rendering
     // and in that case the current window.location is realistic.
     // When it's server-side rendered, the URL is "fake" just to generate
     // the "empty template" page.
     setURL(location.pathname);
   }, [location]);
-
-  // TODO IDEA
-  // Use https://www.npmjs.com/package/string-similarity
-  // to download the /$locale/search-index.json to get a list of all possible
-  // URLs and see if we can compare the current URL with one of those
-  // for making a great suggestion,
-  // like "Did you mean: <a href=$url>$doctitle</a>?"
-  // All of this should be done in a lazy-loaded module.
 
   return (
     <div className="page-not-found">
@@ -52,7 +37,11 @@ export function PageNotFound() {
           </p>
         )}
 
-        {url && <FallbackLink url={url} />}
+        {url && (
+          <React.Suspense fallback={null}>
+            <FallbackLink url={url} />
+          </React.Suspense>
+        )}
 
         <p>
           <a href="/">Go back to the home page</a>
@@ -60,87 +49,4 @@ export function PageNotFound() {
       </PageContentContainer>
     </div>
   );
-}
-
-function FallbackLink({ url }: { url: string }) {
-  const { locale } = useParams();
-  const location = useLocation();
-
-  const [fallbackCheckURL, setFallbackCheckURL] = useState<null | string>(null);
-
-  const { error, data: document } = useSWR<null | Doc>(
-    fallbackCheckURL,
-    async (url) => {
-      const response = await fetch(url);
-      if (response.ok) {
-        const { doc } = await response.json();
-        return doc;
-      } else if (response.status === 404) {
-        return null;
-      }
-      throw new Error(`${response.status} on ${url}`);
-    },
-    { revalidateOnFocus: false }
-  );
-
-  useEffect(() => {
-    if (url && locale.toLowerCase() !== "en-us") {
-      // What if we attempt to see if it would be something there in English?
-      // We'll use the `index.json` version of the URL
-      let enUSURL = url.replace(`/${locale}/`, "/en-US/");
-      // But of the benefit of local development, devs can use `/_404/`
-      // instead of `/docs/` to simulate getting to the Page not found page.
-      // So remove that when constructing the English index.json URL.
-      enUSURL = enUSURL.replace("/_404/", "/docs/");
-
-      // Lastly, because we're going to append `index.json` always make sure
-      // the URL, up to this point, has a trailing /. The "defensiveness" here
-      // is probably only necessary so it works in production and in local development.
-      if (!enUSURL.endsWith("/")) {
-        enUSURL += "/";
-      }
-      enUSURL += "index.json";
-      setFallbackCheckURL(enUSURL);
-    }
-  }, [url, locale, location]);
-
-  if (error) {
-    return (
-      <div className="fallback-document notecard negative">
-        <h4>Oh no!</h4>
-        <p>
-          Unfortunately, when trying to look to see if there was an English
-          fallback, that check failed. This is either because of a temporary
-          network error or because of a bug.
-        </p>
-        <p>
-          The error was: <code>{error.toString()}</code>
-        </p>
-      </div>
-    );
-  } else if (document) {
-    return (
-      <div className="fallback-document notecard success">
-        <h4>Good news!</h4>
-        <p>
-          The page you requested doesn't exist in{" "}
-          <b>{LANGUAGES.get(locale.toLowerCase())?.English}</b> but it exists in{" "}
-          <b>English</b>
-        </p>
-        <p className="fallback-link">
-          <a href={document.mdn_url}>
-            <b>{document.title}</b>
-            <br />
-            <small>{document.mdn_url}</small>
-          </a>
-        </p>
-      </div>
-    );
-  } else if (document === null) {
-    // It means the lookup "worked" in principle, but there wasn't an English
-    // document there. Bummer. But at least we tried.
-    // Should we say something??
-  }
-
-  return null;
 }


### PR DESCRIPTION
Part of #2877

You can trigger that stuff by opening http://localhost:5000/sv-SE/_404/Web/JavaScript/Guide/Introduction which will 
trigger a lazy-load chunk. 

All I really did was to extract a bunch of code from the `index.tsx` and put it into `fallback-link.tsx`. Then, I also refactored some `React` imports so it's using `React. useEffect(` instead of `useEffect`. 