### PR TITLE
merge en-US metadata with translated metadata

### DIFF
--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -254,6 +254,29 @@ test("content built French foo page", () => {
   );
 });
 
+test("French translation using English front-matter bits", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "fr",
+    "docs",
+    "web",
+    "spec_section_extraction"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.title).toBe("Extraction de sections de spécifications");
+  const specifications = doc.body.find(
+    (section) => section.type === "specifications"
+  );
+  expect(specifications.value.query).toBe(
+    "javascript.builtins.Array.toLocaleString"
+  );
+  const bcd = doc.body.find(
+    (section) => section.type === "browser_compatibility"
+  );
+  expect(bcd.value.query).toBe("javascript.builtins.Array.toLocaleString");
+});
+
 test("content built zh-TW page with en-US fallback image", () => {
   const builtFolder = path.join(buildRoot, "zh-tw", "docs", "web", "foo");
   const jsonFile = path.join(builtFolder, "index.json");

--- a/testing/translated-content/files/fr/web/spec_section_extraction/index.html
+++ b/testing/translated-content/files/fr/web/spec_section_extraction/index.html
@@ -1,0 +1,18 @@
+---
+title: Extraction de sections de spécifications
+slug: Web/Spec_Section_Extraction
+---
+
+<p>
+  The purpose of this fixture is to test that this translated document can
+  benefit from the <code>browser-compat</code> front-matter in it's en-US
+  parent.
+</p>
+
+<h2 id="Specifications">Spécifications</h2>
+
+<p>{{Specifications}}</p>
+
+<h2 id="Browser_compatibility">Compatibilité des navigateur</h2>
+
+<p>{{Compat}}</p>


### PR DESCRIPTION
Fixes #3953

Now all the translated content can reap all the front-matter, that it doesn't already have, from the en-US parent. 

Now, in `translated-content/files/fr/web/javascript/reference/global_objects/array/foreach/index.html` can use `{{Compat}}` and `{{Specifications}}` and it gets the `browser-compat` automatically from the en-US parent doc. 