### PR TITLE
/pagenotfound is rendering the homepage route

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -15,3 +15,44 @@ export const AUTOCOMPLETE_SEARCH_WIDGET = JSON.parse(
 export const DEBUG_SEARCH_RESULTS = JSON.parse(
   process.env.REACT_APP_DEBUG_SEARCH_RESULTS || "false"
 );
+
+// Remember to keep this in sync with the list inside the Node code.
+// E.g. libs/constants.js
+// Hardcoding the list in both places is most convenient and most performant.
+// We could encode the list in the SSR rendering but that means the client side
+// code needs to depend on having access to the `window` global first.
+export const VALID_LOCALES = new Set([
+  "ar",
+  "bg",
+  "bn",
+  "ca",
+  "de",
+  "el",
+  "en-US",
+  "es",
+  "fa",
+  "fi",
+  "fr",
+  "he",
+  "hi-IN",
+  "hu",
+  "id",
+  "it",
+  "ja",
+  "kab",
+  "ko",
+  "ms",
+  "my",
+  "nl",
+  "pl",
+  "pt-BR",
+  "pt-PT",
+  "ru",
+  "sv-SE",
+  "th",
+  "tr",
+  "uk",
+  "vi",
+  "zh-CN",
+  "zh-TW",
+]);

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,5 +1,54 @@
 import { useParams } from "react-router-dom";
 
+// This is a bit of a necessary hack!
+// The only reason this list is needed is because of the PageNotFound rendering.
+// If someone requests `https://domain/some-random-word` what will happen is that
+// Lambda@Edge will send the `build/en-us/_spas/404.html` rendered page. That
+// rendered page has all the React stuff like routing.
+// The <App/> component can know what it needs to render but what's problematic
+// is that all and any other app will think that the locale is `some-random-word`
+// just because it's the first portion of the URL.
+// So, for example, the top navbar will think it can use the `useLocale()` hook
+// and get the current locale from the react-router context. Now the navbar menu
+// items, for example, will think the locale is `some-random-word` and make links
+// like `/some-random-word/docs/Web`.
+const VALID_LOCALES = new Set([
+  "ar",
+  "bg",
+  "bn",
+  "ca",
+  "de",
+  "el",
+  "en-US",
+  "es",
+  "fa",
+  "fi",
+  "fr",
+  "he",
+  "hi-IN",
+  "hu",
+  "id",
+  "it",
+  "ja",
+  "kab",
+  "ko",
+  "ms",
+  "my",
+  "nl",
+  "pl",
+  "pt-BR",
+  "pt-PT",
+  "ru",
+  "sv-SE",
+  "th",
+  "tr",
+  "uk",
+  "vi",
+  "zh-CN",
+  "zh-TW",
+]);
+
 export function useLocale() {
-  return useParams().locale || "en-US";
+  const { locale } = useParams();
+  return locale && VALID_LOCALES.has(locale) ? locale : "en-US";
 }

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -12,41 +12,7 @@ import { useParams } from "react-router-dom";
 // and get the current locale from the react-router context. Now the navbar menu
 // items, for example, will think the locale is `some-random-word` and make links
 // like `/some-random-word/docs/Web`.
-const VALID_LOCALES = new Set([
-  "ar",
-  "bg",
-  "bn",
-  "ca",
-  "de",
-  "el",
-  "en-US",
-  "es",
-  "fa",
-  "fi",
-  "fr",
-  "he",
-  "hi-IN",
-  "hu",
-  "id",
-  "it",
-  "ja",
-  "kab",
-  "ko",
-  "ms",
-  "my",
-  "nl",
-  "pl",
-  "pt-BR",
-  "pt-PT",
-  "ru",
-  "sv-SE",
-  "th",
-  "tr",
-  "uk",
-  "vi",
-  "zh-CN",
-  "zh-TW",
-]);
+import { VALID_LOCALES } from "./constants";
 
 export function useLocale() {
   const { locale } = useParams();

--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -42,7 +42,7 @@ export default function FallbackLink({ url }: { url: string }) {
   );
 
   React.useEffect(() => {
-    if (url && locale.toLowerCase() !== "en-us") {
+    if (url && url.includes("/docs/") && locale.toLowerCase() !== "en-us") {
       // What if we attempt to see if it would be something there in English?
       // We'll use the `index.json` version of the URL
       let enUSURL = url.replace(`/${locale}/`, "/en-US/");

--- a/client/src/ui/molecules/main-menu/index.tsx
+++ b/client/src/ui/molecules/main-menu/index.tsx
@@ -12,8 +12,6 @@ export default function MainMenu({
   toggleMainMenu?: () => void;
 }) {
   const locale = useLocale();
-  console.log("MAIN MENU", { locale });
-
   const previousActiveElement = useRef<null | HTMLButtonElement>(null);
   const mainMenuRef = useRef<null | HTMLUListElement>(null);
   const [visibleSubMenu, setVisibleSubMenu] = useState<string | null>(null);

--- a/client/src/ui/molecules/main-menu/index.tsx
+++ b/client/src/ui/molecules/main-menu/index.tsx
@@ -12,6 +12,8 @@ export default function MainMenu({
   toggleMainMenu?: () => void;
 }) {
   const locale = useLocale();
+  console.log("MAIN MENU", { locale });
+
   const previousActiveElement = useRef<null | HTMLButtonElement>(null);
   const mainMenuRef = useRef<null | HTMLUListElement>(null);
   const [visibleSubMenu, setVisibleSubMenu] = useState<string | null>(null);

--- a/server/index.js
+++ b/server/index.js
@@ -162,7 +162,7 @@ app.get("/*/contributors.txt", async (req, res) => {
 });
 
 app.get("/*", async (req, res) => {
-  if (req.url.startsWith("_")) {
+  if (req.url.startsWith("/_")) {
     // URLs starting with _ is exclusively for the meta-work and if there
     // isn't already a handler, it's something wrong.
     return res.status(404).send("Page not found");
@@ -182,11 +182,12 @@ app.get("/*", async (req, res) => {
   }
 
   if (!req.url.includes("/docs/")) {
-    // This should really only be expected for "single page apps".
-    // All *documents* should be handled by the
-    // `if (req.url.includes("/docs/"))` test above.
-    res.sendFile(path.join(STATIC_ROOT, "/index.html"));
-    return;
+    // If it's a known SPA, like `/en-US/search` then that should have been
+    // matched to its file and not end up here in the catchall handler.
+    // Simulate what we do in the Lambda@Edge.
+    return res
+      .status(404)
+      .sendFile(path.join(STATIC_ROOT, "en-us", "_spas", "404.html"));
   }
 
   // TODO: Would be nice to have a list of all supported file extensions


### PR DESCRIPTION
Fixes #3224
Fixes #3287

Here's how I tested it, first run `yarn dev` and then use the "production mode" because that's more like how Lambda works. Now, open:

- http://localhost:5000/pagenotfound
- http://localhost:5000/en-US/pagenotfound
- http://localhost:5000/en-US/docs/pagenotfound
- http://localhost:5000/en-US/
- http://localhost:5000/en-US/search/
- http://localhost:5000/en-US/signin/
- http://localhost:3000/en-US/

The most important one is the first one. That's what this PR really fixes. 
What used to happen is that it would render the home page component. I.e. `<Home/>` and within that component, it would think the current locale is `pagenotfound` because it's the first word in the URL. Just like `/en-US` or `/fr`. 

Now, I'm forcing it to render the `<PageNotFound/>` component if the rendering says to do so. That's part of the solution. 
The other part of the solution is to force the commonly used `useLocale()` hook to NOT accept the first part of the URL (e.g. 'peter' in `/peter`) *unless* it looks like it's a realistic locale. 

This is unfortunately the first and only place in the whole client-side codebase where we have the list of valid locale codes. Until now, it's only ever in the Node code. So it's a verbatim copy. But I think it's a fair comparison. Suppose we some day decide to drop a locale, like `sv-SE` we'll need to delete it in two places. 1) in the Node code (`libs/constants.js`) and 2) in this client code. 