### PR TITLE
Fixing canonical references for Intl related pages

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -57,7 +57,7 @@ if (typeof inheritanceData[mainObj] != 'undefined') {
 // Data for related pages
 var groupData = {
     "Error": ["Error", "EvalError", "InternalError", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"],
-    "Intl": ["Intl", "Collator", "DateTimeFormat", "ListFormat", "NumberFormat", "PluralRules", "RelativeTimeFormat"],
+    "Intl": ["Intl", "Intl.Collator", "Intl.DateTimeFormat", "Intl.ListFormat", "Intl.NumberFormat", "Intl.PluralRules", "Intl.RelativeTimeFormat"],
     "TypedArray": ["TypedArray", "Int8Array", "Uint8Array", "Uint8ClampedArray", "Int16Array", "Uint16Array",
                    "Int32Array", "Uint32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array"],
     "Proxy": ["Proxy", "handler"],


### PR DESCRIPTION
This matches the current structure of the tree and avoids locale to add explicit redirects to match the en-US current state of docs (cf. https://github.com/mdn/translated-content/pull/1320 )