### PR TITLE
Intention to measure: Find out the x-cache values in site-searches

### DIFF
--- a/client/src/site-search/search-results.tsx
+++ b/client/src/site-search/search-results.tsx
@@ -8,6 +8,7 @@ import { appendURL } from "./utils";
 
 import LANGUAGES_RAW from "../languages.json";
 import "./search-results.scss";
+import { useGA } from "../ga-context";
 
 const LANGUAGES = new Map(
   Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
@@ -77,6 +78,7 @@ class ServerOperationalError extends Error {
 }
 
 export default function SearchResults() {
+  const ga = useGA();
   const [searchParams] = useSearchParams();
   const locale = useLocale();
   // A call to `/api/v1/search` will default to mean the same thing as
@@ -102,6 +104,16 @@ export default function SearchResults() {
       } else if (!response.ok) {
         throw new Error(`${response.status} on ${url}`);
       }
+
+      // See docs/experiments/0001_site-search-x-cache.md
+      const xCacheHeaderValue = response.headers.get("x-cache");
+      ga("send", {
+        hitType: "event",
+        eventCategory: "Site-search X-Cache",
+        eventAction: url,
+        eventLabel: xCacheHeaderValue || "no value",
+      });
+
       return await response.json();
     },
     {

--- a/docs/experiments/0001_site-search-x-cache.md
+++ b/docs/experiments/0001_site-search-x-cache.md
@@ -1,0 +1,29 @@
+# Experiment: X-Cache response headers in site-search XHRs
+
+## Issue
+
+<https://github.com/mdn/yari/issues/3420>
+
+## Overview
+
+Find out how the CDN cache is working out for people doing site-search queries.
+The objective is to record what value people get for `X-Cache` from the CDN.
+
+## Start date
+
+Early April 2021.
+
+## End date
+
+May 1 2021.
+
+## Details
+
+As described in the issue, the current `Cache-Control` set by Kuma is 12h
+(`12 * 60 * 60 = 43200`).
+Perhaps we should increase it if too few people are getting cold caches from
+the CDN.
+
+## Analysis
+
+Look at Google Analytics Events under `Site-search X-Cache`.


### PR DESCRIPTION
Part of #3420

This isn't a ground-breaking piece of experimentation, but it's the first and an attempt to try to get structured and organized about experimentations. 

Please review the "structure" as much (if not more!) as the code. 
My intention here is to demonstrate that every experiment (which measurements is a subset of) should have its own `docs/experiments/*.md` file with those headings. 
We mustn't go crazy with this but what matters to me is that there *exists a record* and that an *end date* is picked. That means that if you find the code beyond the experimentation "Due date" you can just delete it without having to worry about "Is somebody still measuring and looking at it? Hello?!"

What do you think @schalkneethling and @escattone ?

Reminder how to test this:

Set:
```
BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
BUILD_GOOGLE_ANALYTICS_DEBUG=true
PROXY_HOSTNAME=developer.allizom.org
```
in your `.env`.
Now start `yarn dev` and navigate to http://localhost:5000/en-US/search
Use a browser that doesn't block GA. View with the Web Console open. 
<img width="535" alt="Screen Shot 2021-04-02 at 12 16 24 PM" src="https://user-images.githubusercontent.com/26739/113433456-40c1cc80-93ad-11eb-9c3c-6b1486630e4d.png">
