### PR TITLE
add a proxyTimeout to the http-proxy-middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -53,6 +53,7 @@ app.use(
             : "http://"
         }${PROXY_HOSTNAME}`,
         changeOrigin: true,
+        proxyTimeout: 3000,
       })
 );
 

--- a/server/index.js
+++ b/server/index.js
@@ -54,6 +54,7 @@ app.use(
         }${PROXY_HOSTNAME}`,
         changeOrigin: true,
         proxyTimeout: 3000,
+        timeout: 3000,
       })
 );
 


### PR DESCRIPTION
Remember, this is only used in local development so I don't mind the proxy timeout being quite long. 
You can still get a 504 Bad Gateway when you refresh your Yari page whilst your `docker-compose up` is restarting. But it's just a lot more patient now. 

