### PR TITLE
move and add redirects

### DIFF
--- a/content/redirect.js
+++ b/content/redirect.js
@@ -192,7 +192,7 @@ function removeOrphanedRedirects(pairs) {
   });
 }
 
-function loadPairsFromFile(filePath, strict = true) {
+function loadPairsFromFile(filePath, strict = true, validate = true) {
   const content = fs.readFileSync(filePath, "utf-8");
   const pairs = content
     .trim()
@@ -205,7 +205,9 @@ function loadPairsFromFile(filePath, strict = true) {
     errorOnEncoded(pairs);
     errorOnDuplicated(pairs);
   }
-  validatePairs(pairs, strict);
+  if (validate) {
+    validatePairs(pairs, strict);
+  }
   return pairs;
 }
 
@@ -229,7 +231,7 @@ function loadLocaleAndAdd(locale, updatePairs, { fix = false } = {}) {
   const pairs = [];
   if (fs.existsSync(redirectsFilePath)) {
     // If we wanna fix we load relaxed, hence the !fix.
-    pairs.push(...loadPairsFromFile(redirectsFilePath, !fix));
+    pairs.push(...loadPairsFromFile(redirectsFilePath, !fix, false));
   }
 
   const cleanPairs = removeConflictingOldRedirects(pairs, updatePairs);
@@ -239,7 +241,6 @@ function loadLocaleAndAdd(locale, updatePairs, { fix = false } = {}) {
   if (fix) {
     simplifiedPairs = removeOrphanedRedirects(simplifiedPairs);
   }
-  validatePairs(simplifiedPairs);
 
   return { pairs: simplifiedPairs, root, changed: simplifiedPairs == pairs };
 }


### PR DESCRIPTION
Part of #2971

As of this change I can now run:

```
yarn tool move Web/API/DocumentOrShadowRoot/fullscreenElement Web/API/Document/fullscreenElement -v -y 
yarn tool validate-redirects
```
and both work. 

I just don't know if it's right. It seems so confusing that `validatePairs()` is called 3 times. One or two of them is probably wrong. 
Thing is, [what's happening](https://github.com/mdn/yari/issues/2971#issuecomment-781546054) is this:

1. The _redirects.txt already had a `X -> A` (multiple in fact)
2. `yarn move A B`

So the path `A` *used* to be good, but it no longer is. `B` is the new hot latest thing. 

@Elchi3 you can use my branch here to get yourself unstuck with the content. It'll produce the right `git mv` and the right edits to `_redirects.txt` so you should be unblocked. 


