### PR TITLE
/en-US/ isn't a broken link

### DIFF
--- a/testing/content/files/en-us/web/homepage_links/index.html
+++ b/testing/content/files/en-us/web/homepage_links/index.html
@@ -1,0 +1,25 @@
+---
+title: A page with links to the home page
+slug: Web/Homepage_links
+---
+<p>
+  <a href="/"><code>/</code></a> - perfect
+</p>
+<p>
+  <a href="/en-US/"><code>/en-US/</code></a> - perfect
+</p>
+<p>
+  <a href="/fr/"><code>/fr/</code></a> - perfect
+</p>
+<p>
+  <a href="/ru"><code>/ru</code></a> - lacking trailing slash
+</p>
+<p>
+  <a href="/JA/"><code>/JA/</code></a> - wrong case
+</p>
+<p>
+  <a href="/ZH-CN"><code>/ZH-CN</code></a> - wrong case and lacking trailing slash
+</p>
+<p>
+  <a href="/notalocale/"><code>/notalocale/</code></a> - not a valid locale
+</p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1374,3 +1374,21 @@ test("translated content broken links can fall back to en-us", () => {
     "Currently only available in English (US)"
   );
 });
+
+test("homepage links and flaws", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "homepage_links"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.flaws.broken_links.length).toBe(4);
+  const map = new Map(doc.flaws.broken_links.map((x) => [x.href, x]));
+  expect(map.get("/ru").suggestion).toBe("/ru/");
+  expect(map.get("/JA/").suggestion).toBe("/ja/");
+  expect(map.get("/ZH-CN").suggestion).toBe("/zh-CN/");
+  expect(map.get("/notalocale/").suggestion).toBeFalsy();
+});


### PR DESCRIPTION
Fixes #3326
Fixes #3447

<img width="858" alt="Screen Shot 2021-04-13 at 7 04 58 AM" src="https://user-images.githubusercontent.com/26739/114542966-9193b980-9c26-11eb-9ac3-ba198df356f5.png">
