### PR TITLE
adding angular docs to the learning area sidebar

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -223,6 +223,13 @@ var text = mdn.localStringMap({
         'Working_with_Svelte_stores': 'Working with Svelte stores',
         'TypeScript_support_in_Svelte': 'TypeScript support in Svelte',
         'Deployment_and_next_steps': 'Deployment and next steps',
+      'Angular': 'Angular',
+        'Getting_started_with_Angular': 'Getting started with Angular',
+        'Beginning_our_Angular_todo_list_app': 'Beginning our Angular todo list app',
+        'Styling_our_Angular_app': 'Styling our Angular app',
+        'Creating_an_item_component': 'Creating an item component',
+        'Filtering_our_to-do_items': 'Filtering our to-do items',
+        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
     'Server-side_website_programming' : 'Server-side website programming',
       'First_steps' : 'First steps',
         'First_steps_overview' : 'First steps overview',
@@ -969,6 +976,13 @@ var text = mdn.localStringMap({
         'Working_with_Svelte_stores': 'Working with Svelte stores',
         'TypeScript_support_in_Svelte': 'TypeScript support in Svelte',
         'Deployment_and_next_steps': 'Deployment and next steps',
+      'Angular': 'Angular',
+        'Getting_started_with_Angular': 'Getting started with Angular',
+        'Beginning_our_Angular_todo_list_app': 'Beginning our Angular todo list app',
+        'Styling_our_Angular_app': 'Styling our Angular app',
+        'Creating_an_item_component': 'Creating an item component',
+        'Filtering_our_to-do_items': 'Filtering our to-do items',
+        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
     'Server-side_website_programming' : 'Программирование серверной части сайта',
       'First_steps' : 'Первые шаги',
         'First_steps_overview' : 'Первые шаги',
@@ -1211,6 +1225,13 @@ var text = mdn.localStringMap({
         'Working_with_Svelte_stores': 'Working with Svelte stores',
         'TypeScript_support_in_Svelte': 'TypeScript support in Svelte',
         'Deployment_and_next_steps': 'Deployment and next steps',
+      'Angular': 'Angular',
+        'Getting_started_with_Angular': 'Getting started with Angular',
+        'Beginning_our_Angular_todo_list_app': 'Beginning our Angular todo list app',
+        'Styling_our_Angular_app': 'Styling our Angular app',
+        'Creating_an_item_component': 'Creating an item component',
+        'Filtering_our_to-do_items': 'Filtering our to-do items',
+        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
     'Server-side_website_programming' : '服务端网页编程',
       'First_steps' : '第一步',
         'First_steps_overview' : '第一步概述',
@@ -1448,6 +1469,13 @@ var text = mdn.localStringMap({
         'Working_with_Svelte_stores': 'Working with Svelte stores',
         'TypeScript_support_in_Svelte': 'TypeScript support in Svelte',
         'Deployment_and_next_steps': 'Deployment and next steps',
+      'Angular': 'Angular',
+        'Getting_started_with_Angular': 'Getting started with Angular',
+        'Beginning_our_Angular_todo_list_app': 'Beginning our Angular todo list app',
+        'Styling_our_Angular_app': 'Styling our Angular app',
+        'Creating_an_item_component': 'Creating an item component',
+        'Filtering_our_to-do_items': 'Filtering our to-do items',
+        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
     'Server-side_website_programming' : '伺服端網站程式設計',
       'First_steps' : '第一步',
         'First_steps_overview' : '第一步概述',
@@ -1716,6 +1744,13 @@ var text = mdn.localStringMap({
         'Working_with_Svelte_stores': 'Working with Svelte stores',
         'TypeScript_support_in_Svelte': 'TypeScript support in Svelte',
         'Deployment_and_next_steps': 'Deployment and next steps',
+      'Angular': 'Angular',
+        'Getting_started_with_Angular': 'Getting started with Angular',
+        'Beginning_our_Angular_todo_list_app': 'Beginning our Angular todo list app',
+        'Styling_our_Angular_app': 'Styling our Angular app',
+        'Creating_an_item_component': 'Creating an item component',
+        'Filtering_our_to-do_items': 'Filtering our to-do items',
+        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
     'Server-side_website_programming' : 'Server-side website programming',
       'First_steps' : 'First steps',
         'First_steps_overview' : 'First steps overview',
@@ -2099,6 +2134,19 @@ var text = mdn.localStringMap({
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_stores"><%=text['Working_with_Svelte_stores']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_TypeScript  "><%=text['TypeScript_support_in_Svelte']%></a></li>
           <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Svelte_deployment_next"><%=text['Deployment_and_next_steps']%></a></li>
+        </ol>
+    </details>
+  </li>
+  <li class="toggle">
+    <details <%=currentPageIsUnder('Tools_and_testing/Client-side_JavaScript_frameworks')%>>
+        <summary><%=text['Angular']%></summary>
+        <ol>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_getting_started"><%=text['Getting_started_with_Angular']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_todo_list_beginning"><%=text['Beginning_our_Angular_todo_list_app']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_styling"><%=text['Styling_our_Angular_app']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_item_component"><%=text['Creating_an_item_component']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_filtering"><%=text['Filtering_our_to-do_items']%></a></li>
+          <li><a href="<%=baseURL%>Tools_and_testing/Client-side_JavaScript_frameworks/Angular_building"><%=text['Building_Angular_applications_and_further_resources']%></a></li>
         </ol>
     </details>
   </li>


### PR DESCRIPTION
This PR updates the LearnSidebar.ejs macro to include the Angular tutorials.

The equivalent content PR to add the documents linked to by these new menu items is at https://github.com/mdn/content/pull/3972

I tested both together locally using my branches on the yari and content repos, and the yari dev server. Looks like it works fine.