### PR TITLE
Expunge all Navigator* mixins

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -1247,18 +1247,7 @@
     },
     "Navigator": {
       "inh": "",
-      "impl": [
-        "NavigatorID",
-        "NavigatorLanguage",
-        "NavigatorOnLine",
-        "NavigatorContentUtils",
-        "NavigatorStorageUtils",
-        "NavigatorFeatures",
-        "NavigatorGeolocation",
-        "NavigatorBattery",
-        "NavigatorDataStore",
-        "NavigatorMobileId"
-      ]
+      "impl": []
     },
     "NetworkInformation": {
       "inh": "EventTarget",
@@ -2271,12 +2260,7 @@
     },
     "WorkerNavigator": {
       "inh": "",
-      "impl": [
-        "NavigatorID",
-        "NavigatorLanguage",
-        "NavigatorOnLine",
-        "NavigatorDataStore"
-      ]
+      "impl": []
     },
     "XMLDocument": {
       "inh": "Document",


### PR DESCRIPTION
Navigator\* mixins are gone from MDN and so need to be dropped from `kumascript/macros/InterfaceData.json` as well.

Otherwise, without this change, with end up with the thing where member names/links get duplicated in the API sidebar.

Fixes https://github.com/mdn/content/issues/7036

Cc @Elchi3 