### PR TITLE
BrokenLinks checking for Markdown documents

### DIFF
--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -13,7 +13,8 @@ function findMatchesInMarkdown(rawContent, href) {
   const matches = [];
   visit(fromMarkdown(rawContent), "link", (node) => {
     if (node.url == href) {
-      matches.push(node.position.start);
+      const { line, column } = node.position.start;
+      matches.push({ line, column });
     }
   });
   return matches;
@@ -144,7 +145,7 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
 
   $("a[href]").each((i, element) => {
     const a = $(element);
-    const href = a.attr("href");
+    const href = decodeURI(a.attr("href"));
 
     // This gives us insight into how many times this exact `href`
     // has been encountered in the doc.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "loglevel": "^1.7.1",
     "lru-cache": "^6.0.0",
     "md5-file": "5.0.0",
+    "mdast-util-from-markdown": "^0.8.5",
     "mdast-util-phrasing": "^2.0.0",
     "mdn-data": "2.0.19",
     "open": "^8.2.1",

--- a/testing/content/files/en-us/web/brokenlinks/index.html
+++ b/testing/content/files/en-us/web/brokenlinks/index.html
@@ -23,7 +23,7 @@ slug: Web/BrokenLinks
 
 <p><a href="/en-US/docs/Glossary/Bézier_curve#identifier">Correct case with hash</a></p>
 
-<p><a href='/en-US/docs/Hopeless/Case'>Will not have a suggestion</></p>
+<p><a href='/en-US/docs/Hopeless/Case'>Will not have a suggestion</a></p>
 
 <p><a href="//www.peterbe.com">Leave me alone! I'm actually external</a></p>
 

--- a/testing/content/files/en-us/web/brokenlinks_markdown/archived/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/archived/index.md
@@ -1,0 +1,7 @@
+---
+title: (Almost) Broken links to archived paged
+slug: Web/BrokenLinks_Markdown/Archived
+---
+[Not an active page, but archive](/en-US/docs/Mozilla/Firefox/Multiple_profiles)
+
+[An archived redirect link](/en-US/docs/The_Mozilla_platform)

--- a/testing/content/files/en-us/web/brokenlinks_markdown/broken_http_link/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/broken_http_link/index.md
@@ -1,0 +1,5 @@
+---
+title: Http:// link that is not a valid link
+slug: Web/BrokenLinks_Markdown/Broken_http_link
+---
+[`http://`](http://)

--- a/testing/content/files/en-us/web/brokenlinks_markdown/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/index.md
@@ -1,0 +1,40 @@
+---
+title: A page peppered with broken links
+slug: Web/BrokenLinks_Markdown
+---
+[Nothing wrong with this one](/en-US/docs/Web/Foo)
+
+[Will redirect](/en-US/docs/Web/CSS/dumber "First title")
+
+[Also, make it appear as text too](/en-US/docs/Web/CSS/dumber "Second title")
+
+`/en-US/docs/Web/CSS/dumber`
+
+[Too verbose!](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
+
+[Also, too verbose but with anchor](https://developer.mozilla.org/en-US/docs/Web/API/Blob#Anchor)
+
+[Also, too verbose but with query string](https://developer.mozilla.org/en-US/docs/Web/API/Blob?a=b)
+
+[This should have a suggestion and the suggestion should keep the `#fragment` on the suggested href.](/en-US/docs/Web/HTML/Element/anchor#fragment)
+
+[Wrong case](/en-us/DOCS/Web/api/BLOB)
+
+[Wrong case with hash](/en-US/docs/glossary/bézier_curve#identifier)
+
+[Correct case with hash](/en-US/docs/Glossary/Bézier_curve#identifier)
+
+[Will not have a suggestion](/en-US/docs/Hopeless/Case)
+
+[](/en-US/docs/Hopeless/Case)
+
+[](/en-US/docs/Hopeless/Case)[Leave me alone! I'm actually external](//www.peterbe.com)
+
+[Link to itself (bad)](/en-US/docs/Web/BrokenLinks_Markdown)
+[Link to itself for anchor (good)](/en-US/docs/Web/BrokenLinks_Markdown#anchor)
+[Link to itself for anchor (good)](#anchor)
+
+[Link to `/contributors.txt`](/en-US/docs/Web/BrokenLinks_Markdown/contributors.txt) (not
+a flaw)
+
+[`http://` external link](http://www.mozilla.org)

--- a/testing/content/files/en-us/web/brokenlinks_markdown/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/index.md
@@ -26,9 +26,7 @@ slug: Web/BrokenLinks_Markdown
 
 [Will not have a suggestion](/en-US/docs/Hopeless/Case)
 
-[](/en-US/docs/Hopeless/Case)
-
-[](/en-US/docs/Hopeless/Case)[Leave me alone! I'm actually external](//www.peterbe.com)
+[Leave me alone! I'm actually external](www.peterbe.com)
 
 [Link to itself (bad)](/en-US/docs/Web/BrokenLinks_Markdown)
 [Link to itself for anchor (good)](/en-US/docs/Web/BrokenLinks_Markdown#anchor)

--- a/testing/content/files/en-us/web/brokenlinks_markdown/self_links/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/self_links/index.md
@@ -1,0 +1,11 @@
+---
+title: Links that link to the current page you're on
+slug: Web/BrokenLinks_Markdown/Self_links
+---
+[Straight up](/en-US/docs/Web/BrokenLinks_Markdown/Self_links)
+
+[Anchored](/en-US/docs/Web/BrokenLinks_Markdown/Self_links#anchored)
+
+[Self-link but wrong case](/en-US/docs/Web/BrokenLinks_Markdown/self_Links)
+
+[Self-link but wrong case and with anchor](/en-US/docs/Web/BrokenLinks_Markdown/self_Links#hash)

--- a/testing/content/files/en-us/web/brokenlinks_markdown/without_locale_prefix/index.md
+++ b/testing/content/files/en-us/web/brokenlinks_markdown/without_locale_prefix/index.md
@@ -1,0 +1,9 @@
+---
+title: Broken links that lack a locale prefix
+slug: Web/BrokenLinks_Markdown/Without_locale_prefix
+---
+[A broken link due to lack of prefix](/docs/Web/CSS/number)
+
+[Will redirect](/docs/Web/CSS/dumber)
+
+[Will not help to try with 'en-US'](/docs/Hopelessly/Broken)

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -682,6 +682,63 @@ test("broken links flaws", () => {
   expect(map.get("http://www.mozilla.org").fixable).toBeTruthy();
 });
 
+test("broken links markdown flaws", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "brokenlinks_markdown"
+  );
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  const { flaws } = doc;
+  // You have to be intimately familiar with the fixture to understand
+  // why these flaws come out as they do.
+  expect(flaws.broken_links.length).toBe(12);
+  // Map them by 'href'
+  const map = new Map(flaws.broken_links.map((x) => [x.href, x]));
+  expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
+  expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(10);
+  expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(13);
+  expect(
+    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob").suggestion
+  ).toBe("/en-US/docs/Web/API/Blob");
+  expect(
+    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob#Anchor")
+      .suggestion
+  ).toBe("/en-US/docs/Web/API/Blob#Anchor");
+  expect(
+    map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob?a=b")
+      .suggestion
+  ).toBe("/en-US/docs/Web/API/Blob?a=b");
+  expect(map.get("/en-us/DOCS/Web/api/BLOB").suggestion).toBe(
+    "/en-US/docs/Web/API/Blob"
+  );
+  expect(
+    map.get("/en-US/docs/Web/HTML/Element/anchor#fragment").suggestion
+  ).toBe("/en-US/docs/Web/HTML/Element/a#fragment");
+  expect(
+    map.get("/en-US/docs/glossary/bézier_curve#identifier").suggestion
+  ).toBe("/en-US/docs/Glossary/Bézier_curve#identifier");
+  expect(map.get("/en-US/docs/Web/BrokenLinks").explanation).toBe(
+    "Link points to the page it's already on"
+  );
+  expect(map.get("/en-US/docs/Web/BrokenLinks#anchor").explanation).toBe(
+    "No need for the pathname in anchor links if it's the same page"
+  );
+  expect(map.get("/en-US/docs/Web/BrokenLinks#anchor").suggestion).toBe(
+    "#anchor"
+  );
+  expect(map.get("http://www.mozilla.org").explanation).toBe(
+    "Is currently http:// but can become https://"
+  );
+  expect(map.get("http://www.mozilla.org").suggestion).toBe(
+    "https://www.mozilla.org"
+  );
+  expect(map.get("http://www.mozilla.org").fixable).toBeTruthy();
+});
+
 test("repeated broken links flaws", () => {
   // This fixture has the same broken link, that redirects, 3 times.
   const builtFolder = path.join(

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -699,8 +699,8 @@ test("broken links markdown flaws", () => {
   // Map them by 'href'
   const map = new Map(flaws.broken_links.map((x) => [x.href, x]));
   expect(map.get("/en-US/docs/Hopeless/Case").suggestion).toBeNull();
-  expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(10);
-  expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(13);
+  expect(map.get("/en-US/docs/Web/CSS/dumber").line).toBe(9);
+  expect(map.get("/en-US/docs/Web/CSS/dumber").column).toBe(1);
   expect(
     map.get("https://developer.mozilla.org/en-US/docs/Web/API/Blob").suggestion
   ).toBe("/en-US/docs/Web/API/Blob");
@@ -721,15 +721,15 @@ test("broken links markdown flaws", () => {
   expect(
     map.get("/en-US/docs/glossary/bézier_curve#identifier").suggestion
   ).toBe("/en-US/docs/Glossary/Bézier_curve#identifier");
-  expect(map.get("/en-US/docs/Web/BrokenLinks").explanation).toBe(
+  expect(map.get("/en-US/docs/Web/BrokenLinks_Markdown").explanation).toBe(
     "Link points to the page it's already on"
   );
-  expect(map.get("/en-US/docs/Web/BrokenLinks#anchor").explanation).toBe(
-    "No need for the pathname in anchor links if it's the same page"
-  );
-  expect(map.get("/en-US/docs/Web/BrokenLinks#anchor").suggestion).toBe(
-    "#anchor"
-  );
+  expect(
+    map.get("/en-US/docs/Web/BrokenLinks_Markdown#anchor").explanation
+  ).toBe("No need for the pathname in anchor links if it's the same page");
+  expect(
+    map.get("/en-US/docs/Web/BrokenLinks_Markdown#anchor").suggestion
+  ).toBe("#anchor");
   expect(map.get("http://www.mozilla.org").explanation).toBe(
     "Is currently http:// but can become https://"
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -13302,6 +13302,17 @@ mdast-util-from-markdown@^0.8.0:
     micromark "~2.10.0"
     parse-entities "^2.0.0"
 
+mdast-util-from-markdown@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
+  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-to-string "^2.0.0"
+    micromark "~2.11.0"
+    parse-entities "^2.0.0"
+    unist-util-stringify-position "^2.0.0"
+
 mdast-util-gfm-autolink-literal@^0.1.0:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-0.1.3.tgz#9c4ff399c5ddd2ece40bd3b13e5447d84e385fb7"


### PR DESCRIPTION
What this does:
- adds a `isMarkdown` conditional branch in `getBrokenLinksFlaws` that traverses the AST to find URL-matching markdown nodes
- used `h2m` to turn the `brokenlinks` test files into `brokenlinks_markdown` and run the same tests on them
