### PR TITLE
fix local server to handle retired-locale redirects

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -140,7 +140,7 @@ app.use("/:locale/search-index.json", searchIndexRoute);
 app.get("/_flaws", flawsRoute);
 
 app.get("/*/contributors.txt", async (req, res) => {
-  const url = req.url.replace(/\/contributors\.txt$/, "");
+  const url = req.path.replace(/\/contributors\.txt$/, "");
   const document = Document.findByURL(url);
   res.setHeader("content-type", "text/plain");
   if (!document) {
@@ -175,7 +175,7 @@ app.get("/*", async (req, res) => {
 
   if (req.url.includes("/_samples_/")) {
     try {
-      return res.send(await buildLiveSamplePageFromURL(req.url));
+      return res.send(await buildLiveSamplePageFromURL(req.path));
     } catch (e) {
       return res.status(404).send(e.toString());
     }
@@ -192,10 +192,10 @@ app.get("/*", async (req, res) => {
 
   // TODO: Would be nice to have a list of all supported file extensions
   // in a constants file.
-  if (/\.(png|webp|gif|jpe?g|svg)$/.test(req.url)) {
+  if (/\.(png|webp|gif|jpe?g|svg)$/.test(req.path)) {
     // Remember, Image.findByURL() will return the absolute file path
     // iff it exists on disk.
-    const filePath = Image.findByURL(req.url);
+    const filePath = Image.findByURL(req.path);
     if (filePath) {
       // The second parameter to `send()` has to be either a full absolute
       // path or a path that doesn't start with `../` otherwise you'd
@@ -206,12 +206,12 @@ app.get("/*", async (req, res) => {
     return res.status(404).send("File not found on disk");
   }
 
-  let lookupURL = decodeURI(req.url);
+  let lookupURL = decodeURI(req.path);
   let extraSuffix = "";
   let bcdDataURL = "";
   const bcdDataURLRegex = /\/(bcd-\d+|bcd)\.json$/;
 
-  if (req.url.endsWith("index.json")) {
+  if (req.path.endsWith("index.json")) {
     // It's a bit special then.
     // The URL like me something like
     // /en-US/docs/HTML/Global_attributes/index.json
@@ -220,8 +220,8 @@ app.get("/*", async (req, res) => {
     // temporarily remove it and remember to but it back when we're done.
     extraSuffix = "/index.json";
     lookupURL = lookupURL.replace(extraSuffix, "");
-  } else if (bcdDataURLRegex.test(req.url)) {
-    bcdDataURL = req.url;
+  } else if (bcdDataURLRegex.test(req.path)) {
+    bcdDataURL = req.path;
     lookupURL = lookupURL.replace(bcdDataURLRegex, "");
   }
 

--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -333,4 +333,28 @@ describe("Basic viewing of functional pages", () => {
     await expect(page).toClick("button", { text: "Update language" });
     await expect(page).toMatch("Yay! Updated settings successfully saved.");
   });
+
+  it("should redirect retired locale to English (document)", async () => {
+    await page.goto(testURL("/ar/docs/Web/Foo"));
+    await expect(page.url()).toMatch(
+      testURL("/en-US/docs/Web/Foo/?retiredLocale=ar")
+    );
+    await expect(page).toMatch("<foo>: A test tag");
+  });
+
+  it("should redirect retired locale to English (index.json)", async () => {
+    await page.goto(testURL("/ar/docs/Web/Foo/index.json"));
+    await expect(page.url()).toMatch(
+      testURL("/en-US/docs/Web/Foo/index.json?retiredLocale=ar")
+    );
+    await expect(page).toMatch("<foo>: A test tag");
+  });
+
+  it("should redirect retired locale to English (search with query string)", async () => {
+    await page.goto(testURL("/ar/search?q=video"));
+    await expect(page.url()).toMatch(
+      testURL("/en-US/search/?q=video&retiredLocale=ar")
+    );
+    await expect(page).toMatch("Search results for: video");
+  });
 });


### PR DESCRIPTION
Part of #3642 

Fixes the local development server to properly handle URL's with query strings, likes the ones added when redirecting retired locales.