### PR TITLE
don't fetch /api/v1/settings till you're authenticated

### DIFF
--- a/client/src/settings/app.tsx
+++ b/client/src/settings/app.tsx
@@ -51,7 +51,7 @@ export default function SettingsApp({ ...appProps }) {
   const userData = useUserData();
 
   const { data, error } = useSWR<UserSettings | null, Error | null>(
-    userData ? "/api/v1/settings" : null,
+    userData && userData.isAuthenticated ? "/api/v1/settings" : null,
     async (url) => {
       const response = await fetch(url);
       if (!response.ok) {


### PR DESCRIPTION
Fixes #3378

The horrible terrible thing that happened was that if you kept your Web console open you'd see an XHR request to `/api/v1/settings` if you're not yet signed in. Oh nooooos! (sarcasm emoji here)