### PR TITLE
Update WebXR group data

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -2074,7 +2074,7 @@
     "WebXR Device API": {
       "overview": ["WebXR Device API"],
       "interfaces": [
-        "XR",
+        "XRSystem",
         "XRBoundedReferenceSpace",
         "XRFrame",
         "XRInputSource",
@@ -2097,7 +2097,7 @@
       "methods": ["WebGLRenderingContext.makeXRCompatible()"],
       "properties": ["Navigator.xr"],
       "events": [
-        "XR: devicechange",
+        "XRSystem: devicechange",
         "XRSession: end",
         "XRSession: inputsourceschange",
         "XRReferenceSpace: reset",
@@ -2105,27 +2105,7 @@
         "XRSession: selectend",
         "XRSession: selectstart",
         "XRSession: visibilitychange"
-      ],
-      "dictionaries": [
-        "XRInputSourcesChangeEventInit",
-        "XRInputSourceEventInit",
-        "XRReferencespaceEventInit",
-        "XRRenderStateInit",
-        "XRSessionEventInit",
-        "XRSessionInit",
-        "XRWebGLLayerInit"
-      ],
-      "types": [
-        "XREnvironmentBlendMode",
-        "XREye",
-        "XRHandedness",
-        "XRReferenceSpaceType",
-        "XRSessionMode",
-        "XRTargetRayMode",
-        "XRVisibilityState",
-        "XRWebGLRenderingContext"
-      ],
-      "callbacks": ["XRFrameRequestCallback"]
+      ]
     },
     "XDomain": {
       "interfaces": ["XDomainRequest"],

--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -2074,7 +2074,7 @@
     "WebXR Device API": {
       "overview": ["WebXR Device API"],
       "interfaces": [
-        "XRSystem",
+        "XRAnchor",
         "XRBoundedReferenceSpace",
         "XRFrame",
         "XRInputSource",
@@ -2089,6 +2089,7 @@
         "XRSession",
         "XRSessionEvent",
         "XRSpace",
+        "XRSystem",
         "XRView",
         "XRViewerPose",
         "XRViewport",


### PR DESCRIPTION
1. We don't document dictionaries, types, and callbacks on separate pages. I removed them here.
2. XR has been renamed to XRSystem