### PR TITLE
unbreak NPM publishing

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -93,7 +93,11 @@ function LoadingFallback({ message }: { message?: string }) {
 export function App(appProps) {
   useDebugGA();
 
-  const homePage = CRUD_MODE ? <WritersHomepage /> : <Homepage {...appProps} />;
+  // When preparing a build for use in the NPM package, CRUD_MODE is always true.
+  // But if the App is loaded from the code that builds the SPAs, then `isServer`
+  // is true. So you have to have `isServer && CRUD_MODE` at the same time.
+  const homePage =
+    !isServer && CRUD_MODE ? <WritersHomepage /> : <Homepage {...appProps} />;
 
   const routes = (
     <Routes>


### PR DESCRIPTION
Fixes #2939

How I tested it:
```
export REACT_APP_CRUD_MODE=true
yarn prepare-build
```
(this is essentially what `npm-publish.yml` does)

Also, after this PR, you when the `yarn prepare-build` has finished you can type `yarn start` (not `yarn dev`) and on <http://localhost:5000> you get the Writers' Homepage. 

I also checked that regular `yarn dev` (without any extra env vars) still works as expected on <http://localhost:3000> and <http://localhost:5000>. 