### PR TITLE
Renaming CSS Box Model spec

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -210,7 +210,7 @@
     "status": "ED"
   },
   "CSS3 Box": {
-    "name": "CSS Basic Box Model",
+    "name": "CSS Box Model",
     "url": "https://drafts.csswg.org/css-box-3/",
     "status": "CR"
   },


### PR DESCRIPTION
"CSS Basic Box Model" is now "CSS Box Model". I'm going to update the MDN page but this fixes the name of the spec.

https://www.w3.org/TR/css-box-3/