### PR TITLE
Any external link to fxsitecompat should be a flaw

### DIFF
--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -227,6 +227,22 @@ function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
         href,
         absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
       );
+    } else if (
+      href.startsWith("http") &&
+      (href.includes("fxsitecompat.com") || href.includes("fxsitecompat.dev"))
+    ) {
+      const domain = new URL(href).hostname;
+      // See https://github.com/mdn/content/issues/7124
+      if (["www.fxsitecompat.com", "www.fxsitecompat.dev"].includes(domain)) {
+        addBrokenLink(
+          a,
+          checked.get(href),
+          href,
+          null,
+          `All external links pointing to ${domain} should be deleted.
+      See https://github.com/mdn/content/issues/7124`
+        );
+      }
     } else if (isHomepageURL(hrefNormalized)) {
       // But did you spell it perfectly?
       const homepageLocale = hrefNormalized.split("/")[1];

--- a/build/index.js
+++ b/build/index.js
@@ -480,7 +480,8 @@ async function buildDocument(document, documentOptions = {}) {
     // present the link in any rendered HTML.
     if (
       a.attribs.href.startsWith("http") &&
-      a.attribs.href.includes("fxsitecompat.com")
+      (a.attribs.href.includes("fxsitecompat.com") ||
+        a.attribs.href.includes("fxsitecompat.dev"))
     ) {
       $(a).attr("href", "https://github.com/mdn/kuma/issues/7647");
     }

--- a/build/index.js
+++ b/build/index.js
@@ -469,6 +469,10 @@ async function buildDocument(document, documentOptions = {}) {
 
   // Some hyperlinks are not easily fixable and we should never include them
   // because they're potentially evil.
+  // NOTE! The day we've cleaned all of these links from all content we can delete
+  // the following code. And we can also delete the broken_links flaw check for it.
+  // See https://github.com/mdn/content/issues/7124
+  // and https://github.com/mdn/translated-content/issues/1634
   $("a[href]").each((i, a) => {
     // See https://github.com/mdn/kuma/issues/7647
     // Ideally we should manually remove this from all sources (archived or not)


### PR DESCRIPTION
This'll help with https://github.com/mdn/content/issues/7124 and https://github.com/mdn/translated-content/issues/1634

Also, in the builder, we used to only look for `fxsitecompat.com` but I noticed there are still links to `fxsitecompat.dev` too. 

Sample pages to test on:

- http://localhost:3000/en-US/docs/Web/API/Element/keydown_event#_flaws
- http://localhost:3000/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts#_flaws

or just grep around in mdn/content. 