### PR TITLE
fetch and update popularities before building

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -110,6 +110,11 @@ jobs:
           echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload }}"
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix }}"
 
+      - name: Fetch and load latest popularities.json
+        env:
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+        run: yarn tool popularities
+
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -136,6 +136,13 @@ jobs:
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
+      # (peterbe, May 2021) Deliberately commented out till we know this works
+      # well enough in Stage and Dev.
+      # - name: Fetch and load latest popularities.json
+      #   env:
+      #     CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+      #   run: yarn tool popularities
+
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -136,6 +136,11 @@ jobs:
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
+      - name: Fetch and load latest popularities.json
+        env:
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+        run: yarn tool popularities
+
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a


### PR DESCRIPTION
@fiji-flo set up a cron job in Athena that updates two S3 objects, from our CDN logs, every month. 
But we're not doing anything with those CSV files. 
[Week before last we manually updated the file checked in git](https://github.com/mdn/content/pull/4945) but it doesn't feel smart to keep doing that every month. 

Also, if we can increase the cron job to weekly, we'd still need to wait until some human updates the file in git. 

By running this right before the build, we'll always get the latest and greatest popularities, that are available, right before building the pages. 