### PR TITLE
don't double-encode the query string when redirecting

### DIFF
--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -49,6 +49,17 @@ function redirect(location, { status = 302, cacheControlSeconds = 0 } = {}) {
   } else {
     cacheControlValue = "no-store";
   }
+  // We need to URL encode the pathname, but leave the query string as is.
+  // Suppose the old URL was `/search?q=text%2Dshadow` and all we need to do
+  // is to inject the locale to that URL, we should not URL encode the whole
+  // new URL otherwise you'd end up with `/en-US/search?q=text%252Dshadow`
+  // since the already encoded `%2D` would become `%252D` which is wrong and
+  // different.
+  const [pathname, querystring] = location.split("?", 2);
+  let newLocation = encodeURI(pathname);
+  if (querystring) {
+    newLocation += `?${querystring}`;
+  }
   return {
     status,
     statusDescription,
@@ -56,7 +67,7 @@ function redirect(location, { status = 302, cacheControlSeconds = 0 } = {}) {
       location: [
         {
           key: "Location",
-          value: encodeURI(location),
+          value: newLocation,
         },
       ],
       "cache-control": [

--- a/deployer/aws-lambda/content-origin-request/server.test.js
+++ b/deployer/aws-lambda/content-origin-request/server.test.js
@@ -25,10 +25,17 @@ describe("root URL redirects", () => {
     expect(r.headers["location"]).toBe("/en-US/");
   });
 
-  it("should preserve the query string", async () => {
+  it("should preserve the basic query string", async () => {
     const r = await get("/?foo=bar");
     expect(r.statusCode).toBe(302);
     expect(r.headers["location"]).toBe("/en-US/?foo=bar");
+  });
+
+  it("should preserve the query string and not encode it twice", async () => {
+    // This test is based on https://github.com/mdn/yari/issues/3425
+    const r = await get("/?q=text%2Dshadow");
+    expect(r.statusCode).toBe(302);
+    expect(r.headers["location"]).toBe("/en-US/?q=text%2Dshadow");
   });
 
   it("should redirect with a trailing slash when cased correctly", async () => {


### PR DESCRIPTION
Fixes #3425

This certainly seems to solve the problem. To test, use:

```
cd deployer/aws-lambda/content-origin-request
yarn serve

# in a new terminal
curl -I http://localhost:7000/search\?q=text%2Dshadow
```
