### PR TITLE
mdn++ cta banner

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import * as React from "react";
 
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
 // import { CATEGORY_LEARNING_SURVEY, useGA } from "../ga-context";
@@ -40,7 +40,7 @@ export type BannerProps = {
 };
 
 function Banner(props: BannerProps) {
-  const [isDismissed, setDismissed] = useState(false);
+  const [isDismissed, setDismissed] = React.useState(false);
   const containerClassNames = props.classname
     ? `mdn-cta-container ${props.classname}`
     : "mdn-cta-container";
@@ -126,7 +126,7 @@ function MDNPlusPlusBanner({ onDismissed }: { onDismissed: () => void }) {
       copy={"Summer is coming."}
       cta={"Check it out"}
       url={`/${locale}/mdn++`}
-      newWindow
+      newWindow={false}
       onDismissed={onDismissed}
       onCTAClick={() => {
         ga("send", {

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -1,8 +1,11 @@
 import React, { useState } from "react";
 
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
-import { CATEGORY_LEARNING_SURVEY, useGA } from "../ga-context";
-import { COMMON_SURVEY_ID } from "./ids";
+// import { CATEGORY_LEARNING_SURVEY, useGA } from "../ga-context";
+import { useGA } from "../ga-context";
+// import { COMMON_SURVEY_ID } from "./ids";
+import { MDN_PLUSPLUS_IDv1 } from "./ids";
+import { useLocale } from "../hooks";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.
@@ -87,24 +90,48 @@ function Banner(props: BannerProps) {
   );
 }
 
-function CommonSurveyBanner({ onDismissed }: { onDismissed: () => void }) {
+// function CommonSurveyBanner({ onDismissed }: { onDismissed: () => void }) {
+//   const ga = useGA();
+
+//   return (
+//     <Banner
+//       id={COMMON_SURVEY_ID}
+//       title={"Learning web development survey"}
+//       copy={
+//         "Help us understand how to make MDN better for beginners (5 minute survey)"
+//       }
+//       cta={"Take the survey"}
+//       url="https://www.surveygizmo.com/s3/6175365/59cfad9c04cf"
+//       newWindow
+//       onDismissed={onDismissed}
+//       onCTAClick={() => {
+//         ga("send", {
+//           hitType: "event",
+//           eventCategory: CATEGORY_LEARNING_SURVEY,
+//           eventAction: "CTA clicked",
+//           eventLabel: "banner",
+//         });
+//       }}
+//     />
+//   );
+// }
+function MDNPlusPlusBanner({ onDismissed }: { onDismissed: () => void }) {
   const ga = useGA();
+  const locale = useLocale();
 
   return (
     <Banner
-      id={COMMON_SURVEY_ID}
-      title={"Learning web development survey"}
-      copy={
-        "Help us understand how to make MDN better for beginners (5 minute survey)"
-      }
-      cta={"Take the survey"}
-      url="https://www.surveygizmo.com/s3/6175365/59cfad9c04cf"
+      id={MDN_PLUSPLUS_IDv1}
+      title={"MDN++ Landing Page Experiment"}
+      copy={"Summer is coming."}
+      cta={"Check it out"}
+      url={`/${locale}/mdn++`}
       newWindow
       onDismissed={onDismissed}
       onCTAClick={() => {
         ga("send", {
           hitType: "event",
-          eventCategory: CATEGORY_LEARNING_SURVEY,
+          eventCategory: MDN_PLUSPLUS_IDv1,
           eventAction: "CTA clicked",
           eventLabel: "banner",
         });
@@ -124,8 +151,11 @@ export default function ActiveBanner({
   id: string;
   onDismissed: () => void;
 }) {
-  if (id === COMMON_SURVEY_ID) {
-    return <CommonSurveyBanner onDismissed={onDismissed} />;
+  if (id === MDN_PLUSPLUS_IDv1) {
+    return <MDNPlusPlusBanner onDismissed={onDismissed} />;
   }
+  // if (id === COMMON_SURVEY_ID) {
+  //   return <CommonSurveyBanner onDismissed={onDismissed} />;
+  // }
   throw new Error(`Unrecognized banner to display (${id})`);
 }

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
 
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
-// import { CATEGORY_LEARNING_SURVEY, useGA } from "../ga-context";
 import { useGA } from "../ga-context";
 // import { COMMON_SURVEY_ID } from "./ids";
 import { MDN_PLUSPLUS_IDv1 } from "./ids";
 import { useLocale } from "../hooks";
+
+// const CATEGORY_LEARNING_SURVEY = "learning web development";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.

--- a/client/src/banners/ids.ts
+++ b/client/src/banners/ids.ts
@@ -1,1 +1,2 @@
-export const COMMON_SURVEY_ID = "common_survey_banner";
+// export const COMMON_SURVEY_ID = "common_survey_banner";
+export const MDN_PLUSPLUS_IDv1 = "mdnplusplus_banner_v1";

--- a/client/src/banners/ids.ts
+++ b/client/src/banners/ids.ts
@@ -1,2 +1,5 @@
 // export const COMMON_SURVEY_ID = "common_survey_banner";
+
 export const MDN_PLUSPLUS_IDv1 = "mdnplusplus_banner_v1";
+// The idea is that we'll add more like this and we might want to
+// leverage older keys to see if they got enrolled in previous versions.

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -9,7 +9,7 @@ import { useUserData } from "../user-context";
 // <ActiveBanner>, at least the CSS will be ready.
 import "./banner.scss";
 
-import { COMMON_SURVEY_ID } from "./ids";
+// import { COMMON_SURVEY_ID } from "./ids";
 
 const ActiveBanner = lazy(() => import("./active-banner"));
 
@@ -65,24 +65,37 @@ export function Banner() {
     return null;
   }
 
-  const isEnabled = (id: string) =>
-    (userData.waffle.flags[id] || userData.waffle.switches[id]) &&
-    !isEmbargoed(id);
+  // The MDN_PLUSPLUS_IDv(N) banner depends on the following logic:
+  // 0. Is the banner not disabled by an environment variable
+  // 1. Are you not on the MDN++ page or sign in/up already.
+  // 2. Are you in the United States
+  // 3. Are you part of the 10% who are randomly selected
+  // 4. Have you not dismissed it previously
+  // 5. Have you seen a different MDN_PLUSPLUS_IDvN banner before
+  // 6. Is your locale en-US?
+  console.log(
+    "REACT_APP_ENABLE_MDNPLUSPLUS",
+    process.env.REACT_APP_ENABLE_MDNPLUSPLUS
+  );
 
-  // The order of the if statements is important and it's our source of
-  // truth about which banner is "more important" than the other.
+  // const isEnabled = (id: string) =>
+  //   (userData.waffle.flags[id] || userData.waffle.switches[id]) &&
+  //   !isEmbargoed(id);
 
-  if (isEnabled(COMMON_SURVEY_ID)) {
-    return (
-      <Suspense fallback={null}>
-        <ActiveBanner
-          id={COMMON_SURVEY_ID}
-          onDismissed={() => {
-            setEmbargoed(COMMON_SURVEY_ID, 5);
-          }}
-        />
-      </Suspense>
-    );
-  }
+  // // The order of the if statements is important and it's our source of
+  // // truth about which banner is "more important" than the other.
+
+  // if (isEnabled(COMMON_SURVEY_ID)) {
+  //   return (
+  //     <Suspense fallback={null}>
+  //       <ActiveBanner
+  //         id={COMMON_SURVEY_ID}
+  //         onDismissed={() => {
+  //           setEmbargoed(COMMON_SURVEY_ID, 5);
+  //         }}
+  //       />
+  //     </Suspense>
+  //   );
+  // }
   return null;
 }

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -61,9 +61,9 @@ function isEmbargoed(id: string) {
   }
 }
 
-function isExclusionPathname(id: string, pathname: string) {
+function isPathnameIncluded(id: string, pathname: string) {
   if (id === MDN_PLUSPLUS_IDv1) {
-    return (
+    return !(
       pathname.includes("/mdn++") ||
       pathname.includes("/signin") ||
       pathname.includes("/signup")
@@ -72,9 +72,9 @@ function isExclusionPathname(id: string, pathname: string) {
   return false;
 }
 
-function isExclusionGeoLocation(id: string, country: string) {
+function isGeoLocationIncluded(id: string, country: string) {
   if (id === MDN_PLUSPLUS_IDv1) {
-    return country !== "United States";
+    return country === "United States";
   }
   return false;
 }
@@ -118,8 +118,8 @@ export function Banner() {
   // 6. Is your locale en-US?
   if (
     ENABLE_MDNPLUSPLUS &&
-    !isExclusionPathname(MDN_PLUSPLUS_IDv1, location.pathname) &&
-    !isExclusionGeoLocation(MDN_PLUSPLUS_IDv1, userData.geo.country) &&
+    isPathnameIncluded(MDN_PLUSPLUS_IDv1, location.pathname) &&
+    isGeoLocationIncluded(MDN_PLUSPLUS_IDv1, userData.geo.country) &&
     isRandomlyIncluded(MDN_PLUSPLUS_IDv1, 10) &&
     !isEmbargoed(MDN_PLUSPLUS_IDv1)
   ) {

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -43,7 +43,5 @@ export const ENABLE_MDNPLUSPLUS = JSON.parse(
     JSON.stringify(process.env.NODE_ENV === "development")
 );
 
-console.log(
-  "IN CONSTANTS:process.env.REACT_APP_ENABLE_MDNPLUSPLUS==",
-  process.env.REACT_APP_ENABLE_MDNPLUSPLUS
-);
+export const DEFAULT_GEO_COUNTRY =
+  process.env.REACT_APP_DEFAULT_GEO_COUNTRY || "United States";

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -42,3 +42,8 @@ export const ENABLE_MDNPLUSPLUS = JSON.parse(
   process.env.REACT_APP_ENABLE_MDNPLUSPLUS ||
     JSON.stringify(process.env.NODE_ENV === "development")
 );
+
+console.log(
+  "IN CONSTANTS:process.env.REACT_APP_ENABLE_MDNPLUSPLUS==",
+  process.env.REACT_APP_ENABLE_MDNPLUSPLUS
+);

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -3,8 +3,6 @@ import { useContext, useEffect, useState } from "react";
 
 export type GAFunction = (...any) => void;
 
-// export const CATEGORY_LEARNING_SURVEY = "learning web development";
-
 const GA_SESSION_STORAGE_KEY = "ga";
 
 function getPostponedEvents() {

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -3,7 +3,7 @@ import { useContext, useEffect, useState } from "react";
 
 export type GAFunction = (...any) => void;
 
-export const CATEGORY_LEARNING_SURVEY = "learning web development";
+// export const CATEGORY_LEARNING_SURVEY = "learning web development";
 
 const GA_SESSION_STORAGE_KEY = "ga";
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -239,6 +239,12 @@ For more information, see the `testing/README.md`.
 
 ## Client
 
+NOTE! Due to a quirk of how we build the client, anything `REACT_APP_*` environment
+variable that you want to be available in the production-grade built JS code
+that gets used when use `localhost:5000` can not only be set in the root `/.env`
+file. Either use `export REACT_APP_*=...` or write it once in `/.env` and
+once in `/client/.env`.
+
 ### `HOST`
 
 **Default: `localhost`**
@@ -306,3 +312,11 @@ present the "Fix fixable flaws" button for example.
 **Default: `NODE_ENV==='development'`**
 
 Determines if the MDN++ SPA should be reachable or not.
+
+### `REACT_APP_DEFAULT_GEO_COUNTRY`
+
+**Default: `United States`**
+
+If the `/api/v1/whoami` does not include a `geo.country` value, fall back on this.
+Setting this allows you to pretend the XHR request to `/api/v1/whoami` included
+this value for `geo.country`.


### PR DESCRIPTION
Part of #3780

This PR isn't closing the issue, yet, because the exact copy on the banner hasn't been decided. 
But we can land this in favor of breaking up the work into manageable chunks.

To test this, it's a bit complicated, because of the random chance (currently set to 10%). 
1. Run `export REACT_APP_ENABLE_MDNPLUSPLUS=true` and `yarn dev`
2. Go to any page.
3. If the banner doesn't appear, it's probably because your random chance was outside 10%. To override that type the following into the web console: `localStorage.setItem('banner.mdnplusplus_banner_v1.chance', 'true')` and refresh the page

I know [we discussed](https://github.com/mdn/yari/discussions/3753) stop relying on waffle flags but I didn't want to mess with that today. But I also didn't want to completely delete all that functionality just yet. 

Here's what it looks like:
<img width="1616" alt="Screen Shot 2021-05-11 at 4 21 16 PM" src="https://user-images.githubusercontent.com/26739/117882639-8c9f4580-b278-11eb-8a2d-24e1f3ded447.png">
