### PR TITLE
ignore translated-content/**/_githistory.json too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,6 @@ mdn-yari-*.tgz
 function.zip
 
 testing/content/files/en-us/_githistory.json
+testing/translated-content/files/**/_githistory.json
 # eslintcache
 client/.eslintcache


### PR DESCRIPTION
Otherwise, you'll get that `testing/translated-content/files/fr/_githistory.json` file too after running the end-to-end test suite.