### PR TITLE
Remove ChildNode from DOM sidebar

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -288,7 +288,6 @@
         "ByteString",
         "CDATASection",
         "CharacterData",
-        "ChildNode",
         "CSSPrimitiveValue",
         "CSSValue",
         "CSSValueList",


### PR DESCRIPTION
ChildNode has been removed a few weeks ago (as ParentNode, …) but was still there.

@Elchi3 Can you confirm this from the content point of view?