### PR TITLE
Slack notify

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -103,6 +103,8 @@ jobs:
           python --version
           poetry --version
 
+          exit 123
+
       - name: Print information about build
         run: |
           echo "notes: ${{ github.event.inputs.notes }}"
@@ -213,3 +215,15 @@ jobs:
           # (Or, make it an optional flag to the `update-lambda-functions` command)
 
           poetry run deployer search-index ../client/build
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: mdn-notifications
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_ICON: https://avatars.slack-edge.com/2020-11-17/1513880588420_fedd7f0e9456888e69ff_96.png
+          SLACK_ICON_EMOJI: ":bell:"
+          SLACK_MESSAGE: "Dev build failed :collision:"
+          # SLACK_TITLE: Post Title
+          # SLACK_USERNAME: rtCamp
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -225,6 +225,6 @@ jobs:
           SLACK_ICON: https://avatars.slack-edge.com/2020-11-17/1513880588420_fedd7f0e9456888e69ff_96.png
           SLACK_ICON_EMOJI: ":bell:"
           SLACK_MESSAGE: "Dev build failed :collision:"
-          # SLACK_TITLE: Post Title
-          # SLACK_USERNAME: rtCamp
+          SLACK_TITLE: "Sample TItle here! :bell:"
+          SLACK_FOOTER: "Powered by dev-build.yml"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -103,8 +103,6 @@ jobs:
           python --version
           poetry --version
 
-          exit 123
-
       - name: Print information about build
         run: |
           echo "notes: ${{ github.event.inputs.notes }}"
@@ -221,10 +219,9 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mdn-notifications
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'good' or '#ff00ff'
+          SLACK_COLOR: ${{ job.status }}
           SLACK_ICON: https://avatars.slack-edge.com/2020-11-17/1513880588420_fedd7f0e9456888e69ff_96.png
-          SLACK_ICON_EMOJI: ":bell:"
-          SLACK_MESSAGE: "Dev build failed :collision:"
-          SLACK_TITLE: "Sample TItle here! :bell:"
+          SLACK_TITLE: "Dev"
+          SLACK_MESSAGE: "Build failed :broken_heart:"
           SLACK_FOOTER: "Powered by dev-build.yml"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -217,6 +217,7 @@ jobs:
           poetry run deployer search-index ../client/build
 
       - name: Slack Notification
+        if: failure()
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_CHANNEL: mdn-notifications

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -250,3 +250,15 @@ jobs:
           poetry run deployer speedcurve-deploy \
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: mdn-notifications
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://avatars.slack-edge.com/2020-11-17/1513880588420_fedd7f0e9456888e69ff_96.png
+          SLACK_TITLE: ":rotating_light: Prod :rotating_light:"
+          SLACK_MESSAGE: "Build failed :collision:"
+          SLACK_FOOTER: "Powered by prod-build.yml"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -247,3 +247,15 @@ jobs:
           poetry run deployer speedcurve-deploy \
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"
+
+      - name: Slack Notification
+        if: failure()
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: mdn-notifications
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_ICON: https://avatars.slack-edge.com/2020-11-17/1513880588420_fedd7f0e9456888e69ff_96.png
+          SLACK_TITLE: "Stage"
+          SLACK_MESSAGE: "Build failed :collision:"
+          SLACK_FOOTER: "Powered by stage-build.yml"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
It looks something like this:
<img width="818" alt="Screen Shot 2021-07-21 at 2 02 05 PM" src="https://user-images.githubusercontent.com/26739/126537511-b8484ff1-cce7-4e60-a856-02de6b985711.png">

Now, if any failure happens inside `(dev|stage|prod)-build.yml` it will post a Slack message to `secrets.SLACK_WEBHOOK`

That current env var is a secret URL which I generated on https://api.slack.com/apps/A01EQTY3F5L/general? which might be entirely tied to my username, I'm not sure. But it's an app that I created, called `Yari Builder`, which as been approved my someone in Mozilla who approves Mozilla Slack apps. 
At the time of writing, that webhook URL encodes exactly channel it goes to and right now it's set to `#mdn-notifications` which is a channel that nobody watches (enough). So I'll change it to `#mdn-dev`. 

NOTE! It's important that just because we can post from GitHub Actions to Slack that we don't "abuse" this. The most important thing right now is that something our prod builds break and we don't notice. That's the most important thing. If we start sending too many automated Slack messages there's a great chance that we cease to pay attention. 