### PR TITLE
Fix how BCD renderer determines the need for notes

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -310,8 +310,11 @@ function getNotes(
               label: "Support removed",
             }
           : null,
-        // if we only have the required version_added and releaseDate properties, assume full support
-        Object.keys(item).length === 2
+        // if we encounter nothing else than the required `version_added` and `release_date` properties,
+        // assume full support
+        Object.keys(item).filter(
+          (x) => !["version_added", "release_date"].includes(x)
+        ).length === 0
           ? {
               iconName: "none",
               label: "Full support",
@@ -370,6 +373,8 @@ function CompatCell({
 }) {
   const supportClassName = getSupportClassName(support);
   const browserReleaseDate = getSupportBrowserReleaseDate(support);
+  // Whenever the support statement is complex (an array with more than one entry),
+  // we need to render support details in `bc-history`
   const hasNotes = support && asList(support).length > 1;
   return (
     <>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -310,8 +310,8 @@ function getNotes(
               label: "Support removed",
             }
           : null,
-        // if we encounter nothing else than the required `version_added` and `release_date` properties,
-        // assume full support
+        // If we encounter nothing else than the required `version_added` and
+        // `release_date` properties, assume full support
         Object.keys(item).filter(
           (x) => !["version_added", "release_date"].includes(x)
         ).length === 0
@@ -373,9 +373,16 @@ function CompatCell({
 }) {
   const supportClassName = getSupportClassName(support);
   const browserReleaseDate = getSupportBrowserReleaseDate(support);
-  // Whenever the support statement is complex (an array with more than one entry),
+  // Whenever the support statement is complex (array with more than one entry)
+  // or if a single entry is complex (prefix, notes, etc.),
   // we need to render support details in `bc-history`
-  const hasNotes = support && asList(support).length > 1;
+  const hasNotes =
+    support &&
+    (asList(support).length > 1 ||
+      asList(support).some(
+        (item) =>
+          item.prefix || item.notes || item.alternative_name || item.flags
+      ));
   return (
     <>
       <td

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -298,6 +298,25 @@ function getNotes(
               label: <FlagsNote browser={browser} supportItem={item} />,
             }
           : null,
+        item.partial_implementation
+          ? {
+              iconName: "none",
+              label: "Partial support",
+            }
+          : null,
+        item.version_removed
+          ? {
+              iconName: "none",
+              label: "Support removed",
+            }
+          : null,
+        // if we only have the required version_added and releaseDate properties, assume full support
+        Object.keys(item).length === 2
+          ? {
+              iconName: "none",
+              label: "Full support",
+            }
+          : null,
       ]
         .flat()
         .filter(isTruthy);
@@ -351,11 +370,7 @@ function CompatCell({
 }) {
   const supportClassName = getSupportClassName(support);
   const browserReleaseDate = getSupportBrowserReleaseDate(support);
-  const hasNotes =
-    support &&
-    asList(support).some(
-      (item) => item.prefix || item.notes || item.alternative_name || item.flags
-    );
+  const hasNotes = support && asList(support).length > 1;
   return (
     <>
       <td

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -277,31 +277,31 @@ function getNotes(
       const supportNotes = [
         item.version_removed
           ? {
-              iconName: "none",
+              iconName: "footnote",
               label: `Removed in version ${item.version_removed} and later`,
             }
           : null,
         item.partial_implementation
           ? {
-              iconName: "none",
+              iconName: "footnote",
               label: "Partial support",
             }
           : null,
         item.prefix
           ? {
-              iconName: "prefix",
+              iconName: "footnote",
               label: `Implemented with the vendor prefix: ${item.prefix}`,
             }
           : null,
         item.alternative_name
           ? {
-              iconName: "altname",
+              iconName: "footnote",
               label: `Alternate name: ${item.alternative_name}`,
             }
           : null,
         item.flags
           ? {
-              iconName: "disabled",
+              iconName: "footnote",
               label: <FlagsNote browser={browser} supportItem={item} />,
             }
           : null,
@@ -316,7 +316,7 @@ function getNotes(
           (x) => !["version_added", "release_date"].includes(x)
         ).length === 0
           ? {
-              iconName: "none",
+              iconName: "footnote",
               label: "Full support",
             }
           : null,

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -209,9 +209,9 @@ function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
   return (
     <div className="bc-icons">
       {supportItem.prefix && <Icon name="prefix" />}
-      {supportItem.notes && <Icon name="footnote" />}
       {supportItem.alternative_name && <Icon name="altname" />}
       {supportItem.flags && <Icon name="disabled" />}
+      {supportItem.notes && <Icon name="footnote" />}
     </div>
   );
 }
@@ -275,27 +275,10 @@ function getNotes(
   return asList(support)
     .flatMap((item, i) => {
       const supportNotes = [
-        item.prefix
+        item.version_removed
           ? {
-              iconName: "prefix",
-              label: `Implemented with the vendor prefix: ${item.prefix}`,
-            }
-          : null,
-        item.notes
-          ? (Array.isArray(item.notes) ? item.notes : [item.notes]).map(
-              (note) => ({ iconName: "footnote", label: note })
-            )
-          : null,
-        item.alternative_name
-          ? {
-              iconName: "altname",
-              label: item.alternative_name,
-            }
-          : null,
-        item.flags
-          ? {
-              iconName: "disabled",
-              label: <FlagsNote browser={browser} supportItem={item} />,
+              iconName: "none",
+              label: `Removed in version ${item.version_removed} and later`,
             }
           : null,
         item.partial_implementation
@@ -304,11 +287,28 @@ function getNotes(
               label: "Partial support",
             }
           : null,
-        item.version_removed
+        item.prefix
           ? {
-              iconName: "none",
-              label: "Support removed",
+              iconName: "prefix",
+              label: `Implemented with the vendor prefix: ${item.prefix}`,
             }
+          : null,
+        item.alternative_name
+          ? {
+              iconName: "altname",
+              label: `Alternate name: ${item.alternative_name}`,
+            }
+          : null,
+        item.flags
+          ? {
+              iconName: "disabled",
+              label: <FlagsNote browser={browser} supportItem={item} />,
+            }
+          : null,
+        item.notes
+          ? (Array.isArray(item.notes) ? item.notes : [item.notes]).map(
+              (note) => ({ iconName: "footnote", label: note })
+            )
           : null,
         // If we encounter nothing else than the required `version_added` and
         // `release_date` properties, assume full support


### PR DESCRIPTION
The BCD table renderer assumes that you only need to render notes when there are `some((item) => item.prefix || item.notes || item.alternative_name || item.flags)`. This is a wrong assumption. 
The table should also render notes whenever the support statement is complex (an array) with more than one entry. It could be that support used to be partial, or that support was removed. Also, the range in which full support was gained should be shown.

Fixes: https://github.com/mdn/yari/issues/3839

Test pages:
http://localhost:3000/en-US/docs/Web/CSS/gap#support_in_grid_layout
http://localhost:3000/en-US/docs/Web/CSS/appearance#browser_compatibility
http://localhost:3000/en-US/docs/Web/SVG/Attribute/stop-opacity#browser_compatibility
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator#browser_compatibility
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSource#browser_compatibility

(and probably many many more given array support statements are not that rare in BCD)