### PR TITLE
Remove RenderingContext typedef from Canvas API sidebar

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -80,7 +80,6 @@
         "ImageData",
         "OffscreenCanvas",
         "Path2D",
-        "RenderingContext",
         "TextMetrics"
       ],
       "methods": [],


### PR DESCRIPTION
The RenderingContext typedef documentation is in the progress of being removed in mdn/content#6592. This cleans the sidebar too.