### PR TITLE
heading links flaws and id-less headings

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -436,8 +436,11 @@ function injectHeadingLinksFlaws(level, doc, $, rawContent) {
       rawContent
     )) {
       line = foundLine;
+      column = foundColumn;
       // This makes sure the column is *after* the ID value (plus quotation mark)
-      column = foundColumn + $heading.attr("id").length + 2;
+      if ($heading.attr("id")) {
+        column += $heading.attr("id").length + 2;
+      }
     }
     // It's never fixable because it's too hard to find in the raw HTML.
     const fixable = false;


### PR DESCRIPTION
As of this change, I was able to build ALL translated content using the uplift branch. ...with the default flaw levels. 