### PR TITLE
restore some security-related headers

### DIFF
--- a/deployer/aws-lambda/content-origin-response/index.js
+++ b/deployer/aws-lambda/content-origin-response/index.js
@@ -9,18 +9,36 @@ exports.handler = async (event) => {
    */
   const request = event.Records[0].cf.request;
   const response = event.Records[0].cf.response;
+  const uri = request.uri.toLowerCase();
 
-  // The live-sample pages should never respond with an X-Frame-Options
-  // header, because they're explicitly created for rendering within an
-  // iframe on a different origin.
-  if (!request.uri.toLowerCase().includes("/_samples_/")) {
-    response.headers["x-frame-options"] = [
-      { key: "X-Frame-Options", value: "DENY" },
+  // This condition exists to accommodate AWS origin-groups, which
+  // include two origins, the primary and the secondary, where the
+  // secondary origin is only attempted if the primary fails. Since
+  // origin groups introduce multiple origins for the same CloudFront
+  // behavior, we have to ensure we only make adjustments for custom
+  // S3 origins.
+  if (
+    request.origin.custom &&
+    request.origin.custom.domainName.includes("s3")
+  ) {
+    // The live-sample pages should never respond with an X-Frame-Options
+    // header, because they're explicitly created for rendering within an
+    // iframe on a different origin.
+    if (!uri.includes("/_samples_/")) {
+      response.headers["x-frame-options"] = [
+        { key: "X-Frame-Options", value: "DENY" },
+      ];
+    }
+    response.headers["x-xss-protection"] = [
+      { key: "X-XSS-Protection", value: "1; mode=block" },
+    ];
+    response.headers["x-content-type-options"] = [
+      { key: "X-Content-Type-Options", value: "nosniff" },
+    ];
+    response.headers["strict-transport-security"] = [
+      { key: "Strict-Transport-Security", value: "max-age=63072000" },
     ];
   }
-  response.headers["strict-transport-security"] = [
-    { key: "Strict-Transport-Security", value: "max-age=63072000" },
-  ];
 
   return response;
 };


### PR DESCRIPTION
Part of #2884

This partially addresses #2884, but needs to be added to the proper Cloudfront (CF) behaviors on `dev` and `prod` to fully address #2884. It has already been added to the CF behaviors on `stage` for testing (and the `stage` CF cache has been invalidated).