### PR TITLE
make Flaws Dashboard work in mdn/content

### DIFF
--- a/server/flaws.js
+++ b/server/flaws.js
@@ -6,7 +6,7 @@ const glob = require("glob");
 const { getPopularities } = require("../content");
 const { FLAW_LEVELS, options: buildOptions } = require("../build");
 
-const BUILD_OUT_ROOT = path.join(__dirname, "..", "client", "build");
+const { BUILD_OUT_ROOT } = require("../build/constants");
 
 // Module-level cache
 const allPopularityValues = [];


### PR DESCRIPTION
Fixes #4082

First, test in regular yari:
```
# One terminal
yarn dev
```
``` 
# Another terminal
yarn build
```
And then open <http://localhost:3000/en-US/_flaws> in your browser. Should show stuff. 

Ultimately the raison-d'etre for this PR is so that https://github.com/mdn/content/pull/6349 can start to work. 
