### PR TITLE
Change vertical-align to bottom on bc-legend atoms for better alignment

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-legend.scss
@@ -30,7 +30,7 @@
 
     dt {
       margin-right: math.div($base-spacing, 2);
-      vertical-align: middle;
+      vertical-align: bottom;
     }
   }
 


### PR DESCRIPTION
Fixes #4087 