### PR TITLE
Remove info related to Ambient Light Events

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -1,12 +1,5 @@
 [
   {
-    "Ambient Light Events": {
-      "overview": ["Ambient Light Events"],
-      "interfaces": ["DeviceLightEvent"],
-      "methods": [],
-      "properties": ["Window.ondevicelight"],
-      "events": ["Window: devicelight"]
-    },
     "Background Tasks": {
       "overview": ["Background Tasks API"],
       "interfaces": ["IdleDeadline"],

--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -460,10 +460,6 @@
       "inh": "EventTarget",
       "impl": []
     },
-    "DeviceLightEvent": {
-      "inh": "Event",
-      "impl": []
-    },
     "DeviceMotionEvent": {
       "inh": "Event",
       "impl": []


### PR DESCRIPTION
In mdn/content#6135, we removed DeviceLightEvent.

This cleans the sidebar and the interface data information.