### PR TITLE
Fix tap size and spacing for tap targets

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -35,6 +35,10 @@ a.new {
 .main-page-content {
   padding: math.div($base-spacing, 2) $base-spacing $base-spacing;
 
+  ul li {
+    margin-bottom: 8px;
+  }
+
   .code-example {
     position: relative;
 

--- a/client/src/document/organisms/metadata/index.scss
+++ b/client/src/document/organisms/metadata/index.scss
@@ -19,6 +19,10 @@
 
   .on-github {
     margin-bottom: $base-spacing;
+
+    ul li {
+      margin-bottom: 8px;
+    }
   }
 
   .last-modified-date {

--- a/client/src/ui/molecules/language-menu/index.scss
+++ b/client/src/ui/molecules/language-menu/index.scss
@@ -21,7 +21,8 @@
 
   select {
     display: inline-block;
-    margin-right: math.div($base-spacing, 4);
+    margin-right: math.div($base-spacing, 3);
+    margin-bottom: math.div($base-spacing, 3);
 
     @media #{$mq-tablet-and-up} {
       display: inline-block;

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -46,6 +46,11 @@
     li {
       display: inline-block;
       margin-right: 10px;
+
+      .social-icon {
+        padding-right: math.div($base-spacing, 4);
+        padding-left: math.div($base-spacing, 4);
+      }
     }
 
     ul {

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -46,11 +46,6 @@
     li {
       display: inline-block;
       margin-right: 10px;
-
-      .social-icon {
-        padding-right: math.div($base-spacing, 4);
-        padding-left: math.div($base-spacing, 4);
-      }
     }
 
     ul {


### PR DESCRIPTION
Part of #4060 

Specifically, failed audits in the SEO section: 
- tap targets are overlapping eachother
- tap targets are not appropriately sized (87% of the 48px by 48px requirement)