### PR TITLE
only run scheduled workflows on mdn/yari

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -51,6 +51,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Only run the scheduled workflows on the main repo.
+    if: github.repository == 'mdn/yari'
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -51,6 +51,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    # Only run the scheduled workflows on the main repo.
+    if: github.repository == 'mdn/yari'
+
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Part of #3229

I've never done this before so I'm not 100% certain it's correct. 

There are also certain actions that run on pushes to `main`. For example, if people merge in the latest `main` from `mdn/yari` and then push that to their fork, that'll trigger a build too. E.g. https://github.com/escattone/yari/commits/main
Perhaps @escattone has, manually, disabled Actions on his fork because I don't see the little green checkmarks. 