### PR TITLE
fix: merge prism styles from minimalist with minimal-prism

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -1,6 +1,6 @@
 // We're assuming that code snippets are so common that it's OK to always
 // include them in every page.
-@import "./minimal-prism.scss";
+@import "./minimal-prism";
 
 @import "~@mdn/minimalist/sass/mdn-minimalist";
 @import "./ui/molecules/grids/grids";

--- a/client/src/minimal-prism.scss
+++ b/client/src/minimal-prism.scss
@@ -1,6 +1,5 @@
-/* This is based on
-    node_modules/prismjs/themes/prism.css
-as of Mar 26, 2021.
+/* 
+This is based on node_modules/prismjs/themes/prism.css as of Mar 26, 2021.
 
 The reason we're not importing all of their CSS is because it contains a lot of
 selectors that we never use. In particular, it has (lots!) CSS for selectors
@@ -8,15 +7,14 @@ like `pre[class*="language-"]` and `code[class*="language-"]` but because we
 don't use any of that, we can safely ignore it.
 */
 
+@import "~@mdn/minimalist/sass/vars/color-palette";
+
 .token.comment,
 .token.prolog,
 .token.doctype,
-.token.cdata {
-  color: slategray;
-}
-
+.token.cdata,
 .token.punctuation {
-  color: #999;
+  color: $neutral-300;
 }
 
 .token.namespace {
@@ -30,7 +28,7 @@ don't use any of that, we can safely ignore it.
 .token.constant,
 .token.symbol,
 .token.deleted {
-  color: #905;
+  color: $red-100;
 }
 
 .token.selector,
@@ -39,7 +37,7 @@ don't use any of that, we can safely ignore it.
 .token.char,
 .token.builtin,
 .token.inserted {
-  color: #690;
+  color: $green-100;
 }
 
 .token.operator,
@@ -47,32 +45,31 @@ don't use any of that, we can safely ignore it.
 .token.url,
 .language-css .token.string,
 .style .token.string {
-  color: #9a6e3a;
-  /* This background color was intended by the author of this theme. */
-  background: hsla(0, 0%, 100%, 0.5);
+  color: $neutral-100;
 }
 
 .token.atrule,
 .token.attr-value,
 .token.keyword {
-  color: #07a;
+  color: $primary-50;
 }
 
 .token.function,
 .token.class-name {
-  color: #dd4a68;
+  color: $red-200;
 }
 
 .token.regex,
 .token.important,
 .token.variable {
-  color: #e90;
+  color: $orange-200;
 }
 
 .token.important,
 .token.bold {
   font-weight: bold;
 }
+
 .token.italic {
   font-style: italic;
 }
@@ -80,46 +77,3 @@ don't use any of that, we can safely ignore it.
 .token.entity {
   cursor: help;
 }
-
-// MINIMALIST....
-
-// .token.keyword {
-//   color: $primary-50;
-// }
-
-// .token.selector,
-// .token.attr-name,
-// .token.string,
-// .token.char,
-// .token.builtin,
-// .token.inserted {
-//   color: $green-100;
-// }
-
-// .token.operator,
-// .token.entity,
-// .token.url,
-// .language-css .token.string,
-// .style .token.string,
-// .token.variable {
-//   background-color: transparent;
-//   color: $neutral-100;
-// }
-
-// .token.atrule,
-// .token.attr-value,
-// .token.function {
-//   color: $red-200;
-// }
-
-// .token.comment,
-// .token.prolog,
-// .token.doctype,
-// .token.cdata {
-//   color: $neutral-300;
-// }
-
-// .token.regex,
-// .token.important {
-//   color: $orange-100;
-// }


### PR DESCRIPTION
Merge prismjs overrides from minimalist with minimal-prism in Yari

Fix #3344
