### PR TITLE
Fixing l10n dashboard for Windows

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -526,7 +526,7 @@ function findAll({
         }
 
         if (locales.size) {
-          const locale = filePath.replace(root, "").split("/")[1];
+          const locale = filePath.replace(root, "").split(path.sep)[1];
           if (!locales.get(locale)) {
             return false;
           }


### PR DESCRIPTION
For context see [this discussion](https://github.com/orgs/mdn/teams/yari-content-fr/discussions/2) 
The localization dashboard did not display any result in Windows because of path manipulation with "/" rather than "\". I was able to check this fix fixes this. (cf. screenshots on the aforementioned discussion)