### PR TITLE
Update CSS Typed OM API name and add link to guide

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -184,8 +184,9 @@
       "properties": [],
       "events": []
     },
-    "CSS Typed OM API": {
+    "CSS Typed Object Model API": {
       "overview": ["CSS Typed OM API"],
+      "guides": ["/docs/Web/API/CSS_Typed_OM_API/Guide"],
       "interfaces": [
         "CSSKeywordValue",
         "CSSImageValue",


### PR DESCRIPTION
In the CSS Typed OM API docs, the sidebar doesn't appear: this PR fixes this as the name of the API were not corresponding.

I also added the link to the Guide that has been written.