### PR TITLE
fix: conditionally add skip to lang menu link

### DIFF
--- a/client/src/ui/molecules/a11y-nav/index.tsx
+++ b/client/src/ui/molecules/a11y-nav/index.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useLocation } from "react-router-dom";
 
 import { useGA } from "../../../ga-context";
 
@@ -6,6 +7,7 @@ import "./index.scss";
 
 export function A11yNav() {
   const ga = useGA();
+  const location = useLocation();
   const [showLangMenuSkiplink, setShowLangMenuSkiplink] = React.useState(false);
 
   /**
@@ -26,10 +28,10 @@ export function A11yNav() {
   }
 
   React.useEffect(() => {
-    if (document && document.location.pathname.includes("docs")) {
+    if (location.pathname.includes("docs")) {
       setShowLangMenuSkiplink(true);
     }
-  }, []);
+  }, [location]);
 
   return (
     <ul id="nav-access" className="a11y-nav">
@@ -40,7 +42,7 @@ export function A11yNav() {
           onClick={sendAccessMenuItemClick}
           onContextMenu={sendAccessMenuItemClick}
         >
-          {"Skip to main content"}
+          Skip to main content
         </a>
       </li>
       <li>
@@ -50,7 +52,7 @@ export function A11yNav() {
           onClick={sendAccessMenuItemClick}
           onContextMenu={sendAccessMenuItemClick}
         >
-          {"Skip to search"}
+          Skip to search
         </a>
       </li>
       {showLangMenuSkiplink && (
@@ -61,7 +63,7 @@ export function A11yNav() {
             onClick={sendAccessMenuItemClick}
             onContextMenu={sendAccessMenuItemClick}
           >
-            {"Skip to select language"}
+            Skip to select language
           </a>
         </li>
       )}

--- a/client/src/ui/molecules/a11y-nav/index.tsx
+++ b/client/src/ui/molecules/a11y-nav/index.tsx
@@ -6,6 +6,7 @@ import "./index.scss";
 
 export function A11yNav() {
   const ga = useGA();
+  const [showLangMenuSkiplink, setShowLangMenuSkiplink] = React.useState(false);
 
   /**
    * Send a signal to GA when there is an interaction on one
@@ -23,6 +24,12 @@ export function A11yNav() {
       eventLabel: label,
     });
   }
+
+  React.useEffect(() => {
+    if (document && document.location.pathname.includes("docs")) {
+      setShowLangMenuSkiplink(true);
+    }
+  }, []);
 
   return (
     <ul id="nav-access" className="a11y-nav">
@@ -46,6 +53,18 @@ export function A11yNav() {
           {"Skip to search"}
         </a>
       </li>
+      {showLangMenuSkiplink && (
+        <li>
+          <a
+            id="skip-select-language"
+            href="#select-language"
+            onClick={sendAccessMenuItemClick}
+            onContextMenu={sendAccessMenuItemClick}
+          >
+            {"Skip to select language"}
+          </a>
+        </li>
+      )}
     </ul>
   );
 }


### PR DESCRIPTION
Conditionally adds the skip to lang menu link to the a11y nav based on the presence of `docs` in the URL.

I tested this on the homepage, docs page, and settings page. It only shows the "Skip to select language" skip link on docs pages.

fix #2756
