### PR TITLE
Add RTCDtlsTransport to InterfaceData

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -1429,6 +1429,10 @@
       "inh": "OrientationSensor",
       "impl": []
     },
+    "RTCDtlsTransport": {
+      "inh": "EventTarget",
+      "impl": []
+    },
     "RTCDTMFSender": {
       "inh": "EventTarget",
       "impl": []


### PR DESCRIPTION
`RTCDtlsTransport` inherits methods and properties from `EventTarget`.

cc/ @Elchi3 to review from the content point of view