### PR TITLE
don't wait for networkidle2 unless a reason to

### DIFF
--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -32,7 +32,6 @@ describe("Basic viewing of functional pages", () => {
     await expect(page).toClick("a.view-in-english", {
       text: "View in English",
     });
-    await page.waitForNavigation({ waitUntil: "networkidle2" });
     await expect(page).toMatchElement("h1", { text: "<foo>: A test tag" });
     // Should have been redirected too...
     // Note! It's important that this happens *after* the `.toMatchElement`


### PR DESCRIPTION
Fixes #3116

Prior to this change I would run `yarn test:testing headless` and sometimes it would break with:
```
node:internal/process/promises:218
          triggerUncaughtException(err, true /* fromPromise */);
          ^

Error: Navigation failed because browser has disconnected!
    at CDPSession.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/LifecycleWatcher.js:46:107)
    at CDPSession.emit (node:events:329:20)
    at CDPSession._onClosed (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/Connection.js:215:10)
    at Connection._onMessage (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/Connection.js:105:17)
    at WebSocket.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/WebSocketTransport.js:44:24)
    at WebSocket.onMessage (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/ws/lib/event-target.js:120:16)
    at WebSocket.emit (node:events:329:20)
    at Receiver.receiverOnMessage (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/ws/lib/websocket.js:789:20)
    at Receiver.emit (node:events:329:20)
    at Receiver.dataMessage (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/ws/lib/receiver.js:422:14)
  -- ASYNC --
    at Frame.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/helper.js:111:15)
    at Page.waitForNavigation (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/Page.js:692:49)
    at Page.waitForNavigation (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/puppeteer/lib/helper.js:112:23)
    at Object.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/testing/tests/headless.test.js:35:16)
    at processTicksAndRejections (node:internal/process/task_queues:93:5)
error Command failed with exit code 1.
```

That error `Navigation failed because browser has disconnected!` supposedly *"means that the node scripts that launched Puppeteer ends without waiting for the Puppeteer actions to be completed."*.
So there's something that attempts to close the `jest` tests without giving the `expect-puppeteer` a chance to close the browser instance. 

I'm more and more unimpressed with `expected-puppeteer`. It feels like walking on egg shells. And when certain errors happen sometimes, you have no idea where/which line in your `*.test.js` code that started the headless `chrome` crashes. 