### PR TITLE
add internal retries to the search-index handler

### DIFF
--- a/server/document-watch.js
+++ b/server/document-watch.js
@@ -10,8 +10,8 @@ const worker = new Worker(path.join(__dirname, "document-watch.worker.js"));
 worker.on("message", (event) => {
   switch (event.type) {
     case "ready":
-      isReady = true;
       searchIndex.sort();
+      isReady = true;
       break;
 
     case "added":
@@ -28,8 +28,37 @@ worker.on("message", (event) => {
   }
 });
 
-module.exports = {
-  searchRoute(req, res) {
+// The `seachRoute` handler depends on a global boolean. That global boolean is
+// changed by the worker.
+// If it's not ready by the time someone queries this endpoint, the chances are
+// they will be if we just let the worker a little bit more time.
+// The max time the handler might take is `(MAX_RETRIES + 1) * RETRY_SLEEPTIME`.
+// This was added because sometimes, when you start up Yari, the Express server
+// is started and ready before the worker has indexed all the known files and if
+// you're really quick to get to the title auto-complete search widget, you
+// can get some strange results. This isn't just a risk when you start Yari for the
+// first time, but also every time `nodemon` notices a change in the server
+// related code which triggers a restart of `SearchIndex`.
+const MAX_RETRIES = 3;
+const RETRY_SLEEPTIME = 1000;
+
+function searchRoute(req, res, retry = 0) {
+  if (isReady) {
     res.json(isReady ? searchIndex.getItems()[req.params.locale] : null);
-  },
+  } else {
+    if (retry > MAX_RETRIES) {
+      // So many retries and it's still not ready. Something must have gone wrong.
+      res
+        .status(500)
+        .send(`Search index is still not ready after after ${retry} retries`);
+    } else {
+      setTimeout(() => {
+        searchRoute(req, res, retry + 1);
+      }, RETRY_SLEEPTIME);
+    }
+  }
+}
+
+module.exports = {
+  searchRoute,
 };

--- a/server/document-watch.js
+++ b/server/document-watch.js
@@ -44,7 +44,7 @@ const RETRY_SLEEPTIME = 1000;
 
 function searchRoute(req, res, retry = 0) {
   if (isReady) {
-    res.json(isReady ? searchIndex.getItems()[req.params.locale] : null);
+    res.json(searchIndex.getItems()[req.params.locale]);
   } else {
     if (retry > MAX_RETRIES) {
       // So many retries and it's still not ready. Something must have gone wrong.

--- a/server/document-watch.js
+++ b/server/document-watch.js
@@ -28,7 +28,7 @@ worker.on("message", (event) => {
   }
 });
 
-// The `seachRoute` handler depends on a global boolean. That global boolean is
+// The `searchRoute` handler depends on a global boolean. That global boolean is
 // changed by the worker.
 // If it's not ready by the time someone queries this endpoint, the chances are
 // they will be if we just let the worker a little bit more time.

--- a/server/document-watch.js
+++ b/server/document-watch.js
@@ -39,7 +39,7 @@ worker.on("message", (event) => {
 // can get some strange results. This isn't just a risk when you start Yari for the
 // first time, but also every time `nodemon` notices a change in the server
 // related code which triggers a restart of `SearchIndex`.
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 5;
 const RETRY_SLEEPTIME = 1000;
 
 function searchRoute(req, res, retry = 0) {


### PR DESCRIPTION
Part of #3091

Here's how I tested this...
I have `yarn dev` running in one terminal. And any file that `nodemon` watches open in my IDE. 
In another terminal I'm ready to run:
```
▶ run-forever.sh  time curl -I http://localhost:5000/en-US/search-index.json
```
[run-forever.sh](https://www.peterbe.com/plog/run-forever.sh)

Now, hit save in and watch `nodemon` restart which will trigger a new search index crawl. E.g. 
```
4:31:12 PM server.1     |  Populate search-index: 5.041s
4:31:12 PM server.1     |  Populated search-index found 11,669 files.
```

By the way, it's fun that in this particular copy of the server outputs it clocked in at `5.041s` which is unusual. But perhaps my computer was busy at the moment. 

But `curl` is just a way to simulate the fix. What's more likely, and I've actually seen this many times, is that you reach for the search input widget on the web app and because the XHR endpoint returns `null` you get one of those... 
<img width="507" alt="Screen Shot 2021-03-01 at 4 33 38 PM" src="https://user-images.githubusercontent.com/26739/109562232-1f1eae00-7aac-11eb-94f0-02ea1a9222d8.png">

You can still get those on other XHR errors such as network connection errors, but at least it should cease to happen just because the server is a bit busy. 

