### PR TITLE
test Flaws dashboard in CI

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -76,15 +76,13 @@ jobs:
           # of the yarn installs above
           PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
         run: |
-          status=0
-          yarn test:testing developing || (
-            status=$?
-            echo "Testing failed! Going to dump stdout and stderr"
-            echo "STDOUT..................................................."
-            cat /tmp/stdout.log
-            echo "STDERR..................................................."
-            cat /tmp/stderr.log
-            echo $status
-            exit $status
-          )
-          exit $status
+          yarn test:testing developing
+
+      - name: Debug server's stdout and stderr if tests failed
+        if: failure()
+        run: |
+          echo "STDOUT..................................................."
+          cat /tmp/stdout.log
+          echo ""
+          echo "STDERR..................................................."
+          cat /tmp/stderr.log

--- a/client/src/writers-homepage/index.tsx
+++ b/client/src/writers-homepage/index.tsx
@@ -14,7 +14,7 @@ export default function WritersHomepage() {
   return (
     <PageContentContainer>
       <div id="writers-homepage">
-        <h2>Welcome to MDN</h2>
+        <h2>Writer's home page</h2>
 
         <Search />
 

--- a/testing/tests/developing.test.js
+++ b/testing/tests/developing.test.js
@@ -26,23 +26,21 @@ const SKIP_DEV_URL = JSON.parse(process.env.DEVELOPING_SKIP_DEV_URL || "false");
 // all `**/*.test.js` it doesn't actually run these tests unless explicitly
 // prepared to do so.
 // The source of this idea comes from https://github.com/facebook/jest/issues/7245
-const withDeveloping = JSON.parse(process.env.TESTING_DEVELOPING || "false")
-  ? it
-  : it.skip;
+const isTesting = JSON.parse(process.env.TESTING_DEVELOPING || "false");
+const withDeveloping = isTesting ? it : it.skip;
+// If the test suite runs in a way that there's no separate dev server,
+// don't bother using the `DEV_BASE_URL`.
+// For example, when it tests the `npm pack` tarball, it's starting only
+// the one server (on `localhost:5000`) that suite will set the `DEV_BASE_URL`
+// to be the same as `SAME_BASE_URL`.
+// In conclusion, if there's only 1 base URL to test again; don't test both.
+const withCrud = isTesting && !SKIP_DEV_URL ? it : it.skip;
 
 describe("Testing the kitchensink page", () => {
-  withDeveloping("open the page", async () => {
-    // If the test suite runs in a way that there's no separate dev server,
-    // don't bother using the `DEV_BASE_URL`.
-    // For example, when it tests the `npm pack` tarball, it's starting only
-    // the one server (on `localhost:5000`) that suite will set the `DEV_BASE_URL`
-    // to be the same as `SAME_BASE_URL`.
-    // In conclusion, if there's only 1 base URL to test again; don't test both.
-    if (!SKIP_DEV_URL) {
-      await page.goto(devURL("/en-US/docs/MDN/Kitchensink"));
-      await expect(page).toMatch("The MDN Content Kitchensink");
-      await expect(page).toMatch("No known flaws at the moment");
-    }
+  withCrud("open the page", async () => {
+    await page.goto(devURL("/en-US/docs/MDN/Kitchensink"));
+    await expect(page).toMatch("The MDN Content Kitchensink");
+    await expect(page).toMatch("No known flaws at the moment");
   });
 
   withDeveloping("server-side render HTML", async () => {
@@ -174,5 +172,19 @@ describe("Testing the Express server", () => {
     });
     expect(response.statusCode).toBe(302);
     expect(response.headers.location).toBe("/sv-SE/");
+  });
+});
+
+describe("Testing the CRUD apps", () => {
+  withCrud("open the writer's home page", async () => {
+    await page.goto(devURL("/"));
+    await expect(page).toMatch("Writer's home page");
+    await expect(page).toMatchElement("a", { text: "Flaws Dashboard" });
+  });
+
+  withCrud("open the Flaws Dashboard", async () => {
+    await page.goto(devURL("/"));
+    await expect(page).toClick("a", { text: "Flaws Dashboard" });
+    await expect(page).toMatch("Documents with flaws found (0)");
   });
 });


### PR DESCRIPTION
I'm killing two birds with one stone here. 
First of all, it doesn't have to be extensive (and opening is better than doing nothing) but at least this checks that the Flaws Dashboard is there and that it can be opened. 
Second of all, I like this use of `if: failure()` instead of a hacky `bash` trick looking for exit codes. 