### PR TITLE
make validate-redirects a teeny bit more insightful

### DIFF
--- a/content/redirect.js
+++ b/content/redirect.js
@@ -246,16 +246,17 @@ function loadLocaleAndAdd(
       const [a1, a2] = a[i] || [];
       const [b1, b2] = b[i] || [];
       if (a1 !== b1 || a2 !== b2) {
-        return true;
+        return [a1, b1, a2, b2];
       }
     }
-    return false;
+    return null;
   };
+  const changed = pairsChanged(pairs, simplifiedPairs);
 
   return {
     pairs: simplifiedPairs,
     root,
-    changed: pairsChanged(pairs, simplifiedPairs),
+    changed,
   };
 }
 
@@ -289,7 +290,8 @@ function validateLocale(locale, strict = false) {
   // To validate strict we check if there is something to fix.
   const { changed } = loadLocaleAndAdd(localeLC, [], { fix: strict, strict });
   if (changed) {
-    throw new Error(` _redirects.txt for ${localeLC} is flawed`);
+    const [a1, b1, a2, b2] = changed;
+    throw new Error(`Invalid redirect for ${a1} -> ${b1} or ${a2} -> ${b2}`);
   }
 }
 


### PR DESCRIPTION
This is a "desperate" follow-up from https://github.com/mdn/content/pull/6979 
Check out version 0e14524aa5282ad673f076857b9f52c920fed9fa of mdn/content and the latest version of mdn/yari and run:

```
yarn tool validate-redirects en-us --strict
```

...which is what our CI runs for mdn/content. It was failing because we recently emptied the `archived.txt` file as we're going to completely abandon archived content. All you would get is:

```
_redirects.txt for en-us is causing issues: Error:  _redirects.txt for en-us is flawed
```
which is "useless" because it doesn't give you any clues to what's possibly wrong with the `_redirects.txt` file. 

In this PR here, I'm desperately trying to elevate *something* that can at least give you *some* clue as to where to start looking. Now you get:

```
▶ yarn tool validate-redirects en-us --strict
yarn run v1.22.10
$ node tool/cli.js validate-redirects en-us --strict
removing orphaned redirect (to doesn't exists): /en-US/docs/Mozilla/Performance/ScrollLinkedEffects	/en-US/docs/Mozilla/Performance/Scroll-linked_effects
info: _redirects.txt for en-us is causing issues: Error: Invalid redirect for /en-US/docs/Mozilla/Performance/ScrollLinkedEffects -> /en-US/docs/Mozilla/Virtualenv or /en-US/docs/Mozilla/Performance/Scroll-linked_effects -> https://github.com/mdn/archived-content/tree/main/files/en-us/mozilla/virtualenv

error: 🔥 Errors loading redirects 🔥
```

I would love to merge this soon and then we can fix the redirect checker version 2.0 so it says exactly which line(s) and what their values were that caused the problem. 