### PR TITLE
orphaned and conflicting URLs should not be added to sitemaps

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -194,7 +194,7 @@ async function buildDocuments(
 
     // Collect non-archived documents' slugs to be used in sitemap building and
     // search index building.
-    if (!document.noIndexing) {
+    if (!builtDocument.noIndexing) {
       const { locale, slug } = document.metadata;
       if (!docPerLocale[locale]) {
         docPerLocale[locale] = [];

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1591,3 +1591,12 @@ test("homepage links and flaws", () => {
   expect(map.get("/ZH-CN").suggestion).toBe("/zh-CN/");
   expect(map.get("/notalocale/").suggestion).toBeFalsy();
 });
+
+test("built search-index.json (en-US)", () => {
+  const searchIndexFile = path.join(buildRoot, "en-us", "search-index.json");
+  const searchIndex = JSON.parse(fs.readFileSync(searchIndexFile));
+  const urlToTitle = new Map(searchIndex.map((o) => [o.url, o.title]));
+  expect(urlToTitle.get("/en-US/docs/Web/Foo")).toBe("<foo>: A test tag");
+  // an archived page should not be in there.
+  expect(urlToTitle.has("/en-US/docs/XUL")).toBeFalsy();
+});


### PR DESCRIPTION
Fixes #3871

I'm stunned we didn't notice this till now! Ah well... 
My fix was to first write a test, then I made the fix.

Thankfully we don't send these `noIndexing` documents into Elasticsearch but we've been including every archived document into sitemaps for a long time. 
I'm glad we discovered this before we enabled auto-complete search. 