### PR TITLE
padding in notifications in auto-complete search

### DIFF
--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -57,6 +57,18 @@
       color: $yellow-100;
     }
 
+    div {
+      padding: $base-unit;
+    }
+
+    .nothing-found {
+      font-style: italic;
+    }
+
+    .fuzzy-engaged {
+      font-size: $tiny-text;
+    }
+
     .result-item {
       border-bottom: 1px solid $neutral-550;
       padding: $base-unit;

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -71,7 +71,6 @@
 
     .result-item {
       border-bottom: 1px solid $neutral-550;
-      padding: $base-unit;
       word-break: break-word;
     }
 


### PR DESCRIPTION
Fixes #3717

<img width="502" alt="Screen Shot 2021-05-11 at 5 04 38 PM" src="https://user-images.githubusercontent.com/26739/117884903-2a940f80-b27b-11eb-9f61-91ea81032a1b.png">

But using `.search-results div` to set the padding, it captures not just the `.nothing-found` but also when there's an error loading the search-index (hard to simulate) or whilst there's that yellow text that says "Initializing search index...". 

Also, I took the liberty of making the "Fuzzy searching by URI" smaller so it stands out as less important and not to be confused as a "result". 