### PR TITLE
make it easier to debug site-search

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -15,11 +15,6 @@ export const AUTOCOMPLETE_SEARCH_WIDGET = JSON.parse(
   process.env.REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET || JSON.stringify(CRUD_MODE)
 );
 
-// You can read more about this in `docs/debugging-sitesearch.md`.
-export const DEBUG_SEARCH_RESULTS = JSON.parse(
-  process.env.REACT_APP_DEBUG_SEARCH_RESULTS || "false"
-);
-
 // Remember to keep this in sync with the list inside the Node code.
 // E.g. libs/constants.js
 // Hardcoding the list in both places is most convenient and most performant.

--- a/client/src/site-search/search-results.tsx
+++ b/client/src/site-search/search-results.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link, createSearchParams, useSearchParams } from "react-router-dom";
 import useSWR from "swr";
 
-import { CRUD_MODE, DEBUG_SEARCH_RESULTS } from "../constants";
+import { CRUD_MODE } from "../constants";
 import { useLocale } from "../hooks";
 import { appendURL } from "./utils";
 
@@ -367,7 +367,7 @@ function Results({
                   <span className="summary">{document.summary}</span>
                 )}
               </p>
-              {DEBUG_SEARCH_RESULTS && (
+              {searchParams.get("debug") !== null && (
                 <span className="nerd-data">
                   <b>score:</b> <code>{document.score}</code>,{" "}
                   <b>popularity:</b> <code>{document.popularity}</code>,{" "}

--- a/docs/debugging-sitesearch.md
+++ b/docs/debugging-sitesearch.md
@@ -13,11 +13,10 @@ displaying it in Yari is optional.
 
 ## How to enable it
 
-To display each search results `score` and `popularity`, set this in your `.env`:
+To display each search results `score` and `popularity`, simply add `&debug`
+to the current URL. E.g. `?q=foreach&debug` or `?debug=1&q=foreach`.
 
-    REACT_APP_DEBUG_SEARCH_RESULTS=true
-
-Now, when you open <http://localhost:3000/en-US/search?q=test> the `score`
+Now, when you open <http://localhost:3000/en-US/search?q=test&debug> the `score`
 and `popularity` is shown.
 
 ## How to use it


### PR DESCRIPTION
I like this approach a lot more than having to set a local environment variable. 
The underlying data is always present in the JSON anyway. E.g. see https://developer.mozilla.org/api/v1/search?q=foreach&locale=en-US

Now, you can just add `&debug` to the end of the URL and you can see these bits without having to view the raw JSON of the XHR request. 