### PR TITLE
lazy-load JS on document metadata

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -1,6 +1,6 @@
 import { Doc } from "./types";
 
-export function OnGitHubLink({ doc }: { doc: Doc }) {
+export default function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
       <h4>Found a problem with this page?</h4>

--- a/client/src/document/organisms/metadata/index.tsx
+++ b/client/src/document/organisms/metadata/index.tsx
@@ -5,6 +5,7 @@ import React from "react";
 
 import "./index.scss";
 
+import "../../../ui/molecules/language-menu/index.scss";
 const LanguageMenu = React.lazy(
   () => import("../../../ui/molecules/language-menu")
 );

--- a/client/src/document/organisms/metadata/index.tsx
+++ b/client/src/document/organisms/metadata/index.tsx
@@ -1,7 +1,14 @@
-import { LanguageMenu } from "../../../ui/molecules/language-menu";
-import { OnGitHubLink } from "../../on-github";
+import React from "react";
+
+// import { LanguageMenu } from "../../../ui/molecules/language-menu";
+// import { OnGitHubLink } from "../../on-github";
 
 import "./index.scss";
+
+const LanguageMenu = React.lazy(
+  () => import("../../../ui/molecules/language-menu")
+);
+const OnGitHubLink = React.lazy(() => import("../../on-github"));
 
 function LastModified({ value, locale }) {
   if (!value) {
@@ -27,21 +34,28 @@ function LastModified({ value, locale }) {
 export function Metadata({ doc, locale }) {
   const translations = doc.other_translations || [];
   const { native } = doc;
+  const isServer = typeof window === "undefined";
 
   return (
     <aside className="metadata">
       <div className="metadata-content-container">
-        {doc.isActive && <OnGitHubLink doc={doc} />}
+        {!isServer && doc.isActive && (
+          <React.Suspense fallback={<p>Loading...</p>}>
+            <OnGitHubLink doc={doc} />
+          </React.Suspense>
+        )}
         <p className="last-modified-date">
           <LastModified value={doc.modified} locale={locale} />,{" "}
           <a href={`${doc.mdn_url}/contributors.txt`}>by MDN contributors</a>
         </p>
-        {translations && !!translations.length && (
-          <LanguageMenu
-            translations={translations}
-            native={native}
-            locale={locale}
-          />
+        {!isServer && translations && !!translations.length && (
+          <React.Suspense fallback={null}>
+            <LanguageMenu
+              translations={translations}
+              native={native}
+              locale={locale}
+            />
+          </React.Suspense>
         )}
       </div>
     </aside>

--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -9,7 +9,7 @@ import "./index.scss";
 // This needs to match what's set in 'libs/constants.js' on the server/builder!
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
 
-export function LanguageMenu({
+export default function LanguageMenu({
   locale,
   translations,
   native,

--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { useGA } from "../../../ga-context";
 import { Translation } from "../../../document/types";
 
-import "./index.scss";
+// import "./index.scss";
 
 // This needs to match what's set in 'libs/constants.js' on the server/builder!
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";


### PR DESCRIPTION
Part of an experiment that @Gregoor and I are preparing for. 
For the record, this shrinks the `main.HASH.chunk.js`...

- from: 58360 bytes (14706 Brotli compressed)
- to: 54308 bytes (13539 Brotli compressed)

That's a saving of:

- 4052 bytes (4.0KB)
- 1167 bytes Brotli (1.1KB)

