### PR TITLE
failed BCD JS chunk shouldn't kill the page

### DIFF
--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -14,7 +14,10 @@ import "./ingredients/browser-compatibility-table/index.scss";
 import { useLocale } from "../hooks";
 
 const BrowserCompatibilityTable = lazy(
-  () => import("./ingredients/browser-compatibility-table")
+  () =>
+    import(
+      /* webpackChunkName: "browser-compatibility-table" */ "./ingredients/browser-compatibility-table"
+    )
 );
 
 const isServer = typeof window === "undefined";
@@ -86,8 +89,72 @@ function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
   }
 
   return (
-    <Suspense fallback={<Loading message="Loading BCD table" />}>
-      <BrowserCompatibilityTable locale={locale} {...data} />
-    </Suspense>
+    <ErrorBoundary>
+      <Suspense fallback={<Loading message="Loading BCD table" />}>
+        <BrowserCompatibilityTable locale={locale} {...data} />
+      </Suspense>
+    </ErrorBoundary>
   );
+}
+
+type ErrorBoundaryProps = {};
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  // componentDidCatch(error: Error, errorInfo) {
+  //   console.log({ error, errorInfo });
+  // }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="notecard negative">
+          <p>
+            <strong>Error loading browser compatibility table</strong>
+          </p>
+          <p>
+            This can happen if the JavaScript, which is loaded later, didn't
+            successfully load.
+          </p>
+          <p>
+            <a
+              href="."
+              className="button"
+              style={{ color: "white", textDecoration: "none" }}
+              onClick={(event) => {
+                event.preventDefault();
+                window.location.reload();
+              }}
+            >
+              Try reloading the page
+            </a>
+          </p>
+          <hr style={{ margin: 20 }} />
+          <p>
+            <small>If you're curious, this was the error:</small>
+            <br />
+            <small style={{ fontFamily: "monospace" }}>
+              {this.state.error.toString()}
+            </small>
+          </p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
 }


### PR DESCRIPTION
Fixes #4260
Fixes #4236

At least three people have suffered this fate now. It happens because the JS chunk of the BCD table is always lazy loaded and if that chunk fails to load, for whatever reason, it causes the whole page to crash and just becomes white. 

First, to test this, use Chrome (has more intuitive tooling for blocking URLs in the devtools)
Go to https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API
Open Network panel and filter by "JS" look for a URL like https://developer.mozilla.org/static/js/6.71db03d1.chunk.js which is supposed to be one of the last ones to load. Right-click and "Block request URL" and then reload the page. 
This is what I get:
<img width="1616" alt="Screen Shot 2021-07-21 at 3 22 02 PM" src="https://user-images.githubusercontent.com/26739/126547449-688fbf9d-1400-4ea1-a2da-71abde9c3230.png">

Now, check out *this* branch locally and run `yarn dev`. 
Then go to http://localhost:5000/en-US/docs/Web/API/Web_Bluetooth_API (NOTE! it's not localhost:3000)
Open Network panel in dev tools again and block the URL that looks something like: http://localhost:5000/static/js/browser-compatibility-table.1b19598c.chunk.js
And reload. Now you should see something like this:
<img width="1067" alt="Screen Shot 2021-07-21 at 3 17 40 PM" src="https://user-images.githubusercontent.com/26739/126547741-24a4677a-bef2-4e08-8291-02f04fa88489.png">

It's not gorgeous but it works and it's a million times better than getting a completely blank screen. 
