### PR TITLE
Field-length norm is too overpowering

### DIFF
--- a/deployer/src/deployer/search/models.py
+++ b/deployer/src/deployer/search/models.py
@@ -229,7 +229,27 @@ text_analyzer = analyzer(
 
 class Document(ESDocument):
     title = Text(required=True, analyzer=text_analyzer)
-    body = Text(analyzer=text_analyzer)
+    body = Text(
+        analyzer=text_analyzer,
+        # Field-length norm
+        # If a word is "rare" amongst all the other words in the document, it's
+        # assumed that that document is more exclusively about that word.
+        # For example, the Glossary page about HTTP2 might mention "HTTP2"
+        # 5 times out of 100 words. But a page that's also mentioning it 5 times,
+        # and that other page has 1,000 means it's more "relevant" on that
+        # Glossary page.
+        # However, many times the field-length norm is skewing real results.
+        # For example, important and popular MDN pages are often longer because
+        # they have more examples and more notes and more everything. That
+        # shouldn't count against the page.
+        # One example we found was "Array" appear less frequently in
+        # "TypedArray.prototype.forEach()" than it did in "Array.prototype.forEach()"
+        # but that's because the former has 493 words and the latter had 1,514 words.
+        # Just because a page has more text doesn't mean it's less about the
+        # keyword to a certain extent.
+        # https://www.elastic.co/guide/en/elasticsearch/guide/current/scoring-theory.html#field-norm
+        norms=False,
+    )
     summary = Text(analyzer=text_analyzer)
     locale = Keyword()
     archived = Boolean()


### PR DESCRIPTION
Fixes #3840

I've tested this quite carefully on my local yari + kuma setup and it worked. 

As you can see `score` is almost identical now. Which is fair and good. Now, it means the popularity boost will benefit better. 
<img width="901" alt="Screen Shot 2021-05-21 at 10 12 51 AM" src="https://user-images.githubusercontent.com/26739/119151159-1c818400-ba1d-11eb-9814-92166b814a22.png">

It's never a perfect science but a constant nudging and poking till you get something you *think* users will expect and like. 