### PR TITLE
fix locale part in Glossaly macro

### DIFF
--- a/kumascript/macros/Glossary.ejs
+++ b/kumascript/macros/Glossary.ejs
@@ -8,18 +8,7 @@
 
 let str = $1 || $0;
 
-let URL = "/en-US/docs/Glossary/";
+let URL = `/${env.locale}/docs/Glossary/`;
 URL += $0.replace(/\s+/g,'_');
-
-if (env.locale !== "en-US") {
-    let page = await wiki.getPage(URL);
-    if (page && page.translations) {
-        for(let translation of page.translations) {
-            if (translation.locale === env.locale) {
-                URL = translation.url;
-            }
-        }
-    }
-}
 
 %><a href="<%- URL %>"><%= str %></a>

--- a/kumascript/macros/Glossary.ejs
+++ b/kumascript/macros/Glossary.ejs
@@ -8,7 +8,7 @@
 
 let str = $1 || $0;
 
-let basePath = `/${env.locale}/docs/Glossary/`;
-let subPath = $0.replace(/\s+/g,'_');
+const basePath = `/${env.locale}/docs/Glossary/`;
+const subPath = $0.replace(/\s+/g,'_');
 const link = web.smartLink(basePath + subPath, null, str, subPath, basePath);
 %><%- link %>

--- a/kumascript/macros/Glossary.ejs
+++ b/kumascript/macros/Glossary.ejs
@@ -8,7 +8,7 @@
 
 let str = $1 || $0;
 
-let URL = `/${env.locale}/docs/Glossary/`;
-URL += $0.replace(/\s+/g,'_');
-
-%><a href="<%- URL %>"><%= str %></a>
+let basePath = `/${env.locale}/docs/Glossary/`;
+let subPath = $0.replace(/\s+/g,'_');
+const link = web.smartLink(basePath + subPath, null, str, subPath, basePath);
+%><%- link %>


### PR DESCRIPTION
The current Glossary macro doesn't change locale part of URL to translation locale .

Example; 
http://localhost:5000/ja/docs/Web/HTTP/Headers

The first of link list, https://developer.mozilla.org/en-US/docs/Glossary/General_header, should be https://developer.mozilla.org/ja/docs/Glossary/General_header.

In the current Glossary macro, page.translations loop doesn't work, but  if translation doesn't exist,  the page not found page displays en-US page URL, so I removed this loop and changed to use $env.locale to make URL as other macros.