### PR TITLE
Fix compat data used for determining cell color in notes

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -315,7 +315,7 @@ function getNotes(
             <div className="bc-notes-wrapper">
               <dt
                 className={`bc-supports-${getSupportClassName(
-                  support
+                  item
                 )} bc-supports`}
               >
                 <CellText support={item} />


### PR DESCRIPTION
Follow-up to https://github.com/mdn/yari/pull/2892 which will make this problem more visible but you can already see it here:

https://developer.mozilla.org/en-US/docs/Web/API/Window/customElements

If you expand, you find historic support and these have removal versions and should appear red. They don't currently. 
I believe the function calls the wrong data.

Here's how it should look like:

![Bildschirmfoto 2021-02-15 um 12 59 52](https://user-images.githubusercontent.com/349114/107943953-b6a0de80-6f8d-11eb-9bbe-259870390fc1.png)
