### PR TITLE
Add locale parameter to markdown converter

### DIFF
--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -4,6 +4,7 @@ import { program } from "@caporal/core";
 import * as chalk from "chalk";
 import * as cliProgress from "cli-progress";
 import { Document } from "../content";
+import { VALID_LOCALES } from "../libs/constants";
 
 import { h2m } from "./h2m";
 const { prettyAST } = require("./utils");
@@ -45,14 +46,24 @@ program
     default: false,
     validator: program.BOOLEAN,
   })
+  .option("--locale", "Targets a specific locale", {
+    default: "all",
+    validator: (Array.from(VALID_LOCALES.values()) as string[]).concat("all"),
+  })
   .argument("[folder]", "convert by folder")
   .action(
     tryOrExit(async ({ args, options }) => {
       console.log(
         `Starting HTML to Markdown conversion in ${options.mode} mode`
       );
-
-      const documents = Document.findAll({ folderSearch: args.folder });
+      let localesMap = new Map();
+      if (options.locale !== "all") {
+        localesMap = new Map([[options.locale.toLowerCase(), options.locale]]);
+      }
+      const documents = Document.findAll({
+        folderSearch: args.folder,
+        locales: localesMap,
+      });
 
       const progressBar = new cliProgress.SingleBar(
         {},


### PR DESCRIPTION
This PR intends to add support for a locale option to the `yarn md h2m` command allowing a user to target only a given locale.
I believe this could be useful once the converter is used by localizers in order to target conversion operations and logging (md-conversion-problems-report files)

This would, for instance, help \<locale\> localizers submit PR on \<locale\> content only and read a report where only errors on \<locale\> content.

In order for this to be backward compatible, I have added a "all" default. This seems to me a bit unelegant to add such an edge case so let me know if you think of a better way :x

I don't know what should be the strategy for the migration regarding retired languages so I opted for `VALID_LOCALES`.

Gently poking @wbamberg here.