### PR TITLE
make 'tool preview' take a built folder argument

### DIFF
--- a/tool/cli.js
+++ b/tool/cli.js
@@ -326,6 +326,19 @@ program
         if (document) {
           url = document.url;
         }
+      } else if (
+        slug.includes(BUILD_OUT_ROOT) &&
+        fs.existsSync(slug) &&
+        fs.existsSync(path.join(slug, "index.json"))
+      ) {
+        // Someone probably yarn `yarn build` and copy-n-pasted one of the lines
+        // it spits out from its CLI.
+        const { doc } = JSON.parse(
+          fs.readFileSync(path.join(slug, "index.json"))
+        );
+        if (doc) {
+          url = doc.mdn_url;
+        }
       } else {
         try {
           const parsed = new URL(slug);


### PR DESCRIPTION
I've wanted and needed this for too long and I often have to mess around to get it to work. 
Now I can type `BUILD_FOLDERSEARCH=bla/bla yarn build` and take any of the lines it spits and out then do something like:
```
▶ yarn tool preview /Users/peterbe/dev/MOZILLA/MDN/yari/client/build/en-us/docs/web/css/_colon_focus-visible -p 3000
```