### PR TITLE
"Edit on GitHub" link first

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -6,6 +6,9 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       <h4>Found a problem with this page?</h4>
       <ul>
         <li>
+          <EditOnGitHubLink doc={doc} />
+        </li>
+        <li>
           <SourceOnGitHubLink doc={doc} />
         </li>
         <li>
@@ -26,6 +29,7 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
     </div>
   );
 }
+
 function SourceOnGitHubLink({ doc }: { doc: Doc }) {
   const { github_url, folder } = doc.source;
   return (
@@ -36,6 +40,20 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       rel="noopener noreferrer"
     >
       Source on <b>GitHub</b>
+    </a>
+  );
+}
+
+function EditOnGitHubLink({ doc }: { doc: Doc }) {
+  const { github_url } = doc.source;
+  return (
+    <a
+      href={github_url.replace("/blob/", "/edit/")}
+      title={`You're going to need to sign in to GitHub first (Opens in a new tab)`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Edit on <b>GitHub</b>
     </a>
   );
 }


### PR DESCRIPTION
This is *not* a solution https://github.com/mdn/yari/issues/4048 
but it inches us slightly towards something. 

Now, the first link there is about editing. We want this to be slightly more prominent because a lot of issues are filed when the user could just make a quick edit themselves. 

*Order of links*
<img width="852" alt="Screen Shot 2021-07-07 at 3 37 54 PM" src="https://user-images.githubusercontent.com/26739/124819042-bf448200-df39-11eb-8319-764361a64e61.png">


*When you mouse-hover over the link*
<img width="715" alt="Screen Shot 2021-07-07 at 3 38 42 PM" src="https://user-images.githubusercontent.com/26739/124819007-b2279300-df39-11eb-94a3-3230141f802a.png">

