### PR TITLE
remove obsolete tests

### DIFF
--- a/testing/integration/headless/test_cdn.py
+++ b/testing/integration/headless/test_cdn.py
@@ -132,34 +132,13 @@ def assert_cached(
 @pytest.mark.parametrize(
     "slug,status,expected_location",
     [
-        ("/miel", 500, None),
         ("/_kuma_status.json", 200, None),
         ("/_whatsdeployed/code.json", 200, None),
         ("/_whatsdeployed/content.json", 200, None),
         ("/healthz", 204, None),
         ("/readiness", 204, None),
         ("/api/v1/whoami", 200, None),
-        ("/csp-violation-capture", 405, None),
-        ("/en-US/users/signin", 200, None),
-        ("/en-US/users/signup", 200, None),
         ("/en-US/users/signout", 302, "/"),
-        ("/en-US/users/account/inactive", 200, None),
-        ("/en-US/users/account/signup", 302, "/en-US/users/signin"),
-        ("/en-US/users/account/signin/error", 200, None),
-        ("/en-US/users/account/signin/cancelled", 200, None),
-        (
-            "/en-US/users/account/email",
-            302,
-            "/en-US/users/account/signup-landing?next=/en-US/users/account/email",
-        ),
-        ("/en-US/users/account/email/confirm", 200, None),
-        ("/en-US/users/account/email/confirm/1", 200, None),
-        ("/en-US/users/account/recover/sent", 200, None),
-        (
-            "/en-US/users/account/recover/done",
-            302,
-            "/en-US/users/signin?next=/en-US/users/account/recover/done",
-        ),
         (
             "/users/github/login/?next=/en-US/",
             302,
@@ -184,7 +163,6 @@ def test_not_cached(base_url, is_behind_cdn, slug, status, expected_location):
     "slug,status,expected_location",
     [
         ("/en-US/", 200, None),
-        ("/en-US/events", 302, "https://mozilla.org/contribute/events"),
         ("/robots.txt", 200, None),
         ("/favicon.ico", 200, None),
         ("/contribute.json", 200, None),

--- a/testing/integration/headless/test_endpoints.py
+++ b/testing/integration/headless/test_endpoints.py
@@ -77,25 +77,31 @@ def test_hreflang_basic(base_url):
     )
 
 
-@pytest.mark.parametrize(
-    "uri,expected_keys",
-    [["/api/v1/whoami", [("waffle", ("flags", "switches"))]]],
-    ids=("whoami",),
-)
-def test_api_basic(base_url, uri, expected_keys):
-    """Basic test of site's api endpoints."""
-    resp = request("get", base_url + uri)
+def test_api_whoami(base_url):
+    """Basic test of site's whoami API."""
+    resp = request("get", f"{base_url}/api/v1/whoami")
     assert resp.status_code == 200
     assert resp.headers.get("content-type") == "application/json"
     data = resp.json()
-    for item in expected_keys:
-        if isinstance(item, tuple):
-            key, sub_keys = item
-        else:
-            key, sub_keys = item, ()
-        assert key in data
-        for sub_key in sub_keys:
-            assert sub_key in data[key]
+    assert len(data) == 1
+    assert "geo" in data
+    assert "country" in data["geo"]
+
+
+def test_api_search(base_url):
+    """Basic test of site's search API."""
+    resp = request("get", f"{base_url}/api/v1/search?q=video")
+    assert resp.status_code == 200
+    assert resp.headers.get("content-type") == "application/json"
+    data = resp.json()
+    assert len(data) == 3
+    assert "documents" in data
+    assert "metadata" in data
+    assert "suggestions" in data
+    assert "took_ms" in data["metadata"]
+    assert "total" in data["metadata"]
+    assert "size" in data["metadata"]
+    assert "page" in data["metadata"]
 
 
 # Test value tuple is:
@@ -136,7 +142,6 @@ LOCALE_SELECTORS = {
         "/signup",
         "/signin",
         "/settings",
-        "/users/signin",
     ],
 )
 def test_locale_selection(base_url, slug, expected, cookie, accept):

--- a/testing/integration/headless/test_endpoints.py
+++ b/testing/integration/headless/test_endpoints.py
@@ -83,7 +83,6 @@ def test_api_whoami(base_url):
     assert resp.status_code == 200
     assert resp.headers.get("content-type") == "application/json"
     data = resp.json()
-    assert len(data) == 1
     assert "geo" in data
     assert "country" in data["geo"]
 
@@ -94,7 +93,6 @@ def test_api_search(base_url):
     assert resp.status_code == 200
     assert resp.headers.get("content-type") == "application/json"
     data = resp.json()
-    assert len(data) == 3
     assert "documents" in data
     assert "metadata" in data
     assert "suggestions" in data


### PR DESCRIPTION
Due to changes in kuma (https://github.com/mdn/kuma/pull/7825 and https://github.com/mdn/kuma/pull/7883), this PR updates the integration tests (and even adds a test for the kuma search API). This has already been tested against stage (which has those kuma changes deployed).