### PR TITLE
Check of unsafe HTML in SVG files

### DIFF
--- a/filecheck/checker.js
+++ b/filecheck/checker.js
@@ -71,7 +71,7 @@ async function checkFile(filePath, options) {
       for (const key in element.attribs) {
         if (/(\\x[a-f0-9]{2}|\b)on\w+/.test(key)) {
           throw new Error(
-            `${filePath} <${tagName}> contains an unsafe attribute key: '${key}'`
+            `${filePath} <${tagName}> contains an unsafe attribute: '${key}'`
           );
         }
       }

--- a/filecheck/checker.js
+++ b/filecheck/checker.js
@@ -62,9 +62,20 @@ async function checkFile(filePath, options) {
       throw new Error(`${filePath} does not appear to be an SVG`);
     }
     const $ = cheerio.load(content);
-    if ($("script").length) {
-      throw new Error(`${filePath} contains a <script> tag`);
-    }
+    const disallowedTagNames = new Set(["script", "object", "iframe", "embed"]);
+    $("*").each((i, element) => {
+      const { tagName } = element;
+      if (disallowedTagNames.has(tagName)) {
+        throw new Error(`${filePath} contains a <${tagName}> tag`);
+      }
+      for (const key in element.attribs) {
+        if (/(\\x[a-f0-9]{2}|\b)on\w+/.test(key)) {
+          throw new Error(
+            `${filePath} <${tagName}> contains an unsafe attribute key: '${key}'`
+          );
+        }
+      }
+    });
   } else {
     // Check that the file extension matches the file header.
     const fileType = await FileType.fromFile(filePath);

--- a/testing/tests/filecheck.test.js
+++ b/testing/tests/filecheck.test.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+
+const { checkFile } = require("../../filecheck/checker");
+
+const SAMPLES_DIRECTORY = path.join(__dirname, "samplefiles");
+
+describe("checking files", () => {
+  it("should spot SVGs with scripts inside them", async () => {
+    const filePath = path.join(SAMPLES_DIRECTORY, "script.svg");
+    // Sanity check the test itself
+    console.assert(fs.existsSync(filePath), `${filePath} does not exist`);
+    await expect(checkFile(filePath)).rejects.toThrow(
+      "contains a <script> tag"
+    );
+  });
+  it("should spot SVGs with onLoad inside an element", async () => {
+    const filePath = path.join(SAMPLES_DIRECTORY, "script.svg");
+    // Sanity check the test itself
+    console.assert(fs.existsSync(filePath), `${filePath} does not exist`);
+    await expect(checkFile(filePath)).rejects.toThrow(
+      "contains a <script> tag"
+    );
+  });
+});

--- a/testing/tests/filecheck.test.js
+++ b/testing/tests/filecheck.test.js
@@ -15,11 +15,11 @@ describe("checking files", () => {
     );
   });
   it("should spot SVGs with onLoad inside an element", async () => {
-    const filePath = path.join(SAMPLES_DIRECTORY, "script.svg");
+    const filePath = path.join(SAMPLES_DIRECTORY, "onhandler.svg");
     // Sanity check the test itself
     console.assert(fs.existsSync(filePath), `${filePath} does not exist`);
     await expect(checkFile(filePath)).rejects.toThrow(
-      "contains a <script> tag"
+      "<path> contains an unsafe attribute: 'onload'"
     );
   });
 });

--- a/testing/tests/samplefiles/index.html
+++ b/testing/tests/samplefiles/index.html
@@ -1,2 +1,3 @@
 <!-- Must be mention in the adjacent index.html file -->
 <img src="script.svg" />
+<img src="onhandler.svg" />

--- a/testing/tests/samplefiles/index.html
+++ b/testing/tests/samplefiles/index.html
@@ -1,0 +1,2 @@
+<!-- Must be mention in the adjacent index.html file -->
+<img src="script.svg" />

--- a/testing/tests/samplefiles/onhandler.svg
+++ b/testing/tests/samplefiles/onhandler.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42.667" height="25.6"
+viewBox="0 0 40 24"><path oNload=alert(1) d="M28 0l4.59 4.59-9.76 9.75-8-8L0 21.17
+2.83 24l12-12 8 8L35.41 7.41 40 12V0z"/></svg>

--- a/testing/tests/samplefiles/script.svg
+++ b/testing/tests/samplefiles/script.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="42.667" height="25.6"
+viewBox="0 0 40 24"><path d="M28 0l4.59 4.59-9.76 9.75-8-8L0 21.17
+2.83 24l12-12 8 8L35.41 7.41 40 12V0z"/><Script>alert(1)</script></svg>


### PR DESCRIPTION
Fixes #3249

First of all, I don't know why CI wasn't running on https://github.com/mdn/content/pull/3162
What's up with that?!

Anyway, based on the file in [that PR](https://github.com/mdn/content/pull/3162/files), it does correctly throw:
```
MOZILLA/MDN/yari  3249-check-of-unsafe-html-in-svg-files ✔
▶ yarn filecheck /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/mozilla/developer_guide/development_process_overview/workflow.svg
yarn run v1.22.10
$ cd filecheck && node cli.js /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/mozilla/developer_guide/development_process_overview/workflow.svg
Error: /Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/mozilla/developer_guide/development_process_overview/workflow.svg <svg> contains an unsafe attribute key: 'onload'
    at Node.<anonymous> (/Users/peterbe/dev/MOZILLA/MDN/yari/filecheck/checker.js:73:17)
    at initialize.exports.each (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/cheerio/lib/api/traversing.js:562:24)
    at checkFile (/Users/peterbe/dev/MOZILLA/MDN/yari/filecheck/checker.js:66:12)
    at async Promise.all (index 0)
    at async Se.run (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/@caporal/core/dist/index.js:1:27579)
    at async Te._run (/Users/peterbe/dev/MOZILLA/MDN/yari/node_modules/@caporal/core/dist/index.js:1:32257)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
