### PR TITLE
Remove mixins that have been removed from MDN content

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -321,7 +321,6 @@
         "NodeFilter",
         "NodeIterator",
         "NodeList",
-        "NonDocumentTypeChildNode",
         "ProcessingInstruction",
         "PromiseResolver",
         "Range",
@@ -1512,12 +1511,7 @@
     },
     "URL API": {
       "overview": ["URL API"],
-      "interfaces": [
-        "URL",
-        "URLSearchParams",
-        "HTMLHyperlinkElementUtils",
-        "URLUtilsReadOnly"
-      ],
+      "interfaces": ["URL", "URLSearchParams", "URLUtilsReadOnly"],
       "methods": [],
       "properties": [],
       "events": []

--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -310,7 +310,7 @@
     },
     "CharacterData": {
       "inh": "Node",
-      "impl": ["ChildNode", "NonDocumentTypeChildNode"]
+      "impl": ["ChildNode"]
     },
     "ChromeWorker": {
       "inh": "Worker",
@@ -518,13 +518,7 @@
     },
     "Element": {
       "inh": "Node",
-      "impl": [
-        "ChildNode",
-        "NonDocumentTypeChildNode",
-        "ParentNode",
-        "Animatable",
-        "GeometryUtils"
-      ]
+      "impl": ["ChildNode", "ParentNode", "Animatable", "GeometryUtils"]
     },
     "EngineeringMode": {
       "inh": "EventTarget",
@@ -608,7 +602,7 @@
     },
     "HTMLAnchorElement": {
       "inh": "HTMLElement",
-      "impl": ["HTMLHyperlinkElementUtils", "URLUtilsSearchParams"]
+      "impl": []
     },
     "HTMLAppletElement": {
       "inh": "HTMLElement",
@@ -620,7 +614,7 @@
     },
     "HTMLAreaElement": {
       "inh": "HTMLElement",
-      "impl": ["HTMLHyperlinkElementUtils", "URLUtilsSearchParams"]
+      "impl": []
     },
     "HTMLAudioElement": {
       "inh": "HTMLMediaElement",


### PR DESCRIPTION
Mixin work is so thankless. Really.
I forgot to remove mixin pages from the infamous InterfaceData and GroupData macros.

This is what is happening: Mixin pages are made redirects to some sensible real interface pages like Element. 
Great for readers because they'll land somewhere, but these lovely macros still make calls to get the sub pages and so they can be rendered twice (once from Element, and also from e.g. NonDocumentTypeChildNode which is now a redirect to Element.)

I'll add this to my mixin checklist, so it doesn't happen again.

Closes https://github.com/mdn/yari/issues/3119

