### PR TITLE
reuse saved feed entries for homepage SPA

### DIFF
--- a/build/feedparser.js
+++ b/build/feedparser.js
@@ -1,15 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+const { promisify } = require("util");
+
 const got = require("got");
 const parser = require("fast-xml-parser");
 const cheerio = require("cheerio");
+const tempy = require("tempy");
+
+const exists = promisify(fs.exists);
+const readFile = promisify(fs.readFile);
+const writeFile = promisify(fs.writeFile);
 
 async function getFeedEntries(url) {
-  const buffer = await got(url, {
-    responseType: "buffer",
-    resolveBodyOnly: true,
-    timeout: 5000,
-    retry: 5,
-  });
-  const feed = parser.parse(buffer.toString());
+  const savedFeedEntriesFilePath = path.join(tempy.root, url2filename(url));
+  const saved = await exists(savedFeedEntriesFilePath);
+
+  let feedText;
+  if (saved) {
+    console.log(
+      `Reusing previously downloaded feed entries from ${savedFeedEntriesFilePath}`
+    );
+    feedText = (await readFile(savedFeedEntriesFilePath)).toString();
+  } else {
+    const buffer = await got(url, {
+      responseType: "buffer",
+      resolveBodyOnly: true,
+      timeout: 5000,
+      retry: 5,
+    });
+    feedText = buffer.toString();
+    await writeFile(savedFeedEntriesFilePath, feedText);
+  }
+
+  const feed = parser.parse(feedText);
   const entries = [];
   for (const item of feed.rss.channel.item) {
     const description = cheerio.load(item.description);
@@ -24,6 +47,12 @@ async function getFeedEntries(url) {
     });
   }
   return entries;
+}
+
+function url2filename(url, suffix = "txt", prefix = "feedentries") {
+  const parsed = new URL(url);
+  const pathnameParts = parsed.pathname.split("/").filter(Boolean);
+  return `${prefix}-${parsed.hostname}-${pathnameParts.join("-")}.${suffix}`;
 }
 
 module.exports = { getFeedEntries };

--- a/build/feedparser.js
+++ b/build/feedparser.js
@@ -7,16 +7,14 @@ const parser = require("fast-xml-parser");
 const cheerio = require("cheerio");
 const tempy = require("tempy");
 
-const exists = promisify(fs.exists);
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
 async function getFeedEntries(url) {
   const savedFeedEntriesFilePath = path.join(tempy.root, url2filename(url));
-  const saved = await exists(savedFeedEntriesFilePath);
 
   let feedText;
-  if (saved) {
+  if (fs.existsSync(savedFeedEntriesFilePath)) {
     console.log(
       `Reusing previously downloaded feed entries from ${savedFeedEntriesFilePath}`
     );


### PR DESCRIPTION
My Wifi was down and I couldn't use `yarn dev`. 
Granted, the macOS `tmp` dir will periodically clean itself up and completely wipe when you restart the computer so there it wouldn't save you either. 
But introducing a simple disk-based cache is cheap and it makes `yarn dev` a little bit more pleasant. 