### PR TITLE
fix: loading states for sign in, up, and settings

### DIFF
--- a/client/src/auth/index.tsx
+++ b/client/src/auth/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { PageContentContainer } from "../ui/atoms/page-content";
 
+import "./index.scss";
+
 const SignInApp = React.lazy(() => import("./sign-in"));
 const SignUpApp = React.lazy(() => import("./sign-up"));
 
@@ -34,7 +36,7 @@ function Container({
 export function SignIn() {
   return (
     <Container className="sign-in">
-      <React.Suspense fallback={<p>Loading...</p>}>
+      <React.Suspense fallback={<p style={{ minHeight: 200 }}>Loading...</p>}>
         <SignInApp />
       </React.Suspense>
     </Container>
@@ -43,7 +45,7 @@ export function SignIn() {
 export function SignUp() {
   return (
     <Container className="sign-up">
-      <React.Suspense fallback={<p>Loading...</p>}>
+      <React.Suspense fallback={<p style={{ minHeight: 200 }}>Loading...</p>}>
         <SignUpApp />
       </React.Suspense>
     </Container>

--- a/client/src/auth/sign-in.tsx
+++ b/client/src/auth/sign-in.tsx
@@ -6,7 +6,6 @@ import { useLocale } from "../hooks";
 import { ReactComponent as GithubLogo } from "@mdn/dinocons/brands/github-mark-small.svg";
 import { ReactComponent as GoogleLogo } from "@mdn/dinocons/brands/google-mono.svg";
 
-import "./index.scss";
 import "./sign-in.scss";
 
 export default function SignInApp() {

--- a/client/src/settings/app.scss
+++ b/client/src/settings/app.scss
@@ -1,0 +1,83 @@
+@import "~@mdn/minimalist/sass/vars/color-palette";
+@import "~@mdn/minimalist/sass/vars/layout";
+@import "~@mdn/minimalist/sass/vars/typography";
+
+.page-content-container.account-settings {
+  h1 {
+    margin: $base-spacing 0;
+  }
+
+  .field-group {
+    margin: ($base-spacing / 2) 0;
+
+    label {
+      font-size: $large-font-size-mobile;
+      line-height: $heading-line-height;
+      margin-bottom: $base-spacing;
+
+      @media #{$mq-tablet-and-up} {
+        font-size: $large-font-size;
+      }
+    }
+  }
+
+  .notecard {
+    @media #{$mq-small-desktop-and-up} {
+      max-width: 80%;
+    }
+  }
+
+  .confirm-account-closure {
+    .button-container {
+      display: flex;
+      gap: $base-spacing;
+    }
+  }
+}
+
+.account-settings-panels-container {
+  @media #{$mq-tablet-and-up} {
+    display: flex;
+    gap: $base-spacing;
+    justify-content: space-between;
+    margin: $base-spacing 0;
+    max-width: $max-width-small-desktop;
+    width: 100%;
+  }
+}
+
+.settings-form {
+  margin: ($base-spacing / 2) 0 ($base-spacing * 2);
+
+  @media #{$mq-tablet-and-up} {
+    margin: 0;
+  }
+}
+
+.close-account {
+  h3 {
+    margin-top: $base-spacing / 2;
+  }
+
+  h4,
+  p {
+    margin-bottom: $base-spacing / 2;
+  }
+
+  h4 {
+    font-family: $heading-font-family;
+    font-size: $small-medium-font-size-mobile;
+
+    @media #{$mq-tablet-and-up} {
+      font-size: $small-medium-font-size;
+    }
+  }
+}
+
+.settings-form,
+.close-account {
+  border: 1px solid $neutral-500;
+  border-top: 5px solid $primary-100;
+  flex-basis: 45%;
+  padding: $base-spacing;
+}

--- a/client/src/settings/app.tsx
+++ b/client/src/settings/app.tsx
@@ -6,7 +6,7 @@ import { DISABLE_AUTH } from "../constants";
 import { useUserData } from "../user-context";
 import { useLocale } from "../hooks";
 
-import "./index.scss";
+import "./app.scss";
 
 interface UserSettings {
   csrfmiddlewaretoken: string;

--- a/client/src/settings/index.scss
+++ b/client/src/settings/index.scss
@@ -1,6 +1,4 @@
-@import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
-@import "~@mdn/minimalist/sass/vars/typography";
 
 .page-content-container.account-settings {
   display: flex;
@@ -10,82 +8,4 @@
   @media #{$mq-large-desktop-and-up} {
     margin: ($base-spacing) auto;
   }
-
-  h1 {
-    margin: $base-spacing 0;
-  }
-
-  .field-group {
-    margin: ($base-spacing / 2) 0;
-
-    label {
-      font-size: $large-font-size-mobile;
-      line-height: $heading-line-height;
-      margin-bottom: $base-spacing;
-
-      @media #{$mq-tablet-and-up} {
-        font-size: $large-font-size;
-      }
-    }
-  }
-
-  .notecard {
-    @media #{$mq-small-desktop-and-up} {
-      max-width: 80%;
-    }
-  }
-
-  .confirm-account-closure {
-    .button-container {
-      display: flex;
-      gap: $base-spacing;
-    }
-  }
-}
-
-.account-settings-panels-container {
-  @media #{$mq-tablet-and-up} {
-    display: flex;
-    gap: $base-spacing;
-    justify-content: space-between;
-    margin: $base-spacing 0;
-    max-width: $max-width-small-desktop;
-    width: 100%;
-  }
-}
-
-.settings-form {
-  margin: ($base-spacing / 2) 0 ($base-spacing * 2);
-
-  @media #{$mq-tablet-and-up} {
-    margin: 0;
-  }
-}
-
-.close-account {
-  h3 {
-    margin-top: $base-spacing / 2;
-  }
-
-  h4,
-  p {
-    margin-bottom: $base-spacing / 2;
-  }
-
-  h4 {
-    font-family: $heading-font-family;
-    font-size: $small-medium-font-size-mobile;
-
-    @media #{$mq-tablet-and-up} {
-      font-size: $small-medium-font-size;
-    }
-  }
-}
-
-.settings-form,
-.close-account {
-  border: 1px solid $neutral-500;
-  border-top: 5px solid $primary-100;
-  flex-basis: 45%;
-  padding: $base-spacing;
 }

--- a/client/src/settings/index.tsx
+++ b/client/src/settings/index.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { PageContentContainer } from "../ui/atoms/page-content";
 
+import "./index.scss";
+
 const SettingsApp = React.lazy(() => import("./app"));
 
 export function Settings() {
@@ -22,7 +24,9 @@ export function Settings() {
        */}
         <h1 className="slab-highlight">{pageTitle}</h1>
         {!isServer && (
-          <React.Suspense fallback={<p>Loading...</p>}>
+          <React.Suspense
+            fallback={<p style={{ minHeight: 200 }}>Loading...</p>}
+          >
             <SettingsApp />
           </React.Suspense>
         )}


### PR DESCRIPTION
Fix CLS like behavior on sign in, up and settings views.

The main reason this was happening is because the CSS that define the layout was only loaded once the `app` was loaded. I now load the relevant layout pieces in the entry "page"

Fix #3360
