### PR TITLE
build(deps-dev): bump & migrate use-debounce to 6.0.0

### DIFF
--- a/client/src/document/forms/form.tsx
+++ b/client/src/document/forms/form.tsx
@@ -71,7 +71,7 @@ export function DocumentForm({
     setAutoSaveEnabled(!autosaveEnabled);
   }
 
-  const { callback: debounceCallback } = useDebouncedCallback(onSave, 1000);
+  const debounceCallback = useDebouncedCallback(onSave, 1000);
 
   useEffect(() => {
     if (willAutosave) {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "swr": "^0.5.5",
     "ts-loader": "^8.1.0",
     "typescript": "^4.2.4",
-    "use-debounce": "^5.2.1",
+    "use-debounce": "^6.0.1",
     "webpack": "^4.44.2",
     "webpack-cli": "^4.6.0",
     "webpack-node-externals": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19395,10 +19395,10 @@ use-composed-ref@^1.0.0:
   dependencies:
     ts-essentials "^2.0.3"
 
-use-debounce@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-5.2.1.tgz#7366543c769f1de3e92104dee64de5c4dfddfd33"
-  integrity sha512-BQG5uEypYHd/ASF6imzYR8tJHh5qGn28oZG/5iVAbljV6MUrfyT4jzxA8co+L+WLCT1U8VBwzzvlb3CHmUDpEA==
+use-debounce@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-6.0.1.tgz#ed1eb2b30189408fb9792ea2887f4c6c3cb401a3"
+  integrity sha512-kpvIxpa0vOLz/2I2sfNJ72mUeaT2CMNCu5BT1f2HkV9qZK27UVSOFf1sSSu+wjJE4TcR2VTXS2SM569+m3TN7Q==
 
 use-isomorphic-layout-effect@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
supersedes #3441

use-debounce changed its return value so there was some manual migration necessary.