### PR TITLE
Use en dash (–) for ranges in compat tables

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -93,8 +93,8 @@ function StatusIcons({ status }: { status: bcd.StatusBlock }) {
   );
 }
 
-function NonBreakingSpace() {
-  return <>{"\u00A0"}</>;
+function HairSpace() {
+  return <>{"\u200A"}</>;
 }
 
 function labelFromString(version: string | boolean | null | undefined) {
@@ -140,8 +140,7 @@ const CellText = React.memo(
         isSupported: "no",
         label: (
           <>
-            {labelFromString(added)}
-            <NonBreakingSpace />– {labelFromString(removed)}
+            {labelFromString(added)}<HairSpace />–<HairSpace />{labelFromString(removed)}
           </>
         ),
       };

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -93,10 +93,6 @@ function StatusIcons({ status }: { status: bcd.StatusBlock }) {
   );
 }
 
-function HairSpace() {
-  return <>{"\u200A"}</>;
-}
-
 function labelFromString(version: string | boolean | null | undefined) {
   if (typeof version !== "string") {
     return <>{"?"}</>;
@@ -140,7 +136,8 @@ const CellText = React.memo(
         isSupported: "no",
         label: (
           <>
-            {labelFromString(added)}<HairSpace />–<HairSpace />{labelFromString(removed)}
+            {labelFromString(added)}&#8202;&ndash;&#8202;
+            {labelFromString(removed)}
           </>
         ),
       };

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -141,7 +141,7 @@ const CellText = React.memo(
         label: (
           <>
             {labelFromString(added)}
-            <NonBreakingSpace />— {labelFromString(removed)}
+            <NonBreakingSpace />– {labelFromString(removed)}
           </>
         ),
       };


### PR DESCRIPTION
The en dash is narrower and more commonly used for ranges.