### PR TITLE
Settings page, briefly, says you're not signed in

### DIFF
--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -27,23 +27,6 @@ export type UserData = {
   };
 };
 
-const defaultUserData: UserData = {
-  username: null,
-  isAuthenticated: false,
-  isBetaTester: false,
-  isStaff: false,
-  isSuperuser: false,
-  avatarUrl: null,
-  isSubscriber: false,
-  subscriberNumber: null,
-  email: null,
-  waffle: {
-    flags: {},
-    switches: {},
-    samples: {},
-  },
-};
-
 const UserDataContext = React.createContext<UserData | null>(null);
 
 export function UserDataProvider(props: { children: React.ReactNode }) {
@@ -74,7 +57,7 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
   );
 
   return (
-    <UserDataContext.Provider value={data ? data : defaultUserData}>
+    <UserDataContext.Provider value={data || null}>
       {props.children}
     </UserDataContext.Provider>
   );

--- a/server/index.js
+++ b/server/index.js
@@ -77,8 +77,8 @@ const proxy = FAKE_V1_API
           : "http://"
       }${PROXY_HOSTNAME}`,
       changeOrigin: true,
-      proxyTimeout: 3000,
-      timeout: 3000,
+      proxyTimeout: 10000,
+      timeout: 10000,
     });
 
 app.use("/api/v1", proxy);


### PR DESCRIPTION
Fixes #3319

Now, the `userUserData` hook will return `null` initially (until the `/api/v1/whoami` XHR request has resolved). 
I still think there might a good opportunity to inject a `sessionStorage` cache into that hook which'll almost always resolve faster than the XHR. 