### PR TITLE
Also check for md files when validating redirects

### DIFF
--- a/content/redirect.js
+++ b/content/redirect.js
@@ -36,11 +36,8 @@ function resolveDocumentPath(url) {
 
   const [, locale, , ...slug] = bareURL.toLowerCase().split("/");
 
-  const relativeFilePath = path.join(
-    locale,
-    slugToFolder(slug.join("/")),
-    "index.html"
-  );
+  const relativeFolderPath = path.join(locale, slugToFolder(slug.join("/")));
+  const relativeFilePath = path.join(relativeFolderPath, "index.html");
 
   if (isArchivedFilePath(relativeFilePath)) {
     return `$ARCHIVED/${relativeFilePath}`;
@@ -52,7 +49,10 @@ function resolveDocumentPath(url) {
     return `$TRANSLATED/${relativeFilePath}`;
   }
   const filePath = path.join(root, relativeFilePath);
-  if (fs.existsSync(filePath)) {
+  if (
+    fs.existsSync(filePath) ||
+    fs.existsSync(path.join(root, relativeFolderPath, "index.md"))
+  ) {
     return filePath;
   }
   return null;


### PR DESCRIPTION
I'm working on getting https://github.com/mdn/content/pull/5193 to pass and deploy. Looks like redirects had a hardcoded `index.html` file which I extended to also consider `index.md`. Maybe also a place in which we'll want to switch to using `Document.read()`? Not sure. For now this seems to work.

## How to test
1. checkout https://github.com/mdn/content/pull/5193
2. run `yarn tool validate-redirects en-us --strict` which should now work on this branch