### PR TITLE
Update JSRef.ejs

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -32,7 +32,7 @@ var output = "";
 if (slug) {
 var locale = env.locale;
 var rtlLocales = ['ar', 'he', 'fa'];
-var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/Reference/Global_Objects/';
+var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/Reference/Global_Objects';
 var mainObj = slug.replace('Web/JavaScript/Reference/Global_Objects/', '').split('/')[0];
 
 // Data for inheritance chain

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -32,7 +32,7 @@ var output = "";
 if (slug) {
 var locale = env.locale;
 var rtlLocales = ['ar', 'he', 'fa'];
-var slug_stdlib = '/' + env.locale + '/docs/Web/JavaScript/Reference/Global_Objects';
+var slug_stdlib = `/${env.locale}/docs/Web/JavaScript/Reference/Global_Objects`;
 var mainObj = slug.replace('Web/JavaScript/Reference/Global_Objects/', '').split('/')[0];
 
 // Data for inheritance chain


### PR DESCRIPTION
The problem with trailing slash you can see at the mdn Promise page (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) for Standard built-in objects -> Promise.

Parser creates link looking like https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects//Promise with two trailing slashes which finally is redirects to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects_Promise

This commit fix this problem.