### PR TITLE
include MD files in Document.findChildren

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -575,7 +575,12 @@ function findChildren(url, recursive = false) {
   const folder = urlToFolderPath(url);
   const globber = recursive ? ["*", "**"] : ["*"];
   const childPaths = glob.sync(
-    path.join(root, folder, ...globber, HTML_FILENAME)
+    path.join(
+      root,
+      folder,
+      ...globber,
+      `+(${HTML_FILENAME}|${MARKDOWN_FILENAME})`
+    )
   );
   return childPaths
     .map((childFilePath) => path.relative(root, path.dirname(childFilePath)))


### PR DESCRIPTION
[Daniel found out that the ListSubPages macro is not working in Markdown land](https://github.com/mdn/content/pull/5193#discussion_r651047082). I dug a little and found that I did not touch `Document.findChildren` yet which so far only worked for HTML files. This PR fixes that.

For testing it you can check-out the page mentioend by Daniel in the referenced PR (it's https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors) and run it with this PR.