### PR TITLE
More concurrent open npm PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 15
     ignore:
       # Need manual updates with "resolutions" in package.json
       # to property hoist versions from react-scripts


### PR DESCRIPTION
Because we reached the limit and it was causing a problem.