### PR TITLE
Stop saying "Building roots:" twice

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
 
+const chalk = require("chalk");
 const cliProgress = require("cli-progress");
 const program = require("@caporal/core").default;
 const { prompt } = require("inquirer");
@@ -10,7 +11,9 @@ const {
   Document,
   slugToFolder,
   translationsOf,
+  CONTENT_ROOT,
   CONTENT_TRANSLATED_ROOT,
+  CONTENT_ARCHIVED_ROOT,
 } = require("../content");
 
 // eslint-disable-next-line node/no-missing-require
@@ -279,7 +282,18 @@ program
   .action(async ({ args, options }) => {
     try {
       if (!options.quiet) {
-        console.log("\nBuilding Documents...");
+        const roots = [
+          ["CONTENT_ROOT", CONTENT_ROOT],
+          ["CONTENT_TRANSLATED_ROOT", CONTENT_TRANSLATED_ROOT],
+          ["CONTENT_ARCHIVED_ROOT", CONTENT_ARCHIVED_ROOT],
+        ];
+        for (const [key, value] of roots) {
+          console.log(
+            `${chalk.grey((key + ":").padEnd(25, " "))}${
+              value ? chalk.white(value) : chalk.grey("not set")
+            }`
+          );
+        }
       }
       const { files } = args;
       const t0 = new Date();

--- a/content/document.js
+++ b/content/document.js
@@ -358,30 +358,20 @@ function findByURL(url, ...args) {
   return doc;
 }
 
-function findAll({
-  files = new Set(),
-  folderSearch = null,
-  quiet = false,
-} = {}) {
+function findAll({ files = new Set(), folderSearch = null } = {}) {
   if (!(files instanceof Set)) throw new TypeError("'files' not a Set");
   if (folderSearch && typeof folderSearch !== "string")
     throw new TypeError("'folderSearch' not a string");
 
-  // TODO: doesn't support archive content yet
-  // console.warn("Currently hardcoded to only build 'en-us'");
   const filePaths = [];
   const roots = [];
   if (CONTENT_ARCHIVED_ROOT) {
-    // roots.push({ path: CONTENT_ARCHIVED_ROOT, isArchive: true });
     roots.push(CONTENT_ARCHIVED_ROOT);
   }
   if (CONTENT_TRANSLATED_ROOT) {
     roots.push(CONTENT_TRANSLATED_ROOT);
   }
   roots.push(CONTENT_ROOT);
-  if (!quiet) {
-    console.log("Building roots:", roots);
-  }
   for (const root of roots) {
     filePaths.push(
       ...glob


### PR DESCRIPTION
Fixes #3253

<img width="609" alt="Screen Shot 2021-03-16 at 11 33 24 AM" src="https://user-images.githubusercontent.com/26739/111336363-8ceddc80-864b-11eb-8f82-5e31176e5153.png">

It's not gorgeous, but it'll work better since it's now only printing that stuff in the CLI. Once. 