### PR TITLE
turn CSP on

### DIFF
--- a/deployer/aws-lambda/content-origin-response/index.js
+++ b/deployer/aws-lambda/content-origin-response/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable node/no-missing-require */
-const { CSP_VALUE_PROD, CSP_VALUE_STAGE } = require("@yari-internal/constants");
+const { CSP_VALUE } = require("@yari-internal/constants");
 
 exports.handler = async (event) => {
   /*
@@ -60,12 +60,10 @@ exports.handler = async (event) => {
     contentType[0].value.startsWith("text/html") &&
     !isLiveSampleURI
   ) {
-    response.headers["content-security-policy-report-only"] = [
+    response.headers["content-security-policy"] = [
       {
-        key: "Content-Security-Policy-Report-Only",
-        value: request.origin.custom.domainName.includes("prod.")
-          ? CSP_VALUE_PROD
-          : CSP_VALUE_STAGE,
+        key: "Content-Security-Policy",
+        value: CSP_VALUE,
       },
     ];
   }

--- a/deployer/aws-lambda/tests/server.test.js
+++ b/deployer/aws-lambda/tests/server.test.js
@@ -244,14 +244,14 @@ describe("response headers", () => {
     const r = await get("/en-US/docs/Web/HTTP/_samples_/Foo/index.html");
     expect(r.statusCode).toBe(200);
     expect(r.headers["x-frame-options"]).toBeFalsy();
-    expect(r.headers["content-security-policy-report-only"]).toBeFalsy();
+    expect(r.headers["content-security-policy"]).toBeFalsy();
   });
 
   it("should not set CSP or X-Frame-Options for /_sample.*", async () => {
     const r = await get("/en-US/docs/Web/HTTP/_sample_.Foo.html");
     expect(r.statusCode).toBe(200);
     expect(r.headers["x-frame-options"]).toBeFalsy();
-    expect(r.headers["content-security-policy-report-only"]).toBeFalsy();
+    expect(r.headers["content-security-policy"]).toBeFalsy();
   });
 
   it("should set CSP and other security headers for non-samples (stage)", async () => {
@@ -263,11 +263,7 @@ describe("response headers", () => {
     expect(r.headers["x-frame-options"]).toBeTruthy();
     expect(r.headers["strict-transport-security"]).toBeTruthy();
     expect(r.headers["x-xss-protection"]).toBeTruthy();
-    expect(r.headers["content-security-policy-report-only"]).toEqual(
-      expect.stringContaining(
-        "report-uri https://sentry.prod.mozaws.net/api/72/security/"
-      )
-    );
+    expect(r.headers["content-security-policy"]).toBeTruthy();
   });
   it("should set CSP and other security headers for non-samples (prod)", async () => {
     const r = await get("/en-US/docs/Web/HTTP", {
@@ -277,11 +273,7 @@ describe("response headers", () => {
     expect(r.headers["x-frame-options"]).toBeTruthy();
     expect(r.headers["strict-transport-security"]).toBeTruthy();
     expect(r.headers["x-xss-protection"]).toBeTruthy();
-    expect(r.headers["content-security-policy-report-only"]).toEqual(
-      expect.stringContaining(
-        "report-uri https://sentry.prod.mozaws.net/api/73/security/"
-      )
-    );
+    expect(r.headers["content-security-policy"]).toBeTruthy();
   });
   it("should not set CSP but other security headers non-HTML", async () => {
     const r = await get("/en-US/docs/Web/HTTP/screenshot.png");
@@ -289,6 +281,6 @@ describe("response headers", () => {
     expect(r.headers["x-frame-options"]).toBeTruthy();
     expect(r.headers["strict-transport-security"]).toBeTruthy();
     expect(r.headers["x-xss-protection"]).toBeTruthy();
-    expect(r.headers["content-security-policy-report-only"]).toBeFalsy();
+    expect(r.headers["content-security-policy"]).toBeFalsy();
   });
 });

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -131,7 +131,6 @@ const CSP_DIRECTIVES = {
   "manifest-src": ["'self'"],
   "media-src": ["'self'", "archive.org", "videos.cdn.mozilla.net"],
   "worker-src": ["'none'"],
-  "report-uri": ["/csp-violation-capture"],
 };
 
 const cspToString = (csp) =>
@@ -139,19 +138,7 @@ const cspToString = (csp) =>
     .map(([directive, values]) => `${directive} ${values.join(" ")};`)
     .join(" ");
 
-const CSP_VALUE_STAGE = cspToString({
-  ...CSP_DIRECTIVES,
-  "report-uri": [
-    "https://sentry.prod.mozaws.net/api/72/security/?sentry_key=25e652a045b642dfaa310e92e800058a",
-  ],
-});
-const CSP_VALUE_PROD = cspToString({
-  ...CSP_DIRECTIVES,
-  "report-uri": [
-    "https://sentry.prod.mozaws.net/api/73/security/?sentry_key=8664389dc16c4e9786e4a396f2964952",
-  ],
-});
-const CSP_VALUE_DEV = cspToString(CSP_DIRECTIVES);
+const CSP_VALUE = cspToString(CSP_DIRECTIVES);
 
 module.exports = {
   ACTIVE_LOCALES,
@@ -161,7 +148,5 @@ module.exports = {
   LOCALE_ALIASES,
   PREFERRED_LOCALE_COOKIE_NAME,
 
-  CSP_VALUE_PROD,
-  CSP_VALUE_STAGE,
-  CSP_VALUE_DEV,
+  CSP_VALUE,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -23,7 +23,7 @@ const {
 } = require("../content");
 // eslint-disable-next-line node/no-missing-require
 const { prepareDoc, renderDocHTML } = require("../ssr/dist/main");
-const { CSP_VALUE_DEV, DEFAULT_LOCALE } = require("../libs/constants");
+const { CSP_VALUE, DEFAULT_LOCALE } = require("../libs/constants");
 
 const { STATIC_ROOT, PROXY_HOSTNAME, FAKE_V1_API } = require("./constants");
 const documentRouter = require("./document");
@@ -296,7 +296,7 @@ app.get("/*", async (req, res) => {
   if (isJSONRequest) {
     res.json({ doc: document });
   } else {
-    res.header("Content-Security-Policy", CSP_VALUE_DEV);
+    res.header("Content-Security-Policy", CSP_VALUE);
     res.send(renderDocHTML(document, lookupURL));
   }
 });

--- a/server/middlewares.js
+++ b/server/middlewares.js
@@ -1,6 +1,6 @@
 const express = require("express");
 
-const { CSP_VALUE_DEV } = require("../libs/constants");
+const { CSP_VALUE } = require("../libs/constants");
 const { resolveFundamental } = require("../libs/fundamental-redirects");
 const { getLocale } = require("../libs/get-locale");
 const { STATIC_ROOT } = require("./constants");
@@ -53,7 +53,7 @@ module.exports = {
     slugRewrite,
     express.static(STATIC_ROOT, {
       setHeaders: (res) => {
-        res.setHeader("Content-Security-Policy", CSP_VALUE_DEV);
+        res.setHeader("Content-Security-Policy", CSP_VALUE);
       },
     }),
   ],


### PR DESCRIPTION
This PR turns CSP on (enforcement mode), removes the `report-uri` directive, and updates the tests.

- [ ] Once this lands, I'll need to update the `dev`, `stage`, and `prod` Cloudfront instances to use this `content-origin-response` lambda version.