### PR TITLE
--prune should leave archived S3 keys

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -204,7 +204,7 @@ jobs:
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          poetry run deployer upload --prune ../client/build
+          poetry run deployer upload --prune --archived-files ../content/archived.txt ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
           # TODO
           # Execute command to tell the Dev CloudFront distribution to use the

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -240,7 +240,7 @@ jobs:
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          poetry run deployer upload  --prune ../client/build
+          poetry run deployer upload  --prune --archived-files ../content/archived.txt ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
 
           # TODO: Depending on how long the upload takes, consider switching to

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -39,6 +39,22 @@ def validate_optional_directory(ctx, param, value):
         return validate_directory(ctx, param, value)
 
 
+def validate_file(ctz, param, value):
+    if not value:
+        raise click.BadParameter(f"{value!r}")
+    path = Path(value)
+    if not path.exists():
+        raise click.BadParameter(f"{value} does not exist")
+    elif not path.is_file():
+        raise click.BadParameter(f"{value} is not a file")
+    return path
+
+
+def validate_optional_file(ctx, param, value):
+    if value:
+        return validate_file(ctx, param, value)
+
+
 @click.group()
 @click.option(
     "--dry-run",
@@ -150,6 +166,15 @@ def whatsdeployed(ctx, directory: Path, output: str):
     default=False,
     show_default=True,
     is_flag=True,
+)
+@click.option(
+    "--archived-files",
+    help=(
+        "The path to the file that lists which files are archived. "
+        "(Only relevant in conjunction with --prune)"
+    ),
+    default=None,
+    callback=validate_optional_file,
 )
 @click.argument("directory", type=click.Path(), callback=validate_directory)
 @click.pass_context

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -186,9 +186,13 @@ def upload(ctx, directory: Path, **kwargs):
     if kwargs["content_archived_root"]:
         content_roots.append(kwargs["content_archived_root"])
 
-    print(kwargs)
+    if kwargs["prune"] and not kwargs["archived_files"]:
+        log.warning(
+            "Warning! Running with --prune but NOT ----archived-files will "
+            "possibly delete all archived content."
+        )
     ctx.obj.update(kwargs)
-    # upload_content(directory, content_roots, ctx.obj)
+    upload_content(directory, content_roots, ctx.obj)
 
 
 @cli.command()

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -185,8 +185,10 @@ def upload(ctx, directory: Path, **kwargs):
         content_roots.append(kwargs["content_translated_root"])
     if kwargs["content_archived_root"]:
         content_roots.append(kwargs["content_archived_root"])
+
+    print(kwargs)
     ctx.obj.update(kwargs)
-    upload_content(directory, content_roots, ctx.obj)
+    # upload_content(directory, content_roots, ctx.obj)
 
 
 @cli.command()

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -643,7 +643,7 @@ def upload_content(build_directory, content_roots, config):
                     # This is the easiest and fastest lookup
                     is_archived = True
                 elif (
-                    re.sub(r"/(index.json|contributors.txt|bcd.json)$", "", key)
+                    re.sub(r"/(index\.json|contributors\.txt|bcd\.json)$", "", key)
                     in archived_files_as_keys
                 ):
                     # This is easy and fast too and covers 99% of the other

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -628,7 +628,7 @@ def upload_content(build_directory, content_roots, config):
 
             # Remember, if `key` is from a "index.html" file it will be represented
             # something like this: `main/en-us/docs/web/api/documentorshadowroot`
-            # with the prefix and the `/index.html` portion removed.
+            # with the `/index.html` portion removed.
             # But every page usually has a `index.json` file, which might look
             # something like this: `main/en-us/docs/web/api/index.json` or
             # `main/en-us/docs/web/api/screenshot.png`

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -518,12 +518,6 @@ def upload_content(build_directory, content_roots, config):
     prune = config["prune"]
     archived_txt_file = config["archived_files"]
 
-    archived_files = set()
-    if archived_txt_file:
-        archived_files.update(parse_archived_txt_file(archived_txt_file))
-        if not archived_files:
-            raise Exception(f"found no entries inside {archived_txt_file}")
-
     log.info(f"Upload files from: {build_directory}")
     if upload_redirects:
         log.info(f"Upload redirects from: {', '.join(str(fp) for fp in content_roots)}")
@@ -600,9 +594,12 @@ def upload_content(build_directory, content_roots, config):
         delete_keys = []
 
         archived_files_as_keys = set()
-        for file in archived_files:
-            locale, slug = file.replace("/index.html", "").split("/", 1)
-            archived_files_as_keys.add(f"{bucket_prefix}/{locale}/docs/{slug}")
+        if archived_txt_file:
+            for file in parse_archived_txt_file(archived_txt_file):
+                locale, slug = file.replace("/index.html", "").split("/", 1)
+                archived_files_as_keys.add(f"{bucket_prefix}/{locale}/docs/{slug}")
+            if not archived_files_as_keys:
+                raise Exception(f"found no entries inside {archived_txt_file}")
 
         for key in existing_bucket_objects:
             if key.startswith(f"{bucket_prefix}/_whatsdeployed/"):

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -499,13 +499,11 @@ class BucketManager:
 
 
 def parse_archived_txt_file(file: Path):
-    file_paths = []
     with open(file) as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#"):
-                file_paths.append(line)
-    return file_paths
+                yield line
 
 
 def upload_content(build_directory, content_roots, config):


### PR DESCRIPTION
Part of #2224

Here's how I tested it:

1. Run a complete build of all of CONTENT_ROOT and all of CONTENT_TRANSLATED_ROOT
2. Then I ran: `DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=false poetry run deployer upload --content-root=/Users/peterbe/dev/MOZILLA/MDN/content/files --bucket=peterbe-yari --prune --archived-files ../content/archived.txt ../client/build` (this is using my personal AWS account)
3. Now, it should have uploaded all en-us docs, uploaded all archived docs, deleted all translated non-archived docs. 
4. It worked!

For example:
<img width="1369" alt="Screen Shot 2021-03-17 at 1 10 20 PM" src="https://user-images.githubusercontent.com/26739/111518715-b599d300-872c-11eb-8c25-e99321904413.png">
