### PR TITLE
Fix: Decode string before using it

### DIFF
--- a/kumascript/macros/jsxref.ejs
+++ b/kumascript/macros/jsxref.ejs
@@ -38,7 +38,7 @@ if ((api.indexOf("..") === -1) && (api.indexOf(".") !== -1)) { // Handle try...c
     basePath += l10n.slug + '/';
     URL += l10n.slug + '/' + $0;
 } else {
-    URL += $0;
+    URL += web.safeDecodeURIComponent($0);
 }
 
 let anchor = $2 || '';


### PR DESCRIPTION
In the [`Expressions and operators`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators) page, the [`new.target`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new.target) and [`import.meta`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import.meta) references aren't linked properly due to the escaped dot in the URL not getting unescaped

This PR fixes the linking issue by trying to unescape the URI before sending it to `web.smartLink`