### PR TITLE
Add PublicKeyCredential to Credential API sidebar

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -141,7 +141,8 @@
         "Credential",
         "CredentialsContainer",
         "FederatedCredential",
-        "PasswordCredential"
+        "PasswordCredential",
+        "PublicKeyCredential"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
Add PublicKeyCredential to the Credential API sidebar (where the other credential interfaces are already listed)