### PR TITLE
MDN++ iframe visibility

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -235,14 +235,16 @@ export function App(appProps) {
                 </StandardLayout>
               }
             />
-            <Route
-              path="/mdn++"
-              element={
-                <StandardLayout>
-                  <MDNplusplus {...appProps} />
-                </StandardLayout>
-              }
-            />
+            {process.env.NODE_ENV === "development" && (
+              <Route
+                path="/mdn++"
+                element={
+                  <StandardLayout>
+                    <MDNplusplus {...appProps} />
+                  </StandardLayout>
+                }
+              />
+            )}
             <Route
               path="/docs/*"
               element={

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -5,7 +5,7 @@ import { Routes, Route, useLocation } from "react-router-dom";
 // and applied before any component specific style
 import "./app.scss";
 
-import { CRUD_MODE } from "./constants";
+import { CRUD_MODE, ENABLE_MDNPLUSPLUS } from "./constants";
 import { Homepage } from "./homepage";
 import { Document } from "./document";
 import { A11yNav } from "./ui/molecules/a11y-nav";
@@ -235,7 +235,7 @@ export function App(appProps) {
                 </StandardLayout>
               }
             />
-            {process.env.NODE_ENV === "development" && (
+            {ENABLE_MDNPLUSPLUS && (
               <Route
                 path="/mdn++"
                 element={

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -59,3 +59,8 @@ export const VALID_LOCALES = new Set([
   "zh-CN",
   "zh-TW",
 ]);
+
+export const ENABLE_MDNPLUSPLUS = JSON.parse(
+  process.env.REACT_APP_ENABLE_MDNPLUSPLUS ||
+    JSON.stringify(process.env.NODE_ENV === "development")
+);

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -300,3 +300,9 @@ button. We use this for previewing PR builds on the content site. Those pages ar
 built with flaw detection set to warn, but since you might be viewing the pages
 on a remote domain (e.g. `pr123.dev.content.mozit.cloud`) it doesn't make sense to
 present the "Fix fixable flaws" button for example.
+
+### `REACT_APP_ENABLE_MDNPLUSPLUS`
+
+**Default: `NODE_ENV==='development'`**
+
+Determines if the MDN++ SPA should be reachable or not.


### PR DESCRIPTION
Fixes #3646

Now it's only visible in local development (e.g. <http://localhost:3000>) and if you want to test it in a production-like environment you can run:
```
export REACT_APP_ENABLE_MDNPLUSPLUS=true
yarn prepare-build
yarn start:static-server
```

Now you get the MDN++ app on (e.g. <http://localhost:5000>)