### PR TITLE
support more search operators

### DIFF
--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -94,6 +94,24 @@ unicorns_char_filter = char_filter(
         "&&= => LogicalANDassignment",
         # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment
         "||= => LogicalORassignment",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment
+        "**= => Exponentiationassignment",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment
+        "*= => Multiplicationassignment",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/CSS/--*
+        "--* => CustompropertiesCSSVariables",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Exponentiation
+        "** => 'Exponentiation",
+        # E.g. http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality
+        "=== => Strictequality",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_inequality
+        "!== => Strictinequality",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality
+        "== => Equality",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Inequality
+        "!= => Inequality",
+        # E.g. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment
+        "= => Assignment",
     ],
 )
 


### PR DESCRIPTION
There are more operators (e.g. `Unsigned right shift assignment (>>>=)`). I picked through the ones that aren't too obscure or ones that could cause confusion. For example, the `in` operator turns up in too many titles and bodies as a regular stopword so it's probably best to leave it alone. 
This'll cover a bunch of more typical ones. 

Some examples:
<img width="1107" alt="Screen Shot 2021-03-03 at 11 45 17 AM" src="https://user-images.githubusercontent.com/26739/109840592-44c7c680-7c16-11eb-8b92-b3702962a73a.png">

<img width="1065" alt="Screen Shot 2021-03-03 at 11 45 23 AM" src="https://user-images.githubusercontent.com/26739/109840615-48f3e400-7c16-11eb-8e05-f308cdfc51c9.png">

<img width="1077" alt="Screen Shot 2021-03-03 at 11 48 16 AM" src="https://user-images.githubusercontent.com/26739/109840691-590bc380-7c16-11eb-8c2f-53e76b40160f.png">

