### PR TITLE
EmbedLiveSample breaks if ID has non-ASCII

### DIFF
--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -139,8 +139,7 @@ class HTMLTool {
     // Kuma looks for the first HTML tag of a limited set of section tags with ANY
     // attribute equal to the "sectionID", but in practice it's always an "id" attribute,
     // so let's simplify this as well as make it much faster.
-    // const sectionStart = $(`#${cssesc(sectionID, { isIdentifier: true })}`);
-    const sectionStart = $(`#${sectionID}`);
+    const sectionStart = $(`#${cssesc(sectionID, { isIdentifier: true })}`);
     if (!sectionStart.length) {
       throw new KumascriptError(
         `unable to find an HTML element with an "id" of "${sectionID}" within ${this.pathDescription}`

--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -139,7 +139,8 @@ class HTMLTool {
     // Kuma looks for the first HTML tag of a limited set of section tags with ANY
     // attribute equal to the "sectionID", but in practice it's always an "id" attribute,
     // so let's simplify this as well as make it much faster.
-    const sectionStart = $(`#${cssesc(sectionID, { isIdentifier: true })}`);
+    // const sectionStart = $(`#${cssesc(sectionID, { isIdentifier: true })}`);
+    const sectionStart = $(`#${sectionID}`);
     if (!sectionStart.length) {
       throw new KumascriptError(
         `unable to find an HTML element with an "id" of "${sectionID}" within ${this.pathDescription}`

--- a/testing/content/files/en-us/web/unicode_livesample/index.html
+++ b/testing/content/files/en-us/web/unicode_livesample/index.html
@@ -1,0 +1,12 @@
+---
+title: A page where the IDs aren't plain ASCII
+slug: Web/Unicode_livesample
+---
+
+<h3 id="Fire🔥">Heading</h3>
+<pre class="brush: css">blink {
+  color: maroon;
+}</pre>
+<pre class="brush: html">&lt;blink&gt;hi&lt;/blink&gt;</pre>
+
+<p>{{EmbedLiveSample('Fire🔥', '500px', '300px')}}</p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1395,3 +1395,19 @@ test("homepage links and flaws", () => {
   expect(map.get("/ZH-CN").suggestion).toBe("/zh-CN/");
   expect(map.get("/notalocale/").suggestion).toBeFalsy();
 });
+
+test("embed live samples with unicode characters in the ID", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "unicode_livesample"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.flaws.macros).toBeFalsy();
+  const samplesRoot = path.join(builtFolder, "_samples_");
+  const found = glob.sync(path.join(samplesRoot, "**", "index.html"));
+  expect(found.length).toBe(2);
+});


### PR DESCRIPTION
Part of #3598

@escattone This is a draft because, at the time of writing, all it does is demonstrate the problem. 
Perhaps I'm completely off, but this seems like a reasonable input:
```
<h3 id="Fire🔥">Heading</h3>
<pre class="brush: css">blink {
  color: maroon;
}</pre>
<pre class="brush: html">&lt;blink&gt;hi&lt;/blink&gt;</pre>

<p>{{EmbedLiveSample('Fire🔥', '500px', '300px')}}</p>
```

Having a Unicode character in the `id="..."` value is valid. I actually sanity-checked it with the w3c validator. 
<img width="459" alt="Screen Shot 2021-04-22 at 10 03 48 AM" src="https://user-images.githubusercontent.com/26739/115727918-0adf8a80-a352-11eb-9cb3-100606e0796d.png">

The code there scares me a bit. I don't know exactly what's going on but I think what happens is that it uses `cssesc` to turn an slugified ID into an *escaped* slugified selector. 
So it ends up doing a (`cheerio`) search for `$('#Fire\1F525')` but the ID of the `h3` hasn't been slugified or escaped. 