### PR TITLE
It's "Account settings" not "Account Settings"

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -51,7 +51,7 @@ async function buildSPAs(options) {
         { prefix: "search", pageTitle: "Search" },
         { prefix: "signin", pageTitle: "Sign in" },
         { prefix: "signup", pageTitle: "Sign up" },
-        { prefix: "settings", pageTitle: "Settings" },
+        { prefix: "settings", pageTitle: "Account settings" },
       ];
       for (const { prefix, pageTitle } of SPAs) {
         const url = `/${locale}/${prefix}`;

--- a/client/src/settings/index.tsx
+++ b/client/src/settings/index.tsx
@@ -5,8 +5,9 @@ import { PageContentContainer } from "../ui/atoms/page-content";
 const SettingsApp = React.lazy(() => import("./app"));
 
 export function Settings() {
+  const pageTitle = "Account settings";
   React.useEffect(() => {
-    document.title = "Settings";
+    document.title = pageTitle;
   }, []);
   const isServer = typeof window === "undefined";
   return (
@@ -19,7 +20,7 @@ export function Settings() {
           present the page feels less flickery at a very affordable cost of
           allowing this to be part of the main JS bundle.
        */}
-        <h1 className="slab-highlight">Account Settings</h1>
+        <h1 className="slab-highlight">{pageTitle}</h1>
         {!isServer && (
           <React.Suspense fallback={<p>Loading...</p>}>
             <SettingsApp />

--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -304,7 +304,7 @@ describe("Basic viewing of functional pages", () => {
 
   it("should say you're not signed in on the settings page", async () => {
     await page.goto(testURL("/en-US/settings"));
-    await expect(page).toMatchElement("h1", { text: "Account Settings" });
+    await expect(page).toMatchElement("h1", { text: "Account settings" });
     await expect(page).toMatchElement("a", {
       text: "Please sign in to continue",
     });
@@ -321,7 +321,7 @@ describe("Basic viewing of functional pages", () => {
     });
 
     await page.goto(url);
-    await expect(page).toMatchElement("h1", { text: "Account Settings" });
+    await expect(page).toMatchElement("h1", { text: "Account settings" });
     await expect(page).toMatchElement("button", { text: "Close account" });
 
     // Change locale to French

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -977,12 +977,13 @@ test("settings page", () => {
   const htmlFile = path.join(builtFolder, "index.html");
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
-  expect($("h1").text()).toContain("Settings");
-  expect($("title").text()).toContain("Settings");
+  expect($("h1").text()).toBe("Account settings");
+  console.log($("title").text());
+  expect($("title").text()).toContain("Account settings");
 
   const jsonFile = path.join(builtFolder, "index.json");
   const data = JSON.parse(fs.readFileSync(jsonFile));
-  expect(data.pageTitle).toBe("Settings");
+  expect(data.pageTitle).toBe("Account settings");
   expect(data.possibleLocales).toBeTruthy();
   const possibleLocale = data.possibleLocales.find((p) => p.locale === "en-US");
   expect(possibleLocale.English).toBe("English (US)");


### PR DESCRIPTION
Fixes #3345

It's quite sad that right now the page title is hardcoded in two places. It kinda has to be like that because the React code is compiled into a bundle that the Yari builder can't easily reach. 