### PR TITLE
Markdown Flaws - Toolbar and bad pre

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -258,6 +258,7 @@ async function buildDocument(document, documentOptions = {}) {
   }
 
   const doc = {
+    isMarkdown: document.isMarkdown,
     isArchive: document.isArchive,
     isTranslated: document.isTranslated,
     isActive: document.isActive,

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -219,6 +219,7 @@ function Flaws({
 
   const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
+  const filePath = doc.source.folder + "/" + doc.source.filename;
   return (
     <div id="document-flaws">
       {!!fixableFlaws.length && !isReadOnly && (
@@ -234,7 +235,7 @@ function Flaws({
             return (
               <BrokenLinks
                 key="broken_links"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 links={doc.flaws.broken_links}
                 isReadOnly={isReadOnly}
               />
@@ -257,7 +258,7 @@ function Flaws({
             return (
               <BadPreTag
                 key="bad_pre_tags"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 flaws={doc.flaws.bad_pre_tags}
                 isReadOnly={isReadOnly}
               />
@@ -266,7 +267,7 @@ function Flaws({
             return (
               <Macros
                 key="macros"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 flaws={doc.flaws.macros}
                 isReadOnly={isReadOnly}
               />
@@ -275,7 +276,7 @@ function Flaws({
             return (
               <Images
                 key="images"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 images={doc.flaws.images}
                 isReadOnly={isReadOnly}
               />
@@ -284,7 +285,7 @@ function Flaws({
             return (
               <ImageWidths
                 key="image_widths"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 flaws={doc.flaws.image_widths}
                 isReadOnly={isReadOnly}
               />
@@ -293,7 +294,7 @@ function Flaws({
             return (
               <HeadingLinks
                 key="heading_links"
-                sourceFolder={doc.source.folder}
+                sourceFilePath={filePath}
                 flaws={doc.flaws.heading_links}
                 isReadOnly={isReadOnly}
               />
@@ -411,11 +412,11 @@ function ShowDiff({ before, after }: { before: string; after: string }) {
 }
 
 function BrokenLinks({
-  sourceFolder,
+  sourceFilePath,
   links,
   isReadOnly,
 }: {
-  sourceFolder: string;
+  sourceFilePath: string;
   links: BrokenLink[];
   isReadOnly: boolean;
 }) {
@@ -434,15 +435,13 @@ function BrokenLinks({
     };
   }, [opening]);
 
-  const filepath = sourceFolder + "/index.html";
-
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
-    sp.set("filepath", filepath);
+    sp.set("filepath", sourceFilePath);
     sp.set("line", `${line}`);
     sp.set("column", `${column}`);
     console.log(
-      `Going to try to open ${filepath}:${line}:${column} in your editor`
+      `Going to try to open ${sourceFilePath}:${line}:${column} in your editor`
     );
     setOpening(key);
     fetch(`/_open?${sp.toString()}`).catch((err) => {
@@ -488,7 +487,7 @@ function BrokenLinks({
                 </>
               ) : (
                 <a
-                  href={`file://${filepath}`}
+                  href={`file://${sourceFilePath}`}
                   onClick={(event: React.MouseEvent) => {
                     event.preventDefault();
                     openInEditor(key, flaw.line, flaw.column);
@@ -571,16 +570,14 @@ function Sectioning({ flaws }: { flaws: SectioningFlaw[] }) {
 
 function BadPreTag({
   flaws,
-  sourceFolder,
+  sourceFilePath,
   isReadOnly,
 }: {
   flaws: BadPreTagFlaw[];
-  sourceFolder: string;
+  sourceFilePath: string;
   isReadOnly: boolean;
 }) {
   const { focus } = useAnnotations(flaws);
-
-  const filepath = sourceFolder + "/index.html";
 
   const [opening, setOpening] = React.useState<string | null>(null);
   useEffect(() => {
@@ -599,11 +596,11 @@ function BadPreTag({
 
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
-    sp.set("filepath", filepath);
+    sp.set("filepath", sourceFilePath);
     sp.set("line", `${line}`);
     sp.set("column", `${column}`);
     console.log(
-      `Going to try to open ${filepath}:${line}:${column} in your editor`
+      `Going to try to open ${sourceFilePath}:${line}:${column} in your editor`
     );
     setOpening(key);
     fetch(`/_open?${sp.toString()}`).catch((err) => {
@@ -636,7 +633,7 @@ function BadPreTag({
                 </>
               ) : (
                 <a
-                  href={`file://${filepath}`}
+                  href={`file://${sourceFilePath}`}
                   onClick={(event: React.MouseEvent) => {
                     event.preventDefault();
                     if (flaw.line && flaw.column)
@@ -658,11 +655,11 @@ function BadPreTag({
 
 function Macros({
   flaws,
-  sourceFolder,
+  sourceFilePath,
   isReadOnly,
 }: {
   flaws: MacroErrorMessage[];
-  sourceFolder: string;
+  sourceFilePath: string;
   isReadOnly: boolean;
 }) {
   const [opening, setOpening] = React.useState<string | null>(null);
@@ -696,9 +693,7 @@ function Macros({
     <div className="flaw flaw__macros">
       <h3>{humanizeFlawName("macros")}</h3>
       {flaws.map((flaw) => {
-        const inPrerequisiteMacro = !flaw.filepath.includes(
-          `${sourceFolder}/index.html`
-        );
+        const inPrerequisiteMacro = !flaw.filepath.includes(sourceFilePath);
         return (
           <details
             key={flaw.id}
@@ -771,11 +766,11 @@ function Macros({
 }
 
 function Images({
-  sourceFolder,
+  sourceFilePath,
   images,
   isReadOnly,
 }: {
-  sourceFolder: string;
+  sourceFilePath: string;
   images: ImageReferenceFlaw[];
   isReadOnly: boolean;
 }) {
@@ -795,15 +790,13 @@ function Images({
     };
   }, [opening]);
 
-  const filepath = sourceFolder + "/index.html";
-
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
-    sp.set("filepath", filepath);
+    sp.set("filepath", sourceFilePath);
     sp.set("line", `${line}`);
     sp.set("column", `${column}`);
     console.log(
-      `Going to try to open ${filepath}:${line}:${column} in your editor`
+      `Going to try to open ${sourceFilePath}:${line}:${column} in your editor`
     );
     setOpening(key);
     fetch(`/_open?${sp.toString()}`).catch((err) => {
@@ -839,7 +832,7 @@ function Images({
                 </>
               ) : (
                 <a
-                  href={`file://${filepath}`}
+                  href={`file://${sourceFilePath}`}
                   onClick={(event: React.MouseEvent) => {
                     event.preventDefault();
                     openInEditor(key, flaw.line, flaw.column);
@@ -867,11 +860,11 @@ function Images({
 }
 
 function ImageWidths({
-  sourceFolder,
+  sourceFilePath,
   flaws,
   isReadOnly,
 }: {
-  sourceFolder: string;
+  sourceFilePath: string;
   flaws: ImageWidthFlaw[];
   isReadOnly: boolean;
 }) {
@@ -891,15 +884,13 @@ function ImageWidths({
     };
   }, [opening]);
 
-  const filepath = sourceFolder + "/index.html";
-
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
-    sp.set("filepath", filepath);
+    sp.set("filepath", sourceFilePath);
     sp.set("line", `${line}`);
     sp.set("column", `${column}`);
     console.log(
-      `Going to try to open ${filepath}:${line}:${column} in your editor`
+      `Going to try to open ${sourceFilePath}:${line}:${column} in your editor`
     );
     setOpening(key);
     fetch(`/_open?${sp.toString()}`).catch((err) => {
@@ -935,7 +926,7 @@ function ImageWidths({
                 </>
               ) : (
                 <a
-                  href={`file://${filepath}`}
+                  href={`file://${sourceFilePath}`}
                   onClick={(event: React.MouseEvent) => {
                     event.preventDefault();
                     openInEditor(key, flaw.line, flaw.column);
@@ -974,11 +965,11 @@ function ImageWidths({
 }
 
 function HeadingLinks({
-  sourceFolder,
+  sourceFilePath,
   flaws,
   isReadOnly,
 }: {
-  sourceFolder: string;
+  sourceFilePath: string;
   flaws: HeadingLinksFlaw[];
   isReadOnly: boolean;
 }) {
@@ -998,15 +989,13 @@ function HeadingLinks({
     };
   }, [opening]);
 
-  const filepath = sourceFolder + "/index.html";
-
   function openInEditor(key: string, line: number, column: number) {
     const sp = new URLSearchParams();
-    sp.set("filepath", filepath);
+    sp.set("filepath", sourceFilePath);
     sp.set("line", `${line}`);
     sp.set("column", `${column}`);
     console.log(
-      `Going to try to open ${filepath}:${line}:${column} in your editor`
+      `Going to try to open ${sourceFilePath}:${line}:${column} in your editor`
     );
     setOpening(key);
     fetch(`/_open?${sp.toString()}`).catch((err) => {
@@ -1030,7 +1019,7 @@ function HeadingLinks({
                   </>
                 ) : (
                   <a
-                    href={`file://${filepath}`}
+                    href={`file://${sourceFilePath}`}
                     onClick={(event: React.MouseEvent) => {
                       event.preventDefault();
                       openInEditor(

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -110,6 +110,7 @@ function useAnnotations(genericFlaws: GenericFlaw[]) {
 }
 
 const FLAWS_HASH = "#_flaws";
+
 export function ToggleDocumentFlaws({
   doc,
   reloadPage,
@@ -1075,7 +1076,9 @@ function UnsafeHTML({ flaws }: { flaws: UnsafeHTMLFlaw[] }) {
                 </>
               )}{" "}
               {flaw.fixable && <FixableFlawBadge />} <br />
-              <b>HTML:</b> <pre className="example-bad">{flaw.html}</pre> <br />
+              <b>HTML:</b>
+              <pre className="example-bad">{flaw.html}</pre>
+              <br />
             </li>
           );
         })}

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -220,9 +220,9 @@ function Flaws({
 
   const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
-  // Note! This will work on Windows. The filename can be sent to 
+  // Note! This will work on Windows. The filename can be sent to
   // the server in POSIX style and the `open-editor` program will make
-  // this work for Windows automatically. 
+  // this work for Windows automatically.
   const filePath = doc.source.folder + "/" + doc.source.filename;
   return (
     <div id="document-flaws">

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -219,6 +219,9 @@ function Flaws({
 
   const isReadOnly = !CRUD_MODE_HOSTNAMES.includes(window.location.hostname);
 
+  // Note! This will work on Windows. The filename can be sent to 
+  // the server in POSIX style and the `open-editor` program will make
+  // this work for Windows automatically. 
   const filePath = doc.source.folder + "/" + doc.source.filename;
   return (
     <div id="document-flaws">

--- a/content/document.js
+++ b/content/document.js
@@ -239,7 +239,6 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
   let filePath = null;
   let folder = null;
   let root = null;
-  let isMarkdown = false;
   let locale = null;
 
   if (fs.existsSync(folderOrFilePath)) {
@@ -285,7 +284,6 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
       if (fs.existsSync(possibleMarkdownFilePath)) {
         root = possibleRoot;
         filePath = possibleMarkdownFilePath;
-        isMarkdown = true;
         break;
       }
     }
@@ -388,7 +386,7 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
     // ...{ rawContent },
     rawContent, // HTML or Markdown whole string with all the front-matter
     rawBody, // HTML or Markdown string without the front-matter
-    isMarkdown,
+    isMarkdown: filePath.endsWith(MARKDOWN_FILENAME),
     isArchive,
     isTranslated,
     isActive,

--- a/testing/content/files/en-us/markdown/index.md
+++ b/testing/content/files/en-us/markdown/index.md
@@ -24,6 +24,9 @@ A bullet point list:
 
 This paragraph as a [link](/en-US/docs/Web).
 
+<pre class="brush: html notranslate"><code><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>pre</span><span class="token punctuation">&gt;</span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>code</span><span class="token punctuation">&gt;</span></span>code
+</code></pre>
+
 ### To-do
 
 - [ ] One

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1563,15 +1563,16 @@ test("basic markdown rendering", () => {
   expect($("article ul li").length).toBe(6);
   expect($('article a[href^="/"]').length).toBe(2);
   expect($('article a[href^="#"]').length).toBe(5);
-  expect($("article pre").length).toBe(3);
-  expect($("article pre.notranslate").length).toBe(3);
+  expect($("article pre").length).toBe(4);
+  expect($("article pre.notranslate").length).toBe(4);
   expect($("article pre.css").hasClass("brush:")).toBe(true);
   expect($("article pre.javascript").hasClass("brush:")).toBe(true);
   expect($("article .fancy strong").length).toBe(1);
 
   const jsonFile = path.join(builtFolder, "index.json");
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(Object.keys(doc.flaws).length).toBe(0);
+  expect(Object.keys(doc.flaws).length).toBe(1);
+  expect(doc.flaws.bad_pre_tags.length).toBe(1);
 });
 
 test("unsafe HTML gets flagged as flaws and replace with its raw HTML", () => {


### PR DESCRIPTION
fixes #3924, fixes #3958

Turns out bad pre tags flaws already work in md, given that we are searching the rawContent for such HTML and markdown could contain just that.

I also wanted to tackle #3957 in here but I think it's gonna get a bit more complicated. Same for MacroLinkError. Might need a meeting to think it through together.