### PR TITLE
show errors if a 400 on sign-up

### DIFF
--- a/client/src/auth/sign-up.tsx
+++ b/client/src/auth/sign-up.tsx
@@ -101,6 +101,8 @@ export default function SignUpApp() {
       mutate("/api/v1/whoami");
 
       navigate(nextURL);
+    } else if (response.status === 400) {
+      setSignupError(new Error(JSON.stringify(await response.json())));
     } else {
       setSignupError(new Error(`${response.status} on ${signupURL}`));
     }


### PR DESCRIPTION
Fixes #3377

This only makes sense once [Kuma starts returning a 400 JSON response](https://github.com/mdn/kuma/pull/7818) instead of  302. 

The explanation for this was that originally the sign-up was always from Yari to Kuma with a HTTP form POST. But then later I realized it's better for Yari to submit the sign-up to Kuma via a POST XHR. But clearly I forget to take care of the error handling when you might have 400 errors. 

We still need to solve https://github.com/mdn/yari/issues/3376 and that's the most important one. This PR (plus the kuma counterpart) is only really about stop hiding the errors if there are errors. 