### PR TITLE
adds Level 5 Color Spec

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -489,6 +489,11 @@
     "url": "https://drafts.csswg.org/css-cascade-5/",
     "status": "WD"
   },
+  "CSS5 Colors": {
+    "name": "CSS Color Module Level&nbsp;5",
+    "url": "https://drafts.csswg.org/css-color-5/",
+    "status": "WD"
+  },
   "CSS5 Media Queries": {
     "name": "Media Queries Level&nbsp;5",
     "url": "https://drafts.csswg.org/mediaqueries-5/",


### PR DESCRIPTION
We now have a CSS Color Level 5 https://drafts.csswg.org/css-color-5/

Adding it to SpecData.