### PR TITLE
Clarified error messages when no BCD is available

### DIFF
--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -36,7 +36,7 @@ if (!query) {
 }
 var depth = $1 || 1;
 var output = `<div class="bc-data" id="bcd:${query}" data-depth="${depth}">
-  If you're able to see this, something went wrong on this page.
+  If you're able to see this, no compatibility data could be found.
 </div>`;
 %>
 

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -18,7 +18,7 @@ if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");
 }
 var output = `<div class="bc-specs" data-bcd-query="${query}">
-  If you're able to see this, something went wrong on this page.
+  If you're able to see this, no compatibility data could be found.
 </div>`;
 %>
 


### PR DESCRIPTION
Changed "If you're able to see this, something went wrong on this page." to "If you're able to see this, no compatibility data could be found." in two files.