### PR TITLE
Expunge AbstractWorker

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -2017,7 +2017,6 @@
         "/docs/Web/API/Web_Workers_API/Structured_clone_algorithm"
       ],
       "interfaces": [
-        "AbstractWorker",
         "ChromeWorker",
         "DedicatedWorkerGlobalScope",
         "ServiceWorker",

--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -1982,7 +1982,7 @@
     },
     "ServiceWorker": {
       "inh": "EventTarget",
-      "impl": ["AbstractWorker"]
+      "impl": []
     },
     "ServiceWorkerContainer": {
       "inh": "EventTarget",
@@ -2010,7 +2010,7 @@
     },
     "SharedWorker": {
       "inh": "EventTarget",
-      "impl": ["AbstractWorker"]
+      "impl": []
     },
     "SharedWorkerGlobalScope": {
       "inh": "WorkerGlobalScope",
@@ -2263,7 +2263,7 @@
     },
     "Worker": {
       "inh": "EventTarget",
-      "impl": ["AbstractWorker"]
+      "impl": []
     },
     "WorkerGlobalScope": {
       "inh": "EventTarget",


### PR DESCRIPTION
`AbstractWorker` is gone from MDN; see the related change at https://github.com/mdn/content/commit/13859f1.

Otherwise, without this change, with end up with thing where member names/links get duplicated in the API sidebar.

Fixes https://github.com/mdn/content/issues/6408