### PR TITLE
Broken link checkers should fallback to en-US if possible

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -215,11 +215,6 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
       $element.text(`${$element.text()} (${DEFAULT_LOCALE})`);
       $element.addClass("only-in-en-us");
       $element.attr("title", "Currently only available in English");
-      fs.appendFileSync(
-        "/tmp/fellback.log",
-        `${doc.mdn_url}\t${enUSFallback}\n`,
-        "utf-8"
-      );
     } else {
       throw new Error("Don't use this function if neither is true");
     }

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -214,7 +214,7 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
       // the `web.smartLink()` function in kumascript rendering.
       $element.text(`${$element.text()} (${DEFAULT_LOCALE})`);
       $element.addClass("only-in-en-us");
-      $element.attr("title", "Currently only available in English");
+      $element.attr("title", "Currently only available in English (US)");
     } else {
       throw new Error("Don't use this function if neither is true");
     }

--- a/kumascript/src/api/web.js
+++ b/kumascript/src/api/web.js
@@ -99,7 +99,7 @@ module.exports = {
         flawAttribute = ` data-flaw-src="${util.htmlEscape(flaw.macroSource)}"`;
         return (
           '<a class="only-in-en-us" ' +
-          'title="Currently only available in English" ' +
+          'title="Currently only available in English (US)" ' +
           `href="${enUSPage.url}"${flawAttribute}>${content} <span>(en-US)</span></a>`
         );
       }

--- a/testing/translated-content/files/fr/web/foo/index.html
+++ b/testing/translated-content/files/fr/web/foo/index.html
@@ -10,3 +10,15 @@ translation_of: Web/Foo
   <img src="screenshot.png" alt="Capture d'écran des couleurs" />
   <figcaption>Une image parfaitement normale</figcaption>
 </figure>
+
+<p>
+  This here demonstrates what happens when translated links exist but they're
+  actually broken. And in this case, what should happen is that it can fall back
+  on the en-US equivalent of those URLs.
+</p>
+<ul>
+  <li><a href="/fr/docs/Web/CSS/dumber">The &quot;dumber&quot; page</a></li>
+  <li>
+    <a href="/fr/docs/Web/CSS/number">The <i>number</i> page</a>
+  </li>
+</ul>


### PR DESCRIPTION
Fixes #3104

Take http://localhost:3000/bg/docs/Web for example. 
Compare it with https://developer.mozilla.org/bg/docs/Web
There are lots of broken links on that page (in Prod). And a lot of them are really broken because when you click on one of them (e.g. https://developer.mozilla.org/bg/docs/Web/Apps) you get a 404 Page not found, but *without* that helpful "Good news!" (green) message that it's available in English. That's because that Belarusian link is so broken and old that it doesn't check for redirects. 

Now it becomes this:
```html
<a href="/en-US/docs/Web/Progressive_web_apps" class="only-in-en-us" 
title="Currently only available in English" data-flaw="link14">Разработка на уеб приложения (en-US)</a>
```

- [x] Add tests
- [x] Check how often this happens for realz: **UPDATE** 5,167 links in all of the translated-content got switched to the en-US fallback URL on a complete build. 
