### PR TITLE
needs-triage label for new content issues

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -106,7 +106,6 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       ? `${doc.title.slice(0, maxLength)}…`
       : doc.title;
   sp.set("title", `Issue with "${titleShort}": (short summary here please)`);
-  sp.append("labels", "needs triage");
 
   const slug = doc.mdn_url.split("/docs/")[1].toLowerCase();
   let contentLabel = "";
@@ -119,7 +118,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   if (!contentLabel) {
     contentLabel = "Other";
   }
-  sp.append("labels", `Content: ${contentLabel}`);
+  sp.set("labels", `Content:${contentLabel},needs-triage`);
 
   const href = `${baseURL}?${sp.toString()}`;
 


### PR DESCRIPTION
Fixes #3166

Not only did I change `needs triage` to `needs-triage` but I also noticed that all the labels prefixed with `Content:` are spelled without a space after the `:`. So I fixed that too. 
Also, I learned the hard way that if you have multiple `labels` you need to make it a comma-separated list. E.g. 
```diff
-&labels=foo&labels=bar
+&labels=foo,bar
```
I don't know how long that's been busted. 

Seems to work now:
<img width="1342" alt="Screen Shot 2021-03-09 at 8 38 06 AM" src="https://user-images.githubusercontent.com/26739/110479237-2dc02300-80b3-11eb-8146-df52bb4ec05d.png">

