### PR TITLE
AvailableInWorkers.ejs should take take a smart optional argument

### DIFF
--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -1,7 +1,19 @@
 <%
-var locale = env.locale;
+// Inserts a notecards about this feature being available in Web Workers.
+//
+// Parameters:
+//
+//  $0 - workerType (optional)
+//
+// The optional first argument has to be one of the ['notservice'].
+//
+//  {{AvailableInWorkers}}
+//  {{AvailableInWorkers("notservice")}}
+//
 
-var note = mdn.localString({
+const locale = env.locale;
+
+const note = mdn.localString({
     "en-US": "Note:",
     "de": "Hinweis:",
     "es": "Nota:",
@@ -11,18 +23,32 @@ var note = mdn.localString({
     "ru": "Примечание:",
 });
 
-var defaultText = mdn.localString({
-  "en-US": "This feature is available in <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Workers</a>.",
-  "zh-CN": "此特性在 <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Worker</a> 中可用。",
-  "de": "Dieses Feature ist in <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Workers</a> verfügbar.",
-  "es": "Esta característica está disponible en <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Workers</a>.",
-  "fr": "Cette fonctionnalité est disponible via les <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Workers</a>.",
-  "ja": "この機能は <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Worker</a> 内で利用可能です。",
-  "ko": "이 기능은 <a href=\"/" + locale + "/docs/Web/API/Web_Workers_API\">Web Worker</a>에서 사용할 수 있습니다.",
-  "ru": "Эта возможность доступна в <a href=\"/ru/docs/Web/API/Web_Workers_API\">Web Workers</a>."
+const textDefault = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
+  "zh-CN": `此特性在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 中可用`,
+  "de": `Dieses Feature ist in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a> verfügbar`,
+  "es": `Esta característica está disponible en <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
+  "fr": `Cette fonctionnalité est disponible via les <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
+  "ja": `この機能は <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 内で利用可能です`,
+  "ko": `이 기능은 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>에서 사용할 수 있습니다`,
+  "ru": `Эта возможность доступна в <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`
 });
 
-var text = $0 || defaultText;
+const textServiceWorkers = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>`,
+})
+
+const workerType = $0;
+
+let text = "";
+
+if (workerType === "notservice") {
+  text = textServiceWorkers;
+} else if (workerType) {
+  throw new Error(`'${workerType}' is not a recognized argument to this macro`);
+} else {
+  text = textDefault;
+}
 
 %>
 


### PR DESCRIPTION
Fixes #3708

Seems to work. I edited the content like this:
```diff
diff --git a/files/en-us/web/api/xmlhttprequest/index.html b/files/en-us/web/api/xmlhttprequest/index.html
index 6bc15b31b..783da14fc 100644
--- a/files/en-us/web/api/xmlhttprequest/index.html
+++ b/files/en-us/web/api/xmlhttprequest/index.html
@@ -22,7 +22,7 @@ tags:
 
 <p>If your communication needs to involve receiving event data or message data from a server, consider using <a href="/en-US/docs/Web/API/Server-sent_events">server-sent events</a> through the {{domxref("EventSource")}} interface. For full-duplex communication, <a href="/en-US/docs/Web/API/WebSockets_API">WebSockets</a> may be a better choice.</p>
 
-<p>{{AvailableInWorkers}}</p>
+<p>{{AvailableInWorkers("service")}}</p>
 <div class="notecard note">
   <h4>Note</h4>
   <p>Not supported in service workers.</p>

```

And now we get this:
<img width="1021" alt="Screen Shot 2021-05-05 at 7 29 06 AM" src="https://user-images.githubusercontent.com/26739/117134606-c7cedf80-ad73-11eb-85a8-c24ab188a703.png">

I'm going to mark this as a draft PR until @hamishwillee has signed off on the idea and I've updated the kumascript unit tests.