### PR TITLE
remove removal of .alllinks from HTML

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -373,10 +373,6 @@ async function buildDocument(document, documentOptions = {}) {
     $("[data-flaw-src]").removeAttr("data-flaw-src");
   }
 
-  // Remove those '<span class="alllinks"><a href="/en-US/docs/tag/Web">View All...</a></span>' links.
-  // If a document has them, they don't make sense in a Yari world anyway.
-  $("span.alllinks").remove();
-
   doc.title = metadata.title;
   doc.mdn_url = document.url;
   doc.locale = metadata.locale;


### PR DESCRIPTION
There are none of these in the en-US content. I manually deleted them ages ago. 
And last week I removed them from all the active locales. 

- https://github.com/mdn/translated-content/pull/506
- https://github.com/mdn/translated-content/pull/505
- https://github.com/mdn/translated-content/pull/487
- https://github.com/mdn/translated-content/pull/486
- https://github.com/mdn/translated-content/pull/485
- https://github.com/mdn/translated-content/pull/763
- https://github.com/mdn/translated-content/pull/764
- https://github.com/mdn/translated-content/pull/765

If there's some left in some unsupported locales, it's fine. 