### PR TITLE
fix stage/prod CSP selection and add test

### DIFF
--- a/deployer/aws-lambda/content-origin-response/index.js
+++ b/deployer/aws-lambda/content-origin-response/index.js
@@ -63,7 +63,7 @@ exports.handler = async (event) => {
     response.headers["content-security-policy-report-only"] = [
       {
         key: "Content-Security-Policy-Report-Only",
-        value: request.origin.custom.domainName.startsWith("prod.")
+        value: request.origin.custom.domainName.includes("prod.")
           ? CSP_VALUE_PROD
           : CSP_VALUE_STAGE,
       },

--- a/deployer/aws-lambda/tests/server.js
+++ b/deployer/aws-lambda/tests/server.js
@@ -28,8 +28,9 @@ async function catchall(req, res) {
   const origin = {};
   origin.custom = {};
   // This always pretends to proceed and do a S3 lookup
+  console.log(req.headers);
   origin.custom.domainName =
-    req.headers["ORIGIN_DOMAIN_NAME"] || "s3.fakey.fake";
+    req.headers["origin_domain_name"] || "s3.fakey.fake";
   const cf = {};
   const headers = {};
   headers.host = [{ value: req.hostname }];

--- a/deployer/aws-lambda/tests/server.test.js
+++ b/deployer/aws-lambda/tests/server.test.js
@@ -254,13 +254,34 @@ describe("response headers", () => {
     expect(r.headers["content-security-policy-report-only"]).toBeFalsy();
   });
 
-  it("should set CSP and other security headers for non-samples", async () => {
-    const r = await get("/en-US/docs/Web/HTTP");
+  it("should set CSP and other security headers for non-samples (stage)", async () => {
+    const r = await get("/en-US/docs/Web/HTTP", {
+      origin_domain_name:
+        "mdn-content-stage.s3-website-us-west-2.amazonaws.com",
+    });
     expect(r.statusCode).toBe(200);
     expect(r.headers["x-frame-options"]).toBeTruthy();
     expect(r.headers["strict-transport-security"]).toBeTruthy();
     expect(r.headers["x-xss-protection"]).toBeTruthy();
-    expect(r.headers["content-security-policy-report-only"]).toBeTruthy();
+    expect(r.headers["content-security-policy-report-only"]).toEqual(
+      expect.stringContaining(
+        "report-uri https://sentry.prod.mozaws.net/api/72/security/"
+      )
+    );
+  });
+  it("should set CSP and other security headers for non-samples (prod)", async () => {
+    const r = await get("/en-US/docs/Web/HTTP", {
+      origin_domain_name: "mdn-content-prod.s3-website-us-west-2.amazonaws.com",
+    });
+    expect(r.statusCode).toBe(200);
+    expect(r.headers["x-frame-options"]).toBeTruthy();
+    expect(r.headers["strict-transport-security"]).toBeTruthy();
+    expect(r.headers["x-xss-protection"]).toBeTruthy();
+    expect(r.headers["content-security-policy-report-only"]).toEqual(
+      expect.stringContaining(
+        "report-uri https://sentry.prod.mozaws.net/api/73/security/"
+      )
+    );
   });
   it("should not set CSP but other security headers non-HTML", async () => {
     const r = await get("/en-US/docs/Web/HTTP/screenshot.png");


### PR DESCRIPTION
Part of #3907

- [ ] Deploy updated content-origin-response lambda
- [ ] Update content-origin-response lambda version in dev/stage/prod Cloudfront instances