### PR TITLE
chore: switch to math.div for sass

### DIFF
--- a/client/src/auth/sign-up.scss
+++ b/client/src/auth/sign-up.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../ui/atoms/avatar/avatar";
 
 .sign-up {
@@ -25,7 +27,7 @@
     max-width: 250px;
 
     .button {
-      margin-top: $base-spacing / 2;
+      margin-top: math.div($base-spacing, 2);
     }
   }
 
@@ -36,7 +38,7 @@
       content: "";
       display: inline-block;
       height: 14px;
-      margin-right: $base-spacing / 4;
+      margin-right: math.div($base-spacing, 4);
       transform: rotate(-90deg);
       vertical-align: middle;
       width: 14px;
@@ -45,7 +47,7 @@
     &:hover,
     &:focus {
       &::before {
-        margin-right: $base-spacing / 3;
+        margin-right: math.div($base-spacing, 3);
       }
     }
   }

--- a/client/src/banners/banner.scss
+++ b/client/src/banners/banner.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/color-gradients";
 @import "~@mdn/minimalist/sass/vars/layout";
@@ -28,7 +30,7 @@
         display: inline-block;
         font-size: $large-font-size;
         font-weight: normal;
-        padding: 0 ($base-spacing / 2);
+        padding: 0 math.div($base-spacing, 2);
       }
     }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/borders";
@@ -47,7 +49,7 @@ a.new {
 }
 
 .main-page-content {
-  padding: ($base-spacing / 2) $base-spacing $base-spacing;
+  padding: math.div($base-spacing, 2) $base-spacing $base-spacing;
 
   @media #{$mq-small-desktop-and-up} {
     margin-bottom: $base-spacing * 2;
@@ -153,7 +155,7 @@ a.new {
     }
 
     a.button {
-      margin-bottom: ($base-spacing / 2);
+      margin-bottom: math.div($base-spacing, 2);
       max-width: inherit;
 
       @media #{$mq-tablet-and-up} {
@@ -170,12 +172,12 @@ a.new {
     columns: 300px;
   }
 
-  iframe:not(.sample-code-frame) {
-    border: 0;
-  }
-
   iframe {
     max-width: 100%;
+  }
+
+  iframe:not(.sample-code-frame) {
+    border: 0;
   }
 }
 
@@ -185,7 +187,7 @@ a.new {
  */
 .archived {
   background-color: $yellow-400;
-  padding: $base-spacing / 4;
+  padding: math.div($base-spacing, 4);
   position: fixed;
   text-align: center;
   top: 0;

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-browsers.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-browsers.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-browsers {
   th {
     border-top: 0;
@@ -15,7 +17,7 @@
     display: inline-block;
     font-weight: normal;
     height: 20px;
-    margin: 0 0 $base-spacing ($base-spacing / 2);
+    margin: 0 0 $base-spacing math.div($base-spacing, 2);
     padding: 0;
     text-align: left;
     transform: rotate(-90deg);

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history-link.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history-link.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-history-link {
   display: none;
 
@@ -14,7 +16,7 @@
     display: block;
     font-size: $tiny-text;
     height: 16px;
-    padding: $base-spacing / 2;
+    padding: math.div($base-spacing, 2);
     position: relative;
     transform: rotate(180deg);
     width: 100%;
@@ -23,7 +25,7 @@
   @media #{$mq-small-desktop-and-up} {
     bottom: 0;
     left: 0;
-    margin: ($base-spacing / 2) 0 0;
+    margin: math.div($base-spacing, 2) 0 0;
     padding: 0;
     position: absolute;
     z-index: $top-layer;

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-history.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 tr.bc-history {
   background-color: $neutral-550;
   display: none;
@@ -28,7 +30,7 @@ tr.bc-history {
     gap: $base-spacing;
     justify-content: space-between;
     max-width: 100%;
-    padding: $base-spacing / 2;
+    padding: math.div($base-spacing, 2);
   }
 
   dt {
@@ -39,7 +41,7 @@ tr.bc-history {
 
   dd {
     font-weight: normal;
-    margin: ($base-spacing / 2) 0;
+    margin: math.div($base-spacing, 2) 0;
     min-height: 24px;
     text-align: left;
 
@@ -54,13 +56,13 @@ tr.bc-history {
 dl.bc-history-mobile {
   background-color: $neutral-550;
   display: block;
-  padding: $base-spacing / 2;
+  padding: math.div($base-spacing, 2);
 
   @media #{$mq-small-desktop-and-up} {
     display: none;
   }
 
   dd {
-    margin: ($base-spacing / 2) 0;
+    margin: math.div($base-spacing, 2) 0;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-icons {
   display: inline-block;
   vertical-align: text-top;
@@ -10,8 +12,8 @@
     display: inline-block;
     height: $base-unit * 3;
     line-height: 1;
-    margin-left: $base-unit / 1.2;
-    margin-right: $base-unit / 1.5;
+    margin-left: math.div($base-unit, 1.2);
+    margin-right: math.div($base-unit, 1.5);
     width: $base-unit * 3;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-legend {
   margin: ($base-spacing * 2) 0;
 
@@ -27,7 +29,7 @@
     }
 
     dt {
-      margin-right: $base-spacing / 2;
+      margin-right: math.div($base-spacing, 2);
       vertical-align: middle;
     }
   }

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-platforms.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-platforms.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-platforms {
   th {
     border-bottom: 2px solid $neutral-100;
@@ -24,7 +26,7 @@
       content: "";
       display: inline-block;
       height: 24px;
-      margin-top: $base-spacing / 2;
+      margin-top: math.div($base-spacing, 2);
       width: 24px;
     }
   }

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .bc-table {
   background-color: $neutral-550;
   border: 0;
@@ -51,7 +53,7 @@
   }
 
   .bc-table-row-header {
-    padding: ($base-spacing / 2) ($base-spacing / 4);
+    padding: math.div($base-spacing, 2) math.div($base-spacing, 4);
 
     code {
       text-decoration: none;
@@ -86,7 +88,7 @@
         border-right: 1px solid $neutral-100;
         display: table-cell;
         overflow: hidden;
-        padding: ($base-spacing / 2) $base-unit;
+        padding: math.div($base-spacing, 2) $base-unit;
         text-align: center;
         vertical-align: middle;
       }
@@ -103,7 +105,7 @@
 
   .bc-browser-name {
     display: inline-block;
-    padding: $base-spacing / 4;
+    padding: math.div($base-spacing, 4);
     width: 75%;
 
     @media #{$mq-small-desktop-and-up} {

--- a/client/src/document/molecules/_breadcrumb-locale-container.scss
+++ b/client/src/document/molecules/_breadcrumb-locale-container.scss
@@ -1,8 +1,10 @@
+@use "sass:math";
+
 .breadcrumb-locale-container {
   align-items: center;
   background-color: $neutral-550;
   display: flex;
-  padding: ($base-spacing / 2) $base-spacing;
+  padding: math.div($base-spacing, 2) $base-spacing;
 
   @media #{$mq-small-desktop-and-up} {
     margin: $base-spacing 0 0;

--- a/client/src/document/molecules/_notecards.scss
+++ b/client/src/document/molecules/_notecards.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/borders";
@@ -26,7 +28,7 @@
   border-left: $base-unit solid $primary-200;
   margin: 0;
   margin-bottom: $base-spacing;
-  padding: ($base-spacing / 2);
+  padding: math.div($base-spacing, 2);
 
   a {
     &:link,
@@ -55,7 +57,7 @@
     font-size: $small-medium-font-size-mobile;
     font-weight: bold;
     margin: 0;
-    margin-bottom: ($base-spacing / 4);
+    margin-bottom: math.div($base-spacing, 4);
     padding: 0;
 
     @media #{$mq-tablet-and-up} {
@@ -72,7 +74,7 @@
       content: "";
       display: inline-block;
       height: 21px;
-      margin-right: $base-spacing / 4;
+      margin-right: math.div($base-spacing, 4);
       position: relative;
       top: 2px;
       width: 20px;
@@ -80,7 +82,7 @@
   }
 
   p {
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: math.div($base-spacing, 4);
 
     &:last-child {
       margin-bottom: 0;
@@ -89,8 +91,8 @@
 
   &.inline {
     font-weight: normal;
-    margin: $base-spacing / 4;
-    padding: ($base-spacing / 8) ($base-spacing / 4);
+    margin: math.div($base-spacing, 4);
+    padding: math.div($base-spacing, 8) math.div($base-spacing, 4);
 
     &::before {
       top: 5px;

--- a/client/src/document/molecules/localized-content-note/index.scss
+++ b/client/src/document/molecules/localized-content-note/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/layout";
 
 .localized-content-note {
@@ -5,6 +7,6 @@
 
   &.inline {
     margin: 0;
-    padding: ($base-spacing / 2) $base-spacing;
+    padding: math.div($base-spacing, 2) $base-spacing;
   }
 }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -20,14 +22,14 @@
     ol,
     ul {
       @media #{$mq-tablet-and-up} {
-        padding-left: $base-spacing / 2;
+        padding-left: math.div($base-spacing, 2);
       }
     }
   }
 
   summary,
   li {
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: math.div($base-spacing, 2);
   }
 
   a {

--- a/client/src/document/organisms/toc/index.scss
+++ b/client/src/document/organisms/toc/index.scss
@@ -1,10 +1,12 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/typography";
 
 .document-toc {
   font-size: $default-font-size;
-  padding: ($base-spacing / 4) $base-spacing;
+  padding: math.div($base-spacing, 4) $base-spacing;
   position: relative;
 
   @media #{$mq-tablet-and-up} {
@@ -28,7 +30,7 @@
     border: 0;
     color: $link-color;
     font-weight: normal;
-    padding: ($base-spacing / 2) 0;
+    padding: math.div($base-spacing, 2) 0;
     text-align: left;
     width: 100%;
 

--- a/client/src/page-not-found/index.scss
+++ b/client/src/page-not-found/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
 
@@ -8,7 +10,7 @@
 
   .fallback-document {
     p {
-      margin-top: $base-spacing / 2;
+      margin-top: math.div($base-spacing, 2);
     }
 
     .fallback-link {

--- a/client/src/settings/index.scss
+++ b/client/src/settings/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -16,7 +18,7 @@
   }
 
   .field-group {
-    margin: ($base-spacing / 2) 0;
+    margin: math.div($base-spacing, 2) 0;
 
     label {
       font-size: $large-font-size-mobile;
@@ -55,7 +57,7 @@
 }
 
 .settings-form {
-  margin: ($base-spacing / 2) 0 ($base-spacing * 2);
+  margin: math.div($base-spacing, 2) 0 ($base-spacing * 2);
 
   @media #{$mq-tablet-and-up} {
     margin: 0;
@@ -64,12 +66,12 @@
 
 .close-account {
   h3 {
-    margin-top: $base-spacing / 2;
+    margin-top: math.div($base-spacing, 2);
   }
 
   h4,
   p {
-    margin-bottom: $base-spacing / 2;
+    margin-bottom: math.div($base-spacing, 2);
   }
 
   h4 {

--- a/client/src/site-search/search-results.scss
+++ b/client/src/site-search/search-results.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -46,7 +48,7 @@
     color: $neutral-100;
     display: inline-block;
     margin: 0;
-    margin-bottom: $base-spacing / 4;
+    margin-bottom: math.div($base-spacing, 4);
     padding: 0;
 
     a {
@@ -58,7 +60,7 @@
   }
 
   .search-result-url {
-    margin-bottom: $base-spacing / 4;
+    margin-bottom: math.div($base-spacing, 4);
   }
 
   // Used to indicate that a search result link is in a different locale
@@ -69,14 +71,14 @@
     font-size: $small-font-size;
     margin-top: $base-unit;
     max-width: max-content;
-    padding: ($base-unit / 2) $base-unit;
+    padding: math.div($base-unit, 2) $base-unit;
     position: relative;
     top: -3px;
 
     @media #{$mq-tablet-and-up} {
       display: inline-block;
       margin: 0;
-      margin-left: $base-spacing / 4;
+      margin-left: math.div($base-spacing, 4);
       padding: $base-unit;
     }
   }
@@ -98,7 +100,7 @@
 
 .language-options,
 .sort-options {
-  margin-top: $base-spacing / 2;
+  margin-top: math.div($base-spacing, 2);
 
   h2 {
     font-family: $site-font-family;
@@ -120,7 +122,7 @@
     li {
       display: inline-block;
       padding: 0;
-      padding-right: ($base-spacing / 4);
+      padding-right: math.div($base-spacing, 4);
 
       &::after {
         content: " | ";
@@ -138,6 +140,6 @@
   margin-bottom: $base-spacing;
 
   p {
-    margin-bottom: $base-unit / 2;
+    margin-bottom: math.div($base-unit, 2);
   }
 }

--- a/client/src/ui/molecules/a11y-nav/index.scss
+++ b/client/src/ui/molecules/a11y-nav/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 /*
 Keyboard & screen reader skip link menu
 ********************************************************************** */
@@ -15,7 +17,7 @@ Keyboard & screen reader skip link menu
     background-color: rgba(255, 255, 255, 0.9);
     font-weight: bold;
     left: 0;
-    padding: ($base-spacing / 2);
+    padding: math.div($base-spacing, 2);
     position: absolute;
     right: 0;
     text-align: center;

--- a/client/src/ui/molecules/blog-feed/index.scss
+++ b/client/src/ui/molecules/blog-feed/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/mixins/utils";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
@@ -18,7 +20,7 @@
 
     li {
       border-bottom: 1px solid $neutral-550;
-      margin-bottom: $base-spacing / 2;
+      margin-bottom: math.div($base-spacing, 2);
     }
   }
 

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/mixins/utils";
 @import "~@mdn/minimalist/sass/mixins/links";
 
@@ -7,7 +9,7 @@
 
 .breadcrumbs-container {
   @media #{$mq-small-desktop-and-up} {
-    padding: ($base-spacing / 2) $base-spacing;
+    padding: math.div($base-spacing, 2) $base-spacing;
   }
 
   @media #{$mq-small-desktop-and-up} {
@@ -57,7 +59,7 @@
 
     [property="name"] {
       display: inline-block;
-      margin: 0 ($base-unit / 2);
+      margin: 0 math.div($base-unit, 2);
     }
 
     .breadcrumb-penultimate {
@@ -68,7 +70,7 @@
         content: "";
         display: inline-block;
         height: 16px;
-        margin-right: $base-spacing / 4;
+        margin-right: math.div($base-spacing, 4);
         transform: rotate(-90deg);
         width: 16px;
 

--- a/client/src/ui/molecules/home-contribute/index.scss
+++ b/client/src/ui/molecules/home-contribute/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/mixins/utils";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
@@ -21,7 +23,7 @@
 
     li {
       border-bottom: 1px solid $neutral-550;
-      margin-bottom: $base-spacing / 2;
+      margin-bottom: math.div($base-spacing, 2);
     }
   }
 }

--- a/client/src/ui/molecules/home-hero/index.scss
+++ b/client/src/ui/molecules/home-hero/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/mixins/utils";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
@@ -77,7 +79,7 @@
     border-bottom: 2px solid $neutral-100;
     color: $neutral-100;
     display: inline-block;
-    padding: ($base-spacing / 2) 0;
+    padding: math.div($base-spacing, 2) 0;
     width: 100%;
 
     &::after {

--- a/client/src/ui/molecules/language-menu/index.scss
+++ b/client/src/ui/molecules/language-menu/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
 
@@ -19,7 +21,7 @@
 
   select {
     display: inline-block;
-    margin-right: $base-spacing / 4;
+    margin-right: math.div($base-spacing, 4);
 
     @media #{$mq-tablet-and-up} {
       display: inline-block;

--- a/client/src/ui/molecules/language-toggle/index.scss
+++ b/client/src/ui/molecules/language-toggle/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/mixins/utils";
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
@@ -51,7 +53,7 @@ ul.language-toggle {
     &::after {
       content: "|";
       display: inline-block;
-      margin: 0 $base-spacing / 4;
+      margin: 0 math.div($base-spacing, 4);
     }
   }
 

--- a/client/src/ui/molecules/search/basic-search-widget.scss
+++ b/client/src/ui/molecules/search/basic-search-widget.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // This file just exists to make the temporary basic search widget
 // look and act like Kuma.
 @import "~@mdn/minimalist/sass/vars/color-palette";
@@ -8,16 +10,16 @@
 }
 
 input.search-input-field {
-  border-width: 0;
-  padding: ($base-spacing / 4) ($base-unit * 6) ($base-spacing / 4)
-    ($base-spacing / 2);
   // make webkit play nice with search input types
-  -webkit-appearance: none;
+  -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
+  border-width: 0;
+  padding: math.div($base-spacing, 4) ($base-unit * 6)
+    math.div($base-spacing, 4) math.div($base-spacing, 2);
 
   &:focus,
   &:invalid {
-    outline: none;
     box-shadow: none;
+    outline: none;
   }
 }
 
@@ -25,7 +27,7 @@ input.search-input-field {
   background: $neutral-600 url("~@mdn/dinocons/general/search.svg") 0 0
     no-repeat;
   height: 21px;
-  padding: $base-spacing / 2;
+  padding: math.div($base-spacing, 2);
   position: absolute;
   right: 10px;
   top: 10px;

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -18,7 +20,7 @@
     width: 100%;
 
     @media #{$mq-tablet-and-up} {
-      margin: ($base-spacing / 2) 0;
+      margin: math.div($base-spacing, 2) 0;
       min-width: 80px;
     }
 

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 @import "~@mdn/minimalist/sass/vars/typography";
@@ -45,7 +47,7 @@
     }
 
     ul {
-      padding-inline-start: $base-spacing / 4;
+      padding-inline-start: math.div($base-spacing, 4);
     }
   }
 

--- a/client/src/ui/organisms/header/index.scss
+++ b/client/src/ui/organisms/header/index.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "~@mdn/minimalist/sass/vars/color-palette";
 @import "~@mdn/minimalist/sass/vars/layout";
 
@@ -37,7 +39,7 @@
   @media #{$mq-tablet-and-up} {
     display: flex;
     flex-flow: column;
-    padding-bottom: ($base-spacing / 2);
+    padding-bottom: math.div($base-spacing, 2);
   }
 
   @media #{$mq-large-desktop-and-up} {


### PR DESCRIPTION
Switch to using `math.div` in SASS

fix #3859
