### PR TITLE
handle /:locale/events redirect in fundamental redirects

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1210,6 +1210,13 @@ const MISC_REDIRECT_PATTERNS = [
     ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
     { permanent: true }
   ),
+  // In the olden days this used to be part of Kuma. What Kuma used to do was
+  //
+  localeRedirect(
+    /^(?<prefix>events)\/?$/i,
+    () => "https://community.mozilla.org/events/",
+    { permanent: false, prependLocale: false }
+  ),
 ];
 
 const REDIRECT_PATTERNS = [].concat(


### PR DESCRIPTION
If we can do this, we no longer need to mess around with any of that from kuma. I.e. [this discussion](https://github.com/mdn/kuma/pull/7932#discussion_r673324407)