### PR TITLE
remove ga.send() debugging

### DIFF
--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -45,8 +45,6 @@ declare global {
 function ga(...args) {
   if (typeof window === "object" && typeof window.ga === "function") {
     window.ga(...args);
-  } else {
-    console.debug("analytics (not sent)", ...args);
   }
 }
 


### PR DESCRIPTION
This was a leftover from the days when we [added Google Analytics to yari](https://github.com/mdn/yari/commit/369a95e0d8bd845642eb3d8f0ee5c4b44bb13b7d).

If someone really needs to debug this, they can add it in the day they're hacking on it. 