### PR TITLE
add /files to CONTENT_TRANSLATED_ROOT if necessary

### DIFF
--- a/content/constants.js
+++ b/content/constants.js
@@ -27,6 +27,24 @@ if (
 let CONTENT_ARCHIVED_ROOT = process.env.CONTENT_ARCHIVED_ROOT;
 let CONTENT_TRANSLATED_ROOT = process.env.CONTENT_TRANSLATED_ROOT;
 
+// If CONTENT_TRANSLATED_ROOT is set, but it lacks the `/files` part, let's
+// deal with that.
+if (CONTENT_TRANSLATED_ROOT) {
+  CONTENT_TRANSLATED_ROOT = fs.realpathSync(CONTENT_TRANSLATED_ROOT);
+  if (
+    path.basename(CONTENT_TRANSLATED_ROOT) !== "files" &&
+    fs.existsSync(path.join(CONTENT_TRANSLATED_ROOT, "files"))
+  ) {
+    // It can be "corrected"
+    CONTENT_TRANSLATED_ROOT = path.join(CONTENT_TRANSLATED_ROOT, "files");
+    console.warn(
+      `Corrected the CONTENT_TRANSLATED_ROOT environment variable to ${CONTENT_TRANSLATED_ROOT}`
+    );
+  } else if (!fs.existsSync(CONTENT_TRANSLATED_ROOT)) {
+    throw new Error(`${path.resolve(CONTENT_TRANSLATED_ROOT)} does not exist`);
+  }
+}
+
 // This makes it possible to know, give a root folder, what is the name of
 // the repository on GitHub.
 // E.g. `'https://github.com/' + REPOSITORY_URLS[document.fileInfo.root]`

--- a/content/constants.js
+++ b/content/constants.js
@@ -6,44 +6,17 @@ require("dotenv").config({
   path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
 });
 
-let CONTENT_ROOT = process.env.CONTENT_ROOT;
+const CONTENT_ROOT = correctContentPathFromEnv("CONTENT_ROOT");
 if (!CONTENT_ROOT) {
   throw new Error("Env var CONTENT_ROOT must be set");
 }
-CONTENT_ROOT = fs.realpathSync(CONTENT_ROOT);
-if (
-  path.basename(CONTENT_ROOT) !== "files" &&
-  fs.existsSync(path.join(CONTENT_ROOT, "files"))
-) {
-  // It can be "corrected"
-  CONTENT_ROOT = path.join(CONTENT_ROOT, "files");
-  console.warn(
-    `Corrected the CONTENT_ROOT environment variable to ${CONTENT_ROOT}`
-  );
-} else if (!fs.existsSync(CONTENT_ROOT)) {
-  throw new Error(`${path.resolve(CONTENT_ROOT)} does not exist`);
-}
 
-let CONTENT_ARCHIVED_ROOT = process.env.CONTENT_ARCHIVED_ROOT;
-let CONTENT_TRANSLATED_ROOT = process.env.CONTENT_TRANSLATED_ROOT;
-
-// If CONTENT_TRANSLATED_ROOT is set, but it lacks the `/files` part, let's
-// deal with that.
-if (CONTENT_TRANSLATED_ROOT) {
-  CONTENT_TRANSLATED_ROOT = fs.realpathSync(CONTENT_TRANSLATED_ROOT);
-  if (
-    path.basename(CONTENT_TRANSLATED_ROOT) !== "files" &&
-    fs.existsSync(path.join(CONTENT_TRANSLATED_ROOT, "files"))
-  ) {
-    // It can be "corrected"
-    CONTENT_TRANSLATED_ROOT = path.join(CONTENT_TRANSLATED_ROOT, "files");
-    console.warn(
-      `Corrected the CONTENT_TRANSLATED_ROOT environment variable to ${CONTENT_TRANSLATED_ROOT}`
-    );
-  } else if (!fs.existsSync(CONTENT_TRANSLATED_ROOT)) {
-    throw new Error(`${path.resolve(CONTENT_TRANSLATED_ROOT)} does not exist`);
-  }
-}
+const CONTENT_ARCHIVED_ROOT = correctContentPathFromEnv(
+  "CONTENT_ARCHIVED_ROOT"
+);
+const CONTENT_TRANSLATED_ROOT = correctContentPathFromEnv(
+  "CONTENT_TRANSLATED_ROOT"
+);
 
 // This makes it possible to know, give a root folder, what is the name of
 // the repository on GitHub.
@@ -57,20 +30,33 @@ const REPOSITORY_URLS = {
 // null.
 const ROOTS = [CONTENT_ROOT];
 if (CONTENT_ARCHIVED_ROOT) {
-  if (!fs.existsSync(CONTENT_ARCHIVED_ROOT)) {
-    throw new Error(`${path.resolve(CONTENT_ARCHIVED_ROOT)} does not exist`);
-  }
-  CONTENT_ARCHIVED_ROOT = fs.realpathSync(CONTENT_ARCHIVED_ROOT);
   ROOTS.push(CONTENT_ARCHIVED_ROOT);
   REPOSITORY_URLS[CONTENT_ARCHIVED_ROOT] = "mdn/archived-content";
 }
 if (CONTENT_TRANSLATED_ROOT) {
-  if (!fs.existsSync(CONTENT_TRANSLATED_ROOT)) {
-    throw new Error(`${path.resolve(CONTENT_TRANSLATED_ROOT)} does not exist`);
-  }
-  CONTENT_TRANSLATED_ROOT = fs.realpathSync(CONTENT_TRANSLATED_ROOT);
   ROOTS.push(CONTENT_TRANSLATED_ROOT);
   REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = "mdn/translated-content";
+}
+
+function correctContentPathFromEnv(envVarName) {
+  let pathName = process.env[envVarName];
+  if (!pathName) {
+    return;
+  }
+  pathName = fs.realpathSync(pathName);
+  if (
+    path.basename(pathName) !== "files" &&
+    fs.existsSync(path.join(pathName, "files"))
+  ) {
+    // It can be "corrected"
+    pathName = path.join(pathName, "files");
+    console.warn(
+      `Corrected the ${envVarName} environment variable to ${pathName}`
+    );
+  } else if (!fs.existsSync(pathName)) {
+    throw new Error(`${path.resolve(pathName)} does not exist`);
+  }
+  return pathName;
 }
 
 module.exports = {


### PR DESCRIPTION
Steps to test:

```
▶ export CONTENT_TRANSLATED_ROOT=~/dev/MOZILLA/MDN/translated-content   # Oops! To err is human

▶ yarn prepare-build  # Should now work

▶ BUILD_FOLDERSEARCH=getting_started BUILD_FLAW_LEVELS="*:ignore, macros:warn" yarn build -l zh-tw
yarn run v1.22.10
$ cross-env NODE_ENV=production node build/cli.js -l zh-tw
Corrected the CONTENT_TRANSLATED_ROOT environment variable to /Users/peterbe/dev/MOZILLA/MDN/translated-content/files
CONTENT_ROOT:            /Users/peterbe/dev/MOZILLA/MDN/content/files
CONTENT_TRANSLATED_ROOT: /Users/peterbe/dev/MOZILLA/MDN/translated-content/files
CONTENT_ARCHIVED_ROOT:   not set
```

Note how it corrected it to `CONTENT_TRANSLATED_ROOT: /Users/peterbe/dev/MOZILLA/MDN/translated-content/files`