### PR TITLE
CSS syntax anchors should always be lowercase

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -320,7 +320,7 @@ async function formatSyntax(rawSyntax) {
             }
 
             var output = "<a href=\"/" + locale + "/docs/CSS/" +
-                s_syntax_value_definition + "#" + operator.anchor +
+                s_syntax_value_definition + "#" + operator.anchor.toLowerCase() +
                 "\" title=\"" + operator.title + "\">" + linkText + "</a>";
             if (linkText === "|") {
                 output = " " + output + " ";


### PR DESCRIPTION
This will help some of the confusion in https://github.com/mdn/yari/pull/3918
Basically, the macro should always create anchor links that are lowercase. 
E.g. `<a href="...#hash_mark">` instead of `<a href="...#Hash_mark">` because any page that has:
```html
<h2 id="Hash_mark">Hash mark</h2>
```
...in its raw form will always become, when rendered:
```html
<h2 id="hash_mark">Hash mark</h2>
```

