### PR TITLE
Add release date for support statements with multiple versions

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -299,28 +299,27 @@ function _addSingleSectionBCD($) {
       block = compat.__compat;
     }
     if (block) {
-      const addReleaseDate = (browser, info) => {
-        const added = info.version_added;
-        if (browserReleaseData.has(browser)) {
-          if (browserReleaseData.get(browser).has(added)) {
-            info.release_date = browserReleaseData
-              .get(browser)
-              .get(added).release_date;
-          }
-        }
-      };
-      for (const [browser, info] of Object.entries(block.support)) {
+      for (let [browser, info] of Object.entries(block.support)) {
         // `info` here will be one of the following:
         //  - a single simple_support_statement:
         //    { version_added: 42 }
         //  - an array of simple_support_statements:
         //    [ { version_added: 42 }, { prefix: '-moz', version_added: 35 } ]
-        if (Array.isArray(info)) {
-          for (const infoEntry of info) {
-            addReleaseDate(browser, infoEntry);
+        //
+        // Standardize the first version to an array of one, so we don't have
+        // to deal with two different forms below
+        if (!Array.isArray(info)) {
+          info = [info];
+        }
+        for (const infoEntry of info) {
+          const added = infoEntry.version_added;
+          if (browserReleaseData.has(browser)) {
+            if (browserReleaseData.get(browser).has(added)) {
+              infoEntry.release_date = browserReleaseData
+                .get(browser)
+                .get(added).release_date;
+            }
           }
-        } else {
-          addReleaseDate(browser, info);
         }
       }
     }

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -299,7 +299,7 @@ function _addSingleSectionBCD($) {
       block = compat.__compat;
     }
     if (block) {
-      for (const [browser, info] of Object.entries(block.support)) {
+      const addReleaseDate = (browser, info) => {
         const added = info.version_added;
         if (browserReleaseData.has(browser)) {
           if (browserReleaseData.get(browser).has(added)) {
@@ -307,6 +307,20 @@ function _addSingleSectionBCD($) {
               .get(browser)
               .get(added).release_date;
           }
+        }
+      };
+      for (const [browser, info] of Object.entries(block.support)) {
+        // `info` here will be one of the following:
+        //  - a single simple_support_statement:
+        //    { version_added: 42 }
+        //  - an array of simple_support_statements:
+        //    [ { version_added: 42 }, { prefix: '-moz', version_added: 35 } ]
+        if (Array.isArray(info)) {
+          for (const infoEntry of info) {
+            addReleaseDate(browser, infoEntry);
+          }
+        } else {
+          addReleaseDate(browser, info);
         }
       }
     }


### PR DESCRIPTION
Noticed while I was poking around testing #2966 that entries with additional flagged versions didn't have a release date tooltip. After some digging, I tracked that down to the code that adds in the release date in the first place, which did not account for [support statements with multiple entries](https://github.com/mdn/browser-compat-data/blob/master/schemas/compat-data-schema.md#the-support_statement-object) (for example, a version with flags or a prefix and then a version with full support), so these entries did not have a release date entry in the support data, and thus no tooltip in the compatibility table.

This PR extends the release date population so that it annotates the release date for all versions in an `array_support_statement`. Happy to get feedback on code structure, the lambda approach to this kind of thing is certainly of a style and I'm not sure if it's in line with the rest of the project. A functionally equivalent approach would be as follows, I went with the lambda because this one seemed less obviously safe in regards to object references/copying, but I tested it and it does indeed work just as well:
```
      for (const [browser, info] of Object.entries(block.support)) {
        const infoEntries = Array.isArray(info) ? info : [info]
        for (const infoEntry of infoEntries) {
          const added = infoEntry.version_added;
          if (browserReleaseData.has(browser)) {
            if (browserReleaseData.get(browser).has(added)) {
              infoEntry.release_date = browserReleaseData
                .get(browser)
                .get(added).release_date;
            }
          }
        }
      }
```
