### PR TITLE
replace hardcoded server port with envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,11 +258,7 @@ sub-dependencies. A sure way to solve it is to run:
 
 ### `Error: listen EADDRINUSE: address already in use :::5000`
 
-The default server port is conflicting with another running process
-(e.g., ControlCenter.app in macOS >= 12). To resolve this, you can pick any
+The default server port `:5000` might be in use by another process. To resolve this, you can pick any
 unused port (e.g., 6000) and run the following:
 
-```
-echo SERVER_PORT=6000 >> .env
-echo BUILD_LIVE_SAMPLES_BASE_URL=http://localhost:6000 >> .env
-```
+    echo SERVER_PORT=6000 >> .env

--- a/README.md
+++ b/README.md
@@ -255,3 +255,14 @@ sub-dependencies. A sure way to solve it is to run:
 
     rm -fr node_modules
     yarn install
+
+### `Error: listen EADDRINUSE: address already in use :::5000`
+
+The default server port is conflicting with another running process
+(e.g., ControlCenter.app in macOS >= 12). To resolve this, you can pick any
+unused port (e.g., 6000) and run the following:
+
+```
+echo SERVER_PORT=6000 >> .env
+echo BUILD_LIVE_SAMPLES_BASE_URL=http://localhost:6000 >> .env
+```

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,9 +1,11 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
-console.log("Setting up a Proxy to localhost:5000");
+const serverPort = process.env.SERVER_PORT;
+
+console.log(`Setting up a Proxy to localhost:${serverPort}`);
 module.exports = function (app) {
   const proxy = createProxyMiddleware({
-    target: "http://localhost:5000",
+    target: `http://localhost:${serverPort}`,
     changeOrigin: true,
   });
   app.use("/api", proxy);

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,11 +1,11 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
-const serverPort = process.env.SERVER_PORT;
+const SERVER_PORT = process.env.SERVER_PORT || 5000;
 
-console.log(`Setting up a Proxy to localhost:${serverPort}`);
+console.log(`Setting up a Proxy to localhost:${SERVER_PORT}`);
 module.exports = function (app) {
   const proxy = createProxyMiddleware({
-    target: `http://localhost:${serverPort}`,
+    target: `http://localhost:${SERVER_PORT}`,
     changeOrigin: true,
   });
   app.use("/api", proxy);

--- a/kumascript/src/constants.js
+++ b/kumascript/src/constants.js
@@ -1,9 +1,12 @@
+const SERVER_PORT = process.env.SERVER_PORT || 5000;
+const SERVER_URL = `http://localhost:${SERVER_PORT}`;
+
 // Allow the `process.env.BUILD_LIVE_SAMPLES_BASE_URL` to be falsy
 // if it *is* set.
 const LIVE_SAMPLES_BASE_URL =
   process.env.BUILD_LIVE_SAMPLES_BASE_URL !== undefined
     ? process.env.BUILD_LIVE_SAMPLES_BASE_URL
-    : "http://localhost:5000";
+    : SERVER_URL;
 
 const INTERACTIVE_EXAMPLES_BASE_URL =
   process.env.BUILD_INTERACTIVE_EXAMPLES_BASE_URL ||


### PR DESCRIPTION
After upgrading to macOS Monterey, I was not able to run the dev server (`yarn dev`) successfully due to the following error:

`Error: listen EADDRINUSE: address already in use :::5000`

From running `lsof -i tcp:5000`, I found out that `ControlCe` (ControlCenter.app) is the program causing this.

To get around this error, I did the following:
1. added two new overrides to `.env` file: `SERVER_PORT` and `BUILD_LIVE_SAMPLES_BASE_URL`to point to an unused port
2. replace the hardcoded port in `setupProxy.js` with `SERVER_PORT` variable

When I investigated the issue, I saw references to port `5000` in few other packages which  I'm not familiar with - so even though the fix solves the main issue, I believe that it is not complete.