### PR TITLE
unbreak clean build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -110,11 +110,6 @@ jobs:
           echo "log_each_successful_upload: ${{ github.event.inputs.log_each_successful_upload }}"
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix }}"
 
-      - name: Fetch and load latest popularities.json
-        env:
-          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
-        run: yarn tool popularities
-
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
@@ -154,6 +149,11 @@ jobs:
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
           yarn prepare-build
+
+          # (July 15, 2021) This is a temporary solution. This should become an
+          # integrated part of 'prepare-build'.
+          # See https://github.com/mdn/yari/issues/4217
+          yarn tool popularities
 
           yarn tool sync-translated-content
           yarn build

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -136,13 +136,6 @@ jobs:
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
-      # (peterbe, May 2021) Deliberately commented out till we know this works
-      # well enough in Stage and Dev.
-      # - name: Fetch and load latest popularities.json
-      #   env:
-      #     CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
-      #   run: yarn tool popularities
-
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
@@ -190,6 +183,11 @@ jobs:
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
           yarn prepare-build
+
+          # (July 15, 2021) This is a temporary solution. This should become an
+          # integrated part of 'prepare-build'.
+          # See https://github.com/mdn/yari/issues/4217
+          yarn tool popularities
 
           yarn tool sync-translated-content
           yarn build

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -136,11 +136,6 @@ jobs:
           echo "deployment_prefix: ${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}"
           echo "BUILD_ARCHIVED_CONTENT: ${{ env.BUILD_ARCHIVED_CONTENT }}"
 
-      - name: Fetch and load latest popularities.json
-        env:
-          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
-        run: yarn tool popularities
-
       - name: Build everything
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
@@ -184,6 +179,11 @@ jobs:
           echo "CONTENT_ARCHIVED_ROOT=$CONTENT_ARCHIVED_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"
           yarn prepare-build
+
+          # (July 15, 2021) This is a temporary solution. This should become an
+          # integrated part of 'prepare-build'.
+          # See https://github.com/mdn/yari/issues/4217
+          yarn tool popularities
 
           yarn tool sync-translated-content
           yarn build


### PR DESCRIPTION
Testing it out in: https://github.com/mdn/yari/actions/runs/1034317579

This is what was going wrong: https://github.com/mdn/yari/runs/3077697402?check_suite_focus=true

Basically, the merge of https://github.com/mdn/yari/pull/3844 broke the build. That PR was bad, but instead of reverting, this PR fixes it a bit better so we can keep the good functionality but not doing in the wrong order. 

The CLI `yarn tool popularities` can't be run until *after* you've run (some part of) `yarn prepare-build`. That's what this PR fixes. 