### PR TITLE
Make sure heading within .on-github container is in sequentially-descending order

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -3,7 +3,7 @@ import { Doc } from "./types";
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
-      <h4>Found a problem with this page?</h4>
+      <OnGitHubHeading doc={doc} />
       <ul>
         <li>
           <SourceOnGitHubLink doc={doc} />
@@ -38,6 +38,18 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       Source on <b>GitHub</b>
     </a>
   );
+}
+function OnGitHubHeading({ doc }: { doc: Doc }) {
+  // The last object of doc.body is either an h2 or h3 element
+  // with text content "See Also", and we can check whether its
+  // an h3 with the isH3 property of `doc` then create the
+  // "Found a problem with this page?" heading appropriately
+  // based on the heading level for last object in doc.body
+  // to ensure the headings are in sequentially-descending order
+  const { body } = doc;
+  const lastHeading = body[body.length - 1]["value"];
+  const text = "Found a problem with this page?";
+  return !lastHeading.isH3 ? <h3>{text}</h3> : <h4>{text}</h4>;
 }
 
 const NEW_ISSUE_TEMPLATE = `

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -3,7 +3,7 @@ import { Doc } from "./types";
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
-      <OnGitHubHeading doc={doc} />
+      <h3>Found a problem with this page?</h3>
       <ul>
         <li>
           <SourceOnGitHubLink doc={doc} />
@@ -38,18 +38,6 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       Source on <b>GitHub</b>
     </a>
   );
-}
-function OnGitHubHeading({ doc }: { doc: Doc }) {
-  // The last object of doc.body is either an h2 or h3 element
-  // with text content "See Also", and we can check whether its
-  // an h3 with the isH3 property of `doc` then create the
-  // "Found a problem with this page?" heading appropriately
-  // based on the heading level for last object in doc.body
-  // to ensure the headings are in sequentially-descending order
-  const { body } = doc;
-  const lastHeading = body[body.length - 1]["value"];
-  const text = "Found a problem with this page?";
-  return !lastHeading.isH3 ? <h3>{text}</h3> : <h4>{text}</h4>;
 }
 
 const NEW_ISSUE_TEMPLATE = `


### PR DESCRIPTION
Part of #4060 

Fixes "Heading elements are not in a sequentially-descending order" in Accessibility section of Lighthouse Audit. Since the `<h4>` was hardcoded before, we could always add a `className` to mimic the `<h4>` styles for the final heading produced by `<OnGitHubHeading />` if it is an `<h3>`.

My original plan was to use cheerio and replace the heading with the correctly ordered heading, but I quickly found out I could only access stuff with cheerio that was within `doc.body` and since the `<aside id="metadata">` is not apart of that, I couldn't select the heading in aside. The functional component to determine which heading to use seems better anyways since it was already React to begin with.