### PR TITLE
building by locales in parallel

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -140,7 +140,13 @@ jobs:
           yarn tool popularities
 
           yarn tool sync-translated-content
-          yarn build
+
+          # Spread the work across 2 processes. Why 2? Because that's what you
+          # get in the default GitHub hosting Linux runners.
+          # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+          yarn build --locale     en-us --locale     ja --locale     fr &
+          yarn build --not-locale en-us --not-locale ja --not-locale fr &
+          wait
 
           # TODO: When the deployer is available this is where we
           # would upload the whole content of client/build

--- a/build/cli.js
+++ b/build/cli.js
@@ -368,7 +368,7 @@ program
         if (locales.size) {
           console.log(
             chalk.yellow(
-              `(only builing locales: ${[...locales.keys()].join(", ")})`
+              `(only building locales: ${[...locales.keys()].join(", ")})`
             )
           );
         }


### PR DESCRIPTION
An experiment to speed up the `yarn build` time by spreading the work across 2 CPUs. 
Building one locale is thread-safe by design but it's not safe to spread the documents within a locale. 

As a reference, I kicked off a Dev build earlier today and it clocks in at...
<img width="933" alt="Screen Shot 2021-07-26 at 4 49 07 PM" src="https://user-images.githubusercontent.com/26739/127057225-805a7f1e-c69e-4182-8e3c-538a0f4856e7.png">

It's hard to tell exactly how long each locale takes so we could experiment with some measurements there to find a good balance. 
