### PR TITLE
Add OpenSearch support

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -35,6 +35,20 @@
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
+    <!-- OpenSearch -->
+    <link
+      rel="search"
+      type="application/opensearchdescription+xml"
+      title="MDN Web Docs"
+      href="https://developer.mozilla.org/en-US/search/xml"
+    />
+
+    <Url
+      type="application/opensearchdescription+xml"
+      rel="self"
+      template="https://developer.mozilla.org/en-US/search/xml"
+    />
+
     <script>
       // Only include the polyfill for browsers that seem to not have
       // certain JS features. E.g. Firefox 58.


### PR DESCRIPTION
[OpenSearch](https://developer.mozilla.org/en-US/docs/Web/OpenSearch) was supported by MDN in the past, but for some reason was removed some time ago. This is a very useful feature, so I'm opening this PR to add support for OpenSearch back!