### PR TITLE
Treat BCD ranges as exact versions to avoid confusion for the reader

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -106,6 +106,7 @@ function labelFromString(version: string | boolean | null | undefined) {
     return <>{"?"}</>;
   }
   // Treat BCD ranges as exact versions to avoid confusion for the reader
+  // See https://github.com/mdn/yari/issues/3238
   if (version.startsWith("≤")) {
     return <>{version.slice(1)}</>;
   }

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -105,16 +105,11 @@ function labelFromString(version: string | boolean | null | undefined) {
   if (typeof version !== "string") {
     return <>{"?"}</>;
   }
-  if (!version.startsWith("≤")) {
-    return <>{version}</>;
+  // Treat BCD ranges as exact versions to avoid confusion for the reader
+  if (version.startsWith("≤")) {
+    return <>{version.slice(1)}</>;
   }
-  const title = `Supported in version ${version.slice(1)} or earlier.`;
-  return (
-    <span title={title}>
-      <sup>≤&#xA0;</sup>
-      {version.slice(1)}
-    </span>
-  );
+  return <>{version}</>;
 }
 
 const CellText = React.memo(


### PR DESCRIPTION
Fixes https://github.com/mdn/yari/issues/3238. 

BCD has version ranges to signal that the exact support version is unknown still. This is useful for data maintenance and data improvements but displaying the "≤" hint to readers on MDN compat tables has lead to confusion and the tooltip we've provided didn't really help with that either (apparently). So, let's not expose this to readers at all.  

