### PR TITLE
"Change your language" appears in print

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -71,7 +71,8 @@
       nav.sidebar,
       .page-header-main,
       .page-footer,
-      ul.prev-next {
+      ul.prev-next,
+      .language-menu {
         display: none !important;
       }
       .main-page-content,


### PR DESCRIPTION
Fixes #3941

One thing to ponder is; should components know about not appearing in print or should we continue to control it globally.
For example, I could put this:
```css
@media print { .hide-in-print { display: none }}
```
and then, the `<LanguageMenu>` component could do this:
```diff
export function LanguageMenu({
  locale,
  translations,
  native,
}: {
  locale: string;
  translations: Translation[];
  native: string;
  }) {
 // ...

  return (
    <form
-     className="language-menu"
+     className="language-menu hide-in-print"

```

It's the same solution, both done very differently. The same goes for all sort of other components which are today listed by each and every CSS selector here: https://github.com/mdn/yari/blob/c52ff314897c37332f0c03f4b84d432711e67c2a/client/public/index.html#L67-L74

Our print stylesheet is so tiny that it's not a matter of optimization really. 

Because we use SCSS and not something more component-oriented (like styled-components or CSS modules), then this makes sense. If we were to move the responsibility to each component, each component will know if it should be hidden in print or not but then it still needs to know that the magic keyword is `hide-in-print`. 