### PR TITLE
Cache .local for a faster poetry installation

### DIFF
--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Custom install Poetry
         run: |
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+          poetry --version
 
       # - name: Install Python poetry
       #   uses: snok/install-poetry@v1.1.6

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,16 +18,6 @@ jobs:
         with:
           python-version: "3.8"
 
-      # - name: Cache pip
-      #   uses: actions/cache@v2.1.6
-      #   with:
-      #     path: ~/.cache/pip
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
-
-      # - name: Debug pip cache dir
-      #   run: |
-      #     pip cache dir
-
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v2.1.6
@@ -41,11 +31,6 @@ jobs:
           path: ~/.local
           key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
-      # - name: Custom install Poetry
-      #   run: |
-      #     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - -y --path deployer/.venv
-      #     poetry --version
-
       - name: Install Python poetry
         uses: snok/install-poetry@v1.1.6
         with:
@@ -57,13 +42,6 @@ jobs:
           cd deployer
           poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-
-      - name: Debug poetry install
-        run: |
-          which poetry
-          cat `which poetry`
-          echo "POETRY_HOME??"
-          echo $POETRY_HOME
 
       - name: Lint Python code
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -36,7 +36,6 @@ jobs:
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       - name: Load cached .local
-        id: cached-poetry-dependencies
         uses: actions/cache@v2.1.6
         with:
           path: ~/.local

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+          virtualenvs-path: deployer/.venv
 
       - name: Install deployer
         run: |
@@ -55,6 +56,7 @@ jobs:
 
       - name: Basic run of deployer
         run: |
+          source deployer/.venv/bin/activate
           cd deployer
           poetry run deployer --help
 

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,12 +18,13 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Load cached venv
-        id: cached-pip-cache
+      - name: Cache pip
         uses: actions/cache@v2.1.6
         with:
-          path: $(pip cache dir)
-          key: pipcache-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       - name: Debug pip cache dir
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -35,12 +35,16 @@ jobs:
           path: deployer/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
-      - name: Install Python poetry
-        uses: snok/install-poetry@v1.1.6
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          virtualenvs-path: deployer/.venv
+      - name: Custom install Poetry
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+
+      # - name: Install Python poetry
+      #   uses: snok/install-poetry@v1.1.6
+      #   with:
+      #     virtualenvs-create: true
+      #     virtualenvs-in-project: true
+      #     # virtualenvs-path: deployer/.venv
 
       - name: Install deployer
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,11 +18,9 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install Python poetry
-        uses: snok/install-poetry@v1.1.6
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+      - name: Debug pip cache dir
+        run: |
+          pip cache dir
 
       - name: Load cached venv
         id: cached-poetry-dependencies
@@ -30,6 +28,12 @@ jobs:
         with:
           path: deployer/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install Python poetry
+        uses: snok/install-poetry@v1.1.6
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
       - name: Install deployer
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,15 +18,15 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Cache pip
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+      # - name: Cache pip
+      #   uses: actions/cache@v2.1.6
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
-      - name: Debug pip cache dir
-        run: |
-          pip cache dir
+      # - name: Debug pip cache dir
+      #   run: |
+      #     pip cache dir
 
       - name: Load cached venv
         id: cached-poetry-dependencies
@@ -37,6 +37,7 @@ jobs:
 
       - name: Install Python poetry
         uses: snok/install-poetry@v1.1.6
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -41,6 +41,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           virtualenvs-path: deployer/.venv
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
       - name: Install deployer
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: Load cached venv
+        id: cached-pip-cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: $(pip cache dir)
+          # CORRECT
+          # key: pipcache-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          # OLD
+          key: pipcache-${{ runner.os }}
+
       - name: Debug pip cache dir
         run: |
           pip cache dir
@@ -27,6 +37,9 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: deployer/.venv
+          # CORRECT
+          # key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          # OLD
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install Python poetry
@@ -40,11 +53,6 @@ jobs:
           cd deployer
           poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-
-      - name: Display Python & Poetry version
-        run: |
-          python --version
-          poetry --version
 
       - name: Lint Python code
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: $(pip cache dir)
-          # CORRECT
+          # CORRECTx
           # key: pipcache-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
-          # OLD
+          # OLDx
           key: pipcache-${{ runner.os }}
 
       - name: Debug pip cache dir

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       - name: Debug pip cache dir
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Cache pip
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+      # - name: Cache pip
+      #   uses: actions/cache@v2.1.6
+      #   with:
+      #     path: ~/.cache/pip
+      #     key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       # - name: Debug pip cache dir
       #   run: |
@@ -35,17 +35,23 @@ jobs:
           path: deployer/.venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
-      - name: Custom install Poetry
-        run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - -y --path deployer/.venv
-          poetry --version
+      - name: Load cached .local
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.local
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
-      # - name: Install Python poetry
-      #   uses: snok/install-poetry@v1.1.6
-      #   with:
-      #     virtualenvs-create: true
-      #     virtualenvs-in-project: true
-      #     # virtualenvs-path: deployer/.venv
+      # - name: Custom install Poetry
+      #   run: |
+      #     curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - -y --path deployer/.venv
+      #     poetry --version
+
+      - name: Install Python poetry
+        uses: snok/install-poetry@v1.1.6
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
       - name: Install deployer
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Debug poetry install
         run: |
           which poetry
+          cat `which poetry`
 
       - name: Lint Python code
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Custom install Poetry
         run: |
           curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - -y --path deployer/.venv
-          poetry version
+          poetry --version
 
       # - name: Install Python poetry
       #   uses: snok/install-poetry@v1.1.6

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -48,6 +48,10 @@ jobs:
           poetry install
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
+      - name: Debug poetry install
+        run: |
+          which poetry
+
       - name: Lint Python code
         run: |
           source deployer/.venv/bin/activate

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -23,10 +23,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: $(pip cache dir)
-          # CORRECTx
-          # key: pipcache-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
-          # OLDx
-          key: pipcache-${{ runner.os }}
+          key: pipcache-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       - name: Debug pip cache dir
         run: |
@@ -37,10 +34,7 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: deployer/.venv
-          # CORRECT
-          # key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
-          # OLD
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       - name: Install Python poetry
         uses: snok/install-poetry@v1.1.6

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -37,7 +37,6 @@ jobs:
 
       - name: Install Python poetry
         uses: snok/install-poetry@v1.1.6
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
@@ -56,12 +55,10 @@ jobs:
 
       - name: Basic run of deployer
         run: |
-          source deployer/.venv/bin/activate
           cd deployer
           poetry run deployer --help
 
       - name: Run deployer unit tests
         run: |
-          source deployer/.venv/bin/activate
           cd deployer
           poetry run pytest

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           which poetry
           cat `which poetry`
+          echo "POETRY_HOME??"
+          echo $POETRY_HOME
 
       - name: Lint Python code
         run: |

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           python-version: "3.8"
 
-      # - name: Cache pip
-      #   uses: actions/cache@v2.1.6
-      #   with:
-      #     path: ~/.cache/pip
-      #     key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+      - name: Cache pip
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
 
       # - name: Debug pip cache dir
       #   run: |
@@ -41,7 +41,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           virtualenvs-path: deployer/.venv
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
 
       - name: Install deployer
         run: |
@@ -57,7 +56,6 @@ jobs:
 
       - name: Basic run of deployer
         run: |
-          source deployer/.venv/bin/activate
           cd deployer
           poetry run deployer --help
 

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Custom install Poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
-          poetry --version
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python - -y --path deployer/.venv
+          poetry version
 
       # - name: Install Python poetry
       #   uses: snok/install-poetry@v1.1.6

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -56,10 +56,12 @@ jobs:
 
       - name: Basic run of deployer
         run: |
+          source deployer/.venv/bin/activate
           cd deployer
           poetry run deployer --help
 
       - name: Run deployer unit tests
         run: |
+          source deployer/.venv/bin/activate
           cd deployer
           poetry run pytest

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -9,7 +9,7 @@ this is the way we upload a new version of the site.
 Second, it is used to update and publish changes to existing AWS Lambda
 functions. For example, we use it to update and publish new versions of
 a Lambda function that we use to transform incoming document URL's into
-their corresponding S3 keys.
+their corresponding AWS S3 keys.
 
 ## Getting started
 

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -1,6 +1,6 @@
 # Deployer
 
-The Yari deployer does two things. First, it's used to upload document
+The Yari Deployer does two things. First, it's used to upload document
 redirects, pre-built document pages, static files (e.g. JS, CSS, and
 image files), and sitemap files into an existing AWS S3 bucket. Since
 we serve MDN document pages from an S3 bucket via a CloudFront CDN,
@@ -46,7 +46,7 @@ most likely what you'll want for uploads to the `mdn-content-stage` and
 bucket, the prefix is often used to specify a different folder for each
 variation of the site that is being reviewed/considered.
 
-When uploading files (not redirects), the deployer is intelligent about
+When uploading files (not redirects), the Deployer is intelligent about
 what it uploads. If only uploads files whose content has changed, skipping
 the rest. However, since the `cache-control` attribute of a file is not
 considered part of its content, if you'd like to change the `cache-control`

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -310,7 +310,7 @@ That should have installed the CLI:
 poetry run deployer
 ```
 
-If you wanna make a PR, make sure it's formatted with `black` and
+If you want to make a PR, make sure it's formatted with `black` and
 passes `flake8`.
 
 You can check that all files are `flake8` fine by running:

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -3,7 +3,7 @@
 The Yari Deployer does two things. First, it's used to upload document
 redirects, pre-built document pages, static files (e.g. JS, CSS, and
 image files), and sitemap files into an existing AWS S3 bucket. Since
-we serve MDN document pages from an AWS S3 bucket via a CloudFront CDN,
+we serve MDN document pages from an S3 bucket via a CloudFront CDN,
 this is the way we upload a new version of the site.
 
 Second, it is used to update and publish changes to existing AWS Lambda

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -3,7 +3,7 @@
 The Yari Deployer does two things. First, it's used to upload document
 redirects, pre-built document pages, static files (e.g. JS, CSS, and
 image files), and sitemap files into an existing AWS S3 bucket. Since
-we serve MDN document pages from an S3 bucket via a CloudFront CDN,
+we serve MDN document pages from an AWS S3 bucket via a CloudFront CDN,
 this is the way we upload a new version of the site.
 
 Second, it is used to update and publish changes to existing AWS Lambda

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -307,7 +307,7 @@ poetry install
 That should have installed the CLI:
 
 ```sh
-poetry run deployer
+poetry run deployer --help
 ```
 
 If you want to make a PR, make sure it's formatted with `black` and

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -9,7 +9,7 @@ this is the way we upload a new version of the site.
 Second, it is used to update and publish changes to existing AWS Lambda
 functions. For example, we use it to update and publish new versions of
 a Lambda function that we use to transform incoming document URL's into
-their corresponding AWS S3 keys.
+their corresponding S3 keys.
 
 ## Getting started
 

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -13,7 +13,7 @@ their corresponding AWS S3 keys.
 
 ## Getting started
 
-You can install it globally or in a virtualenv environment. Whichever you
+You can install it globally or in a `virtualenv` environment. Whichever you
 prefer.
 
 ```sh

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -28,7 +28,7 @@ with regards to configuring AWS access credentials.
 ## Uploads
 
 The `poetry run deployer upload DIRECTORY` command uploads files as well as redirects
-into an existing S3 bucket. Currently, we have three main S3 buckets that we
+into an existing S3 bucket. Currently, we have three S3 buckets that we
 upload into: `mdn-content-dev` (for variations or experimental versions of
 the site), `mdn-content-stage`, and `mdn-content-prod`.
 

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -1,4 +1,4 @@
-# Deployer
+# Deployer.
 
 The Yari Deployer does two things. First, it's used to upload document
 redirects, pre-built document pages, static files (e.g. JS, CSS, and

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -1,4 +1,4 @@
-# Deployer.
+# Deployer
 
 The Yari Deployer does two things. First, it's used to upload document
 redirects, pre-built document pages, static files (e.g. JS, CSS, and


### PR DESCRIPTION
See https://github.com/snok/install-poetry/issues/43#issuecomment-887529694 and https://www.peterbe.com/plog/install-python-poetry-github-actions-faster for the background. 

The context is that I want to make https://github.com/mdn/content/actions/workflows/pr-review-companion.yml much faster. Its slowest part is the installation of `poetry` itself. When a PR author has created a PR, it's a very cognitively high probability that that author wants quick feedback about their work. A) we want fast automated CI, and B) fast preview URLs. 