### PR TITLE
Fix SVG <text> “Permitted content”

### DIFF
--- a/kumascript/macros/L10n-SVG.json
+++ b/kumascript/macros/L10n-SVG.json
@@ -288,6 +288,9 @@
     "zh-CN": "结构化元素",
     "ru": "Структурные элементы"
   },
+  "textContentChildElements": {
+    "en-US": "Text content child elements"
+  },
   "textContentElements": {
     "en-US": "Text content elements",
     "de": "Textinhaltselemente",

--- a/kumascript/macros/SVGData.json
+++ b/kumascript/macros/SVGData.json
@@ -1768,7 +1768,7 @@
         "elements": [
           "animationElements",
           "descriptiveElements",
-          "textContentElements",
+          "textContentChildElements",
           "&lt;a&gt;"
         ]
       },

--- a/kumascript/macros/svginfo.ejs
+++ b/kumascript/macros/svginfo.ejs
@@ -49,8 +49,6 @@ if (name === "preview-wiki-content") {
             } else {
                 var anchor = element.replace(/[A-Z]/g, function(match) {
                         return "_" + match.toLowerCase();
-                    }).replace(/^./, function(match) {
-                        return match.toUpperCase();
                     });
                 elementGroups.push("<a href=\"/" + env.locale +
                     "/docs/Web/SVG/Element#" + anchor + "\">" +


### PR DESCRIPTION
Per https://svgwg.org/svg2-draft/text.html#elementdef-text the permitted content for the SVG `<text>` element includes “text content child elements” — not “text content elements” (which is something different).

Fixes https://github.com/mdn/content/issues/3882

This change also makes a change to the `svginfo` macro to cause it to use all-lowercase for the link anchors it generates (rather than initial cap).