### PR TITLE
respect character unicorns

### DIFF
--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -82,10 +82,18 @@ unicorns_char_filter = char_filter(
     mappings=[
         # e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
         # Also see https://github.com/mdn/yari/issues/3074
-        "?. => optionalchaining",
+        "?. => Optionalchaining",
         # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this
         # Also see https://github.com/mdn/yari/issues/3070
         "this => javascriptthis",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment
+        "??= => Logicalnullishassignment",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator
+        "?? => Nullishcoalescingoperator",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND_assignment
+        "&&= => LogicalANDassignment",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment
+        "||= => LogicalORassignment",
     ],
 )
 

--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -76,6 +76,19 @@ keep_html_char_filter = char_filter(
     replacement="_$1_",
 )
 
+unicorns_char_filter = char_filter(
+    "unicorns_char_filter",
+    type="mapping",
+    mappings=[
+        # e.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
+        # Also see https://github.com/mdn/yari/issues/3074
+        "?. => optionalchaining",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this
+        # Also see https://github.com/mdn/yari/issues/3070
+        "this => javascriptthis",
+    ],
+)
+
 text_analyzer = analyzer(
     "text_analyzer",
     tokenizer="standard",
@@ -97,7 +110,7 @@ text_analyzer = analyzer(
     # Note that we don't use the `html_strip` char_filter.
     # With that, we'd lose some of the valueable characters like: `<video>` which
     # is an actual title.
-    char_filter=[keep_html_char_filter],
+    char_filter=[unicorns_char_filter, keep_html_char_filter],
 )
 
 


### PR DESCRIPTION
Fixes #3074
Fixes #3070

Here's what you get now:

<img width="1147" alt="Screen Shot 2021-02-26 at 3 51 04 PM" src="https://user-images.githubusercontent.com/26739/109354316-a02b3a80-784b-11eb-81e0-0f6d6499694d.png">

<img width="1044" alt="Screen Shot 2021-02-26 at 3 50 34 PM" src="https://user-images.githubusercontent.com/26739/109354334-a4efee80-784b-11eb-83e2-920a90823e39.png">

As you can see, some of the "rest results", pages beyond the 1st hit are a bit off. But who looks beyond the first search result these days?

I don't know how long this whack-a-mole race is going to go for, but I think it makes us look professional to support these kinds of things. This kind of detail-work is why it's good to own search. Had we gone for something shrink-wrapped (aka. Saas) we probably would be unable to solve things like this. 