### PR TITLE
Include compat query in all page reports

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -27,7 +27,7 @@ const NEW_ISSUE_TEMPLATE = `
 <details>
 <summary>MDN page report details</summary>
 
-* Query: \`$QUERY_ID\`
+* \`browser-compat\`: \`$BROWSER_COMPAT\`
 * MDN URL: https://developer.mozilla.org$PATHNAME
 * Report started: $DATE
 
@@ -122,7 +122,7 @@ export default function BrowserCompatibilityTable({
     const sp = new URLSearchParams();
     const body = NEW_ISSUE_TEMPLATE.replace(/\$PATHNAME/g, location.pathname)
       .replace(/\$DATE/g, new Date().toISOString())
-      .replace(/\$QUERY_ID/g, query)
+      .replace(/\$BROWSER_COMPAT/g, query)
       .trim();
     sp.set("body", body);
     sp.set("title", `${query} - <PUT TITLE HERE>`);

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -64,6 +64,7 @@ MDN URL: https://developer.mozilla.org$PATHNAME
 * GitHub URL: $GITHUB_URL
 * Last commit: $LAST_COMMIT_URL
 * Document last modified: $DATE
+* \`browser-compat\`: \`$BROWSER_COMPAT\`
 
 </details>
   `.trim();
@@ -89,11 +90,16 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   const baseURL = "https://github.com/mdn/content/issues/new";
   const sp = new URLSearchParams();
 
+  const browser_compat = () => {
+    throw new Error("I don't know how to get the front matter from here");
+  };
+
   const { folder, github_url, last_commit_url } = doc.source;
   const body = NEW_ISSUE_TEMPLATE.replace(/\$PATHNAME/g, doc.mdn_url)
     .replace(/\$FOLDER/g, folder)
     .replace(/\$GITHUB_URL/g, github_url)
     .replace(/\$LAST_COMMIT_URL/g, last_commit_url)
+    .replace(/\$BROWSER_COMPAT/g, browser_compat)
     .replace(
       /\$DATE/g,
       doc.modified ? new Date(doc.modified).toISOString() : "*date not known*"


### PR DESCRIPTION
The BCD issue template includes the compat query in the page details; the content issue template does not. If a reader uses the wrong link to report a problem and the issue is transferred from mdn/content to browser-compat-data, then there's no record of the page's compat front matter. This is my (incomplete) attempt to make sure both reports have the query.

(There's probably something more clever to be done here, like including a common chunk of JSON-formatted page metadata in a comment in all issue templates, but I got lost trying to trace a single front matter value from the relevant react components.)

cc: @Rumyra 