### PR TITLE
sign-up form nits and copy changes

### DIFF
--- a/client/src/plus/index.scss
+++ b/client/src/plus/index.scss
@@ -790,6 +790,11 @@
           }
         }
 
+        textarea,
+        input[type="email"] {
+          font-family: "Inter";
+        }
+
         ::placeholder {
           font-family: "Inter";
           color: #20113970;

--- a/client/src/plus/landing-page-survey/index.tsx
+++ b/client/src/plus/landing-page-survey/index.tsx
@@ -268,7 +268,7 @@ export function LandingPageSurvey({ variant }: { variant: number }) {
               value={priceComment}
               onChange={(e) => setPriceComment(e.target.value)}
               placeholder="Let us know what you think"
-              rows={2}
+              rows={3}
               cols={80}
             ></textarea>
             <button type="submit">Submit</button>
@@ -329,7 +329,7 @@ export function LandingPageSurvey({ variant }: { variant: number }) {
               value={featuresComment}
               onChange={(e) => setFeaturesComment(e.target.value)}
               placeholder="Let us know what you think"
-              rows={2}
+              rows={3}
               cols={80}
             ></textarea>
           </div>
@@ -360,7 +360,8 @@ export function LandingPageSurvey({ variant }: { variant: number }) {
                 >
                   Privacy Policy
                 </a>
-                .
+                . Your information will only be used to notify you about
+                platform availability.
               </small>
             </p>
           </div>


### PR DESCRIPTION
Part of #3886

- [x] Can we make the input field bigger? (*I made it 3 rows instead of 2*)
- [x] Make the font in the signup match the font in the free form survey answer text area. (*textarea and input[type="email"] now also uses `Inter`*)
- [x] Missing disclaimer needs to be added under "By clicking" (*see following screenshot*)

<img width="1055" alt="Screen Shot 2021-05-25 at 4 39 16 PM" src="https://user-images.githubusercontent.com/26739/119565573-1faba580-bd78-11eb-9429-51926c90a85e.png">

