### PR TITLE
cap review companion to 100 URLs

### DIFF
--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -265,6 +265,11 @@ def upload(ctx, directory: Path, **kwargs):
     default=None,
     callback=validate_optional_file,
 )
+@click.option(
+    "--max-urls",
+    help=("Maximum number of URLs to show if the PR touches too many files."),
+    default=100,
+)
 @click.argument("directory", type=click.Path(), callback=validate_directory)
 @click.pass_context
 def analyze_pr_build(ctx, directory: Path, **kwargs):

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "dry_run": False,
     "github_token": "",
     "diff_file": None,
+    "max_urls": 99,
 }
 
 


### PR DESCRIPTION
Here's how I tested this:

Go to https://github.com/mdn/content/actions/runs/899181989 and download that `build.zip` in the "Artifacts" section. 
Unpack that in `~/Download`
Then
```
▶ cd deployer
▶ poetry run deployer --dry-run --verbose analyze-pr-build --prefix="pr3" ~/Downloads/build --analyze-flaws --analyze-dangerous-content  --repo=mdn/content --pr-number=3 --github-token=xxx  --diff-file ~/Downloads/build/DIFF --max-urls=3
```

It produces the following:
<img width="958" alt="Screen Shot 2021-06-02 at 9 06 25 AM" src="https://user-images.githubusercontent.com/26739/120485191-da900080-c381-11eb-9f8e-66920a89e99e.png">
This is with override of `--max-urls=3` but the default is going to be 100. 