### PR TITLE
update search-index till we figure out yari/issues/3359

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -238,7 +238,9 @@ jobs:
           # where the Elasticsearch server is nearly empty.
           # Consider doing something like a clean indexing on Sundays and
           # use `--update` on all the other week days.
-          poetry run deployer search-index ../client/build --priority-prefix=en-us/docs/web
+          # poetry run deployer search-index ../client/build --priority-prefix=en-us/docs/web
+          # TEMPORARY
+          poetry run deployer search-index ../client/build --update
 
           # Record the deployment in our Speedcurve account. This should always
           # be done after the upload of the documents and Lambda functions, as well

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -251,7 +251,9 @@ jobs:
           # where the Elasticsearch server is nearly empty.
           # Consider doing something like a clean indexing on Sundays and
           # use `--update` on all the other week days.
-          poetry run deployer search-index ../client/build --priority-prefix=en-us/docs/web
+          # poetry run deployer search-index ../client/build --priority-prefix=en-us/docs/web
+          # TEMPORARY
+          poetry run deployer search-index ../client/build --update
 
           # Record the deployment in our Speedcurve account. This should always
           # be done after the upload of the documents and Lambda functions, as well


### PR DESCRIPTION
Part of #3359

The default behavior is that it wipes the Elasticsearch index and fills it back up again. Recently we've seen lots `ReadTimeoutError` problems. [For example](https://github.com/mdn/yari/runs/2214594218?check_suite_focus=true)

This changes the strategy to instead just update the index. 

The right and full solution is to treat the index "transactionally" by using aliases. Then we don't even need a priority solution. 