### PR TITLE
use fdir for server search-index gathering

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "ejs": "3.1.6",
     "express": "4.17.1",
     "fast-xml-parser": "3.19.0",
+    "fdir": "5.0.0",
     "file-type": "16.3.0",
     "front-matter": "^4.0.2",
     "fs-extra": "9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8631,6 +8631,11 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fdir@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-5.0.0.tgz#a40b5d9adfb530daeca55558e8ad87ec14a44769"
+  integrity sha512-cteqwWMA43lEmgwOg5HSdvhVFD39vHjQDhZkRMlKmeoNPtSSgUw1nUypydiY2upMdGiBFBZvNBDbnoBh0yCzaQ==
+
 fecha@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"


### PR DESCRIPTION
My original hack to make that `populateSearchIndex()` fast is very similar to what `fdir` can do. But it feels safer and better to rely on it instead of home-cooked on in this case. 