### PR TITLE
Spec section: Avoid dupe titles; treat anchors as optional

### DIFF
--- a/client/src/document/ingredients/spec-section.tsx
+++ b/client/src/document/ingredients/spec-section.tsx
@@ -17,6 +17,37 @@ export function SpecificationSection({
   }>;
   query: string;
 }) {
+  function TableRow(props) {
+    const spec = props.specification;
+
+    let shortTitle = "";
+    if (spec.title !== spec.shortTitle) {
+      shortTitle = `(${spec.shortTitle})`;
+    }
+
+    let anchor;
+    const hasAnchor = spec.bcdSpecificationURL.includes("#");
+    if (hasAnchor) {
+      anchor = (
+        <span>
+          {" "}
+          <br />{" "}
+          <small> # {`${spec.bcdSpecificationURL.split("#")[1]}`} </small>{" "}
+        </span>
+      );
+    }
+
+    return (
+      <tr key={spec.bcdSpecificationURL}>
+        <td>
+          <a href={spec.bcdSpecificationURL}>
+            {spec.title} {shortTitle} {anchor}
+          </a>
+        </td>
+      </tr>
+    );
+  }
+
   return (
     <>
       {title && !isH3 && <DisplayH2 id={id} title={title} />}
@@ -30,16 +61,8 @@ export function SpecificationSection({
             </tr>
           </thead>
           <tbody>
-            {specifications.map((spec) => (
-              <tr key={spec.bcdSpecificationURL}>
-                <td>
-                  <a href={spec.bcdSpecificationURL}>
-                    {spec.title} ({spec.shortTitle})
-                    <br />{" "}
-                    <small>#{spec.bcdSpecificationURL.split("#")[1]}</small>
-                  </a>
-                </td>
-              </tr>
+            {specifications.map((specification) => (
+              <TableRow specification={specification} />
             ))}
           </tbody>
         </table>


### PR DESCRIPTION
It was a bit naive to think that we will find anchored links for all specification urls.
There are in fact a few features that won't have it, see https://github.com/mdn/browser-compat-data/pull/10353
So, the renderer should check if it is there and only then display the anchor.

The other change is duplicate titles: Sometimes the w3c/browser-specs package uses the same `title` and `shortTitle`. Displaying both looks weird. So, we shouldn't do that. Test case: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#specifications