### PR TITLE
pre-launch plus experiment

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -162,6 +162,11 @@ jobs:
           # You get the ID from
           # https://speedcurve.com/mozilla-add-ons/mdn/settings/updated/#lux
           BUILD_SPEEDCURVE_LUX_ID: 108906238
+
+          # This enables the Plus call-to-action banner and the Plus landing page
+          # (deliberately commented out until May 25)
+          # REACT_APP_ENABLE_PLUS: true
+
         run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -168,6 +168,9 @@ jobs:
           # kind of document it is.
           BUILD_ALWAYS_NO_ROBOTS: true
 
+          # This enables the Plus call-to-action banner and the Plus landing page
+          REACT_APP_ENABLE_PLUS: true
+
         run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"


### PR DESCRIPTION
@escattone Let's merge this on Monday. That means Stage will become "hot". If we can't wait till the (Monday) evening, we can kick off a build so it's hot from the afternoon already. Then we know the env var trick works. 

Then, Hermina, Daryl, etc. will carefully test the landing page on Stage on the following Tuesday morning. 
They will not be able to test the CTA banner even if they do the `localStorage` web console trick. 

Then, on Tuesday, after a go-ahead signal we'll uncomment the lines in `prod-build.yml` and kick off a build and we're live-live. 