### PR TITLE
Add overview page for Web MIDI API in GroupData.json

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -1779,6 +1779,7 @@
       ]
     },
     "Web MIDI API": {
+      "overview": ["Web MIDI API"],
       "interfaces": [
         "MIDIInputMap",
         "MIDIOutputMap",


### PR DESCRIPTION
The issue mdn/content#2649 was opened to get https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API created.
@rachelandrew created the overview in mdn/content#5433 .

This PR adds it to the GroupData.json, allowin as to close mdn/content#2649