### PR TITLE
Improve legend for non-standard track features

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -8,7 +8,7 @@ const LEGEND_LABELS = {
   no: "No support",
   unknown: "Compatibility unknown",
   experimental: "Experimental. Expect behavior to change in the future.",
-  "non-standard": "Non-standard. Expect poor cross-browser support.",
+  "non-standard": "Non-standard. Check cross-browser support before using.",
   deprecated: "Deprecated. Not for use in new websites.",
   footnote: "See implementation notes.",
   disabled: "User must explicitly enable this feature.",

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -139,8 +139,7 @@
     "url": "https://w3c.github.io/webappsec-credential-management/",
     "status": "WD"
   },
-
-  "name": "Content Security Policy 1.0",
+    "name": "Content Security Policy 1.0",
     "url": "https://www.w3.org/TR/CSP1/",
     "status": "Obsolete"
   },

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -139,6 +139,7 @@
     "url": "https://w3c.github.io/webappsec-credential-management/",
     "status": "WD"
   },
+  "CSP 1.0": {
     "name": "Content Security Policy 1.0",
     "url": "https://www.w3.org/TR/CSP1/",
     "status": "Obsolete"

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -146,7 +146,7 @@
   },
   "CSP 1.1": {
     "name": "Content Security Policy Level 2",
-    "url": "https://w3c.github.io/webappsec-csp/2/",
+    "url": "https://www.w3.org/TR/CSP2/",
     "status": "REC"
   },
   "CSP 3.0": {

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -139,14 +139,14 @@
     "url": "https://w3c.github.io/webappsec-credential-management/",
     "status": "WD"
   },
-  "CSP 1.0": {
-    "name": "Content Security Policy 1.0",
+
+  "name": "Content Security Policy 1.0",
     "url": "https://www.w3.org/TR/CSP1/",
     "status": "Obsolete"
   },
   "CSP 1.1": {
     "name": "Content Security Policy Level 2",
-    "url": "https://www.w3.org/TR/CSP2/",
+    "url": "https://w3c.github.io/webappsec-csp/2/",
     "status": "REC"
   },
   "CSP 3.0": {


### PR DESCRIPTION
Suggested change to legend used for non-standard track features from 
```
 "non-standard": "Non-standard. Expect poor cross-browser support.",
```
to
```
"non-standard": "Non-standard. Check cross-browser support before using.",
```
This comes from discussion here: https://github.com/mdn/browser-compat-data/pull/8785#issuecomment-793650145 which says that while expecting poor cross browser support is probably correct in most cases the actual support data should tell readers whether they should expect cross-browser support.

We could reduce this further to "Non-standard." but I think it is a good hint that they check the support rather than expect poor support.