### PR TITLE
Remove deleted mixins from InterfaceData

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -310,7 +310,7 @@
     },
     "CharacterData": {
       "inh": "Node",
-      "impl": ["ChildNode"]
+      "impl": []
     },
     "ChromeWorker": {
       "inh": "Worker",
@@ -482,20 +482,15 @@
     },
     "Document": {
       "inh": "Node",
-      "impl": [
-        "XPathEvaluator",
-        "GlobalEventHandlers",
-        "ParentNode",
-        "GeometryUtils"
-      ]
+      "impl": ["XPathEvaluator", "GlobalEventHandlers"]
     },
     "DocumentFragment": {
       "inh": "Node",
-      "impl": ["ParentNode"]
+      "impl": []
     },
     "DocumentType": {
       "inh": "Node",
-      "impl": ["ChildNode"]
+      "impl": []
     },
     "DownloadEvent": {
       "inh": "Event",
@@ -511,7 +506,7 @@
     },
     "Element": {
       "inh": "Node",
-      "impl": ["ChildNode", "ParentNode", "Animatable", "GeometryUtils"]
+      "impl": []
     },
     "EngineeringMode": {
       "inh": "EventTarget",
@@ -743,7 +738,7 @@
     },
     "HTMLLinkElement": {
       "inh": "HTMLElement",
-      "impl": ["LinkStyle"]
+      "impl": []
     },
     "HTMLMapElement": {
       "inh": "HTMLElement",
@@ -855,7 +850,7 @@
     },
     "HTMLStyleElement": {
       "inh": "HTMLElement",
-      "impl": ["LinkStyle"]
+      "impl": []
     },
     "HTMLTableCaptionElement": {
       "inh": "HTMLElement",
@@ -1483,11 +1478,11 @@
     },
     "Request": {
       "inh": "",
-      "impl": ["Body"]
+      "impl": []
     },
     "Response": {
       "inh": "",
-      "impl": ["Body"]
+      "impl": []
     },
     "SensorErrorEvent": {
       "inh": "Event",
@@ -2111,7 +2106,7 @@
     },
     "Text": {
       "inh": "CharacterData",
-      "impl": ["GeometryUtils"]
+      "impl": []
     },
     "TextTrack": {
       "inh": "EventTarget",


### PR DESCRIPTION
We are in the process of removing mixins from MDN. Mixins that doesn't have a page anymore are creating numerous flaws when building sidebars.

This removes any mentions of `ParentNode`, `ChildNode`, `GeometryUtils`, `Animatable`, `LinkStyle` and `Body`.

(It will lower our macro flaw counters, by 100-200.)

cc/ @Elchi3 for a review from the content point of view

[I dream of the day we will get rid of `InterfaceData.json`, removing the mixins from the content is a first step towards this mid-term goal)
