### PR TITLE
skip empty srcs for safe iframe srcs

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -130,8 +130,8 @@ function injectUnsafeHTMLFlaws(doc, $, { rawContent }) {
     if (tagName === "iframe") {
       // For iframes we only check the 'src' value
       const src = $(element).attr("src");
-      if (src.startsWith("/") && !src.includes("://")) {
-        // Local URLs are always safe
+      // Local URLs are always safe.
+      if (!(src.startsWith("//") || src.includes("://"))) {
         return;
       }
       if (!safeIFrameSrcs.find((s) => src.toLowerCase().startsWith(s))) {

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -61,9 +61,15 @@ function injectFlaws(doc, $, options, document) {
       doc.flaws[flawName] &&
       doc.flaws[flawName].length > 0
     ) {
-      throw new Error(
-        `${flawName} flaws: ${doc.flaws[flawName].map((f) => f.explanation)}`
-      );
+      // To make the stdout output a bit more user-friendly, print one warning
+      // for each explanation
+      doc.flaws[flawName].forEach((flaw, i) => {
+        console.warn(
+          i + 1,
+          chalk.yellow(`${chalk.bold(flawName)} flaw: ${flaw.explanation}`)
+        );
+      });
+      throw new Error(`${doc.flaws[flawName].length} ${flawName} flaws`);
     }
   }
 }
@@ -103,8 +109,6 @@ function injectUnsafeHTMLFlaws(doc, $, { rawContent }) {
   }
 
   const safeIFrameSrcs = [
-    LIVE_SAMPLES_BASE_URL.toLowerCase(),
-    INTERACTIVE_EXAMPLES_BASE_URL.toLowerCase(),
     // EmbedGHLiveSample.ejs
     "https://mdn.github.io",
     // EmbedYouTube.ejs
@@ -114,12 +118,22 @@ function injectUnsafeHTMLFlaws(doc, $, { rawContent }) {
     // EmbedTest262ReportResultsTable.ejs
     "https://test262.report",
   ];
+  if (LIVE_SAMPLES_BASE_URL) {
+    safeIFrameSrcs.push(LIVE_SAMPLES_BASE_URL.toLowerCase());
+  }
+  if (INTERACTIVE_EXAMPLES_BASE_URL) {
+    safeIFrameSrcs.push(INTERACTIVE_EXAMPLES_BASE_URL.toLowerCase());
+  }
 
   $("script, embed, object, iframe").each((i, element) => {
     const { tagName } = element;
     if (tagName === "iframe") {
       // For iframes we only check the 'src' value
       const src = $(element).attr("src");
+      if (src.startsWith("/") && !src.includes("://")) {
+        // Local URLs are always safe
+        return;
+      }
       if (!safeIFrameSrcs.find((s) => src.toLowerCase().startsWith(s))) {
         addFlaw(element, `Unsafe <iframe> 'src' value (${src})`);
       }

--- a/testing/content/files/en-us/web/unsafe_html/index.html
+++ b/testing/content/files/en-us/web/unsafe_html/index.html
@@ -20,6 +20,8 @@ slug: Web/Unsafe_HTML
 
 <iframe src="https://www.peterbe.com/"></iframe>
 
+<iframe src="//evil.com/"></iframe>
+
 <p>Here's a link that contains the string <code>:JavaScript</code> within the <code>href</code>
 attribute:<br>
   <a href="https://wiki.mozilla.org/JavaScript:New_to_SpiderMonkey">

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1292,10 +1292,10 @@ test("unsafe HTML gets flagged as flaws and replace with its raw HTML", () => {
 
   const jsonFile = path.join(builtFolder, "index.json");
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(doc.flaws.unsafe_html.length).toBe(5);
+  expect(doc.flaws.unsafe_html.length).toBe(6);
 
   const htmlFile = path.join(builtFolder, "index.html");
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
-  expect($("code.unsafe-html").length).toBe(5);
+  expect($("code.unsafe-html").length).toBe(6);
 });


### PR DESCRIPTION
Fixes #3215

It looks like this now:

<img width="984" alt="Screen Shot 2021-03-12 at 10 43 39 AM" src="https://user-images.githubusercontent.com/26739/110963258-da9ed800-831f-11eb-877a-e5cc3e954dc1.png">

Contrast that with: https://github.com/mdn/content/pull/3064/checks?check_run_id=2095600358

