### PR TITLE
make sign-up work again

### DIFF
--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -7,6 +7,7 @@ module.exports = function (app) {
     changeOrigin: true,
   });
   app.use("/api", proxy);
+  app.use("/*/users/account/signup", proxy);
   app.use("/_+(flaws|translations|open|document)", proxy);
   // E.g. search-index.json or index.json
   app.use("**/*.json", proxy);


### PR DESCRIPTION
The sign-up didn't break because of https://github.com/mdn/kuma/pull/7825
It broke because when we made file attachments, inside the docs, work directly on file attachments. 
Now I was able to use this and your kuma branch to sign up. 