### PR TITLE
link translations when doing local dev

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -25,7 +25,6 @@ const { syntaxHighlight } = require("./syntax-highlight");
 const buildOptions = require("./build-options");
 const { gather: gatherGitHistory } = require("./git-history");
 const { buildSPAs } = require("./spas");
-const { findDocumentTranslations } = require("./translations");
 const { renderCache: renderKumascriptCache } = require("../kumascript");
 
 const DEFAULT_BRANCH_NAME = "main"; // That's what we use for github.com/mdn/content
@@ -462,13 +461,6 @@ async function buildDocument(document, documentOptions = {}) {
 
   doc.modified = metadata.modified || null;
 
-  if (options.findTranslations) {
-    // When you're doing a CLI build (e.g. `yarn build`) there's a step
-    // where it first figures out ALL possible translations. This might be
-    // be available when you're just doing one call to `buildDocument()` which
-    // is what happens when you run the dev server.
-    document.translations = findDocumentTranslations(document);
-  }
   const otherTranslations = document.translations || [];
   if (!otherTranslations.length && metadata.translation_of) {
     // If built just-in-time, we won't have a record of all the other translations
@@ -508,14 +500,6 @@ async function buildDocument(document, documentOptions = {}) {
     document.metadata.slug.startsWith("conflicting/");
 
   return { doc, liveSamples, fileAttachments, bcdData };
-}
-
-async function buildDocumentFromURL(url, documentOptions = {}) {
-  const document = Document.findByURL(url);
-  if (!document) {
-    return null;
-  }
-  return await buildDocument(document, documentOptions);
 }
 
 async function buildLiveSamplePageFromURL(url) {
@@ -566,7 +550,6 @@ module.exports = {
 
   buildDocument,
 
-  buildDocumentFromURL,
   buildLiveSamplePageFromURL,
   renderContributorsTxt,
 

--- a/build/index.js
+++ b/build/index.js
@@ -25,6 +25,7 @@ const { syntaxHighlight } = require("./syntax-highlight");
 const buildOptions = require("./build-options");
 const { gather: gatherGitHistory } = require("./git-history");
 const { buildSPAs } = require("./spas");
+const { findDocumentTranslations } = require("./translations");
 const { renderCache: renderKumascriptCache } = require("../kumascript");
 
 const DEFAULT_BRANCH_NAME = "main"; // That's what we use for github.com/mdn/content
@@ -461,6 +462,13 @@ async function buildDocument(document, documentOptions = {}) {
 
   doc.modified = metadata.modified || null;
 
+  if (options.findTranslations) {
+    // When you're doing a CLI build (e.g. `yarn build`) there's a step
+    // where it first figures out ALL possible translations. This might be
+    // be available when you're just doing one call to `buildDocument()` which
+    // is what happens when you run the dev server.
+    document.translations = findDocumentTranslations(document);
+  }
   const otherTranslations = document.translations || [];
   if (!otherTranslations.length && metadata.translation_of) {
     // If built just-in-time, we won't have a record of all the other translations

--- a/build/translations.js
+++ b/build/translations.js
@@ -1,0 +1,27 @@
+const { Document } = require("../content");
+const { VALID_LOCALES } = require("../libs/constants");
+
+function findDocumentTranslations(document) {
+  const translations = [];
+
+  for (const locale of VALID_LOCALES.values()) {
+    if (document.metadata.locale === locale) {
+      continue;
+    }
+    const translatedDocumentURL = document.url.replace(
+      `/${document.metadata.locale}/`,
+      `/${locale}/`
+    );
+    const translatedDocument = Document.findByURL(translatedDocumentURL);
+    if (translatedDocument) {
+      translations.push({
+        locale,
+        title: translatedDocument.metadata.title,
+        url: translatedDocument.url,
+      });
+    }
+  }
+  return translations;
+}
+
+module.exports = { findDocumentTranslations };

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,13 @@ const {
   buildLiveSamplePageFromURL,
   renderContributorsTxt,
 } = require("../build");
-const { CONTENT_ROOT, Document, Redirect, Image } = require("../content");
+const {
+  CONTENT_ROOT,
+  Document,
+  Redirect,
+  Image,
+  CONTENT_TRANSLATED_ROOT,
+} = require("../content");
 // eslint-disable-next-line node/no-missing-require
 const { prepareDoc, renderDocHTML } = require("../ssr/dist/main");
 
@@ -196,6 +202,7 @@ app.get("/*", async (req, res) => {
       // to ship you don't want the cache to stand have any hits
       // since it might prevent reading fresh data from disk.
       clearKumascriptRenderCache: true,
+      findTranslations: Boolean(CONTENT_TRANSLATED_ROOT),
     });
     if (built) {
       document = built.doc;


### PR DESCRIPTION
Try by setting the `CONTENT_TRANSLATED_ROOT` and then `yarn dev` and then visit a page like
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment 

Yes, since the `memoization` is switched off in local dev, we have to do ~30 attempts to `fs.readFile` but it's so incredibly fast that you don't notice anyway. It's just one document at a time so it doesn't need to be optimized. 