### PR TITLE
don't even attempt files URIs that start with //

### DIFF
--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -88,7 +88,7 @@ exports.handler = async (event) => {
   // opening `https://evil.com/` in the browser, because the browser will
   // treat `//evil.com/ == https://evil.com/`.
   // Prevent any pathnames that start with a double //.
-  // This essentiall means that a request for `GET /////anyhing` becomes
+  // This essentially means that a request for `GET /////anything` becomes
   // 302 with `Location: /anything`.
   if (request.uri.startsWith("//")) {
     return redirect(`/${request.uri.replace(/^\/+/g, "")}`);

--- a/deployer/aws-lambda/content-origin-request/server.test.js
+++ b/deployer/aws-lambda/content-origin-request/server.test.js
@@ -188,11 +188,15 @@ describe("always check for fundamental redirects first", () => {
   });
 });
 
-describe("avoid double-slash redirects", () => {
-  it("should 404 on any pathname that starts with //", async () => {
+describe("redirect double-slash prefix URIs", () => {
+  it("should 302 redirect anything that starts with //", async () => {
     const r = await get(`//en-US/search/`);
-    expect(r.statusCode).toBe(404);
-    expect(r.headers["location"]).toBeFalsy();
-    expect(r.body).toContain("URL pathname can't start with //");
+    expect(r.statusCode).toBe(302);
+    expect(r.headers["location"]).toBe("/en-US/search/");
+  });
+  it("should 302 redirect anything that starts with // on anything", async () => {
+    const r = await get(`//blablabla`);
+    expect(r.statusCode).toBe(302);
+    expect(r.headers["location"]).toBe("/blablabla");
   });
 });


### PR DESCRIPTION
Fixes #3225

Basically, any request for something like `//////whatever` becomes a 302 to `/whatever` and then we'll see what happens next. 

I think this is much better than what we had before. 
For example request for `https://deverloper.m.o//evil.com/` becomes a redirect to `https://deverloper.m.o/evil.com/` which just ends up being a 404 in the end. But a request for `https://developer.m.o//en-US/docs/Web` actually becomes a 302 to `/en-US/docs/Web` which will eventually 200 OK. 

I think it'll have to be a separate issue but check out:
```
▶ curl -I https://developer.mozilla.org/en-US/docs/Web//JavaScript
HTTP/2 301
...
location: /en-US/docs/Web_JavaScript
```

What the heck is `Web_JavaScript`? :)

I think it would be better that `/en-US/docs/Web//JavaScript` becomes a 302 to `/en-US/docs/Web/JavaScript` and that'll "start the whole thing over" and we'll see what happens next. 
