### PR TITLE
dry-run redirect argument as part of deletion

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -676,6 +676,7 @@ function remove(
   const docs = [slug, ...children.map(({ metadata }) => metadata.slug)];
 
   if (dry) {
+    Redirect.add(locale, [[url, redirect]], { dry });
     return docs;
   }
 

--- a/content/redirect.js
+++ b/content/redirect.js
@@ -259,13 +259,19 @@ function loadLocaleAndAdd(
   };
 }
 
-function add(locale, updatePairs, { fix = false, strict = false } = {}) {
+function add(
+  locale,
+  updatePairs,
+  { fix = false, strict = false, dry = false } = {}
+) {
   const localeLC = locale.toLowerCase();
   const { pairs, root } = loadLocaleAndAdd(localeLC, updatePairs, {
     fix,
     strict,
   });
-  save(path.join(root, localeLC), pairs);
+  if (!dry) {
+    save(path.join(root, localeLC), pairs);
+  }
 }
 
 function remove(locale, urls, { strict = false } = {}) {


### PR DESCRIPTION
Fixes #4123

```
▶ yarn tool delete --redirect /gargbage Web/API/BluetoothRemoteGATTService/getIncludedService
yarn run v1.22.10
$ node tool/cli.js delete --redirect /gargbage Web/API/BluetoothRemoteGATTService/getIncludedService

error: The URL is expected to start with /$locale/docs/: /gargbage

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

And now it no longer executed the deletion part. 
