### PR TITLE
generate pre in CSSSyntax

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -433,4 +433,8 @@ if (!formattedSyntax) {
     throw new Error(`No syntax found in DB for '${name}'`);
 }
 
-%><%- formattedSyntax %>
+const rtlLocales = ['ar', 'he', 'fa'];
+const rtl = rtlLocales.includes(env.locale);
+const out = `<pre${rtl ? ' dir="rtl"' : ""}>${formattedSyntax}</pre>`
+
+%><%- out %>


### PR DESCRIPTION
https://developer.mozilla.org/de/docs/Web/CSS/border#formale_syntax 

vs 

https://developer.mozilla.org/en-US/docs/Web/CSS/border#formal_syntax

I think also we should avoid marcos inside `<pre>` in general.