### PR TITLE
Add reference links to JS code blocks

### DIFF
--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -145,18 +145,19 @@ function syntaxHighlight($, doc) {
         const slug = JS_KEYWORD_DOCS[keyword];
         if (slug) {
           hasLinks = true;
-          $el
-            .empty()
-            .append(
-              $("<a>")
-                .attr(
-                  "href",
-                  `/${doc.locale}/docs/Web/JavaScript/Reference/${slug}`
-                )
-                .css("text-decoration", "none")
-                .css("border-bottom", "1px dashed rgba(0,0,0,0.4)")
-                .text(keyword)
-            );
+          $el.empty().append(
+            $("<a>")
+              .attr({
+                href: `/${doc.locale}/docs/Web/JavaScript/Reference/${slug}`,
+                draggable: false,
+              })
+              .css({
+                "text-decoration": "none",
+                "border-bottom": "1px dashed rgba(0,0,0,0.4)",
+                "user-select": "text",
+              })
+              .text(keyword)
+          );
         }
       });
     }

--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -42,6 +42,61 @@ const ALIASES = new Map([["sh", "shell"]]);
 // this, it should become a flaw.
 const IGNORE = new Set(["none", "text", "plain", "unix"]);
 
+const JS_KEYWORD_DOCS = {
+  var: "Statements/var",
+  let: "Statements/let",
+  const: "Statements/const",
+
+  import: "Statements/import",
+  as: "Statements/import#rename_multiple_exports_during_import",
+  export: "Statements/export",
+
+  async: "Statements/async_function",
+
+  class: "Statements/class",
+
+  extends: "Classes/extends",
+
+  if: "Statements/if...else",
+  else: "Statements/if...else",
+
+  switch: "Statements/switch",
+  case: "Statements/switch",
+  default: "Statements/switch",
+
+  do: "Statements/do...while",
+  while: "Statements/while",
+  continue: "Statements/continue",
+
+  break: "Statements/break",
+
+  return: "Statements/return",
+
+  throw: "Statements/throw",
+  try: "Statements/try...catch",
+  catch: "Statements/try...catch#conditional_catch-blocks",
+  finally: "Statements/try...catch#the_finally-block",
+
+  function: "Global_Objects/Function",
+  null: "Global_Objects/null",
+  undefined: "Global_Objects/undefined",
+
+  new: "Operators/new",
+  this: "Operators/this",
+  super: "Operators/super",
+  static: "Operators/static",
+
+  delete: "Operators/delete",
+  void: "Operators/void",
+  typeof: "Operators/typeof",
+  instanceof: "Operators/instanceof",
+  await: "Operators/await",
+  yield: "Operators/yield",
+
+  get: "Functions/get",
+  set: "Functions/set",
+};
+
 /**
  * Mutate the `$` instance for by looking for <pre> tags that can be
  * syntax highlighted with Prism.
@@ -80,6 +135,44 @@ function syntaxHighlight($, doc) {
     const code = $pre.text();
     const html = Prism.highlight(code, grammar, name);
     const $code = $("<code>").html(html);
+
+    let hasLinks = false;
+
+    if (name == "js") {
+      $code.find(".keyword").each((i, el) => {
+        const $el = $(el);
+        const keyword = $el.text();
+        const slug = JS_KEYWORD_DOCS[keyword];
+        if (slug) {
+          hasLinks = true;
+          $el
+            .empty()
+            .append(
+              $("<a>")
+                .attr(
+                  "href",
+                  `/${doc.locale}/docs/Web/JavaScript/Reference/${slug}`
+                )
+                .css("text-decoration", "none")
+                .css("border-bottom", "1px dashed rgba(0,0,0,0.4)")
+                .text(keyword)
+            );
+        }
+      });
+    }
+
+    if (hasLinks) {
+      $pre.parent().append(
+        $(
+          "<div><em>You can click underlined keywords to open their reference docs.</em></div>"
+        ).css({
+          "border-left": "6px solid #00458b",
+          margin: "-24px 0 24px 0",
+          "padding-left": "24px",
+          background: "#e6e6e6",
+        })
+      );
+    }
 
     $pre.empty().append($code);
   });

--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -151,11 +151,7 @@ function syntaxHighlight($, doc) {
                 href: `/${doc.locale}/docs/Web/JavaScript/Reference/${slug}`,
                 draggable: false,
               })
-              .css({
-                "text-decoration": "none",
-                "border-bottom": "1px dashed rgba(0,0,0,0.4)",
-                "user-select": "text",
-              })
+              .addClass("code-reference-link")
               .text(keyword)
           );
         }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -233,6 +233,15 @@ a.new {
     }
   }
 
+  /*
+   * Reference links inside of code blocks
+   */
+  .code-reference-link {
+    text-decoration: none;
+    border-bottom: 1px dashed rgba(0, 0, 0, 0.4);
+    user-select: text;
+  }
+
   iframe {
     max-width: 100%;
   }

--- a/docs/experiments/0003_ref-links-in-code-blocks.md
+++ b/docs/experiments/0003_ref-links-in-code-blocks.md
@@ -1,0 +1,27 @@
+# Experiment: Reference links in JS code blocks
+
+## Issue
+
+<https://github.com/mdn/yari/pull/4089>
+
+## Overview
+
+We add reference links for keywords to JS code blocks. When someone clicks
+one of those links, we record a GA event.
+
+## Start date
+
+TODO: make more specific than "End of July"
+
+## End date
+
+2 weeks later
+
+## Success metric
+
+1. Multiple thousands of clicks on the reference links per-day
+2. A couple of mentions on Twitter about the feature
+
+## Analysis
+
+Look at Google Analytics Events under `Code Block Reference Link`.


### PR DESCRIPTION
Sometime last year, in the kuma time, I built a small FF extension to add that capability. Unfortunately I lost the source, so I just put it together again, this time as part of the yari build process. Currently it only does that for JS code blocks, happy to extend it (e.g. for CSS) if you people like the idea. This is what it looks like:
<img width="620" alt="Screenshot 2021-06-25 at 12 17 40" src="https://user-images.githubusercontent.com/4051932/123410414-97efcb80-d5af-11eb-85e4-62e3938c1829.png">

The extension also had a popover-on-hover which would show the ref page's summary. Not sure yet if I should put that back in as well.

I'm thinking about adding some analytics for this as well. My dream would be to not just track how many clicks there are, but set-up a full-on A/B test to check how it affects metrics like time-spent on MDN. But that will probably remain a dream

I just tagged a couple of my coworkers as reviewers as I'd like to get feedback if you think this might be useful in general or if you have ideas how it could be improved.