### PR TITLE
CompatibilityTable.ejs injects HTML that's considered unsafe

### DIFF
--- a/kumascript/macros/CompatibilityTable.ejs
+++ b/kumascript/macros/CompatibilityTable.ejs
@@ -42,7 +42,7 @@ var cta = mdn.localString({
 <div class="htab">
     <a id="AutoCompatibilityTable" name="AutoCompatibilityTable"></a>
     <ul>
-        <li class="selected"><a href="javascript:;"><%- s_header[0] %></a></li>
-        <li><a href="javascript:;"><%- s_header[1] %></a></li>
+        <li class="selected"><a href="#compat-desktop"><%- s_header[0] %></a></li>
+        <li><a href="#compat-mobile"><%- s_header[1] %></a></li>
     </ul>
 </div>


### PR DESCRIPTION
Fixes #3269

http://localhost:3000/ru/docs/Web/API/Element/classList#_flaws used to have "Unsafe HTML" flaws. Now it no longer does. 