### PR TITLE
Update styling to prevent bc-table-row-header text from overflowing its content-box

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
@@ -57,6 +57,7 @@
 
     code {
       text-decoration: none;
+      white-space: normal;
     }
   }
 

--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
@@ -54,6 +54,7 @@
 
   .bc-table-row-header {
     padding: math.div($base-spacing, 2) math.div($base-spacing, 4);
+    display: flex;
 
     code {
       text-decoration: none;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -425,6 +425,29 @@ function CompatCell({
   );
 }
 
+function ShrinkText(props: { text: string }) {
+  const text: string = props.text || "";
+  // 75% of the string text is a reasonable
+  // cutoff point, but could be improved
+  // if we find that 75% of string isn't
+  // looking nice
+  const rate: number = 0.75;
+  let cutoff: number = Math.floor(text.length * rate);
+  // split the original string into two strings
+  // 1: 75% of original string
+  // 2: remaining 25%
+  let leftSide: string = text.slice(0, cutoff);
+  let rightSide: string = text.slice(cutoff);
+  return (
+    <>
+      <code title={text}>
+        <span className="left-side">{leftSide}</span>
+        <span className="right-side">{rightSide}</span>
+      </code>
+    </>
+  );
+}
+
 export const FeatureRow = React.memo(
   ({
     index,
@@ -449,7 +472,7 @@ export const FeatureRow = React.memo(
     const title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
-      <code>{name}</code>
+      <ShrinkText text={name} />
     );
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -425,29 +425,6 @@ function CompatCell({
   );
 }
 
-function ShrinkText(props: { text: string }) {
-  const text: string = props.text || "";
-  // 75% of the string text is a reasonable
-  // cutoff point, but could be improved
-  // if we find that 75% of string isn't
-  // looking nice
-  const rate: number = 0.75;
-  let cutoff: number = Math.floor(text.length * rate);
-  // split the original string into two strings
-  // 1: 75% of original string
-  // 2: remaining 25%
-  let leftSide: string = text.slice(0, cutoff);
-  let rightSide: string = text.slice(cutoff);
-  return (
-    <>
-      <code title={text}>
-        <span className="left-side">{leftSide}</span>
-        <span className="right-side">{rightSide}</span>
-      </code>
-    </>
-  );
-}
-
 export const FeatureRow = React.memo(
   ({
     index,
@@ -472,7 +449,7 @@ export const FeatureRow = React.memo(
     const title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
-      <ShrinkText text={name} />
+      <code>{name}</code>
     );
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -18,3 +18,28 @@
 .only-icon span {
   @include visually-hidden();
 }
+
+.bc-table-row-header {
+  code {
+    display: flex;
+    overflow: hidden;
+  }
+
+  .left-side,
+  .right-side {
+    white-space: pre;
+    overflow: hidden;
+  }
+
+  /* Can only flex-shrink and not flex-grow 
+  ie the "slider" in a sliding glass door */
+  .left-side {
+    flex: 0 1 auto;
+    text-overflow: ellipsis;
+  }
+  /* Can flex-grow and not flex-shrink as
+  its the stationary portion */
+  .right-side {
+    flex: 1 0 auto;
+  }
+}


### PR DESCRIPTION
Fixes #4230 
Fixes #4509

<img width="987" alt="Screen Shot 2021-07-21 at 11 25 11 AM" src="https://user-images.githubusercontent.com/48612525/126540428-ce45360d-9cef-46db-bbc8-182764369ee5.png">