### PR TITLE
Get rid of 'pre.language-*`

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -1,6 +1,6 @@
-// (At least without a theme) regular prism.css is really small so we can
-// afford to load it on all pages globally.
-@import "prismjs/themes/prism";
+// We're assuming that code snippets are so common that it's OK to always
+// include them in every page.
+@import "./minimal-prism.scss";
 
 @import "~@mdn/minimalist/sass/mdn-minimalist";
 @import "./ui/molecules/grids/grids";

--- a/client/src/minimal-prism.scss
+++ b/client/src/minimal-prism.scss
@@ -1,0 +1,125 @@
+/* This is based on
+    node_modules/prismjs/themes/prism.css
+as of Mar 26, 2021.
+
+The reason we're not importing all of their CSS is because it contains a lot of
+selectors that we never use. In particular, it has (lots!) CSS for selectors
+like `pre[class*="language-"]` and `code[class*="language-"]` but because we
+don't use any of that, we can safely ignore it.
+*/
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: slategray;
+}
+
+.token.punctuation {
+  color: #999;
+}
+
+.token.namespace {
+  opacity: 0.7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #9a6e3a;
+  /* This background color was intended by the author of this theme. */
+  background: hsla(0, 0%, 100%, 0.5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #07a;
+}
+
+.token.function,
+.token.class-name {
+  color: #dd4a68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+  color: #e90;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+// MINIMALIST....
+
+// .token.keyword {
+//   color: $primary-50;
+// }
+
+// .token.selector,
+// .token.attr-name,
+// .token.string,
+// .token.char,
+// .token.builtin,
+// .token.inserted {
+//   color: $green-100;
+// }
+
+// .token.operator,
+// .token.entity,
+// .token.url,
+// .language-css .token.string,
+// .style .token.string,
+// .token.variable {
+//   background-color: transparent;
+//   color: $neutral-100;
+// }
+
+// .token.atrule,
+// .token.attr-value,
+// .token.function {
+//   color: $red-200;
+// }
+
+// .token.comment,
+// .token.prolog,
+// .token.doctype,
+// .token.cdata {
+//   color: $neutral-300;
+// }
+
+// .token.regex,
+// .token.important {
+//   color: $orange-100;
+// }


### PR DESCRIPTION
Fixes #3279

This incomplete because it's going to require a change to minimalist too. 
In particular, [this line needs to be deleted](https://github.com/mdn/mdn-minimalist/blob/1e2d9294d34a019f44fef10f53e88e732214a6c8/sass/mdn-minimalist.scss#L29).

Now, we're only using the bare essentials for Prism. This actually makes a decent difference. 
When I build the static assets based on this branch, and then compare with what I'd get on the `main` branch, the difference is as follows:
```
▶ ls -ltr main.*
-rw-r--r--  1 peterbe  wheel  50317 Mar 24 22:35 main.optimized.chunk.min.css
-rw-r--r--  1 peterbe  wheel  51600 Mar 24 22:37 main.main.chunk.min.css
```
This new optimized CSS is 1,283 bytes lighter. It's only 238 bytes smaller when you compare the Brotli compressed files but after the Brotli download has been downloaded and decompressed, it's still 1,283 bytes larger in terms of CSS that needs to be parsed and prepared by the browser. 
We know that making the CSS minimal is always a big win for web performance. 

@schalkneethling The one big thing to look out for is that, in this branch, I disregarded all the overrides that existed in the `./atoms/_primsjs.scss` file! So we'll need to fix that. 
What we need exactly is the perfect merge of your overrides with the minimal defaults from `node_modules/prismjs/themes/prism.css`. Because the edits in minialist's `primsjs.scss` assumes it's extending whatever `node_modules/prismjs/themes/prism.css` did. 
So there's a decent amount of work to do. **Taking all the best bits from `atoms/primsjs.scss` and putting them here into the `minimal-prism.scss` file?**

A good way to test this is to open these pages in parallel. 

1. http://localhost:3000/en-US/docs/Learn/Accessibility/HTML vs. https://developer.mozilla.org/en-US/docs/Learn/Accessibility/HTML
2. http://localhost:3000/en-US/docs/MDN/Kitchensink vs. https://developer.mozilla.org/en-US/docs/MDN/Kitchensink#axis-aligned_bounding_box