### PR TITLE
fix: localized content notes

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -8,7 +8,7 @@
 
 @import "./molecules/breadcrumb-locale-container";
 @import "./molecules/notecards";
-@import "./molecules/localized-content-note/";
+@import "./molecules/localized-content-note";
 
 .main-content {
   @media #{$mq-small-desktop-and-up} {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -8,6 +8,7 @@
 
 @import "./molecules/breadcrumb-locale-container";
 @import "./molecules/notecards";
+@import "./molecules/localized-content-note/";
 
 .main-content {
   @media #{$mq-small-desktop-and-up} {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -7,6 +7,7 @@
 @import "~@mdn/minimalist/sass/mixins/utils";
 
 @import "./molecules/breadcrumb-locale-container";
+@import "./molecules/notecards";
 
 .main-content {
   @media #{$mq-small-desktop-and-up} {

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -14,6 +14,7 @@ import { LazyBrowserCompatibilityTable } from "./lazy-bcd-table";
 // Sub-components
 import { Breadcrumbs } from "../ui/molecules/breadcrumbs";
 import { LanguageToggle } from "../ui/molecules/language-toggle";
+import { LocalizedContentNote } from "./molecules/localized-content-note";
 import { TOC } from "./organisms/toc";
 import { RenderSideBar } from "./organisms/sidebar";
 import { MainContentContainer } from "../ui/atoms/page-content";
@@ -154,6 +155,10 @@ export function Document(props /* TODO: define a TS interface for this */) {
             <LanguageToggle locale={locale} translations={translations} />
           )}
         </div>
+      )}
+
+      {doc.isTranslated && (
+        <LocalizedContentNote isActive={doc.isActive} locale={locale} />
       )}
 
       {doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}

--- a/client/src/document/molecules/_breadcrumb-locale-container.scss
+++ b/client/src/document/molecules/_breadcrumb-locale-container.scss
@@ -4,10 +4,6 @@
   display: flex;
   padding: ($base-spacing / 2) $base-spacing;
 
-  @media #{$mq-tablet-and-up} {
-    margin: ($base-spacing / 2) 0;
-  }
-
   @media #{$mq-small-desktop-and-up} {
     margin: $base-spacing 0 0;
   }

--- a/client/src/document/molecules/_notecards.scss
+++ b/client/src/document/molecules/_notecards.scss
@@ -1,0 +1,173 @@
+@import "~@mdn/minimalist/sass/vars/color-palette";
+@import "~@mdn/minimalist/sass/vars/layout";
+@import "~@mdn/minimalist/sass/vars/borders";
+@import "~@mdn/minimalist/sass/vars/typography";
+
+@mixin set-notecard-icon($icon) {
+  h3,
+  h4,
+  &.inline {
+    &::before {
+      background: transparent url($icon) 0 0 no-repeat;
+    }
+  }
+}
+
+@mixin set-notecard-icon-only($icon) {
+  h3,
+  h4 {
+    &::before {
+      background-image: url($icon);
+    }
+  }
+}
+
+.notecard {
+  border-left: $notecard-border;
+  margin: 0;
+  margin-bottom: $base-spacing;
+  padding: ($base-spacing / 2);
+
+  a {
+    &:link,
+    &:visited {
+      color: $neutral-100;
+      text-decoration: underline;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+
+  h3,
+  h4 {
+    /* 
+     * Because we also allow h3, we need to undo some of its styling here.
+     * This relates specifically to `background-color`, `color`, 
+     * `padding` and `font-weight`
+     */
+    background-color: inherit;
+    color: inherit;
+    display: inline-block;
+    font-family: $site-font-family;
+    font-size: $small-medium-font-size-mobile;
+    font-weight: bold;
+    margin: 0;
+    margin-bottom: ($base-spacing / 4);
+    padding: 0;
+
+    @media #{$mq-tablet-and-up} {
+      font-size: $small-medium-font-size;
+    }
+  }
+
+  h3,
+  h4,
+  &.inline {
+    &::before {
+      background-repeat: no-repeat;
+      background-size: 18px;
+      content: "";
+      display: inline-block;
+      height: 21px;
+      margin-right: $base-spacing / 4;
+      position: relative;
+      top: 2px;
+      width: 20px;
+    }
+  }
+
+  p {
+    margin-bottom: $base-spacing / 2;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &.inline {
+    font-weight: normal;
+    margin: $base-spacing / 4;
+    padding: ($base-spacing / 8) ($base-spacing / 4);
+
+    &::before {
+      top: 5px;
+    }
+
+    p {
+      display: inline-block;
+      margin-bottom: 0;
+    }
+  }
+
+  &.neutral {
+    @include set-notecard-icon("~@mdn/dinocons/general/globe.svg");
+
+    background-color: $primary-500;
+    color: $primary-50;
+  }
+
+  &.success {
+    @include set-notecard-icon("~@mdn/dinocons/general/check-mark.svg");
+
+    background-color: $green-400;
+    border-color: $green-200;
+    color: $neutral-100;
+  }
+
+  &.note {
+    @include set-notecard-icon("~@mdn/dinocons/file-icons/file.svg");
+
+    background-color: $primary-500;
+  }
+
+  &.warning,
+  &.experimental,
+  &.draft,
+  &.secure {
+    @include set-notecard-icon(
+      "~@mdn/dinocons/notifications/exclamation-triangle.svg"
+    );
+
+    background-color: $yellow-400;
+    border-color: $yellow-300;
+    color: $neutral-100;
+  }
+
+  &.experimental {
+    @include set-notecard-icon-only("~@mdn/dinocons/general/flask.svg");
+  }
+
+  &.draft {
+    @include set-notecard-icon-only("~@mdn/dinocons/general/pencil.svg");
+  }
+
+  &.secure {
+    @include set-notecard-icon-only("~@mdn/dinocons/general/lock.svg");
+  }
+
+  &.negative,
+  &.obsolete,
+  &.deprecated {
+    @include set-notecard-icon("~@mdn/dinocons/general/trash.svg");
+
+    background-color: $red-400;
+    border-color: $red-300;
+    color: $neutral-100;
+  }
+
+  &.deprecated {
+    @include set-notecard-icon-only("~@mdn/dinocons/emojis/thumbs-down.svg");
+  }
+}
+
+.localized-content-note {
+  border-left: 0;
+
+  &.inline {
+    margin: 0;
+    padding: ($base-spacing / 2) $base-spacing;
+  }
+}

--- a/client/src/document/molecules/_notecards.scss
+++ b/client/src/document/molecules/_notecards.scss
@@ -162,12 +162,3 @@
     @include set-notecard-icon-only("~@mdn/dinocons/emojis/thumbs-down.svg");
   }
 }
-
-.localized-content-note {
-  border-left: 0;
-
-  &.inline {
-    margin: 0;
-    padding: ($base-spacing / 2) $base-spacing;
-  }
-}

--- a/client/src/document/molecules/localized-content-note/index.scss
+++ b/client/src/document/molecules/localized-content-note/index.scss
@@ -1,0 +1,10 @@
+@import "~@mdn/minimalist/sass/vars/layout";
+
+.localized-content-note {
+  border-left: 0;
+
+  &.inline {
+    margin: 0;
+    padding: ($base-spacing / 2) $base-spacing;
+  }
+}

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -53,8 +53,8 @@ export function LocalizedContentNote({
     },
     "en-US": {
       lead:
-        "This page was translated from English by the community, but it is not actively maintained therefore it may be out-of-date. If you'd like to help maintain it, ",
-      linkText: "find out how to activate inactive locales.",
+        "This page was translated from English by the community, but it's not maintained and may be out-of-date. To help maintain it, ",
+      linkText: "learn how to activate locales.",
       url:
         "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
     },

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -7,7 +7,7 @@ interface LocalizedNoteContent {
 function getNote(noteContent: LocalizedNoteContent, noteType: string) {
   return (
     <div className={`localized-content-note notecard inline ${noteType}`}>
-      {noteContent.lead}
+      {noteContent.lead}{" "}
       <a href={noteContent.url} className="external">
         {noteContent.linkText}
       </a>

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -5,7 +5,7 @@ function getNote(noteLinktext: string, noteType: string) {
       : "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1";
   return (
     <div className={`localized-content-note notecard inline ${noteType}`}>
-      <a href={url} className="external">
+      <a href={url} className={!url.startsWith('/') ? 'external' : undefined}>
         {noteLinktext}
       </a>
     </div>

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -1,0 +1,77 @@
+interface LocalizedNoteContent {
+  lead: string;
+  url: string;
+  linkText: string;
+}
+
+function getNote(noteContent: LocalizedNoteContent, noteType: string) {
+  return (
+    <div className={`localized-content-note notecard inline ${noteType}`}>
+      {noteContent.lead}
+      <a href={noteContent.url} className="external">
+        {noteContent.linkText}
+      </a>
+    </div>
+  );
+}
+
+export function LocalizedContentNote({
+  isActive,
+  locale,
+}: {
+  isActive: boolean;
+  locale: string;
+}) {
+  const activeLocaleNoteContent = {
+    "en-US": {
+      lead: "This page was translated from English by the community.",
+      linkText: "Learn more and join the MDN Web Docs community.",
+      url: "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize",
+    },
+    fr: {
+      lead:
+        "Cette page a été traduite à partir de l'anglais par la communauté.",
+      linkText:
+        "Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
+      url:
+        "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize#french_fr",
+    },
+    ko: {
+      lead: "이 페이지는 커뮤니티에서 영어로 번역되었습니다.",
+      linkText: "MDN Web Docs에서 한국 커뮤니티에 가입하여 자세히 알아보세요.",
+      url: "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize",
+    },
+  };
+  const inactiveLocaleNoteContent = {
+    de: {
+      lead:
+        "Der Inhalt dieser Seite wurde von der Community übersetzt, jedoch wird er nicht mehr aktiv gepflegt und kann daher veraltet sein. Wenn du mithelfen möchtest, kannst du",
+      linkText:
+        "hier herausfinden wie deaktivierte Übersetzung reaktiviert werden.",
+      url:
+        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+    },
+    "en-US": {
+      lead:
+        "This page was translated from English by the community, but it is not actively maintained therefore it may be out-of-date. If you'd like to help maintain it, ",
+      linkText: "find out how to activate inactive locales.",
+      url:
+        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+    },
+    es: {
+      lead:
+        "Esta página fue traducida del inglés por la comunidad, pero no se mantiene activamente, por lo que puede estar desactualizada.",
+      linkText:
+        "Si desea ayudar a mantenerlo, descubra cómo activar las configuraciones regionales inactivas.",
+      url:
+        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+    },
+  };
+
+  const noteContent = isActive
+    ? activeLocaleNoteContent[locale] || activeLocaleNoteContent["en-US"]
+    : inactiveLocaleNoteContent[locale] || inactiveLocaleNoteContent["en-US"];
+  const noteType = isActive ? "neutral" : "warning";
+
+  return getNote(noteContent, noteType);
+}

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -5,7 +5,7 @@ function getNote(noteLinktext: string, noteType: string) {
       : "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1";
   return (
     <div className={`localized-content-note notecard inline ${noteType}`}>
-      <a href={url} className={!url.startsWith('/') ? 'external' : undefined}>
+      <a href={url} className={!url.startsWith("/") ? "external" : undefined}>
         {noteLinktext}
       </a>
     </div>

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -1,7 +1,7 @@
 function getNote(noteLinktext: string, noteType: string) {
   const url =
     noteType === "neutral"
-      ? "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize#active_locales"
+      ? "/en-US/docs/MDN/Contribute/Localize#active_locales"
       : "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1";
   return (
     <div className={`localized-content-note notecard inline ${noteType}`}>

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -1,15 +1,12 @@
-interface LocalizedNoteContent {
-  lead: string;
-  url: string;
-  linkText: string;
-}
-
-function getNote(noteContent: LocalizedNoteContent, noteType: string) {
+function getNote(noteLinktext: string, noteType: string) {
+  const url =
+    noteType === "neutral"
+      ? "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize#active_locales"
+      : "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1";
   return (
     <div className={`localized-content-note notecard inline ${noteType}`}>
-      {noteContent.lead}{" "}
-      <a href={noteContent.url} className="external">
-        {noteContent.linkText}
+      <a href={url} className="external">
+        {noteLinktext}
       </a>
     </div>
   );
@@ -24,54 +21,37 @@ export function LocalizedContentNote({
 }) {
   const activeLocaleNoteContent = {
     "en-US": {
-      lead: "This page was translated from English by the community.",
-      linkText: "Learn more and join the MDN Web Docs community.",
-      url: "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize",
+      linkText:
+        "This page was translated from English by the community. Learn more and join the MDN Web Docs community.",
     },
     fr: {
-      lead:
-        "Cette page a été traduite à partir de l'anglais par la communauté.",
       linkText:
-        "Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
-      url:
-        "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize#french_fr",
+        "Cette page a été traduite à partir de l'anglais par la communauté. Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
     },
     ko: {
-      lead: "이 페이지는 커뮤니티에서 영어로 번역되었습니다.",
-      linkText: "MDN Web Docs에서 한국 커뮤니티에 가입하여 자세히 알아보세요.",
-      url: "https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize",
+      linkText:
+        "이 페이지는 커뮤니티에서 영어로 번역되었습니다. MDN Web Docs에서 한국 커뮤니티에 가입하여 자세히 알아보세요.",
     },
   };
   const inactiveLocaleNoteContent = {
     de: {
-      lead:
-        "Der Inhalt dieser Seite wurde von der Community übersetzt, jedoch wird er nicht mehr aktiv gepflegt und kann daher veraltet sein. Wenn du mithelfen möchtest, kannst du",
       linkText:
-        "hier herausfinden wie deaktivierte Übersetzung reaktiviert werden.",
-      url:
-        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+        "Der Inhalt dieser Seite wurde von der Community übersetzt, jedoch wird er nicht mehr aktiv gepflegt und kann daher veraltet sein. Wenn du mithelfen möchtest, kannst du hier herausfinden wie deaktivierte Übersetzung reaktiviert werden.",
     },
     "en-US": {
-      lead:
-        "This page was translated from English by the community, but it's not maintained and may be out-of-date. To help maintain it, ",
-      linkText: "learn how to activate locales.",
-      url:
-        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+      linkText:
+        "This page was translated from English by the community, but it's not maintained and may be out-of-date. To help maintain it, learn how to activate locales.",
     },
     es: {
-      lead:
-        "Esta página fue traducida del inglés por la comunidad, pero no se mantiene activamente, por lo que puede estar desactualizada.",
       linkText:
-        "Si desea ayudar a mantenerlo, descubra cómo activar las configuraciones regionales inactivas.",
-      url:
-        "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1",
+        "Esta página fue traducida del inglés por la comunidad, pero no se mantiene activamente, por lo que puede estar desactualizada. Si desea ayudar a mantenerlo, descubra cómo activar las configuraciones regionales inactivas.",
     },
   };
 
-  const noteContent = isActive
+  const noteLinktext = isActive
     ? activeLocaleNoteContent[locale] || activeLocaleNoteContent["en-US"]
     : inactiveLocaleNoteContent[locale] || inactiveLocaleNoteContent["en-US"];
   const noteType = isActive ? "neutral" : "warning";
 
-  return getNote(noteContent, noteType);
+  return getNote(noteLinktext.linkText, noteType);
 }

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -5,13 +5,14 @@
 
     @media #{$mq-small-desktop-and-up} {
       grid-template-columns: minmax(25%, 75%) minmax(75%, 25%);
-      grid-template-rows: repeat(4, auto) max-content 1fr;
+      grid-template-rows: repeat(3, auto) max-content 1fr;
     }
   }
 
   .document-page {
     .page-header,
     .breadcrumb-locale-container,
+    .localized-content-note,
     .document-toc-container,
     .main-content,
     .sidebar,
@@ -27,8 +28,29 @@
       grid-row: 2/3;
     }
 
-    .document-toc-container {
+    .localized-content-note {
       grid-row: 3/4;
+    }
+
+    .document-toc-container {
+      grid-row: 4/5;
+
+      @media #{$mq-small-desktop-and-up} {
+        grid-column: 1/2;
+      }
+    }
+
+    .main-content {
+      grid-row: 5/6;
+
+      @media #{$mq-small-desktop-and-up} {
+        grid-column: 2/3;
+        grid-row: 4/6;
+      }
+    }
+
+    .sidebar {
+      grid-row: 6/7;
 
       @media #{$mq-small-desktop-and-up} {
         grid-column: 1/2;
@@ -36,26 +58,8 @@
       }
     }
 
-    .main-content {
-      grid-row: 4/5;
-
-      @media #{$mq-small-desktop-and-up} {
-        grid-column: 2/3;
-        grid-row: 5/7;
-      }
-    }
-
-    .sidebar {
-      grid-row: 5/6;
-
-      @media #{$mq-small-desktop-and-up} {
-        grid-column: 1/2;
-        grid-row: 6/7;
-      }
-    }
-
     .metadata {
-      grid-row: 6/7;
+      grid-row: 7/8;
     }
   }
 }


### PR DESCRIPTION
Moves notecards into Yari.
Add localized content notes for active and inactive translated content.

## Not translated

![Screenshot 2021-04-29 at 17 28 41](https://user-images.githubusercontent.com/10350960/116577181-8a4ff980-a910-11eb-9850-794000c264c4.png)

## Active translations

![Screenshot 2021-04-29 at 17 28 34](https://user-images.githubusercontent.com/10350960/116577220-920f9e00-a910-11eb-8a20-7e4b8982ecb2.png)

## Inactive translations

![Screenshot 2021-04-29 at 17 28 26](https://user-images.githubusercontent.com/10350960/116577248-9936ac00-a910-11eb-928d-4def318ac2ec.png)


Fix #3588
