### PR TITLE
cope with odd svg content-types

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -591,7 +591,9 @@ async function fixFixableFlaws(doc, options, document) {
         if (
           !fileType &&
           flaw.src.toLowerCase().endsWith(".svg") &&
-          imageResponse.headers["content-type"] === "image/svg+xml"
+          imageResponse.headers["content-type"]
+            .toLowerCase()
+            .startsWith("image/svg+xml")
         ) {
           // If the SVG doesn't have the `<?xml version="1.0" encoding="UTF-8"?>`
           // and/or the `<!DOCTYPE svg PUBLIC ...` in the first couple of bytes


### PR DESCRIPTION
Fixes #3072

```
▶ curl -I https://www.w3.org/TR/2017/WD-css-timing-1-20170221/step-timing-func-examples.svg
HTTP/2 200
...
content-type: image/svg+xml; qs=0.85
```

Thanks to this fix I was able to fix the external images flaws in https://github.com/mdn/content/pull/2982