### PR TITLE
Update CSS Grid spec to point to CR link

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -535,8 +535,8 @@
     "status": "Draft"
   },
   "CSS Grid": {
-    "name": "CSS Grid Layout",
-    "url": "https://drafts.csswg.org/css-grid/",
+    "name": "CSS Grid Layout Module Level 1",
+    "url": "https://www.w3.org/TR/css-grid-1/",
     "status": "CR"
   },
   "CSS Grid 2": {


### PR DESCRIPTION
This change:

- Updates the `url` of the `CSS Grid` spec data property to point to the [Candidate Recommendation](https://www.w3.org/TR/css-grid-1/) for Grid module level 1
- Updates the `name` of the `CSS Grid` spec data to be consistent with the names of the other Grid specs. 

I noticed while on the [MDN Page](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) for CSS Grids that the [CR spec link](https://drafts.csswg.org/css-grid/) took me to the module level 2 editor's draft, so I figured I'd try and change it here. However, I also see that most of the CSS2+ links point to csswg, so I may be wrong here (or perhaps on the csswg site the that link points to the wrong draft?)