### PR TITLE
Add title attribute to live sample <iframe>'s created by EmbedLiveSample KS macro

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -23,6 +23,7 @@ var className = $5 || "sample-code-frame";
 var allowedFeatures = $6;
 
 var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
+var title = $0.replace(/[_]+/gm, " ");
 
 var MIN_HEIGHT = 60;
 // Forcibly make sure the height is at least `MIN_HEIGHT` pixels.
@@ -74,7 +75,7 @@ if (hasScreenshot) {
       %><td><%
 } // end hasScreenshot
 %><iframe class="<%= className %>"<%
-%> id="frame_<%= web.slugify(web.safeDecodeURIComponent(sampleId)) %>"<%
+%> title="<%= title %> sample" id="frame_<%= web.slugify(web.safeDecodeURIComponent(sampleId)) %>"<%
 if (width) { %> width="<%= width %>"<% }
 if (height) { %> height="<%= height %>"<% }
 %> src="<%- url %>"<%

--- a/kumascript/tests/macros/EmbedLiveSample.test.js
+++ b/kumascript/tests/macros/EmbedLiveSample.test.js
@@ -19,6 +19,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Quotations"),
       '<iframe class="sample-code-frame"' +
+        ' title="Quotations sample"' +
         ' id="frame_Quotations"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/_sample_.Quotations.html">' +
         "</iframe>"
@@ -30,6 +31,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("SVG_&lt;switch&gt;_example"),
       '<iframe class="sample-code-frame"' +
+        ' title="SVG &amp;lt;switch&amp;gt; example sample"' +
         ' id="frame_SVG_ltswitchgt_example"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Element/switch/_sample_.SVG_ltswitchgt_example.html">' +
         "</iframe>"
@@ -40,6 +42,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("SVG_%3Cswitch%3E_example"),
       '<iframe class="sample-code-frame"' +
+        ' title="SVG %3Cswitch%3E example sample"' +
         ' id="frame_SVG_switch_example"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Element/switch/_sample_.SVG_switch_example.html">' +
         "</iframe>"
@@ -51,6 +54,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Dégradés_linéaires_simples"),
       '<iframe class="sample-code-frame"' +
+        ' title="Dégradés linéaires simples sample"' +
         ' id="frame_Dégradés_linéaires_simples"' +
         ' src="https://mdn.mozillademos.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS/_sample_.D%C3%A9grad%C3%A9s_lin%C3%A9aires_simples.html">' +
         "</iframe>"
@@ -61,6 +65,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call('"><script>alert("XSS");</script>'),
       '<iframe class="sample-code-frame"' +
+        ' title="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt; sample"' +
         ' id="frame_scriptalertXSSscript"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/_sample_.scriptalertXSSscript.html">' +
         "</iframe>"
@@ -71,6 +76,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Example", "100%"),
       '<iframe class="sample-code-frame"' +
+        ' title="Example sample"' +
         ' id="frame_Example"' +
         ' width="100%"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width/_sample_.Example.html">' +
@@ -82,6 +88,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Example", '"><script>alert("XSS");</script>'),
       '<iframe class="sample-code-frame"' +
+        ' title="Example sample"' +
         ' id="frame_Example"' +
         ' width="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width/_sample_.Example.html">' +
@@ -93,6 +100,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Images", "100%", 250),
       '<iframe class="sample-code-frame"' +
+        ' title="Images sample"' +
         ' id="frame_Images"' +
         ' width="100%" height="250"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/_sample_.Images.html">' +
@@ -105,6 +113,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("增加关键帧", "100%", "250"),
       '<iframe class="sample-code-frame"' +
+        ' title="增加关键帧 sample"' +
         ' id="frame_增加关键帧"' +
         ' width="100%" height="250"' +
         ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations/_sample_.%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7.html">' +
@@ -120,6 +129,7 @@ describeMacro("EmbedLiveSample", function () {
         160
       ),
       '<iframe class="sample-code-frame"' +
+        ' title="%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6 sample"' +
         ' id="frame_一个模板骨架"' +
         ' width="160" height="160"' +
         ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage/_sample_.%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6.html">' +
@@ -131,6 +141,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Images", "100%", '"><script>alert("XSS");</script>'),
       '<iframe class="sample-code-frame"' +
+        ' title="Images sample"' +
         ' id="frame_Images"' +
         ' width="100%" height="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/_sample_.Images.html">' +
@@ -142,6 +153,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Adding_quotation_marks", "500", "50", ""),
       '<iframe class="sample-code-frame"' +
+        ' title="Adding quotation marks sample"' +
         ' id="frame_Adding_quotation_marks"' +
         ` width="500" height="${MIN_HEIGHT}"` +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/::before/_sample_.Adding_quotation_marks.html">' +
@@ -164,8 +176,9 @@ describeMacro("EmbedLiveSample", function () {
         "<tbody><tr><td>" +
         '<img alt="" class="internal" src="/files/722/SVG_Linear_Gradient_Example.png" />' +
         "</td><td>" +
-        '<iframe class="sample-code-frame" ' +
-        'id="frame_SVGLinearGradient"' +
+        '<iframe class="sample-code-frame"' +
+        ' title="SVGLinearGradient sample"' +
+        ' id="frame_SVGLinearGradient"' +
         ' width="120" height="240"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Tutorial/Gradients/_sample_.SVGLinearGradient.html">' +
         "</iframe></td></tr></tbody></table>"
@@ -189,8 +202,9 @@ describeMacro("EmbedLiveSample", function () {
           "<tbody><tr><td>" +
           '<img alt="" class="internal" src="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;" />' +
           "</td><td>" +
-          '<iframe class="sample-code-frame" ' +
-          'id="frame_SVGLinearGradient"' +
+          '<iframe class="sample-code-frame"' +
+          ' title="SVGLinearGradient sample"' +
+          ' id="frame_SVGLinearGradient"' +
           ' width="120" height="240"' +
           ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Tutorial/Gradients/_sample_.SVGLinearGradient.html">' +
           "</iframe></td></tr></tbody></table>"
@@ -199,6 +213,7 @@ describeMacro("EmbedLiveSample", function () {
   );
   const same_slug_iframe =
     '<iframe class="sample-code-frame"' +
+    ' title="Examples sample"' +
     ' id="frame_Examples"' +
     ' width="700px" height="700px"' +
     ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/flex-wrap/_sample_.Examples.html">' +
@@ -225,6 +240,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("Event delegation", "", "", "", "Web/Events/blur"),
       '<iframe class="sample-code-frame"' +
+        ' title="Event delegation sample"' +
         ' id="frame_Event_delegation"' +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/Events/blur/_sample_.Event_delegation.html">' +
         "</iframe>"
@@ -256,6 +272,7 @@ describeMacro("EmbedLiveSample", function () {
           '"><script>alert("XSS");</script>'
         ),
         '<iframe class="sample-code-frame"' +
+          ' title="Event delegation sample"' +
           ' id="frame_Event_delegation"' +
           ' src="https://mdn.mozillademos.org/en-US/docs/%22%3E%3Cscript%3Ealert(%22XSS%22);%3C/script%3E/_sample_.Event_delegation.html">' +
           "</iframe>"
@@ -267,6 +284,7 @@ describeMacro("EmbedLiveSample", function () {
     return assert.eventually.equal(
       macro.call("sampleNone", 100, 50, "", "", "nobutton"),
       '<iframe class="nobutton"' +
+        ' title="sampleNone sample"' +
         ' id="frame_sampleNone"' +
         ` width="100" height="${MIN_HEIGHT}"` +
         ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance/_sample_.sampleNone.html">' +
@@ -287,6 +305,7 @@ describeMacro("EmbedLiveSample", function () {
           '"><script>alert("XSS");</script>'
         ),
         '<iframe class="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
+          ' title="sampleNone sample"' +
           ' id="frame_sampleNone"' +
           ` width="100" height="${MIN_HEIGHT}"` +
           ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/-moz-appearance/_sample_.sampleNone.html">' +
@@ -309,6 +328,7 @@ describeMacro("EmbedLiveSample", function () {
           "video; microphone"
         ),
         '<iframe class="sample-code-frame"' +
+          ' title="Example Constraint exerciser sample"' +
           ' id="frame_Example_Constraint_exerciser"' +
           ' width="650" height="800"' +
           ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints/_sample_.Example_Constraint_exerciser.html"' +
@@ -332,6 +352,7 @@ describeMacro("EmbedLiveSample", function () {
           '"><script>alert("XSS");</script>'
         ),
         '<iframe class="sample-code-frame"' +
+          ' title="Example Constraint exerciser sample"' +
           ' id="frame_Example_Constraint_exerciser"' +
           ' width="650" height="800"' +
           ' src="https://mdn.mozillademos.org/en-US/docs/Web/API/Media_Streams_API/Constraints/_sample_.Example_Constraint_exerciser.html"' +


### PR DESCRIPTION
Part of #4060

> 1. <frame> or <iframe> elements do not have a title attribute

Fixes the above accessibility issue from Lighthouse audit. The `<iframe>` elements generated from EmbedLiveSample KS macros now include unique `title` attributes. I used the `sampleId` value that is being passed into the KS macros as `$0` and the deslugified it and concatenated the text "sample" to end. I noticed some `sampleId` values already have the word "example" in them so I opted for "sample" instead considering they are embedded live samples and for the cases when "Some thing example sample" is better than "Some thing example example". This situation only occurs periodically and I'm not sure how many times it does, therefore I chose to add "sample" to the end of each `sampleId` to attempt creating unique and descriptive `title` attributes.

Example - http://localhost:3000/en-US/docs/Web/CSS/grid#examples

```html
<iframe class="sample-code-frame" title="Creating a grid layout sample" id="frame_Creating_a_grid_layout" width="100%" height="150" src="http://localhost:5000/en-US/docs/Web/CSS/grid/_sample_.Creating_a_grid_layout.html" loading="lazy"></iframe>
```