### PR TITLE
Add UI Events KeyboardEvent key/code Values

### DIFF
--- a/kumascript/macros/SpecData.json
+++ b/kumascript/macros/SpecData.json
@@ -1544,6 +1544,16 @@
     "url": "https://w3c.github.io/uievents/",
     "status": "WD"
   },
+  "UI Events Code": {
+    "name": "UI Events KeyboardEvent code Values",
+    "url": "https://www.w3.org/TR/uievents-code/",
+    "status": "CR"
+  },
+  "UI Events Key": {
+    "name": "UI Events KeyboardEvent key Values",
+    "url": "https://www.w3.org/TR/uievents-key/",
+    "status": "CR"
+  },
   "Undo Manager": {
     "name": "UndoManager and DOMTransaction",
     "url": "https://dvcs.w3.org/hg/undomanager/raw-file/tip/undomanager.html",


### PR DESCRIPTION
It will be great if I can add these two specs to the following pages as reference:

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/Code_Values