### PR TITLE
downloading external images for translated-content

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -21,6 +21,7 @@ const {
 } = require("./matches-in-text");
 const { humanFileSize } = require("./utils");
 const { VALID_MIME_TYPES } = require("../filecheck/constants");
+const { DEFAULT_LOCALE } = require("../libs/constants");
 
 function injectFlaws(doc, $, options, { rawContent }) {
   if (doc.isArchive) return;
@@ -574,7 +575,9 @@ async function fixFixableFlaws(doc, options, document) {
     // HTML. It's only proper HTML when the kumascript macros have been
     // expanded.
     let newSrc;
-    if (flaw.externalImage) {
+    if (flaw.suggestion) {
+      newSrc = flaw.suggestion;
+    } else {
       // Sanity check that it's an external image
       const url = new URL(forceExternalURL(flaw.src));
       if (url.protocol !== "https:") {
@@ -673,8 +676,6 @@ async function fixFixableFlaws(doc, options, document) {
           throw error;
         }
       }
-    } else {
-      newSrc = flaw.suggestion;
     }
     newRawHTML = replaceMatchesInText(flaw.src, newRawHTML, newSrc, {
       inAttribute: "src",

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -21,7 +21,6 @@ const {
 } = require("./matches-in-text");
 const { humanFileSize } = require("./utils");
 const { VALID_MIME_TYPES } = require("../filecheck/constants");
-const { DEFAULT_LOCALE } = require("../libs/constants");
 
 function injectFlaws(doc, $, options, { rawContent }) {
   if (doc.isArchive) return;


### PR DESCRIPTION
Fixes #3174

Seems to work! I was able to create https://github.com/mdn/translated-content/pull/110 with this change. 
And just to check that then `en-US` fixable external image flaws still work, I was able to create https://github.com/mdn/content/pull/3040
It almost seemed too good to be true. 

The assumption this is based on is that the basename of the external image URL would match perfectly the en-US equivalent. 
I think it's a safe assumption. It COULD be that someone has a "localized image" which they uploaded under a different ID but with the exact same basename. I find that unlikely enough to not care. 

I've noticed that in `fr` there are a lot of images that are genuinely different. For example `choix-firefox.png` was one I found. In these cases, if a `fr` translator downloads it, it'll be fine. It'll simply be a different binary image.