### PR TITLE
HTML escaping in feed titles

### DIFF
--- a/build/feedparser.js
+++ b/build/feedparser.js
@@ -14,9 +14,10 @@ async function getFeedEntries(url) {
   for (const item of feed.rss.channel.item) {
     const description = cheerio.load(item.description);
     const summary = description("p").text();
+    const title = cheerio.load(item.title).text();
     entries.push({
       url: item.link,
-      title: item.title,
+      title,
       pubDate: new Date(item.pubDate),
       creator: item["dc:creator"],
       summary,


### PR DESCRIPTION
Fixes #3088

Yay!
<img width="875" alt="Screen Shot 2021-03-01 at 12 03 00 PM" src="https://user-images.githubusercontent.com/26739/109531610-1fa44e00-7a86-11eb-9aa5-014a52699673.png">
