### PR TITLE
make search execute after search-index comes in

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -179,6 +179,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     searchIndexError,
     initializeSearchIndex,
   ] = useSearchIndex();
+
   const [resultItems, setResultItems] = useState<ResultItem[]>([]);
   const [isFocused, setIsFocused] = useState(false);
 
@@ -190,6 +191,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         // This can happen if the initialized hasn't completed yet or
         // completed un-successfully.
         setResultItems([]);
+        setIsWaiting(true);
         return;
       }
 
@@ -238,6 +240,14 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
   React.useEffect(() => {
     setInputQueryValue(initialQuery);
   }, [initialQuery]);
+
+  const [isWaiting, setIsWaiting] = useState(false);
+  useEffect(() => {
+    if (isWaiting && searchIndex && inputQueryValue) {
+      setIsWaiting(false);
+      updateResults(inputQueryValue);
+    }
+  }, [searchIndex, isWaiting, inputQueryValue, updateResults]);
 
   const {
     getInputProps,

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -190,9 +190,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
       if (!searchIndex) {
         // This can happen if the initialized hasn't completed yet or
         // completed un-successfully.
-        if (!searchIndexError) {
-          setIsWaiting(true);
-        }
+        setIsWaiting(true);
         return;
       }
       if (!inputValue) {
@@ -250,11 +248,17 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
 
   const [isWaiting, setIsWaiting] = useState(false);
   useEffect(() => {
-    if (isWaiting && searchIndex && inputQueryValue) {
+    if (isWaiting && searchIndex && inputQueryValue && !searchIndexError) {
       setIsWaiting(false);
       updateResults(inputQueryValue);
     }
-  }, [searchIndex, isWaiting, inputQueryValue, updateResults]);
+  }, [
+    searchIndex,
+    searchIndexError,
+    isWaiting,
+    inputQueryValue,
+    updateResults,
+  ]);
 
   const {
     getInputProps,

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -187,11 +187,18 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
 
   const updateResults = useCallback(
     (inputValue: string | undefined) => {
-      if (!searchIndex || !inputValue) {
+      if (!searchIndex) {
+        // This can happen if the initialized hasn't completed yet or
+        // completed un-successfully.
+        if (!searchIndexError) {
+          setIsWaiting(true);
+        }
+        return;
+      }
+      if (!inputValue) {
         // This can happen if the initialized hasn't completed yet or
         // completed un-successfully.
         setResultItems([]);
-        setIsWaiting(true);
         return;
       }
 


### PR DESCRIPTION
Fixes #3718
Fixes #3695

Let's not move to the autocomplete search widget until this is resolved. 

The change makes sense. I'm just not sure I'm doing the hooks and effects right. Always makes me nervous. 

What can happen is that almost simultaneously (e.g. within less than 100ms) you quickly put the mouse into the search field and you type really fast. Typing triggers the `updateResult()` function (which searches the `searchIndex`) but until the slow XHR request has finished that `searchIndex` will be `null`.
So what this fix does is that it notices if the `updateResult()` was called when `searchIndex` is `null` and then, there's a `useEffect` that waits for the `searchIndex` to become truthy and when it is, it manually forces a call to `updateResult()` again. 
Feels like it makes sense. 

It's pretty easy to reproduce and simulate. Have a fuzzy search string (e.g. `/en-US/docs/Web/API/Node/textContent`) ready in your clipboard and be quick to paste that into the search field. Remember that both `onMouseOver` and `onFocus` will commence the XHR request for `search-index.json` so as soon as you've triggered that you need to be quick to trigger the `onChange` with some input. 