### PR TITLE
fix fail image.js on windows

### DIFF
--- a/content/image.js
+++ b/content/image.js
@@ -31,7 +31,12 @@ function isImage(filePath) {
 }
 
 function urlToFilePath(url) {
-  const [, locale, , ...slugParts] = decodeURI(url).split("/");
+  let sep = "/";
+  //check is os specific path separator like windows.
+  if(url.indexOf(path.sep) === 0){
+    sep = path.sep;
+  }
+  const [, locale, , ...slugParts] = decodeURI(url).split(sep);
   return path.join(locale.toLowerCase(), slugToFolder(slugParts.join("/")));
 }
 


### PR DESCRIPTION
take measures against path.join uses backslash separator on windows. 
path.join use and replace os specific separator. path.join('foo/bar', 'hoge') -> foo\bar\hoge on windows

see build/check-images.js:127