### PR TITLE
strip ( and ) when downloading images

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -632,6 +632,9 @@ async function fixFixableFlaws(doc, options, document) {
           Document.getFolderPath(document.metadata),
           path
             .basename(imageBasename)
+            // Names like `screenshot-(1).png` are annoying because the `(` often
+            // has to be escaped when working on the command line.
+            .replace(/[\(\)]/g, "")
             .replace(/\s+/g, "_")
             // From legacy we have a lot of images that are named like
             // `/@api/deki/files/247/=HTMLBlinkElement.gif` for example.


### PR DESCRIPTION
Now, when downloading an external image like `https://mdn.mozillademos.org/files/8685/boxmodel-(3).png` it gets saved as `boxmodel-3.png` instead of `boxmodel-(3).png`. 