### PR TITLE
remove waitlist anchor on plus page

### DIFF
--- a/client/src/plus/app.tsx
+++ b/client/src/plus/app.tsx
@@ -369,13 +369,6 @@ export default function App() {
                 )}
               </div>
             </div>
-            {showDeepDive && (
-              <h3>
-                Liked what you read? Want more? Sign up for the waitlist and be
-                the first notified when we launch!{" "}
-                <a href="#waitlist"> To waitlist » </a>
-              </h3>
-            )}
           </div>
         </section>
         <section className="purple-bg secondary-feature">


### PR DESCRIPTION
Clearly, I missed one in https://github.com/mdn/yari/pull/3917

This resolves https://twitter.com/karlhorky/status/1398530432463953922

Before:
<img width="1473" alt="Screen Shot 2021-06-02 at 7 24 29 AM" src="https://user-images.githubusercontent.com/26739/120472410-dceb5e00-c373-11eb-8211-460e4b34f566.png">

After:
<img width="1447" alt="Screen Shot 2021-06-02 at 7 24 38 AM" src="https://user-images.githubusercontent.com/26739/120472430-e248a880-c373-11eb-87e0-97e7cb7660c1.png">
