### PR TITLE
Update interface list on {{WebRTCSidebar}}

### DIFF
--- a/kumascript/macros/WebRTCSidebar.ejs
+++ b/kumascript/macros/WebRTCSidebar.ejs
@@ -84,17 +84,17 @@ var text = mdn.localStringMap({
     <details open>
       <summary><%=text['Interfaces']%></summary>
       <ol>
-        <li><%-await template("domxref", ["RTCPeerConnection"])%></li>
-        <li><%-await template("domxref", ["RTCSessionDescription"])%></li>
-        <li><%-await template("domxref", ["RTCIceCandidate"])%></li>
-        <li><%-await template("domxref", ["RTCPeerConnectionIceEvent"])%></li>
-        <li><%-await template("domxref", ["MessageEvent"])%></li>
+        <li><%-await template("domxref", ["MediaDevices"])%></li>
         <li><%-await template("domxref", ["MediaStream"])%></li>
-        <li><%-await template("domxref", ["RTCStatsReport"])%></li>
         <li><%-await template("domxref", ["MediaStreamEvent"])%></li>
         <li><%-await template("domxref", ["MediaStreamTrack"])%></li>
-        <li><%-await template("domxref", ["MediaDevices"])%></li>
+        <li><%-await template("domxref", ["MessageEvent"])%></li>
         <li><%-await template("domxref", ["RTCDataChannel"])%></li>
+        <li><%-await template("domxref", ["RTCIceCandidate"])%></li>
+        <li><%-await template("domxref", ["RTCPeerConnection"])%></li>
+        <li><%-await template("domxref", ["RTCPeerConnectionIceEvent"])%></li>
+        <li><%-await template("domxref", ["RTCSessionDescription"])%></li>
+        <li><%-await template("domxref", ["RTCStatsReport"])%></li>
       </ol>
     </details>
   </li>

--- a/kumascript/macros/WebRTCSidebar.ejs
+++ b/kumascript/macros/WebRTCSidebar.ejs
@@ -91,11 +91,10 @@ var text = mdn.localStringMap({
         <li><%-await template("domxref", ["MessageEvent"])%></li>
         <li><%-await template("domxref", ["MediaStream"])%></li>
         <li><%-await template("domxref", ["RTCStatsReport"])%></li>
-        <li><%-await template("domxref", ["RTCIdentityEvent"])%></li>
-        <li><%-await template("domxref", ["RTCIdentityErrorEvent"])%></li>
         <li><%-await template("domxref", ["MediaStreamEvent"])%></li>
         <li><%-await template("domxref", ["MediaStreamTrack"])%></li>
         <li><%-await template("domxref", ["MediaDevices"])%></li>
+        <li><%-await template("domxref", ["RTCDataChannel"])%></li>
       </ol>
     </details>
   </li>


### PR DESCRIPTION
I removed `RTCIdentityEvent` and `RTCIdentityErrorEvent` removed from the spec and MDN (and marked as _flaws_ on each page using the macro).
I added `RTCDataChannel` one of the most important interface of WebRTC, that was missing.

cc/ @Elchi3 for the review from the content point of view.