### PR TITLE
make all front-matter available in KS rendering

### DIFF
--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -56,14 +56,10 @@ const renderFromURL = async (
   const [renderedHtml, errors] = await renderMacros(
     rawHTML,
     {
-      ...{
-        url,
-        locale: metadata.locale,
-        slug: metadata.slug,
-        title: metadata.title,
-        tags: metadata.tags || [],
-        selective_mode,
-      },
+      ...metadata,
+      url,
+      tags: metadata.tags || [],
+      selective_mode,
       interactive_examples: {
         base_url: INTERACTIVE_EXAMPLES_BASE_URL,
       },

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -30,7 +30,7 @@ Example calls
 
 */
 
-var query = $0;
+var query = $0 || env['browser-compat'];
 var depth = $1 || 1;
 var output = `<div class="bc-data" id="bcd:${query}" data-depth="${depth}">
   If you're able to see this, something went wrong on this page.

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -31,6 +31,9 @@ Example calls
 */
 
 var query = $0 || env['browser-compat'];
+if (!query) {
+  throw new Error("No first query argument or 'browser-compat' front-matter value passed");
+}
 var depth = $1 || 1;
 var output = `<div class="bc-data" id="bcd:${query}" data-depth="${depth}">
   If you're able to see this, something went wrong on this page.


### PR DESCRIPTION
Fixes #3258

In principle, this was an easy fix. Now I can make this change in the content:
```diff
diff --git a/files/en-us/web/api/headers/index.html b/files/en-us/web/api/headers/index.html
index d7e613f48..72eeaf9b3 100644
--- a/files/en-us/web/api/headers/index.html
+++ b/files/en-us/web/api/headers/index.html
@@ -9,6 +9,7 @@ tags:
   - Headers
   - Interface
   - Reference
+browser-compat: api.Headers
 ---
 <div>{{APIRef("Fetch API")}}</div>
 
@@ -118,7 +119,7 @@ myHeaders.get('Content-Type') // should return 'text/xml'
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Headers")}}</p>
+<p>{{Compat}}</p>
 
 <h2 id="See_also">See also</h2>
 
```

and it works! It works because now any key in the front-matter becomes available in that `env` object you get inside the context of KS rendering. 
We used to hardcode the "transfer" of `slug`, `title`, and `tags`. Now it just takes all and everything from the front-matter and makes it available. There is a slight exception for the front-matter `tags` because it could potentially be `undefined` but I think the KS macros expects it to always be an array. By leaving it to always fall back on an empty array, no macro code would need to do something like `if (!Array.isArray(env.tags)) {` or anything like that. 
But yes, the `env['browser-compat']` might be `undefined` but this is a new thing so I think it's fair for KS macros to always check for truthy'ness before using it. 

I'm not entirely sure what the consequences might be related to KS rendering caching so I'm tempted to make this a draft for @escattone to ponder. But I don't usually make draft PRs if there's nothing left on my to-do list for the branch work. 