### PR TITLE
http links should be considered a flaw

### DIFF
--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -131,7 +131,6 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
     }
 
     if (href.startsWith("http://")) {
-      console.log(doc.mdn_url, "!!", href);
       addBrokenLink(
         a,
         checked.get(href),

--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -130,7 +130,16 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
       return;
     }
 
-    if (href.startsWith("https://developer.mozilla.org/")) {
+    if (href.startsWith("http://")) {
+      console.log(doc.mdn_url, "!!", href);
+      addBrokenLink(
+        a,
+        checked.get(href),
+        href,
+        href.replace("http://", "https://"),
+        "http:// external links are not allowed (will be forced to https:// at build-time)"
+      );
+    } else if (href.startsWith("https://developer.mozilla.org/")) {
       // It might be a working 200 OK link but the link just shouldn't
       // have the full absolute URL part in it.
       const absoluteURL = new URL(href);

--- a/testing/content/files/en-us/web/brokenlinks/index.html
+++ b/testing/content/files/en-us/web/brokenlinks/index.html
@@ -36,3 +36,7 @@ slug: Web/BrokenLinks
 <p>
   <a href="/en-US/docs/Web/BrokenLinks/contributors.txt">Link to <code>/contributors.txt</code></a> (not a flaw)
 </p>
+
+<p>
+  <a href="http://www.mozilla.org"><code>http://</code> external link</a>
+</p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -521,7 +521,7 @@ test("broken links flaws", () => {
   const { flaws } = doc;
   // You have to be intimately familiar with the fixture to understand
   // why these flaws come out as they do.
-  expect(flaws.broken_links.length).toBe(11);
+  expect(flaws.broken_links.length).toBe(12);
   // Map them by 'href'
   const map = new Map(flaws.broken_links.map((x) => [x.href, x]));
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
@@ -556,6 +556,13 @@ test("broken links flaws", () => {
   expect(map.get("/en-US/docs/Web/BrokenLinks#anchor").suggestion).toBe(
     "#anchor"
   );
+  expect(map.get("http://www.mozilla.org").explanation).toBe(
+    "http:// external links are not allowed (will be forced to https:// at build-time)"
+  );
+  expect(map.get("http://www.mozilla.org").suggestion).toBe(
+    "https://www.mozilla.org"
+  );
+  expect(map.get("http://www.mozilla.org").fixable).toBeTruthy();
 });
 
 test("repeated broken links flaws", () => {


### PR DESCRIPTION
Fixes #3565

This will increase the number of `broken_link` flaws quite a bit. To find out exactly how many, I ran `BUILD_FLAW_LEVELS="*:ignore, broken_links: warn" yarn build` before and after. 

- Before: 1,560
- After: 2,190

I'm working in producing a complete report of all of these. When I did the build, I recorded every known `http://` link we have and now we can post-process that. 