### PR TITLE
Add Web App Manifest Application Information specification

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -1102,7 +1102,7 @@
   "ManifestAppInfo": {
     "name": "Web App Manifest - Application Information",
     "url": "https://w3c.github.io/manifest-app-info/",
-    "status": "NOTE"
+    "status": "ED"
   },
   "MathML2": {
     "name": "MathML 2.0",

--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -1099,6 +1099,11 @@
     "url": "https://w3c.github.io/manifest/",
     "status": "WD"
   },
+  "ManifestAppInfo": {
+    "name": "Web App Manifest - Application Information",
+    "url": "https://w3c.github.io/manifest-app-info/",
+    "status": "NOTE"
+  },
   "MathML2": {
     "name": "MathML 2.0",
     "url": "https://www.w3.org/TR/MathML2/",


### PR DESCRIPTION
The `categories`, `description`, `iarc_rating_id` and `screenshots` members of [Web App Manifest](https://w3c.github.io/manifest/) have been moved into new [Web App Manifest - Application Information](https://w3c.github.io/manifest-app-info/) specification.

I will also soon create a separate PR to https://github.com/mdn/content to update needed spec links.