### PR TITLE
remove extra fwd slash to fix object link

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -239,7 +239,7 @@ output += '<li><strong><a href="'+slug_stdlib+'">'+text['stdlib']+'</a></strong>
           output += '<li><strong>'+text['Inheritance']+'</strong></li>';
         }
 
-        output += '<li><strong><a href="'+slug_stdlib + '/' + resultTitle +'"><code>'+resultTitle+'</code></a></strong></li>';
+        output += '<li><strong><a href="'+slug_stdlib + resultTitle +'"><code>'+resultTitle+'</code></a></strong></li>';
 
         if (resultProperties.length > 0) {
           output += buildSublist(resultProperties, text['Properties'], resultOpen);


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/2755 ... I think?

Looks like there was an extra slash being added to the generated built-in object landing page link, which was causing it to be broken. I've tested this change on a few sets of pages, and it looks like it works, but I'm not sure if there are any other complications or edge cases should know about.

Therefore, calling in an expert to review this ;-)