### PR TITLE
add Open Graph HTML meta tags

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -55,7 +55,10 @@ async function buildSPAs(options) {
       ];
       for (const { prefix, pageTitle } of SPAs) {
         const url = `/${locale}/${prefix}`;
-        const context = { pageTitle };
+        const context = {
+          pageTitle,
+          locale: VALID_LOCALES.get(locale) || locale,
+        };
         if (prefix === "settings") {
           // This SPA needs a list of all valid locales
           const languages = getLanguages();

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -50,6 +50,34 @@
       name="description"
       content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."
     />
+
+    <!--
+      Why these Open Graph meta tags? ...when the '<title>' and '<meta name=description>'
+      already exist?
+      Well, because of Twitter.
+      When you paste in an MDN URL into Twitter it will not make a "card".
+      See this comment: https://github.com/mdn/yari/issues/3590#issuecomment-825153396
+
+      According to Twitter's documentation on "Cards" they will use their proprietary
+      tags (e.g. `<meta name="twitter:card" content="summary">`) but if not available
+      they will fall back to Open Graph meta tags.
+      See https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#opengraph
+
+      It is a lot of repetition and additional bloat to the index.html files. But
+      keep in mind that repeated strings of texts compresses very well and most
+      clients will only download the Gzip or Brotli compressed HTML file.
+
+      Remember, all of these are *default* values. The actual values are processed in
+      ssr/render.js and uses cheerio to replace the content on all of these.
+    -->
+    <meta property="og:url" content="https://developer.mozilla.org" />
+    <meta property="og:title" content="MDN Web Docs" />
+    <meta
+      property="og:description"
+      content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."
+    />
+    <meta property="og:locale" content="en-US" />
+
     <link rel="canonical" href="https://developer.mozilla.org" />
     <style media="print">
       .breadcrumbs-container,

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -145,6 +145,7 @@ export default function render(
     feedEntries = null,
     pageTitle = null,
     possibleLocales = null,
+    locale = null,
   } = {}
 ) {
   const buildHtml = readBuildHTML();
@@ -224,6 +225,7 @@ export default function render(
     // This overrides the default description. Also assumes there's always
     // one tag there already.
     $('meta[name="description"]').attr("content", pageDescription);
+    $('meta[property="og:description"]').attr("content", pageDescription);
   }
 
   const robotsContent =
@@ -267,6 +269,12 @@ export default function render(
 
   const $title = $("title");
   $title.text(pageTitle);
+  $('meta[property="og:url"]').attr("content", canonicalURL);
+  $('meta[property="og:title"]').attr("content", pageTitle);
+  $('meta[property="og:locale"]').attr(
+    "content",
+    locale ? locale : doc ? doc.locale : "en-US"
+  );
 
   for (const webfontURL of webfontURLs) {
     $('<link rel="preload" as="font" type="font/woff2" crossorigin>')

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -118,6 +118,9 @@ test("content built foo page", () => {
   expect($('meta[name="description"]').attr("content")).toBe(
     "This becomes the summary."
   );
+  expect($('meta[property="og:description"]').attr("content")).toBe(
+    "This becomes the summary."
+  );
 
   // Before testing the `<img>` tags, assert that there's only 1 image in total.
   expect($("img").length).toBe(1);
@@ -200,6 +203,10 @@ test("content built French foo page", () => {
   expect($('link[rel="alternate"]').length).toBe(2);
   expect($('link[rel="alternate"][hreflang="en"]').length).toBe(1);
   expect($('link[rel="alternate"][hreflang="fr"]').length).toBe(1);
+  expect($('meta[property="og:locale"]').attr("content")).toBe("fr");
+  expect($('meta[property="og:title"]').attr("content")).toBe(
+    "<foo>: Une page de test | MDN"
+  );
 });
 
 test("wrong xref macro errors", () => {
@@ -968,6 +975,7 @@ test("404 page", () => {
   expect($("title").text()).toContain("Page not found");
   expect($("h1").text()).toContain("Page not found");
   expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("en-US");
 });
 
 test("sign in page", () => {
@@ -978,6 +986,20 @@ test("sign in page", () => {
   const $ = cheerio.load(html);
   expect($("h1").text()).toContain("Sign in to MDN Web Docs");
   expect($("title").text()).toContain("Sign in");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("en-US");
+  expect($('meta[property="og:title"]').attr("content")).toBe("Sign in");
+});
+
+test("French sign in page", () => {
+  const builtFolder = path.join(buildRoot, "fr", "signin");
+  expect(fs.existsSync(builtFolder)).toBeTruthy();
+  const htmlFile = path.join(builtFolder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+  const $ = cheerio.load(html);
+  // This will be translated the day we support localized chrome.
+  expect($("h1").text()).toContain("Sign in to MDN Web Docs");
+  expect($("title").text()).toContain("Sign in");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("fr");
 });
 
 test("sign up page", () => {


### PR DESCRIPTION
Part of #3590

This adds `<meta property="og:title" content="...">`, `<meta property="og:url" content="...">`, and `<meta property="og:description" content="...">`

It [seems that](https://github.com/mdn/yari/issues/3590) Twitter won't display MDN URLs nicely unless you have the `twitter` card HTML meta tags or Open Graph HTML meta tags. 
Thankfully, it seems that Twitter will fall back to Open Graph if Twitter card tags don't exist. 