### PR TITLE
don't broken_links check home page urls with hash

### DIFF
--- a/build/flaws.js
+++ b/build/flaws.js
@@ -281,9 +281,6 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
 
   function isHomepageURL(url) {
     // Return true if the URL is something like `/` or `/en-US` or `/fr/`
-    // If the URL was something like this: `/en-US#anchor` we don't
-    // want the hash to get in the way.
-    [url] = url.split("#");
     if (url === "/") {
       return true;
     }
@@ -307,6 +304,17 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
     // that function knows which match it's referring to.
     checked.set(href, checked.has(href) ? checked.get(href) + 1 : 0);
 
+    // Note, a lot of links are like this:
+    //  <a href="/docs/Learn/Front-end_web_developer">
+    // which means the author wanted the link to work in any language.
+    // When checking it against disk, we'll have to assume a locale.
+    const hrefSplit = href.split("#");
+    let hrefNormalized = hrefSplit[0];
+    if (hrefNormalized.startsWith("/docs/")) {
+      const thisDocumentLocale = doc.mdn_url.split("/")[1];
+      hrefNormalized = `/${thisDocumentLocale}${hrefNormalized}`;
+    }
+
     if (href.startsWith("https://developer.mozilla.org/")) {
       // It might be a working 200 OK link but the link just shouldn't
       // have the full absolute URL part in it.
@@ -317,13 +325,13 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
         href,
         absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
       );
-    } else if (isHomepageURL(href)) {
+    } else if (isHomepageURL(hrefNormalized)) {
       // But did you spell it perfectly?
-      const homepageLocale = href.split("/")[1];
+      const homepageLocale = hrefNormalized.split("/")[1];
       if (
-        href !== "/" &&
+        hrefNormalized !== "/" &&
         (VALID_LOCALES.get(homepageLocale.toLowerCase()) !== homepageLocale ||
-          !href.endsWith("/"))
+          !hrefNormalized.endsWith("/"))
       ) {
         addBrokenLink(
           a,
@@ -335,16 +343,6 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
     } else if (href.startsWith("/") && !href.startsWith("//")) {
       // Got to fake the domain to sensible extract the .search and .hash
       const absoluteURL = new URL(href, "http://www.example.com");
-      // Note, a lot of links are like this:
-      //  <a href="/docs/Learn/Front-end_web_developer">
-      // which means the author wanted the link to work in any language.
-      // When checking it against disk, we'll have to assume a locale.
-      const hrefSplit = href.split("#");
-      let hrefNormalized = hrefSplit[0];
-      if (hrefNormalized.startsWith("/docs/")) {
-        const thisDocumentLocale = doc.mdn_url.split("/")[1];
-        hrefNormalized = `/${thisDocumentLocale}${hrefNormalized}`;
-      }
       const found = Document.findByURL(hrefNormalized);
       if (!found) {
         // Before we give up, check if it's an image.

--- a/build/flaws.js
+++ b/build/flaws.js
@@ -281,6 +281,9 @@ function injectBrokenLinksFlaws(doc, $, { rawContent }, level) {
 
   function isHomepageURL(url) {
     // Return true if the URL is something like `/` or `/en-US` or `/fr/`
+    // If the URL was something like this: `/en-US#anchor` we don't
+    // want the hash to get in the way.
+    [url] = url.split("#");
     if (url === "/") {
       return true;
     }

--- a/content/document.js
+++ b/content/document.js
@@ -390,6 +390,9 @@ function update(url, rawBody, metadata) {
 
 function findByURL(url, ...args) {
   const [bareURL, hash = ""] = url.split("#", 2);
+  if (!bareURL.includes("/docs/")) {
+    throw new Error("URL doesn't include the '/docs/' part");
+  }
   const doc = read(urlToFolderPath(bareURL), ...args);
   if (doc && hash) {
     return { ...doc, url: `${doc.url}#${hash}` };

--- a/content/document.js
+++ b/content/document.js
@@ -63,7 +63,7 @@ function extractLocale(folder) {
   // locale as we prefer to spell it (e.g. 'pt-BR' not 'Pt-bR')
   if (!locale) {
     throw new Error(
-      `Unable to figure out locale from ${folder} with ${localeFolderName}`
+      `Unable to figure out locale from '${folder}' with '${localeFolderName}'`
     );
   }
   return locale;
@@ -240,6 +240,9 @@ const read = memoize((folder) => {
     CONTENT_ARCHIVED_ROOT && filePath.startsWith(CONTENT_ARCHIVED_ROOT);
 
   const rawContent = fs.readFileSync(filePath, "utf8");
+  if (!rawContent) {
+    throw new Error(`${filePath} is an empty file`);
+  }
 
   // This is very useful in CI where every page gets built. If there's an
   // accidentally unresolved git conflict, that's stuck in the content,
@@ -390,8 +393,8 @@ function update(url, rawBody, metadata) {
 
 function findByURL(url, ...args) {
   const [bareURL, hash = ""] = url.split("#", 2);
-  if (!bareURL.includes("/docs/")) {
-    throw new Error("URL doesn't include the '/docs/' part");
+  if (!bareURL.toLowerCase().includes("/docs/")) {
+    return;
   }
   const doc = read(urlToFolderPath(bareURL), ...args);
   if (doc && hash) {

--- a/testing/content/files/en-us/web/homepage_links/index.html
+++ b/testing/content/files/en-us/web/homepage_links/index.html
@@ -23,3 +23,9 @@ slug: Web/Homepage_links
 <p>
   <a href="/notalocale/"><code>/notalocale/</code></a> - not a valid locale
 </p>
+<p>
+  <a href="/#anchor"><code>/#anchor</code></a> - perfect but with hash
+</p>
+<p>
+  <a href="/en-US/#anchor"><code>/en-US/#anchor</code></a> - perfect but with hash
+</p>


### PR DESCRIPTION
Fixes #3515

Steps to test, 
Go to http://localhost:3000/en-US/docs/Web/API/DirectoryReaderSync before this patch
But to really mess with it, create an empty file called `index.html` (or a directory!) in the `files` directory of your `$CONTENT_ROOT`. 

Basically, doing `Document.findByURL('/')` doesn't make sense. It'll never be a document. `Document.findByURL('/en-US/')` doesn't make sense either. 

Our `broken_links` flaw detection already [knows to treat links to the home page differently](https://github.com/mdn/yari/pull/3507) and not expect them to lead to a document. But clearly it was buggy in that it wouldn't treat the URL as bare. That's what this fixes. 