### PR TITLE
enable subscription on stage

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -166,6 +166,11 @@ jobs:
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true
 
+          # This makes the Stripe subscription button appear on the Account
+          # Settings page.
+          # Note that if this URL, once set, doesn't 200 OK, it will stop the build.
+          # BUILD_SUBSCRIPTION_CONFIG_URL: https://developer.mozilla.org/api/v1/subscriptions/config/
+
         run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -171,6 +171,11 @@ jobs:
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true
 
+          # This makes the Stripe subscription button appear on the Account
+          # Settings page.
+          # Note that if this URL, once set, doesn't 200 OK, it will stop the build.
+          BUILD_SUBSCRIPTION_CONFIG_URL: https://developer.allizom.org/api/v1/subscriptions/config/
+
         run: |
           if [ ${{ env.BUILD_ARCHIVED_CONTENT }} == "true" ]; then
             echo "Will build mdn/archived-content too"


### PR DESCRIPTION
@Gregoor @escattone One thing I realize is that we can't use waffle *flags* we need to use waffle *switches*.
But let's be open-minded and think this through a bit. 

The config URL is protected by the same waffle flag we use for checkout and customer portal (these are both redirects). 
I think we might have rushed through https://github.com/mdn/kuma/pull/7917 without thinking this through. 

Everything the kuma `/api/v1/subscriptions/config/` endpoint reveals is a public key and the price. Perhaps it's foolish to protect that with a waffle flag. If the price is supposed to be a secret, let's make sure we pick a silly price that doesn't reflect what we're going to do in the MVP. 

There is however one subtle advantage of how things are working now. If the config doesn't work, the checkout and customer portal won't work. So it gives you an early hint so you don't "accidentally" let the Yari client even try to present the "Subscribe" button in the UI. 

Let's discuss offline and return to this PR when we're more ready. 