### PR TITLE
document-watch worker and finding files

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -215,6 +215,12 @@ async function buildDocument(document, documentOptions = {}) {
   const options = Object.assign({}, buildOptions, documentOptions);
   const { metadata, fileInfo } = document;
 
+  if (Document.urlToFolderPath(document.url) !== document.fileInfo.folder) {
+    throw new Error(
+      `The document's slug (${metadata.slug}) doesn't match its disk folder name (${document.fileInfo.folder})`
+    );
+  }
+
   const doc = {
     isArchive: document.isArchive,
     isTranslated: document.isTranslated,

--- a/server/document-watch.worker.js
+++ b/server/document-watch.worker.js
@@ -1,9 +1,21 @@
+const fs = require("fs");
 const path = require("path");
 const { parentPort } = require("worker_threads");
 
-const glob = require("glob");
-
 const { CONTENT_ROOT, Document } = require("../content");
+
+function* walker(root) {
+  const files = fs.readdirSync(root);
+  for (const name of files) {
+    const filepath = path.join(root, name);
+    const isDirectory = fs.statSync(filepath).isDirectory();
+    if (isDirectory) {
+      yield* walker(filepath);
+    } else {
+      yield filepath;
+    }
+  }
+}
 
 function postEvent(type, data = {}) {
   parentPort.postMessage({
@@ -21,41 +33,24 @@ function postDocumentInfo(filePath, changeType) {
     if (!document) {
       return;
     }
-
-    // We check that the metadata (through `document.url`)
-    // matches the filePath by using `Document.urlToFolderPath`.
-    // This would prevent the document from being added in the first place
-    // if the filePath doesn't map correctly to the URL, but in reverse.
-    if (!filePath.includes(Document.urlToFolderPath(document.url))) {
-      console.warn(
-        `The slug of ${filePath} doesn't match the folder is located in.`
-      );
-      return;
-    }
-
     postEvent(changeType, { filePath, document });
   } catch (e) {
     console.error(`Error while adding document ${filePath} to index:`, e);
   }
 }
 
-const SEARCH_PATTERN = path.join(CONTENT_ROOT, "en-us", "**", "*.html");
+const SEARCH_ROOT = path.join(CONTENT_ROOT, "en-us");
 
-const label = "Populate search-index with glob";
+const label = "Populate search-index";
 console.time(label);
 let count = 0;
-glob.sync(SEARCH_PATTERN).forEach((filePath) => {
-  // Note! On Windows, `glob.sync()` will return URLs that always use
-  // the `/` character (POSIX STYLE, https://www.npmjs.com/package/glob#windows)
-  // But the `Document.urlToFolderPath()` function will respect Windows
-  // notation and use `\` characters.
-  // Now, when we use it, it'll work as if `glob.sync()` and returned paths
-  // in a fashion that is expected in the OS.
-  postDocumentInfo(filePath.split("/").join(path.sep), "added");
-  count++;
-});
+for (const filePath of walker(SEARCH_ROOT)) {
+  const basename = path.basename(filePath);
+  if (basename === "index.html" || basename === "index.md") {
+    postDocumentInfo(filePath, "added");
+    count++;
+  }
+}
 postEvent("ready");
 console.timeEnd(label);
-console.log(
-  `Populated search-index with ${count.toLocaleString()} found files.`
-);
+console.log(`Populated search-index found ${count.toLocaleString()} files.`);

--- a/server/index.js
+++ b/server/index.js
@@ -195,7 +195,6 @@ app.get("/*", async (req, res) => {
       // since it might prevent reading fresh data from disk.
       clearKumascriptRenderCache: true,
     });
-    console.timeEnd(`buildDocumentFromURL(${lookupURL})`);
     if (built) {
       document = built.doc;
       bcdData = built.bcdData;
@@ -203,6 +202,8 @@ app.get("/*", async (req, res) => {
   } catch (error) {
     console.error(`Error in buildDocumentFromURL(${lookupURL})`, error);
     return res.status(500).send(error.toString());
+  } finally {
+    console.timeEnd(`buildDocumentFromURL(${lookupURL})`);
   }
 
   if (!document) {

--- a/testing/archived-content/files/en-us/xul/index.html
+++ b/testing/archived-content/files/en-us/xul/index.html
@@ -1,6 +1,6 @@
 ---
 title: Ancient XUL Thing
-slug: XUL/ancientness
+slug: XUL
 summary: >-
   A sample archive content page
 tags:
@@ -9,7 +9,7 @@ tags:
 
 <div class="noinclude">
   <span class="breadcrumbs xulRefAttr_breadcrumbs"
-    >« <a href="/en-US/docs/XUL/ancientness">Ancient XUL Thing</a></span
+    >« <a href="/en-US/docs/XUL">Ancient XUL Thing</a></span
   >
 </div>
 <p>This is considered ancient and has no macros in it.</p>


### PR DESCRIPTION
Fixes #2976

Suppose that you mess with the slug and change it to something that doesn't match its folder name. 
For example, I edited the `content/files/mdn/kitchensink/index.html` front-matter and changed the `slug` value. Now opening http://localhost:3000/en-US/docs/MDN/Kitchensink you get a nice descriptive error. 
Also, 
```
yarn build /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/mdn/kitchensink/index.html
```
(still) fails but now with much better error message. 