### PR TITLE
Avoid "-x-" prefix atom getting broken across lines

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-icons.scss
@@ -57,6 +57,7 @@
     font-style: normal;
     font-weight: bold;
     text-decoration: none;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
At least on some browsers on some OSes (e.g., Chrome and Safari on macOS) end up with taking a line-break opportunity after the "-x". We don't want this atom to ever have a line-break within it.