### PR TITLE
scroll to top on picking search result

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -260,6 +260,11 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         if (onResultPicked) {
           onResultPicked();
         }
+        window.scroll({
+          top: 0,
+          left: 0,
+          behavior: "smooth",
+        });
       }
     },
   });


### PR DESCRIPTION
Fixes #4282

To test, 

- open any page and type a single character in the search, like `c`. 
- scroll down a bit
- click the last search result
