### PR TITLE
CLI delete command: dry redirect only as needed

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -589,7 +589,9 @@ function remove(
   const docs = [slug, ...children.map(({ metadata }) => metadata.slug)];
 
   if (dry) {
-    Redirect.add(locale, [[url, redirect]], { dry });
+    if (redirect) {
+      Redirect.add(locale, [[url, redirect]], { dry });
+    }
     return docs;
   }
 


### PR DESCRIPTION
This PR fixes #4210 by only attempting to perform a redirect as needed.  This prevents an error when attempting to delete a document without specifying another page to redirect to.