### PR TITLE
Update styling for code elements in sidebar to better handle overflowed content

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -38,6 +38,8 @@
 
   code {
     background-color: transparent;
+    white-space: normal;
+    word-wrap: normal;
   }
 
   summary {


### PR DESCRIPTION
Fixes #4326 
Related #4241 

To prevent sidebar text from overflowing into the `<main>` content, I changed the `white-space` and `word-wrap` properties from:

```scss
code {
  white-space: nowrap;
  word-wrap: break-word;
}
```

to

```scss
// overrides the above code {} styles in _code.scss
.sidebar code {
  whites-space: normal;
  word-wrap: normal;
}
```


https://user-images.githubusercontent.com/48612525/127099973-48de49ec-ba98-48ef-af15-539189233080.mov

With the already in place `hyphens` usage, this works nicely to fix the overflow problem and avoids the "odd" word-break placement where the final closing method parentheses wrapped to the next line which was happening with `word-wrap: break-word`.

cc @schalkneethling 