### PR TITLE
Ability to control default cache-control in Deployer uploads

### DIFF
--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -10,6 +10,7 @@ from .constants import (
     CONTENT_ARCHIVED_ROOT,
     DEFAULT_BUCKET_NAME,
     DEFAULT_BUCKET_PREFIX,
+    DEFAULT_CACHE_CONTROL,
     DEFAULT_NO_PROGRESSBAR,
     DEFAULT_REPO,
     DEFAULT_GITHUB_TOKEN,
@@ -185,6 +186,12 @@ def whatsdeployed(ctx, directory: Path, output: str):
     ),
     default=None,
     callback=validate_optional_file,
+)
+@click.option(
+    "--default-cache-control",
+    help="The default Cache-Control value used when uploading files (0 to disable)",
+    default=DEFAULT_CACHE_CONTROL,
+    show_default=True,
 )
 @click.argument("directory", type=click.Path(), callback=validate_directory)
 @click.pass_context

--- a/deployer/src/deployer/upload.py
+++ b/deployer/src/deployer/upload.py
@@ -125,13 +125,20 @@ class UploadFileTask(UploadTask):
     Class for file upload tasks.
     """
 
-    def __init__(self, file_path: Path, key: str, dry_run=False):
+    def __init__(
+        self,
+        file_path: Path,
+        key: str,
+        dry_run=False,
+        default_cache_control=DEFAULT_CACHE_CONTROL,
+    ):
         self.key = key
         self.file_path = file_path
         self.dry_run = dry_run
+        self.default_cache_control = default_cache_control
 
     def __repr__(self):
-        return f"UploadFileTask({self.file_path}, {self.key})"
+        return f"{self.__class__.__name__}({self.file_path}, {self.key})"
 
     def __str__(self):
         return self.key
@@ -203,9 +210,12 @@ class UploadFileTask(UploadTask):
         if self.is_hashed:
             cache_control_seconds = HASHED_CACHE_CONTROL
         else:
-            cache_control_seconds = DEFAULT_CACHE_CONTROL
+            cache_control_seconds = self.default_cache_control
 
-        return f"max-age={cache_control_seconds}, public"
+        if cache_control_seconds == 0:
+            return "max-age=0, no-cache, no-store, must-revalidate"
+        else:
+            return f"max-age={cache_control_seconds}, public"
 
     def upload(self, bucket_manager):
         if not self.dry_run:
@@ -344,7 +354,13 @@ class BucketManager:
                 break
         return result
 
-    def iter_file_tasks(self, build_directory, for_counting_only=False, dry_run=False):
+    def iter_file_tasks(
+        self,
+        build_directory,
+        for_counting_only=False,
+        dry_run=False,
+        default_cache_control=DEFAULT_CACHE_CONTROL,
+    ):
         # The order matters! In particular the order of static assets compared to
         # the HTML files that reference said static assets.
         # If you upload the HTML files before we upload the static assets, what
@@ -378,7 +394,12 @@ class BucketManager:
             if for_counting_only:
                 yield 1
             else:
-                yield UploadFileTask(fp, key, dry_run=dry_run)
+                yield UploadFileTask(
+                    fp,
+                    key,
+                    dry_run=dry_run,
+                    default_cache_control=default_cache_control,
+                )
             done.add(key)
 
         # Prepare a computation of what the root /index.html file would be
@@ -414,7 +435,12 @@ class BucketManager:
             if for_counting_only:
                 yield 1
             else:
-                yield UploadFileTask(fp, key, dry_run=dry_run)
+                yield UploadFileTask(
+                    fp,
+                    key,
+                    dry_run=dry_run,
+                    default_cache_control=default_cache_control,
+                )
 
     def iter_redirect_tasks(
         self, content_roots, for_counting_only=False, dry_run=False
@@ -463,6 +489,7 @@ class BucketManager:
         on_task_complete=None,
         skip_redirects=False,
         dry_run=False,
+        default_cache_control=DEFAULT_CACHE_CONTROL,
     ):
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=MAX_WORKERS_PARALLEL_UPLOADS
@@ -474,7 +501,13 @@ class BucketManager:
                 task_iters.append(
                     self.iter_redirect_tasks(content_roots, dry_run=dry_run)
                 )
-            task_iters.append(self.iter_file_tasks(build_directory, dry_run=dry_run))
+            task_iters.append(
+                self.iter_file_tasks(
+                    build_directory,
+                    dry_run=dry_run,
+                    default_cache_control=default_cache_control,
+                )
+            )
             for task_iter in task_iters:
                 futures = {}
                 for task in task_iter:
@@ -558,6 +591,7 @@ def upload_content(build_directory, content_roots, config):
     upload_redirects = not config["no_redirects"]
     prune = config["prune"]
     archived_txt_file = config["archived_files"]
+    default_cache_control = config["default_cache_control"]
 
     log.info(f"Upload files from: {build_directory}")
     if upload_redirects:
@@ -611,6 +645,7 @@ def upload_content(build_directory, content_roots, config):
             on_task_complete=on_task_complete,
             skip_redirects=not upload_redirects,
             dry_run=dry_run,
+            default_cache_control=default_cache_control,
         )
 
     if dry_run:


### PR DESCRIPTION
Fixes #3516

If we land this, we can change [this line](https://github.com/mdn/content/blob/2c6f017de416f5817a109191417d549c60e90055/.github/workflows/pr-review-companion.yml#L102) to add `--default-cache-control 0`