### PR TITLE
Search for <a>

### DIFF
--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -276,7 +276,8 @@ def analyze(
             print()
             for key in keys:
                 print(f"{key:{longest_key + 1}} {token[key]!r}")
-
+    elif not analysis:
+        print("No tokens found!")
     else:
         # Desperate if it's not a list of tokens
         print(json.dumps(analysis, indent=2))


### PR DESCRIPTION
Fixes #3004

Now:

```
▶ DEPLOYER_ELASTICSEARCH_URL=localhost:9200 poetry run deployer search-analyze "<a> <video>"

token         '_a_'
start_offset  0
end_offset    3
type          '<ALPHANUM>'
position      0

token         '_video_'
start_offset  4
end_offset    11
type          '<ALPHANUM>'
position      1

token         'video'
start_offset  5
end_offset    10
type          '<ALPHANUM>'
position      1
```

Here are the results:
<img width="1348" alt="Screen Shot 2021-02-22 at 10 32 09 AM" src="https://user-images.githubusercontent.com/26739/108730216-4e0bb180-74f9-11eb-86ec-c178dcb2a394.png">

<img width="1294" alt="Screen Shot 2021-02-22 at 10 32 34 AM" src="https://user-images.githubusercontent.com/26739/108730231-5106a200-74f9-11eb-8260-b57ce7a488d4.png">

<img width="1212" alt="Screen Shot 2021-02-22 at 10 33 08 AM" src="https://user-images.githubusercontent.com/26739/108730280-5fed5480-74f9-11eb-9ae2-4c381d6b0f75.png">

The way Elasticsearch works is that you define your token filters and your char filters. Now both indexing and searching goes through the same path. So
```
<video> =indexing=> ['_video_', 'video']

<video> =searching=> ['_video_', 'video']
video =searching=> ['video']
```
