### PR TITLE
skip uploading of redirects

### DIFF
--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -136,6 +136,13 @@ def whatsdeployed(ctx, directory: Path, output: str):
     show_default=True,
     is_flag=True,
 )
+@click.option(
+    "--no-redirects",
+    help="Don't upload redirects from the content roots",
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
 @click.argument("directory", type=click.Path(), callback=validate_directory)
 @click.pass_context
 def upload(ctx, directory: Path, **kwargs):

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -473,7 +473,8 @@ def upload_content(build_directory, content_roots, config):
         log.info("No uploads. Dry run!")
     else:
         log.info(
-            f"Total uploaded files: {totals.uploaded_files:,} ",
+            f"Total uploaded files: {totals.uploaded_files:,} "
+            f"({fmt_size(totals.uploaded_files_size)})"
         )
         if upload_redirects:
             log.info(f"Total uploaded redirects: {totals.uploaded_redirects:,} ")

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -447,6 +447,7 @@ def upload_content(build_directory, content_roots, config):
                 )
         log.info(f"Total pending redirect uploads: {total_redirects:,} ({timer})")
     else:
+        total_redirects = 0
         log.info("Not going to upload any redirects")
 
     with StopWatch() as timer:


### PR DESCRIPTION
I need this when doing PR builds because then redirects are not useful at all. And it takes quite a long time to upload all 12k redirects when it's all in vain. 

Also, as you know Ryan, last week I didn't notice that I had `--dry-run` set and I was desperately trying to figure out why no uploads happened. So I make the `info.log()` lines aware that it might be a dry-run mode. 
```
▶ poetry run deployer --dry-run upload --content-root=/Users/peterbe/dev/MOZILLA/MDN/content/files --no-redirects --bucket=peterbe-yari /Users/peterbe/dev/MOZILLA/MDN/content/build
Deployer (0.3.0)
Upload files from: /Users/peterbe/dev/MOZILLA/MDN/content/build
Upload into: main/ of peterbe-yari
Not going to upload any redirects
Total pending file uploads: 124 (3.7ms)
Total existing S3 objects: 52,065 (45.2s)
No uploads. Dry run!
Done in 45.2s.
```