### PR TITLE
Add more descriptive tooltip for <= versions

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -101,14 +101,19 @@ function NonBreakingSpace() {
   return <>{"\u00A0"}</>;
 }
 
-function labelFromString(version: string | boolean | null | undefined) {
+function labelFromString(
+  version: string | boolean | null | undefined,
+  action: string
+) {
   if (typeof version !== "string") {
     return <>{"?"}</>;
   }
   if (!version.startsWith("≤")) {
     return <>{version}</>;
   }
-  const title = `Supported in version ${version.slice(1)} or earlier.`;
+  const actionDescription = action === "added" ? "starting" : "ending";
+  const versionDescription = `version ${version.slice(1)} or earlier.`;
+  const title = `Exact version unknown: supported ${actionDescription} in ${versionDescription}`;
   return (
     <span title={title}>
       <sup>≤&#xA0;</sup>
@@ -139,7 +144,7 @@ const CellText = React.memo(
         status = { isSupported: "no" };
         break;
       default:
-        status = { isSupported: "yes", label: labelFromString(added) };
+        status = { isSupported: "yes", label: labelFromString(added, "added") };
         break;
     }
 
@@ -148,15 +153,18 @@ const CellText = React.memo(
         isSupported: "no",
         label: (
           <>
-            {labelFromString(added)}
-            <NonBreakingSpace />— {labelFromString(removed)}
+            {labelFromString(added, "added")}
+            <NonBreakingSpace />— {labelFromString(removed, "removed")}
           </>
         ),
       };
     } else if (currentSupport && currentSupport.partial_implementation) {
       status = {
         isSupported: "partial",
-        label: typeof added === "string" ? labelFromString(added) : "Partial",
+        label:
+          typeof added === "string"
+            ? labelFromString(added, "added")
+            : "Partial",
       };
     }
 

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -111,9 +111,9 @@ function labelFromString(
   if (!version.startsWith("≤")) {
     return <>{version}</>;
   }
-  const actionDescription = action === "added" ? "starting" : "ending";
-  const versionDescription = `version ${version.slice(1)} or earlier.`;
-  const title = `Exact version unknown: supported ${actionDescription} in ${versionDescription}`;
+  const actionDescription = action === "removed" ? "ended" : "started";
+  const versionDescription = `version ${version.slice(1)} or earlier`;
+  const title = `Support ${actionDescription} in ${versionDescription} (specific version unknown)`;
   return (
     <span title={title}>
       <sup>≤&#xA0;</sup>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -103,7 +103,7 @@ function NonBreakingSpace() {
 
 function labelFromString(
   version: string | boolean | null | undefined,
-  action: string
+  removed?: boolean
 ) {
   if (typeof version !== "string") {
     return <>{"?"}</>;
@@ -111,7 +111,7 @@ function labelFromString(
   if (!version.startsWith("≤")) {
     return <>{version}</>;
   }
-  const actionDescription = action === "removed" ? "ended" : "started";
+  const actionDescription = removed ? "ended" : "started";
   const versionDescription = `version ${version.slice(1)} or earlier`;
   const title = `Support ${actionDescription} in ${versionDescription} (specific version unknown)`;
   return (
@@ -144,7 +144,7 @@ const CellText = React.memo(
         status = { isSupported: "no" };
         break;
       default:
-        status = { isSupported: "yes", label: labelFromString(added, "added") };
+        status = { isSupported: "yes", label: labelFromString(added) };
         break;
     }
 
@@ -153,18 +153,15 @@ const CellText = React.memo(
         isSupported: "no",
         label: (
           <>
-            {labelFromString(added, "added")}
-            <NonBreakingSpace />— {labelFromString(removed, "removed")}
+            {labelFromString(added)}
+            <NonBreakingSpace />— {labelFromString(removed, true)}
           </>
         ),
       };
     } else if (currentSupport && currentSupport.partial_implementation) {
       status = {
         isSupported: "partial",
-        label:
-          typeof added === "string"
-            ? labelFromString(added, "added")
-            : "Partial",
+        label: typeof added === "string" ? labelFromString(added) : "Partial",
       };
     }
 


### PR DESCRIPTION
The existing tooltip can easily be read as implying the feature is only supported in the given range, rather than support starting in that range. It's doubly confusing when the _removed_ version is <=, because the tooltip is written primarily for the added case.

I considered creating an enum rather than `'added'`/`'removed'` magic string values, or just having a boolean e.g. `isAdded`, so I'm open to suggestions on how to communicate the difference between those cases.

Examples of what this looks like in practice:
 - Added: [`:last-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child#browser_compatibility)
 - Added and removed: [`-webkit-mask-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-mask-attachment#browser_compatibility)
 
 (Edit: I have now gotten it set up locally and it seems to work as expected :+1:)