### PR TITLE
fix DOM fundamental redirects

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1162,7 +1162,15 @@ const MISC_REDIRECT_PATTERNS = [
     // which is what we use today.
     colonToSlash: true,
   }),
-  localeRedirect(/^DOM[\/$]?/i, "/docs/DOM", { permanent: true }),
+  // This takes care of a majority of the 404's that we see in Yari by
+  // simply inserting "/docs/" between the locale and the slug. Further
+  // redirects often take over from there, so let's only insert "/docs/"
+  // and let any other redirect rules work from that point onwards.
+  localeRedirect(
+    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|SVG|Tools|Using_files_from_web_applications|Web|XMLHttpRequest)(?<subPath>\/.+?)?\/?$/i,
+    ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
+    { permanent: true }
+  ),
 ];
 
 const REDIRECT_PATTERNS = [].concat(

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -979,3 +979,58 @@ FIREFOX_SOURCE_DOCS_URLS = list(
         )
     )
 )
+
+MISC_REDIRECT_URLS = [
+    url_test("/en-US/DOM", "/en-US/docs/DOM"),
+    url_test("/en-US/DOM/", "/en-US/docs/DOM"),
+    url_test(
+        "/en-US/DOM/element.addEventListener",
+        "/en-US/docs/DOM/element.addEventListener",
+    ),
+    url_test("/en-US/DOM/CSSRule/cssText/", "/en-US/docs/DOM/CSSRule/cssText"),
+    url_test("/fr/DOM", "/fr/docs/DOM"),
+    url_test("/fr/DOM/", "/fr/docs/DOM"),
+    url_test(
+        "/fr/DOM/element.addEventListener", "/fr/docs/DOM/element.addEventListener"
+    ),
+    url_test("/fr/DOM/CSSRule/cssText/", "/fr/docs/DOM/CSSRule/cssText"),
+    url_test("/en-US/AJAX", "/en-US/docs/AJAX"),
+    url_test("/en-US/AJAX/", "/en-US/docs/AJAX"),
+    url_test("/en-US/AJAX/Getting_Started/", "/en-US/docs/AJAX/Getting_Started"),
+    url_test("/en-US/CSS", "/en-US/docs/CSS"),
+    url_test("/en-US/CSS/", "/en-US/docs/CSS"),
+    url_test("/en-US/CSS/time/", "/en-US/docs/CSS/time"),
+    url_test("/en-US/DragDrop", "/en-US/docs/DragDrop"),
+    url_test("/en-US/DragDrop/", "/en-US/docs/DragDrop"),
+    url_test("/en-US/DragDrop/Drag_and_Drop/", "/en-US/docs/DragDrop/Drag_and_Drop"),
+    url_test("/en-US/HTML", "/en-US/docs/HTML"),
+    url_test("/en-US/HTML/", "/en-US/docs/HTML"),
+    url_test("/en-US/HTML/Canvas/", "/en-US/docs/HTML/Canvas"),
+    url_test("/en-US/JavaScript", "/en-US/docs/JavaScript"),
+    url_test("/en-US/JavaScript/", "/en-US/docs/JavaScript"),
+    url_test(
+        "/en-US/JavaScript/Reference/About/", "/en-US/docs/JavaScript/Reference/About"
+    ),
+    url_test("/en-US/SVG", "/en-US/docs/SVG"),
+    url_test("/en-US/SVG/", "/en-US/docs/SVG"),
+    url_test("/en-US/SVG/Element/font/", "/en-US/docs/SVG/Element/font"),
+    url_test("/en-US/Tools", "/en-US/docs/Tools"),
+    url_test("/en-US/Tools/", "/en-US/docs/Tools"),
+    url_test(
+        "/en-US/Tools/Memory/Treemap_view/", "/en-US/docs/Tools/Memory/Treemap_view"
+    ),
+    url_test(
+        "/en-US/Using_files_from_web_applications",
+        "/en-US/docs/Using_files_from_web_applications",
+    ),
+    url_test(
+        "/en-US/Using_files_from_web_applications/",
+        "/en-US/docs/Using_files_from_web_applications",
+    ),
+    url_test("/en-US/Web", "/en-US/docs/Web"),
+    url_test("/en-US/Web/", "/en-US/docs/Web"),
+    url_test("/en-US/Web/API/ArrayBuffer/", "/en-US/docs/Web/API/ArrayBuffer"),
+    url_test("/en-US/XMLHttpRequest", "/en-US/docs/XMLHttpRequest"),
+    url_test("/en-US/XMLHttpRequest/", "/en-US/docs/XMLHttpRequest"),
+    url_test("/en-US/XMLHttpRequest/FormData/", "/en-US/docs/XMLHttpRequest/FormData"),
+]

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -553,8 +553,8 @@ LEGACY_URLS = list(
             url_test("/patches/foo", status_code=404),
             url_test("/web-tech", status_code=404),
             url_test("/web-tech/feed/atom/", status_code=404),
-            url_test("/css/wiki.css", status_code=404),
-            url_test("/css/base.css", status_code=404),
+            url_test("/css/wiki.css", follow_redirects=True, final_status_code=404),
+            url_test("/css/base.css", follow_redirects=True, final_status_code=404),
             url_test("/contests", "http://www.mozillalabs.com/", status_code=302),
             url_test("/contests/", "http://www.mozillalabs.com/", status_code=302),
             url_test(

--- a/testing/integration/headless/test_redirects.py
+++ b/testing/integration/headless/test_redirects.py
@@ -9,6 +9,7 @@ from .map_301 import (
     GITHUB_IO_URLS,
     LEGACY_URLS,
     MARIONETTE_URLS,
+    MISC_REDIRECT_URLS,
     MOZILLADEMOS_URLS,
     REDIRECT_URLS,
     SCL3_REDIRECT_URLS,
@@ -103,5 +104,15 @@ def test_firefox_accounts_redirects(url, base_url):
     ids=[item["url"] for item in FIREFOX_SOURCE_DOCS_URLS],
 )
 def test_firefox_source_docs_redirects(url, base_url):
+    url["base_url"] = base_url
+    assert_valid_url(**url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    MISC_REDIRECT_URLS,
+    ids=[item["url"] for item in MISC_REDIRECT_URLS],
+)
+def test_misc_redirects(url, base_url):
     url["base_url"] = base_url
     assert_valid_url(**url)

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -1002,6 +1002,70 @@ const LOCALE_ALIAS_URLS = [].concat(
   url_test("/zh", "/zh-CN/")
 );
 
+const MISC_REDIRECT_URLS = [].concat(
+  url_test("/en-US/DOM", "/en-US/docs/DOM"),
+  url_test("/en-US/DOM/", "/en-US/docs/DOM"),
+  url_test(
+    "/en-US/DOM/element.addEventListener",
+    "/en-US/docs/DOM/element.addEventListener"
+  ),
+  url_test("/en-US/DOM/CSSRule/cssText/", "/en-US/docs/DOM/CSSRule/cssText"),
+  url_test("/fr/DOM", "/fr/docs/DOM"),
+  url_test("/fr/DOM/", "/fr/docs/DOM"),
+  url_test(
+    "/fr/DOM/element.addEventListener",
+    "/fr/docs/DOM/element.addEventListener"
+  ),
+  url_test("/fr/DOM/CSSRule/cssText/", "/fr/docs/DOM/CSSRule/cssText"),
+  url_test("/en-US/AJAX", "/en-US/docs/AJAX"),
+  url_test("/en-US/AJAX/", "/en-US/docs/AJAX"),
+  url_test("/en-US/AJAX/Getting_Started/", "/en-US/docs/AJAX/Getting_Started"),
+  url_test("/en-US/CSS", "/en-US/docs/CSS"),
+  url_test("/en-US/CSS/", "/en-US/docs/CSS"),
+  url_test("/en-US/CSS/time/", "/en-US/docs/CSS/time"),
+  url_test("/en-US/DragDrop", "/en-US/docs/DragDrop"),
+  url_test("/en-US/DragDrop/", "/en-US/docs/DragDrop"),
+  url_test(
+    "/en-US/DragDrop/Drag_and_Drop/",
+    "/en-US/docs/DragDrop/Drag_and_Drop"
+  ),
+  url_test("/en-US/HTML", "/en-US/docs/HTML"),
+  url_test("/en-US/HTML/", "/en-US/docs/HTML"),
+  url_test("/en-US/HTML/Canvas/", "/en-US/docs/HTML/Canvas"),
+  url_test("/en-US/JavaScript", "/en-US/docs/JavaScript"),
+  url_test("/en-US/JavaScript/", "/en-US/docs/JavaScript"),
+  url_test(
+    "/en-US/JavaScript/Reference/About/",
+    "/en-US/docs/JavaScript/Reference/About"
+  ),
+  url_test("/en-US/SVG", "/en-US/docs/SVG"),
+  url_test("/en-US/SVG/", "/en-US/docs/SVG"),
+  url_test("/en-US/SVG/Element/font/", "/en-US/docs/SVG/Element/font"),
+  url_test("/en-US/Tools", "/en-US/docs/Tools"),
+  url_test("/en-US/Tools/", "/en-US/docs/Tools"),
+  url_test(
+    "/en-US/Tools/Memory/Treemap_view/",
+    "/en-US/docs/Tools/Memory/Treemap_view"
+  ),
+  url_test(
+    "/en-US/Using_files_from_web_applications",
+    "/en-US/docs/Using_files_from_web_applications"
+  ),
+  url_test(
+    "/en-US/Using_files_from_web_applications/",
+    "/en-US/docs/Using_files_from_web_applications"
+  ),
+  url_test("/en-US/Web", "/en-US/docs/Web"),
+  url_test("/en-US/Web/", "/en-US/docs/Web"),
+  url_test("/en-US/Web/API/ArrayBuffer/", "/en-US/docs/Web/API/ArrayBuffer"),
+  url_test("/en-US/XMLHttpRequest", "/en-US/docs/XMLHttpRequest"),
+  url_test("/en-US/XMLHttpRequest/", "/en-US/docs/XMLHttpRequest"),
+  url_test(
+    "/en-US/XMLHttpRequest/FormData/",
+    "/en-US/docs/XMLHttpRequest/FormData"
+  )
+);
+
 describe("scl3 redirects", () => {
   for (const [url, t] of SCL3_REDIRECT_URLS) {
     it(url, t);
@@ -1091,6 +1155,12 @@ const CORE_JAVASCRIPT_1_5_URLs = [].concat(
 
 describe("Core_JavaScript_1.5 redirects", () => {
   for (const [url, t] of CORE_JAVASCRIPT_1_5_URLs) {
+    it(url, t);
+  }
+});
+
+describe("misc redirects", () => {
+  for (const [url, t] of MISC_REDIRECT_URLS) {
     it(url, t);
   }
 });


### PR DESCRIPTION
This PR arose from https://github.com/mdn/yari/issues/3012#issuecomment-783722097, but it's only one of two reasons why the DOM redirects didn't work:

1. The first reason was because the behaviors for the `dev`, `stage`, and `prod` CDN's hadn't been updated with the latest Lambda@Edge function which included the new `@yari-internal/fundamental-redirects` package.
2. The second reason (and the reason for this PR) was that https://github.com/mdn/yari/pull/2872 was broken. For example, it would redirect `/en-US/DOM/element.addEventListener` to `/en-US/docs/DOMelement.addEventListener` instead of the correct `/en-US/docs/DOM/element.addEventListener`.

This PR fixes the second, and once it lands, needs to be deployed to the CDN's to take effect.

Adding both @fiji-flo and @peterbe just so they're aware of this, but only one review is required.