### PR TITLE
read-only crud mode by hostname

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -7,8 +7,8 @@ export const CRUD_MODE = JSON.parse(
     JSON.stringify(process.env.NODE_ENV === "development")
 );
 
-export const CRUD_MODE_READONLY_HOSTNAMES = (
-  process.env.REACT_APP_CRUD_MODE_READONLY_HOSTNAMES ||
+export const CRUD_MODE_HOSTNAMES = (
+  process.env.REACT_APP_CRUD_MODE_HOSTNAMES ||
   "localhost,localhost.org,127.0.0.1"
 )
   .split(",")

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -7,9 +7,13 @@ export const CRUD_MODE = JSON.parse(
     JSON.stringify(process.env.NODE_ENV === "development")
 );
 
-export const CRUD_MODE_READONLY = JSON.parse(
-  process.env.REACT_APP_CRUD_MODE_READONLY || "false"
-);
+export const CRUD_MODE_READONLY_HOSTNAMES = (
+  process.env.REACT_APP_CRUD_MODE_READONLY_HOSTNAMES ||
+  "localhost,localhost.org,127.0.0.1"
+)
+  .split(",")
+  .map((x) => x.trim())
+  .filter(Boolean);
 
 export const AUTOCOMPLETE_SEARCH_WIDGET = JSON.parse(
   process.env.REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET || JSON.stringify(CRUD_MODE)

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
-import { CRUD_MODE_READONLY } from "../../constants";
+import { CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
 
 import "./edit-actions.scss";
 
@@ -61,9 +61,15 @@ export function EditActions({
     return null;
   }
 
+  // If window.location.host is 'localhost:3000` then
+  // window.location.hostname is 'localhost'
+  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
+    window.location.hostname
+  );
+
   return (
     <ul className="edit-actions">
-      {!CRUD_MODE_READONLY && (
+      {!isReadOnly && (
         <li>
           <button
             type="button"
@@ -85,7 +91,7 @@ export function EditActions({
         </a>
       </li>
 
-      {!CRUD_MODE_READONLY && (
+      {!isReadOnly && (
         <li>
           <Link
             to={location.pathname.replace("/docs/", "/_edit/")}

--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
-import { CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
+import { CRUD_MODE_HOSTNAMES } from "../../constants";
 
 import "./edit-actions.scss";
 
@@ -63,9 +63,7 @@ export function EditActions({
 
   // If window.location.host is 'localhost:3000` then
   // window.location.hostname is 'localhost'
-  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
-    window.location.hostname
-  );
+  const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
   return (
     <ul className="edit-actions">

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -4,7 +4,7 @@ import { annotate, annotationGroup } from "rough-notation";
 import { RoughAnnotation } from "rough-notation/lib/model";
 import { diffWords } from "diff";
 
-import { CRUD_MODE, CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
+import { CRUD_MODE, CRUD_MODE_HOSTNAMES } from "../../constants";
 import { humanizeFlawName } from "../../flaw-utils";
 import { useDocumentURL } from "../hooks";
 import {
@@ -199,9 +199,7 @@ function Flaws({
     })
     .flat();
 
-  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
-    window.location.hostname
-  );
+  const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
   return (
     <div id="document-flaws">

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -4,7 +4,7 @@ import { annotate, annotationGroup } from "rough-notation";
 import { RoughAnnotation } from "rough-notation/lib/model";
 import { diffWords } from "diff";
 
-import { CRUD_MODE, CRUD_MODE_READONLY } from "../../constants";
+import { CRUD_MODE, CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
 import { humanizeFlawName } from "../../flaw-utils";
 import { useDocumentURL } from "../hooks";
 import {
@@ -199,9 +199,13 @@ function Flaws({
     })
     .flat();
 
+  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
+    window.location.hostname
+  );
+
   return (
     <div id="document-flaws">
-      {!!fixableFlaws.length && !CRUD_MODE_READONLY && (
+      {!!fixableFlaws.length && !isReadOnly && (
         <FixableFlawsAction
           count={fixableFlaws.length}
           reloadPage={reloadPage}
@@ -216,6 +220,7 @@ function Flaws({
                 key="broken_links"
                 sourceFolder={doc.source.folder}
                 links={doc.flaws.broken_links}
+                isReadOnly={isReadOnly}
               />
             );
           case "bad_bcd_links":
@@ -238,6 +243,7 @@ function Flaws({
                 key="bad_pre_tags"
                 sourceFolder={doc.source.folder}
                 flaws={doc.flaws.bad_pre_tags}
+                isReadOnly={isReadOnly}
               />
             );
           case "macros":
@@ -246,6 +252,7 @@ function Flaws({
                 key="macros"
                 sourceFolder={doc.source.folder}
                 flaws={doc.flaws.macros}
+                isReadOnly={isReadOnly}
               />
             );
           case "images":
@@ -254,6 +261,7 @@ function Flaws({
                 key="images"
                 sourceFolder={doc.source.folder}
                 images={doc.flaws.images}
+                isReadOnly={isReadOnly}
               />
             );
           case "image_widths":
@@ -262,6 +270,7 @@ function Flaws({
                 key="image_widths"
                 sourceFolder={doc.source.folder}
                 flaws={doc.flaws.image_widths}
+                isReadOnly={isReadOnly}
               />
             );
           case "heading_links":
@@ -270,6 +279,7 @@ function Flaws({
                 key="heading_links"
                 sourceFolder={doc.source.folder}
                 flaws={doc.flaws.heading_links}
+                isReadOnly={isReadOnly}
               />
             );
           case "unsafe_html":
@@ -380,9 +390,11 @@ function ShowDiff({ before, after }: { before: string; after: string }) {
 function BrokenLinks({
   sourceFolder,
   links,
+  isReadOnly,
 }: {
   sourceFolder: string;
   links: BrokenLink[];
+  isReadOnly: boolean;
 }) {
   const [opening, setOpening] = React.useState<string | null>(null);
   useEffect(() => {
@@ -445,7 +457,7 @@ function BrokenLinks({
               >
                 👀
               </span>{" "}
-              {CRUD_MODE_READONLY ? (
+              {isReadOnly ? (
                 <>
                   {/* It would be cool if we can change this to a link to the line in the
                   file in GitHub's UI. */}
@@ -535,9 +547,11 @@ function Sectioning({ flaws }: { flaws: SectioningFlaw[] }) {
 function BadPreTag({
   flaws,
   sourceFolder,
+  isReadOnly,
 }: {
   flaws: BadPreTagFlaw[];
   sourceFolder: string;
+  isReadOnly: boolean;
 }) {
   const { focus } = useAnnotations(flaws);
 
@@ -591,7 +605,7 @@ function BadPreTag({
               👀
             </span>{" "}
             {flaw.line && flaw.column ? (
-              CRUD_MODE_READONLY ? (
+              isReadOnly ? (
                 <>
                   line {flaw.line}:{flaw.column}
                 </>
@@ -620,9 +634,11 @@ function BadPreTag({
 function Macros({
   flaws,
   sourceFolder,
+  isReadOnly,
 }: {
   flaws: MacroErrorMessage[];
   sourceFolder: string;
+  isReadOnly: boolean;
 }) {
   const [opening, setOpening] = React.useState<string | null>(null);
   useEffect(() => {
@@ -670,7 +686,7 @@ function Macros({
           >
             <summary>
               <code>{flaw.name}</code> from <code>{flaw.macroName}</code>{" "}
-              {CRUD_MODE_READONLY ? (
+              {isReadOnly ? (
                 <>
                   line {flaw.line}:{flaw.column}
                 </>
@@ -732,9 +748,11 @@ function Macros({
 function Images({
   sourceFolder,
   images,
+  isReadOnly,
 }: {
   sourceFolder: string;
   images: ImageReferenceFlaw[];
+  isReadOnly: boolean;
 }) {
   // XXX rewrite to a hook
   const [opening, setOpening] = React.useState<string | null>(null);
@@ -790,7 +808,7 @@ function Images({
               >
                 👀
               </span>{" "}
-              {CRUD_MODE_READONLY ? (
+              {isReadOnly ? (
                 <>
                   line {flaw.line}:{flaw.column}
                 </>
@@ -826,9 +844,11 @@ function Images({
 function ImageWidths({
   sourceFolder,
   flaws,
+  isReadOnly,
 }: {
   sourceFolder: string;
   flaws: ImageWidthFlaw[];
+  isReadOnly: boolean;
 }) {
   // XXX rewrite to a hook
   const [opening, setOpening] = React.useState<string | null>(null);
@@ -884,7 +904,7 @@ function ImageWidths({
               >
                 👀
               </span>{" "}
-              {CRUD_MODE_READONLY ? (
+              {isReadOnly ? (
                 <>
                   line {flaw.line}:{flaw.column}
                 </>
@@ -931,9 +951,11 @@ function ImageWidths({
 function HeadingLinks({
   sourceFolder,
   flaws,
+  isReadOnly,
 }: {
   sourceFolder: string;
   flaws: HeadingLinksFlaw[];
+  isReadOnly: boolean;
 }) {
   // XXX rewrite to a hook
   const [opening, setOpening] = React.useState<string | null>(null);
@@ -977,7 +999,7 @@ function HeadingLinks({
             <li key={key}>
               <b>{flaw.explanation}</b>{" "}
               {flaw.line && flaw.column ? (
-                CRUD_MODE_READONLY ? (
+                isReadOnly ? (
                   <>
                     line {flaw.line}:{flaw.column}
                   </>

--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { CRUD_MODE_READONLY } from "../../constants";
+import { CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
 import { Doc } from "../types";
 import { EditActions } from "./edit-actions";
 import { ToggleDocumentFlaws } from "./flaws";
@@ -33,6 +33,10 @@ export default function Toolbar({
     localStorage.setItem(localStorageKey, JSON.stringify(visits.slice(0, 20)));
   }, [doc]);
 
+  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
+    window.location.hostname
+  );
+
   return (
     <div className="toolbar">
       <div className="toolbar-first-row">
@@ -41,7 +45,7 @@ export default function Toolbar({
           filename={doc.source.filename}
         />
       </div>
-      {CRUD_MODE_READONLY && (
+      {isReadOnly && (
         <p>
           <i>
             You're in <b>read-only</b> mode.

--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { CRUD_MODE_READONLY_HOSTNAMES } from "../../constants";
+import { CRUD_MODE_HOSTNAMES } from "../../constants";
 import { Doc } from "../types";
 import { EditActions } from "./edit-actions";
 import { ToggleDocumentFlaws } from "./flaws";
@@ -33,9 +33,7 @@ export default function Toolbar({
     localStorage.setItem(localStorageKey, JSON.stringify(visits.slice(0, 20)));
   }, [doc]);
 
-  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
-    window.location.hostname
-  );
+  const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
   return (
     <div className="toolbar">

--- a/client/src/sitemap/index.tsx
+++ b/client/src/sitemap/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import useSWR from "swr";
 
-import { CRUD_MODE, CRUD_MODE_READONLY } from "../constants";
+import { CRUD_MODE, CRUD_MODE_READONLY_HOSTNAMES } from "../constants";
 import { useLocale } from "../hooks";
 import { PageContentContainer } from "../ui/atoms/page-content";
 
@@ -399,6 +399,10 @@ function Breadcrumb({
   const root = pathname.split("/").slice(0, 2);
   root.push("_sitemap");
 
+  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
+    window.location.hostname
+  );
+
   return (
     <>
       <ul className="breadcrumb">
@@ -427,7 +431,7 @@ function Breadcrumb({
               <Link to={thisDoc.url}>
                 <em>{thisDoc.title}</em>
               </Link>{" "}
-              {CRUD_MODE && !CRUD_MODE_READONLY && (
+              {CRUD_MODE && !isReadOnly && (
                 <small>
                   (
                   <a
@@ -467,6 +471,9 @@ function ShowTree({
   openInYourEditor: (url: string) => void;
 }) {
   const locale = useLocale();
+  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
+    window.location.hostname
+  );
   return (
     <div className="tree">
       <ul>
@@ -492,8 +499,8 @@ function ShowTree({
                 <Link to={doc.url} title={`Go to: ${doc.title}`}>
                   View
                 </Link>
-                {!CRUD_MODE_READONLY && " | "}
-                {!CRUD_MODE_READONLY && (
+                {!isReadOnly && " | "}
+                {!isReadOnly && (
                   <Link
                     to={doc.url}
                     title={`Edit: ${doc.title}`}

--- a/client/src/sitemap/index.tsx
+++ b/client/src/sitemap/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import useSWR from "swr";
 
-import { CRUD_MODE, CRUD_MODE_READONLY_HOSTNAMES } from "../constants";
+import { CRUD_MODE, CRUD_MODE_HOSTNAMES } from "../constants";
 import { useLocale } from "../hooks";
 import { PageContentContainer } from "../ui/atoms/page-content";
 
@@ -399,9 +399,7 @@ function Breadcrumb({
   const root = pathname.split("/").slice(0, 2);
   root.push("_sitemap");
 
-  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
-    window.location.hostname
-  );
+  const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
   return (
     <>
@@ -471,9 +469,7 @@ function ShowTree({
   openInYourEditor: (url: string) => void;
 }) {
   const locale = useLocale();
-  const isReadOnly = !CRUD_MODE_READONLY_HOSTNAMES.includes(
-    window.location.hostname
-  );
+  const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
   return (
     <div className="tree">
       <ul>

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -284,7 +284,7 @@ It defaults to `NODE_ENV==='development'` if not set which means that
 it's enable by default when doing development with the `localhost:3000`
 dev server.
 
-### `REACT_APP_CRUD_MODE_READONLY_HOSTNAMES`
+### `REACT_APP_CRUD_MODE_HOSTNAMES`
 
 **Default: `localhost, localhost.org, 127.0.0.1`**
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -284,9 +284,19 @@ It defaults to `NODE_ENV==='development'` if not set which means that
 it's enable by default when doing development with the `localhost:3000`
 dev server.
 
-### `REACT_APP_CRUD_MODE_READONLY`
+### `REACT_APP_CRUD_MODE_READONLY_HOSTNAMES`
 
-**Default: `false`**
+**Default: `localhost, localhost.org, 127.0.0.1`**
 
-Only applicable if `REACT_APP_CRUD_MODE` is truthy. This setting disables all
-options like "Fix fixable flaws" or "Quick-edit"
+Only applicable if `REACT_APP_CRUD_MODE` is truthy. Essentially you can disable
+certain CRUD mode features depending on the hostname you use. So if you built
+the static assets (the React code) with `REACT_APP_CRUD_MODE=true` it might
+disable certain features if you use a `window.location.hostname` that is _not_
+in this list.
+
+The use case for this is when you build the site in a pull request and want
+flaws to _appear_ but without the "Fix fixable flaws" link or the "Open in your editor"
+button. We use this for previewing PR builds on the content site. Those pages are
+built with flaw detection set to warn, but since you might be viewing the pages
+on a remote domain (e.g. `pr123.dev.content.mozit.cloud`) it doesn't make sense to
+present the "Fix fixable flaws" button for example.


### PR DESCRIPTION
Now the read-only is determined by the `window.location.hostname` NOT being in the default list of `localhost`, `localhost.org`, or `127.0.0.1`. 

To test this, let's pretend that `localhost.org` (or `127.0.0.1`) is the equivalent of `pr123.dev.content.mozit.cloud`. 
So type this:
```
export REACT_APP_CRUD_MODE_READONLY_HOSTNAMES=localhost
export REACT_APP_CRUD_MODE=true
yarn prepare-build && yarn start:server
```
Now it's like using the Yari preview server from the perspective of the mdn/content repo. 
To got http://localhost.org:5000/en-US/docs/Games/Tutorials#_flaws and http://localhost:5000/en-US/docs/Games/Tutorials#_flaws and compare. 
Or go to http://localhost.org:5000/en-US/_sitemap/Games vs. http://localhost:5000/en-US/_sitemap/Games

Man I'm so thankful for TypeScript for this! It made it super easy to refactor all that usage without allowing me to even start the server until all code made sense. 