### PR TITLE
fix: heading underline on hover and focus

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -125,6 +125,11 @@
     a:visited {
       text-decoration: none;
     }
+
+    a:hover,
+    a:focus {
+      text-decoration: underline;
+    }
   }
 
   table {


### PR DESCRIPTION
Add underline on hover and focus for linked headings

Fix #3205
