### PR TITLE
Image flaw checking should be different for translated content

### DIFF
--- a/build/check-images.js
+++ b/build/check-images.js
@@ -199,7 +199,6 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
           }
         }
       }
-      console.log("SETTING src=", finalSrc);
       img.attr("src", finalSrc);
     }
     if (

--- a/build/check-images.js
+++ b/build/check-images.js
@@ -133,13 +133,34 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
       // We can use the `finalSrc` to look up and find the image independent
       // of the correct case because `Image.findByURL` operates case
       // insensitively.
-      const filePath = Image.findByURL(finalSrc);
+      let filePath = Image.findByURL(finalSrc);
+      let enUSFallback = false;
+      if (
+        !filePath &&
+        doc.locale !== "en-US" &&
+        !finalSrc.startsWith("/en-us/")
+      ) {
+        const enFinalSrc = finalSrc.replace(
+          `/${doc.locale.toLowerCase()}/`,
+          "/en-us/"
+        );
+        if (Image.findByURL(enFinalSrc)) {
+          // Use the en-US src instead
+          finalSrc = enFinalSrc;
+          // Note that this `<img src="...">` value can work if you use the
+          // en-US equivalent URL instead.
+          enUSFallback = true;
+        }
+      }
       if (filePath) {
         filePaths.add(filePath);
       }
 
       if (checkImages) {
-        if (!filePath) {
+        if (enUSFallback) {
+          // If it worked by switching to the en-US src, don't do anything more.
+          // Do nothing! I.e. don't try to perfect the spelling.
+        } else if (!filePath) {
           // E.g. <img src="doesnotexist.png"
           addImageFlaw(img, src, {
             explanation: "File not present on disk",
@@ -178,6 +199,7 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
           }
         }
       }
+      console.log("SETTING src=", finalSrc);
       img.attr("src", finalSrc);
     }
     if (

--- a/build/index.js
+++ b/build/index.js
@@ -358,7 +358,6 @@ async function buildDocument(document, documentOptions = {}) {
 
   // Check and scrutinize any local image references
   const fileAttachments = checkImageReferences(doc, $, options, document);
-  console.log("fileAttachments:", fileAttachments);
 
   // Check the img tags for possible flaws and possible build-time rewrites
   checkImageWidths(doc, $, options, document);

--- a/build/index.js
+++ b/build/index.js
@@ -358,6 +358,7 @@ async function buildDocument(document, documentOptions = {}) {
 
   // Check and scrutinize any local image references
   const fileAttachments = checkImageReferences(doc, $, options, document);
+  console.log("fileAttachments:", fileAttachments);
 
   // Check the img tags for possible flaws and possible build-time rewrites
   checkImageWidths(doc, $, options, document);

--- a/testing/translated-content/files/fr/web/foo/index.html
+++ b/testing/translated-content/files/fr/web/foo/index.html
@@ -5,3 +5,8 @@ translation_of: Web/Foo
 ---
 
 <p>Foë</p>
+
+<figure>
+  <img src="screenshot.png" alt="Capture d'écran des couleurs" />
+  <figcaption>Une image parfaitement normale</figcaption>
+</figure>


### PR DESCRIPTION
Part of #3174

This is just one of the cases. But it's an important one, to start with. 
Imagine there's an `en-US` page that contains `<img src="foo.png">` in that English page and that works (and that there exists a `foo.png` next to that English `index.html`). Now you copy that page to `translated-content/files/fr/*`. The page should work. No flaw. And the final `cheerio` transformation, for both the `en-US` and the `fr` page, should become: `/en-US/docs/Foo/bar/foo.png`. 

Perhaps a better way to explain it is to look at the test fixtures. We have, in English:
```html
<figure>
  <img src="screenshot.png" alt="Screenshot of colors">
  <figcaption>A perfectly normal image</figcaption>
</figure>
```
and on the `fr` equivalent we have:
```html
<figure>
  <img src="screenshot.png" alt="Capture d'écran des couleurs" />
  <figcaption>Une image parfaitement normale</figcaption>
</figure>
```

What you get in the end is:
<img width="652" alt="Screen Shot 2021-03-09 at 5 04 16 PM" src="https://user-images.githubusercontent.com/26739/110544296-7d294200-80f9-11eb-8591-6a3dcd560e9a.png">

