### PR TITLE
general non-image file attachments

### DIFF
--- a/build/cli.js
+++ b/build/cli.js
@@ -186,7 +186,6 @@ async function buildDocuments(
       fs.writeFileSync(liveSamplePath, html);
     }
 
-    console.log({ fileAttachments });
     for (const filePath of fileAttachments) {
       // We *could* use symlinks instead. But, there's no point :)
       // Yes, a symlink is less disk I/O but it's nominal.

--- a/build/cli.js
+++ b/build/cli.js
@@ -186,6 +186,7 @@ async function buildDocuments(
       fs.writeFileSync(liveSamplePath, html);
     }
 
+    console.log({ fileAttachments });
     for (const filePath of fileAttachments) {
       // We *could* use symlinks instead. But, there's no point :)
       // Yes, a symlink is less disk I/O but it's nominal.

--- a/build/index.js
+++ b/build/index.js
@@ -10,6 +10,8 @@ const {
   Image,
   REPOSITORY_URLS,
   execGit,
+  VALID_FILE_TYPES,
+  VALID_IMAGE_EXTENSIONS,
 } = require("../content");
 const kumascript = require("../kumascript");
 
@@ -260,18 +262,20 @@ function makeTOC(doc) {
 }
 
 /**
- * Return an array of all images that are inside the documents source folder.
+ * Return an array of all images and files that are inside the documents source folder.
  *
  * @param {Document} document
  */
-function getAdjacentImages(documentDirectory) {
+function getAdjacentFileAttachments(documentDirectory) {
   const dirents = fs.readdirSync(documentDirectory, { withFileTypes: true });
   return dirents
     .filter((dirent) => {
       // This needs to match what we do in filecheck/checker.py
+      const extension = dirent.name.split(".").pop().toLowerCase();
       return (
         !dirent.isDirectory() &&
-        /\.(png|jpeg|jpg|gif|svg|webp)$/i.test(dirent.name)
+        (VALID_IMAGE_EXTENSIONS.has(extension) ||
+          VALID_FILE_TYPES.has(extension))
       );
     })
     .map((dirent) => path.join(documentDirectory, dirent.name));
@@ -449,9 +453,9 @@ async function buildDocument(document, documentOptions = {}) {
   // current document's folder and they might be referenced in live samples.
   // The checkImageReferences() does 2 things. Checks image *references* and
   // it returns which images it checked. But we'll need to complement any
-  // other images in the folder.
-  getAdjacentImages(path.dirname(document.fileInfo.path)).forEach((fp) =>
-    fileAttachments.add(fp)
+  // other images and files in the folder.
+  getAdjacentFileAttachments(path.dirname(document.fileInfo.path)).forEach(
+    (fp) => fileAttachments.add(fp)
   );
 
   // Check the img tags for possible flaws and possible build-time rewrites

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -14,4 +14,7 @@ module.exports = function (app) {
   app.use("**/*.(png|webp|gif|jpe?g|svg)", proxy);
   // All those root-level images like /favicon-48x48.png
   app.use("/*.(png|webp|gif|jpe?g|svg)", proxy);
+  // This needs to match what we put into content/constants.js
+  // in the keys of the VALID_FILE_TYPES map.
+  app.use("**/*.(ttf|woff2?)", proxy);
 };

--- a/content/constants.js
+++ b/content/constants.js
@@ -55,6 +55,23 @@ if (CONTENT_TRANSLATED_ROOT) {
   REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = "mdn/translated-content";
 }
 
+// These are the files we can accept that are not images. The files that can
+// chec checked into the content repo(s).
+const VALID_FILE_TYPES = new Map([
+  // Explanation:
+  // Each row is [fileextension, Array of mime types]
+  ["ttf", ["font/ttf"]],
+]);
+
+const VALID_IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpeg",
+  "jpg",
+  "gif",
+  "svg",
+  "webp",
+]);
+
 module.exports = {
   CONTENT_ROOT,
   CONTENT_ARCHIVED_ROOT,
@@ -63,4 +80,6 @@ module.exports = {
   ROOTS,
   VALID_LOCALES,
   ACTIVE_LOCALES,
+  VALID_FILE_TYPES,
+  VALID_IMAGE_EXTENSIONS,
 };

--- a/content/index.js
+++ b/content/index.js
@@ -5,12 +5,15 @@ const {
   REPOSITORY_URLS,
   ROOTS,
   VALID_LOCALES,
+  VALID_FILE_TYPES,
+  VALID_IMAGE_EXTENSIONS,
 } = require("./constants");
 const Document = require("./document");
 const Translation = require("./translation");
 const { getPopularities } = require("./popularities");
 const Redirect = require("./redirect");
 const Image = require("./image");
+const File = require("./file");
 const Archive = require("./archive");
 const {
   buildURL,
@@ -29,12 +32,15 @@ module.exports = {
   REPOSITORY_URLS,
   ROOTS,
   VALID_LOCALES,
+  VALID_FILE_TYPES,
+  VALID_IMAGE_EXTENSIONS,
 
   getPopularities,
 
   Document,
   Redirect,
   Image,
+  File,
   Archive,
   Translation,
 

--- a/server/index.js
+++ b/server/index.js
@@ -19,6 +19,7 @@ const {
   Document,
   Redirect,
   Image,
+  File,
   CONTENT_TRANSLATED_ROOT,
 } = require("../content");
 // eslint-disable-next-line node/no-missing-require
@@ -209,6 +210,20 @@ app.get("/*", async (req, res) => {
     return res
       .status(404)
       .sendFile(path.join(STATIC_ROOT, "en-us", "_spas", "404.html"));
+  }
+
+  if (/\.(ttf|woff2?)$/.test(req.path)) {
+    const filePath = File.findByURL(req.path);
+    if (filePath) {
+      // The second parameter to `send()` has to be either a full absolute
+      // path or a path that doesn't start with `../` otherwise you'd
+      // get a 403 Forbidden.
+      // See https://github.com/mdn/yari/issues/1297
+      return send(req, path.resolve(filePath)).pipe(res);
+    }
+    // If it's not a file on disk, in the content repo(s), let it try to build
+    // it as a page. For example, there could be a slug whose name is
+    // something "Web/CSS/Fonts/About_the.woff2"
   }
 
   // TODO: Would be nice to have a list of all supported file extensions


### PR DESCRIPTION
Part of #3984

This makes it possible to go to http://localhost:3000/en-US/docs/Web/CSS/font-stretch and download that `.ttf` file and put it in next to the `index.html`. It'll work in preview and it'll be included in the build. It's a quick job and if people are interested this PR will need some tests and some thinking with regards to running CI on the content. 