### PR TITLE
Added CSS Cascade Level 5 spec. to SpecData macro

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -484,6 +484,11 @@
     "url": "https://drafts.csswg.org/css-writing-modes-4/",
     "status": "CR"
   },
+  "CSS5 Cascade": {
+    "name": "CSS Cascading and Inheritance Level&nbsp;5",
+    "url": "https://drafts.csswg.org/css-cascade-5/",
+    "status": "WD"
+  },
   "CSS5 Media Queries": {
     "name": "Media Queries Level&nbsp;5",
     "url": "https://drafts.csswg.org/mediaqueries-5/",


### PR DESCRIPTION
The [CSS Cascading and Inheritance Level 5 specification](https://www.w3.org/TR/css-cascade-5/) got published as Working Draft earlier this year. Therefore, I've added it to the SpecData macro.