### PR TITLE
Generate clickable anchor links for the `htmlattrdef` macro.

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -96,6 +96,13 @@ a.new {
         background-color: transparent;
       }
     }
+
+    &[id^="attr-"] {
+      &:link,
+      &:visited {
+        color: $neutral-100;
+      }
+    }
   }
 
   h2 {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -101,6 +101,12 @@ a.new {
       &:link,
       &:visited {
         color: $neutral-100;
+        text-decoration: none;
+      }
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
       }
     }
   }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -108,6 +108,10 @@ a.new {
       &:focus {
         text-decoration: underline;
       }
+
+      &:active {
+        color: $text-color-inverted;
+      }
     }
   }
 

--- a/kumascript/macros/htmlattrdef.ejs
+++ b/kumascript/macros/htmlattrdef.ejs
@@ -1,2 +1,2 @@
 <%/* Example: <span class="script">htmlattrdef("placeholder")</span> */%>
-<a id="attr-<%=$0%>" href="#attr-<%=$0%>"><strong><code><%=$0%></code></strong></a>
+<a id="attr-<%=$0%>" href="#attr-<%=$0%>"><b><code><%=$0%></code></b></a>

--- a/kumascript/macros/htmlattrdef.ejs
+++ b/kumascript/macros/htmlattrdef.ejs
@@ -1,2 +1,2 @@
 <%/* Example: <span class="script">htmlattrdef("placeholder")</span> */%>
-<strong id="attr-<%=$0%>"><code><%=$0%></code></strong>
+<a id="attr-<%=$0%>" href="#attr-<%=$0%>"><strong><code><%=$0%></code></strong></a>


### PR DESCRIPTION
Wraps the heading generated by the `htmlattrdef` macro into a self-link to allow for easy linking.

Closes #3148 