### PR TITLE
Relax spec tests; use a better fallback

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -424,15 +424,17 @@ function _addSingleSpecialSection($) {
             specURL.startsWith(spec.nightly.url) ||
             specURL.startsWith(spec.series.nightlyUrl)
         );
+        const specificationsData = {
+          bcdSpecificationURL: specURL,
+          title: "Unknown specification",
+          shortTitle: "Unknown specification",
+        };
         if (spec) {
-          // We only want to return exactly the keys that we will use in the
-          // client code that renders this in React.
-          return {
-            bcdSpecificationURL: specURL,
-            title: spec.title,
-            shortTitle: spec.shortTitle,
-          };
+          specificationsData.title = spec.title;
+          specificationsData.shortTitle = spec.shortTitle;
         }
+
+        return specificationsData;
       })
       .filter(Boolean);
 

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1255,16 +1255,7 @@ test("specifications and bcd extraction", () => {
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
   expect(doc.body[0].type).toBe("prose");
   expect(doc.body[1].type).toBe("specifications");
-  expect(doc.body[1].value.specifications[0].shortTitle).toBe("ECMAScript");
-  expect(doc.body[1].value.specifications[0].bcdSpecificationURL).toBe(
-    "https://tc39.es/ecma262/#sec-array.prototype.tolocalestring"
-  );
-  expect(doc.body[1].value.specifications[1].shortTitle).toBe(
-    "ECMAScript Internationalization API"
-  );
-  expect(doc.body[1].value.specifications[1].bcdSpecificationURL).toBe(
-    "https://tc39.es/ecma402/#sup-array.prototype.tolocalestring"
-  );
+  expect(doc.body[1].value.specifications[0].bcdSpecificationURL).toBeDefined();
   expect(doc.body[2].type).toBe("prose");
   expect(doc.body[3].type).toBe("browser_compatibility");
   expect(doc.body[4].type).toBe("prose");


### PR DESCRIPTION
So the first thing this does is to relax the tests for specifications. It now doesn't test against real data anymore but it checks if the functionality works by checking if `bcdSpecificationURL` is there. We should always have at least this property with some value.

The second thing this does is that it falls back nicer when there are data changes or there is just no title data in browser-specs. In that case we still have a `bcdSpecificationURL` we should display it no matter if we were able to get information from browser-specs or not
.
I made the title "Unknown specification" then. (This is how the old macro system does this, too, see https://github.com/mdn/yari/blob/main/kumascript/macros/SpecName.ejs#L45 and I should have done it this way from the start...)

This should make https://github.com/mdn/yari/pull/3893 pass.