### PR TITLE
automatically change language if cookied

### DIFF
--- a/testing/tests/headless.test.js
+++ b/testing/tests/headless.test.js
@@ -253,6 +253,18 @@ describe("Basic viewing of functional pages", () => {
     await expect(page).toClick("button", { text: "Change language" });
     await expect(page).toMatch("<foo>: Une page de test");
     expect(page.url()).toBe(testURL("/fr/docs/Web/Foo/"));
+
+    // Now that you've picked a cookie, if you go to a page whose URL doesn't
+    // match your preferred locale, it will automatically navigate to the locale
+    // you picked.
+    await page.goto(testURL("/en-us/docs/Web/Foo"));
+    await expect(page).toMatch("<foo>: Une page de test");
+    expect(page.url()).toBe(testURL("/fr/docs/Web/Foo/"));
+    // Now delete the cookie and it should not redirect this second time.
+    await page.deleteCookie({ name: "preferredlocale" });
+    await page.goto(testURL("/en-US/docs/Web/Foo"));
+    await expect(page).toMatch("<foo>: A test tag");
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo/"));
   });
 
   it("clicking 'Sign in' should offer links to all identity providers", async () => {


### PR DESCRIPTION
Fixes #3949

This is something we've wanted to do for a long time. I've thought about it for a long time too. #3949 is just one of many similar issues filed. A lot of people change the locale, but keep stumbling into different locales which are different from what they prefer. For example, a user in Spain prefers to read in en-US because they're comfortable with that and/or they know it's more up-to-date. But a Google search in their country for "mdn array foreach" links to the `/es/docs/Web/...` URL. Or, someone prefers `zh-CN` but there's a blog post or tweet with an absolute URL for `en-US`.

According to the GA event we have on the "Change language" form (document footer), only ~15% use that where they *don't* have a `preferredlocale` cookie already. In the last 30 days, ~107,000 times people have used the "Change language" button. And ~97,000 times people have clicked on the "Switch to English". So roughly 200k times people have had to change the language. With this PR, it effectively does that language switch automatically for them. 

It would have been nice to do this on the server, with a  302 redirect but then we'd need to make the CDN cache hashing depend on this cookie and the worst thing is that in the Lambda@Edge code (where we'd do that redirect), it can't know if the translation is available (unless it's for redirecting to `en-US` which can always be assumed to exist now that slugs are never translated).