### PR TITLE
correct spacing for simpler diff

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -240,7 +240,7 @@ jobs:
           # XXX would be nice to validate here that $DEPLOYER_BUCKET_PREFIX is truthy
           echo "DEPLOYER_BUCKET_PREFIX=$DEPLOYER_BUCKET_PREFIX"
 
-          poetry run deployer upload  --prune --archived-files ../content/archived.txt ../client/build
+          poetry run deployer upload --prune --archived-files ../content/archived.txt ../client/build
           poetry run deployer update-lambda-functions ./aws-lambda
 
           # TODO: Depending on how long the upload takes, consider switching to


### PR DESCRIPTION
Now the `diff .github/workflows/prod-build.yml .github/workflows/stage-build.yml` should only mention stuff that actually is and *should* be different across the two files. Otherwise you'd also get a mention of ...

```diff
230c243
<           poetry run deployer upload --prune --archived-files ../content/archived.txt ../client/build
---
>           poetry run deployer upload  --prune --archived-files ../content/archived.txt ../client/build

```