### PR TITLE
display popularity ranking in toolbar

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -9,6 +9,7 @@ const {
   CONTENT_ROOT,
   REPOSITORY_URLS,
   execGit,
+  getPopularities,
 } = require("../content");
 const kumascript = require("../kumascript");
 
@@ -519,6 +520,11 @@ async function buildDocument(document, documentOptions = {}) {
     ? Number(metadata.popularity.toFixed(4))
     : 0.0;
 
+  if (doc.popularity) {
+    doc.popularityRanking =
+      1 + getAllPopularityValues().filter((p) => p > doc.popularity).length;
+  }
+
   doc.modified = metadata.modified || null;
 
   const otherTranslations = document.translations || [];
@@ -593,6 +599,18 @@ async function buildLiveSamplePageFromURL(url) {
     }
   }
   throw new Error(`No live-sample "${sampleID}" found within ${documentURL}`);
+}
+
+// Module-level cache
+const allPopularityValues = [];
+
+function getAllPopularityValues() {
+  if (!allPopularityValues.length) {
+    for (const value of getPopularities().values()) {
+      allPopularityValues.push(value);
+    }
+  }
+  return allPopularityValues;
 }
 
 // This is used by the builder (yarn build) and by the server (JIT).

--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -42,6 +42,20 @@ export default function Toolbar({
           folder={doc.source.folder}
           filename={doc.source.filename}
         />
+
+        {doc.popularityRanking ? (
+          <small
+            title={`Meaning, there are ${
+              doc.popularityRanking - 1
+            } documents with more pageviews.`}
+          >
+            Popularity ranking: {getGetOrdinal(doc.popularityRanking)}
+          </small>
+        ) : (
+          <small title={`Not enough pageviews to have a popularity ranking.`}>
+            Popularity ranking: n/a
+          </small>
+        )}
       </div>
       {isReadOnly && (
         <p>
@@ -53,4 +67,11 @@ export default function Toolbar({
       <ToggleDocumentFlaws doc={doc} reloadPage={reloadPage} />
     </div>
   );
+}
+
+// https://gist.github.com/jlbruno/1535691/db35b4f3af3dcbb42babc01541410f291a8e8fac
+function getGetOrdinal(n: number) {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n.toLocaleString() + (s[(v - 20) % 10] || s[v] || s[0]);
 }

--- a/client/src/document/types.tsx
+++ b/client/src/document/types.tsx
@@ -138,4 +138,6 @@ export interface Doc {
   isArchive: boolean;
   isTranslated: boolean;
   isActive: boolean;
+  popularity: number;
+  popularityRanking?: number;
 }

--- a/server/flaws.js
+++ b/server/flaws.js
@@ -3,22 +3,9 @@ const path = require("path");
 
 const glob = require("glob");
 
-const { getPopularities } = require("../content");
 const { FLAW_LEVELS, options: buildOptions } = require("../build");
 
 const BUILD_OUT_ROOT = path.join(__dirname, "..", "client", "build");
-
-// Module-level cache
-const allPopularityValues = [];
-
-function getAllPopularityValues() {
-  if (!allPopularityValues.length) {
-    for (const value of getPopularities().values()) {
-      allPopularityValues.push(value);
-    }
-  }
-  return allPopularityValues;
-}
 
 function anyMatchSearchFlaws(searchFlaws, flaws) {
   for (const [flaw, search] of searchFlaws) {
@@ -117,9 +104,7 @@ function packageDocument(doc) {
   const { modified, mdn_url, title } = doc;
   const popularity = {
     value: doc.popularity,
-    ranking: doc.popularity
-      ? 1 + getAllPopularityValues().filter((p) => p > doc.popularity).length
-      : NaN,
+    ranking: doc.popularityRanking || NaN,
   };
   const flaws = packageFlaws(doc.flaws);
   return { popularity, flaws, modified, mdn_url, title };
@@ -266,9 +251,7 @@ module.exports = (req, res) => {
       continue;
     }
     if (popularityFilter) {
-      const docRanking = doc.popularity
-        ? 1 + getAllPopularityValues().filter((p) => p > doc.popularity).length
-        : NaN;
+      const docRanking = doc.popularityRanking || NaN;
       if (popularityFilter.min) {
         if (isNaN(docRanking) || docRanking > popularityFilter.min) {
           continue;


### PR DESCRIPTION
It's something I often lack when I look at a document. You look at the flaws and you don't know if this page gets any traffic at all and that's important when you make judgment calls about flaws and just "Should I worry about that imperfection?". For example, if you see some broken links, it might not matter if the popularity ranking is 4,591st place. 

At the moment, this only displays in the toolbar but it'll render equally when in CRUD read-only mode (how the PR Review companion renders previews). 
Maybe someday we can decide to expose this more for regular readers. Perhaps we can incorporate in other things such as PDF printing or note-taking. 

Here's what it looks like on
http://localhost:3000/en-US/docs/Web/HTTP/CSP
<img width="1174" alt="Screen Shot 2021-06-02 at 4 13 48 PM" src="https://user-images.githubusercontent.com/26739/120546564-04ffaf00-c3be-11eb-8e3c-155242fa3080.png">

And on a page that's so "unpopular" that it doesn't even make it into the `popularities.json` file:
http://localhost:3000/en-US/docs/Glossary/Boot2Gecko
<img width="374" alt="Screen Shot 2021-06-02 at 4 13 18 PM" src="https://user-images.githubusercontent.com/26739/120546638-1b0d6f80-c3be-11eb-950e-b0fd27ec95e0.png">

