### PR TITLE
Getting img references from en-US didn't work if not lowercase

### DIFF
--- a/build/check-images.js
+++ b/build/check-images.js
@@ -157,7 +157,7 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
         !finalSrc.startsWith(`/${DEFAULT_LOCALE.toLowerCase()}/`)
       ) {
         const enUSFinalSrc = finalSrc.replace(
-          new RegExp(`^/${doc.locale}/`),
+          new RegExp(`^/${doc.locale}/`, "i"),
           `/${DEFAULT_LOCALE}/`
         );
         if (Image.findByURL(enUSFinalSrc)) {

--- a/build/check-images.js
+++ b/build/check-images.js
@@ -157,8 +157,8 @@ function checkImageReferences(doc, $, options, { url, rawContent }) {
         !finalSrc.startsWith(`/${DEFAULT_LOCALE.toLowerCase()}/`)
       ) {
         const enUSFinalSrc = finalSrc.replace(
-          `/${doc.locale.toLowerCase()}/`,
-          `/${DEFAULT_LOCALE.toLowerCase()}/`
+          new RegExp(`^/${doc.locale}/`),
+          `/${DEFAULT_LOCALE}/`
         );
         if (Image.findByURL(enUSFinalSrc)) {
           // Use the en-US src instead

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -197,9 +197,10 @@ test("content built foo page", () => {
   );
 
   // Because this en-US page has a French translation
-  expect($('link[rel="alternate"]').length).toBe(2);
+  expect($('link[rel="alternate"]').length).toBe(3);
   expect($('link[rel="alternate"][hreflang="en"]').length).toBe(1);
   expect($('link[rel="alternate"][hreflang="fr"]').length).toBe(1);
+  expect($('link[rel="alternate"][hreflang="zh"]').length).toBe(1);
   const toEnUSURL = $('link[rel="alternate"][hreflang="en"]').attr("href");
   const toFrURL = $('link[rel="alternate"][hreflang="fr"]').attr("href");
   // The domain is hardcoded because the URL needs to be absolute and when
@@ -243,12 +244,41 @@ test("content built French foo page", () => {
   const htmlFile = path.join(builtFolder, "index.html");
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
-  expect($('link[rel="alternate"]').length).toBe(2);
+  expect($('link[rel="alternate"]').length).toBe(3);
   expect($('link[rel="alternate"][hreflang="en"]').length).toBe(1);
   expect($('link[rel="alternate"][hreflang="fr"]').length).toBe(1);
+  expect($('link[rel="alternate"][hreflang="zh"]').length).toBe(1);
   expect($('meta[property="og:locale"]').attr("content")).toBe("fr");
   expect($('meta[property="og:title"]').attr("content")).toBe(
     "<foo>: Une page de test | MDN"
+  );
+});
+
+test("content built zh-TW page with en-US fallback image", () => {
+  const builtFolder = path.join(buildRoot, "zh-tw", "docs", "web", "foo");
+  const jsonFile = path.join(builtFolder, "index.json");
+  expect(fs.existsSync(jsonFile)).toBeTruthy();
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(Object.keys(doc.flaws).length).toBe(0);
+  expect(doc.title).toBe("<foo>: 測試網頁");
+  expect(doc.isTranslated).toBe(true);
+  expect(doc.other_translations[0].locale).toBe("en-US");
+  expect(doc.other_translations[0].native).toBe("English (US)");
+  expect(doc.other_translations[0].title).toBe("<foo>: A test tag");
+
+  const htmlFile = path.join(builtFolder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+  const $ = cheerio.load(html);
+  expect($('link[rel="alternate"]').length).toBe(3);
+  expect($('link[rel="alternate"][hreflang="en"]').length).toBe(1);
+  expect($('link[rel="alternate"][hreflang="fr"]').length).toBe(1);
+  expect($('link[rel="alternate"][hreflang="zh"]').length).toBe(1);
+  expect($('meta[property="og:locale"]').attr("content")).toBe("zh-TW");
+  expect($('meta[property="og:title"]').attr("content")).toBe(
+    "<foo>: 測試網頁 | MDN"
+  );
+  expect($("#content img").attr("src")).toBe(
+    "/en-US/docs/Web/Foo/screenshot.png"
   );
 });
 

--- a/testing/translated-content/files/zh-tw/web/foo/index.html
+++ b/testing/translated-content/files/zh-tw/web/foo/index.html
@@ -1,0 +1,15 @@
+---
+title: "<foo>: 測試網頁"
+slug: Web/Foo
+translation_of: Web/Foo
+---
+
+<p>
+  Peter's note. I don't know how to express anything in Chinese beyond Google
+  Translate
+</p>
+
+<figure>
+  <img src="screenshot.png" alt="顏色的屏幕截圖" />
+  <figcaption>顏色的屏幕截圖</figcaption>
+</figure>


### PR DESCRIPTION
Fixes #3786

Demonstrated here:
```js
const DEFAULT_LOCALE = "en-US";
const doc = { locale: "zh-TW" };
const finalSrc = "/zh-Tw/docs/Foo";

const enUSFinalSrc = finalSrc.replace(
  // `/${doc.locale}/`,
  new RegExp(`^/${doc.locale}/`, "i"),
  `/${DEFAULT_LOCALE}/`
);
console.log({ enUSFinalSrc });
```

It basically makes it case-agnostic to turn a potential image URL into the `en-US` equivalent. 
