### PR TITLE
Specs: Look for nightly series spec urls as well

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -420,7 +420,9 @@ function _addSingleSpecialSection($) {
       .map((specURL) => {
         const spec = specs.find(
           (spec) =>
-            specURL.startsWith(spec.url) || specURL.startsWith(spec.nightly.url)
+            specURL.startsWith(spec.url) ||
+            specURL.startsWith(spec.nightly.url) ||
+            specURL.startsWith(spec.series.nightlyUrl)
         );
         if (spec) {
           // We only want to return exactly the keys that we will use in the


### PR DESCRIPTION
This was released in https://github.com/w3c/browser-specs/releases/tag/1.37.0

The story is that CSS specifications come in series like 
https://drafts.csswg.org/css-box/
https://drafts.csswg.org/css-box-3/
https://drafts.csswg.org/css-box-4/

We want to match against https://drafts.csswg.org/css-box/ which is stored in `series.nightlyUrl`.

Additional info: https://github.com/w3c/browser-specs/issues/279#issuecomment-832862800