### PR TITLE
Expunge URLUtilsReadOnly

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -1523,7 +1523,7 @@
     },
     "URL API": {
       "overview": ["URL API"],
-      "interfaces": ["URL", "URLSearchParams", "URLUtilsReadOnly"],
+      "interfaces": ["URL", "URLSearchParams"],
       "methods": [],
       "properties": [],
       "events": []

--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -2267,7 +2267,7 @@
     },
     "WorkerLocation": {
       "inh": "",
-      "impl": ["URLUtilsReadOnly"]
+      "impl": []
     },
     "WorkerNavigator": {
       "inh": "",


### PR DESCRIPTION
URLUtilsReadOnly is gone from MDN; see the related change at https://github.com/mdn/content/commit/5e27ba0.

Otherwise, without this change, with end up with thing where member names/links get duplicated in the API sidebar.