### PR TITLE
calm down the Dependabot upgrades for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,12 +20,12 @@ updates:
   - package-ecosystem: "pip"
     directory: "/deployer"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "pip"
     directory: "/testing/integration"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: npm
     directory: "/deployer/aws-lambda/content-origin-request"


### PR DESCRIPTION
This should reduce [the crazy traffic of `boto3` upgrades](https://github.com/mdn/yari/pulls?q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed+boto3)