### PR TITLE
always measure how long gatherTranslations() takes

### DIFF
--- a/content/translations.js
+++ b/content/translations.js
@@ -36,7 +36,10 @@ function gatherTranslations() {
 
 function translationsOf({ slug, locale: currentLocale }) {
   if (TRANSLATIONS_OF.size === 0) {
+    const label = "Time to gather all translations";
+    console.time(label);
     gatherTranslations();
+    console.timeEnd(label);
   }
   const translations = TRANSLATIONS_OF.get(slug.toLowerCase());
   if (translations && currentLocale) {


### PR DESCRIPTION
I know it's slow but I'd like to understand it more. We do other measurements like this that stem from the `yarn build` CLI. 
