### PR TITLE
'page' macro considered important for translation differences

### DIFF
--- a/content/translation.js
+++ b/content/translation.js
@@ -67,6 +67,7 @@ const IMPORTANT_MACROS = new Map(
     "WebGLSidebar",
     "WebRTCSidebar",
     "languages",
+    "page",
   ].map((name) => [name.toLowerCase(), name])
 );
 

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -282,7 +282,8 @@ test("content built zh-TW page with en-US fallback image", () => {
   const jsonFile = path.join(builtFolder, "index.json");
   expect(fs.existsSync(jsonFile)).toBeTruthy();
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(Object.keys(doc.flaws).length).toBe(0);
+  expect(Object.keys(doc.flaws).length).toBe(1);
+  expect(doc.flaws.translation_differences.length).toBe(1);
   expect(doc.title).toBe("<foo>: 測試網頁");
   expect(doc.isTranslated).toBe(true);
   expect(doc.other_translations[0].locale).toBe("en-US");


### PR DESCRIPTION
Good page to test: http://localhost:3000/zh-CN/docs/Web/API/MediaElementAudioSourceNode#_flaws

Before:
<img width="960" alt="Screen Shot 2021-06-23 at 1 19 05 PM" src="https://user-images.githubusercontent.com/26739/123140963-deb1ba00-d425-11eb-998e-eb41c58a6aaa.png">

After:
<img width="1111" alt="Screen Shot 2021-06-23 at 1 19 15 PM" src="https://user-images.githubusercontent.com/26739/123140987-e3766e00-d425-11eb-9b11-e05a8bd4eff9.png">

After this is merged, it might be a good idea to announce this to all the translation communities so they can help to do what @hamishwillee has been doing in https://github.com/mdn/content/issues/3196 but for each locale. 