### PR TITLE
Live samples should have a border

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -182,7 +182,7 @@ a.new {
     columns: 300px;
   }
 
-  iframe {
+  iframe:not(.sample-code-frame) {
     border: 0;
   }
 }


### PR DESCRIPTION
Fixes #3260

<img width="1051" alt="Screen Shot 2021-04-20 at 11 22 50 AM" src="https://user-images.githubusercontent.com/26739/115422269-bfe73b00-a1ca-11eb-951d-6b01dfc2ac05.png">

<img width="955" alt="Screen Shot 2021-04-20 at 11 25 04 AM" src="https://user-images.githubusercontent.com/26739/115422610-10f72f00-a1cb-11eb-9865-6784be970771.png">

<img width="1069" alt="Screen Shot 2021-04-20 at 11 25 40 AM" src="https://user-images.githubusercontent.com/26739/115422702-266c5900-a1cb-11eb-8d0e-7e6454f9ed7c.png">


Here's a regular `iframe`:
<img width="888" alt="Screen Shot 2021-04-20 at 11 24 32 AM" src="https://user-images.githubusercontent.com/26739/115422537-fde45f00-a1ca-11eb-95b0-109f13b50aab.png">
