### PR TITLE
consider <style> to be unsafe

### DIFF
--- a/build/flaws/unsafe-html.js
+++ b/build/flaws/unsafe-html.js
@@ -54,7 +54,7 @@ function getAndMarkupUnsafeHTMLFlaws(doc, $, { rawContent, fileInfo }) {
     flaws.push(flaw);
   }
 
-  $("script, embed, object, iframe").each((i, element) => {
+  $("script, embed, object, iframe, style").each((i, element) => {
     const { tagName } = element;
     if (tagName === "iframe") {
       // For iframes we only check the 'src' value

--- a/testing/content/files/en-us/web/unsafe_html/index.html
+++ b/testing/content/files/en-us/web/unsafe_html/index.html
@@ -34,3 +34,7 @@ attribute:<br>
 </ul>
 
 <script>alert(1)</script>
+
+<style>
+  * { background-image: url(/api/v1/settings);}
+</style>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1344,12 +1344,12 @@ test("unsafe HTML gets flagged as flaws and replace with its raw HTML", () => {
 
   const jsonFile = path.join(builtFolder, "index.json");
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(doc.flaws.unsafe_html.length).toBe(6);
+  expect(doc.flaws.unsafe_html.length).toBe(7);
 
   const htmlFile = path.join(builtFolder, "index.html");
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
-  expect($("code.unsafe-html").length).toBe(6);
+  expect($("code.unsafe-html").length).toBe(7);
 });
 
 test("translated content broken links can fall back to en-us", () => {


### PR DESCRIPTION
It's hard to conceive what could be done without this protection. What if someone makes a content PR that looks harmless but sneaks in some really carefully crafted CSS that makes the page look like something it isn't. Or, what if they use something clever like `*{background-image: url('/api/v1/subscriptions')}`. 
Also, beyond security, I can't imagine a sensible reason why we should allow the content to dictate style at all. That would just make the Markdown effort even harder and weirder. 