### PR TITLE
block indexing of live samples

### DIFF
--- a/kumascript/src/live-sample.js
+++ b/kumascript/src/live-sample.js
@@ -15,6 +15,7 @@ const LIVE_SAMPLE_HTML = `
 <html>
     <head>
         <meta charset="utf-8">
+        <meta name="robots" content="noindex, nofollow">
         <style type="text/css">
             body {
               padding: 0;


### PR DESCRIPTION
We should have done this long ago, but better late than never! Let's block indexing of the live-sample pages.