### PR TITLE
Make popularities.json dynamic instead of checked into git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ testing/content/files/en-us/_githistory.json
 testing/translated-content/files/**/_githistory.json
 # eslintcache
 client/.eslintcache
+popularities.json

--- a/content/popularities.js
+++ b/content/popularities.js
@@ -1,20 +1,20 @@
 const fs = require("fs");
 const path = require("path");
 
-const { CONTENT_ROOT } = require("./constants");
-
 // Module-level cache
 const popularities = new Map();
 
 function getPopularities() {
   if (!popularities.size) {
-    Object.entries(
-      JSON.parse(
-        fs.readFileSync(path.join(CONTENT_ROOT, "popularities.json"), "utf-8")
-      )
-    ).forEach(([url, value]) => {
-      popularities.set(url, value);
-    });
+    // This is the file that's *not* checked into git.
+    const filePath = path.resolve(
+      path.join(__dirname, "..", "popularities.json")
+    );
+    Object.entries(JSON.parse(fs.readFileSync(filePath, "utf-8"))).forEach(
+      ([url, value]) => {
+        popularities.set(url, value);
+      }
+    );
   }
   return popularities;
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fiori:build": "cd client && build-storybook",
     "fiori:start": "cd client && start-storybook -p 6006",
     "md": "ts-node markdown/cli.ts",
-    "prepare-build": "yarn build:client && yarn build:ssr && yarn tool optimize-client-build && yarn tool google-analytics-code && yarn tool spas && yarn tool gather-git-history && yarn tool build-robots-txt",
+    "prepare-build": "yarn build:client && yarn build:ssr && yarn tool optimize-client-build && yarn tool google-analytics-code && yarn tool spas && yarn tool gather-git-history && yarn tool build-robots-txt && yarn tool popularities",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",
     "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",

--- a/tool/popularities.js
+++ b/tool/popularities.js
@@ -1,6 +1,6 @@
 /**
  * This script exists only to periodically generate a
- * 'content/popularities.json' file from a Cloudfront access CSV export.
+ * 'popularities.json' file from a Cloudfront access CSV export.
  *
  * Generally, only the core MDN Web Docs team needs to run this. The output
  * file gets checked into git so it's easily available to everyone.
@@ -18,8 +18,8 @@ const CURRENT_URL =
   "https://mdn-popularities-prod.s3.amazonaws.com/current.txt";
 
 async function fetchPopularities() {
-  let { body: csvURL } = await got(CURRENT_URL);
-  let { body: csv } = await got(csvURL);
+  const { body: csvURL } = await got(CURRENT_URL);
+  const { body: csv } = await got(csvURL);
   return csv;
 }
 


### PR DESCRIPTION
Part of #4217

The idea is that we drive the popularities from `/popularities.json` instead. Reading it is always done via the `getPopularities()` function and it now hardcodes the location of the file. 

If you're doing local development in `yari` with `yarn dev` you get:
```
info: Reusing exising /Users/peterbe/dev/MOZILLA/MDN/yari/popularities.json (Thu Jul 22 2021 14:34:37 GMT-0400 (Eastern Daylight Time)) for popularities.
info: Reset /Users/peterbe/dev/MOZILLA/MDN/yari/popularities.json by running: yarn tool popularities --refresh
```
which makes consecutive runs of `yarn dev` fast. 

Then, when it bundles up yari as an NPM package, you're going to get a tarball that, at its root, contains a `popularities.json` which got created (every time) from the `.github/workflows/npm-publish.yml`. So when you run yari from within the `mdn/content` repo, you will find a `node_modules/@mdn/yari/popularities.json` which the `node_modules/@mdn/yari/content/popularities.js`  can always reach.

This way, every new npm package will have a fresh `popularities.json` from S3. So writers, who use the autocomplete search on localhost:5000 will get the latest and greatest (or at least as fresh as the Athena job runs). And their `yarn start` will still be fast and not need to download from S3. 

The reason this PR is only `Part of #4217` is because once shipped to NPM we need to go into `mdn/content` and run `git rm files/popularities.json`. 