### PR TITLE
hide 'fix fixable flaws' button for now

### DIFF
--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -224,15 +224,27 @@ function Flaws({
   // the server in POSIX style and the `open-editor` program will make
   // this work for Windows automatically.
   const filePath = doc.source.folder + "/" + doc.source.filename;
+
   return (
     <div id="document-flaws">
-      {!!fixableFlaws.length && !isReadOnly && (
-        <FixableFlawsAction
-          count={fixableFlaws.length}
-          reloadPage={reloadPage}
-        />
-      )}
-
+      {!!fixableFlaws.length && !isReadOnly && fixableFlaws.length > 0 && (
+        <>
+          {doc.isMarkdown ? (
+            <small>
+              Automatic fixing fixable flaws not yet enabled for Markdown
+              documents. See{" "}
+              <a href="https://github.com/mdn/yari/issues/4333">
+                mdn/yari#4333
+              </a>
+            </small>
+          ) : (
+            <FixableFlawsAction
+              count={fixableFlaws.length}
+              reloadPage={reloadPage}
+            />
+          )}
+        </>
+      )}{" "}
       {flaws.map((flaw) => {
         switch (flaw.name) {
           case "broken_links":
@@ -360,9 +372,6 @@ function FixableFlawsAction({
     }
   }
 
-  if (!count) {
-    return null;
-  }
   return (
     <div>
       {fixingError && (

--- a/client/src/document/types.tsx
+++ b/client/src/document/types.tsx
@@ -137,4 +137,5 @@ export interface Doc {
   contributors: string[];
   isTranslated: boolean;
   isActive: boolean;
+  isMarkdown: boolean;
 }


### PR DESCRIPTION
Part of #4333
Part of #4392


Before:

<img width="982" alt="Screen Shot 2021-07-27 at 11 44 12 AM" src="https://user-images.githubusercontent.com/26739/127184882-7c1dfb8f-6cdf-41ee-a6ae-6010968e252a.png">

After:

<img width="1229" alt="Screen Shot 2021-07-27 at 11 40 21 AM" src="https://user-images.githubusercontent.com/26739/127184683-57020947-ccb7-48ff-9a3c-f605d2bd1955.png">


This is better than [getting cryptic 500 ISE from the server](https://github.com/mdn/translated-content/pull/1717).
...for now. 