### PR TITLE
invalid external URLs should be considered broken

### DIFF
--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -159,7 +159,7 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
           checked.get(href),
           href,
           null,
-          `Not a valid link URL`
+          "Not a valid link URL"
         );
       }
       // If a URL's domain is in the list that getSafeToHttpDomains() provides,

--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -153,8 +153,7 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
       let domain = null;
       try {
         domain = new URL(href).hostname;
-      } catch (err) {}
-      if (!domain) {
+      } catch (err) {
         return addBrokenLink(
           a,
           checked.get(href),

--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -150,7 +150,19 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
     }
 
     if (href.startsWith("http://")) {
-      const domain = new URL(href).hostname;
+      let domain = null;
+      try {
+        domain = new URL(href).hostname;
+      } catch (err) {}
+      if (!domain) {
+        return addBrokenLink(
+          a,
+          checked.get(href),
+          href,
+          null,
+          `Not a valid link URL`
+        );
+      }
       // If a URL's domain is in the list that getSafeToHttpDomains() provides,
       // that means we've tested that you can turn that into a HTTPS link
       // simply by replacing the `http://` for `https://`.

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -484,12 +484,14 @@ function BrokenLinks({
               {flaw.fixable && <FixableFlawBadge />}{" "}
               {opening && opening === key && <span>Opening...</span>}
               <br />
-              {flaw.suggestion && (
+              {flaw.suggestion ? (
                 <span>
                   <b>Suggestion:</b>
                   <ShowDiff before={flaw.href} after={flaw.suggestion} />
                 </span>
-              )}{" "}
+              ) : (
+                <code>{flaw.explanation}</code>
+              )}
             </li>
           );
         })}

--- a/testing/content/files/en-us/web/brokenlinks/broken_http_link/index.html
+++ b/testing/content/files/en-us/web/brokenlinks/broken_http_link/index.html
@@ -1,0 +1,6 @@
+---
+title: Http:// link that is not a valid link
+slug: Web/BrokenLinks/Broken_http_link
+---
+
+<p><a href="http://"><code>http://</code></a></p>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -641,6 +641,27 @@ test("repeated broken links flaws", () => {
   expect(map.get("link3").suggestion).toBe("/en-US/docs/Web/CSS/number");
 });
 
+test("broken http:// link that is not a valid URL", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "brokenlinks",
+    "broken_http_link"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  const { flaws } = doc;
+  expect(flaws.broken_links.length).toBe(1);
+
+  const map = new Map(flaws.broken_links.map((x) => [x.id, x]));
+  expect(map.size).toBe(1);
+  expect(map.get("link1").suggestion).toBeNull();
+  expect(map.get("link1").explanation).toBe("Not a valid link URL");
+  expect(map.get("link1").fixable).toBeFalsy();
+});
+
 test("without locale prefix broken links flaws", () => {
   // This fixture has the same broken link, that redirects, 3 times.
   const builtFolder = path.join(


### PR DESCRIPTION
Fixes #3698

Before... it crashed. 

Now...
<img width="1234" alt="Screen Shot 2021-05-04 at 1 48 35 PM" src="https://user-images.githubusercontent.com/26739/117048562-1f703b00-ace1-11eb-977a-300582e23e05.png">

