### PR TITLE
fix: hide take survey cta if submitted

### DIFF
--- a/client/src/plus/deep-dives/article.tsx
+++ b/client/src/plus/deep-dives/article.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { SeriesCard, SerieData } from "./series-card";
@@ -24,12 +24,29 @@ const SERIES = [
 ];
 
 export default function Article({ slug }: { slug: string }) {
+  const SESSION_KEY = "market-research-survey-page";
+  const [showTakeSurveyButton, setShowTakeSurveyButton] = useState(true);
+
+  function getSessionStorageData(key: string) {
+    try {
+      return sessionStorage.getItem(key);
+    } catch (err) {
+      console.warn("Unable to get sessionStorage key");
+    }
+  }
+
   // Only when served via static Express does it force a trailing
   // slash to the end of the URL. So we have to, for testing reasons,
   // remove any trailing slashes.
   if (slug.endsWith("/")) {
     slug = slug.slice(0, -1);
   }
+
+  useEffect(() => {
+    if (getSessionStorageData(SESSION_KEY) === "success") {
+      setShowTakeSurveyButton(false);
+    }
+  }, [showTakeSurveyButton]);
 
   useEffect(() => {
     const serie = SERIES.find(
@@ -116,11 +133,13 @@ export default function Article({ slug }: { slug: string }) {
           )}
         </p>
       </div>
-      <div className="take-survey-mobile">
-        <a href="#survey-form" className="take-survey-link">
-          Take our survey
-        </a>
-      </div>
+      {showTakeSurveyButton && (
+        <div className="take-survey-mobile">
+          <a href="#survey-form" className="take-survey-link">
+            Take our survey
+          </a>
+        </div>
+      )}
     </>
   );
 }

--- a/client/src/plus/deep-dives/series-card/index.tsx
+++ b/client/src/plus/deep-dives/series-card/index.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import "./index.scss";
 
 export interface SerieData {
@@ -15,6 +17,23 @@ export function SeriesCard({
   titleLink: string;
   seriesList: SerieData[];
 }) {
+  const SESSION_KEY = "market-research-survey-page";
+  const [showTakeSurveyButton, setShowTakeSurveyButton] = React.useState(true);
+
+  function getSessionStorageData(key: string) {
+    try {
+      return sessionStorage.getItem(key);
+    } catch (err) {
+      console.warn("Unable to get sessionStorage key");
+    }
+  }
+
+  React.useEffect(() => {
+    if (getSessionStorageData(SESSION_KEY) === "success") {
+      setShowTakeSurveyButton(false);
+    }
+  }, [showTakeSurveyButton]);
+
   return (
     <section className="series-card" aria-labelledby="series-card-title">
       <p className="card-type">In this series</p>
@@ -34,11 +53,13 @@ export function SeriesCard({
           );
         })}
       </ul>
-      <p className="take-survey">
-        <a href="#survey-form" className="take-survey-link">
-          Take our survey
-        </a>
-      </p>
+      {showTakeSurveyButton && (
+        <p className="take-survey">
+          <a href="#survey-form" className="take-survey-link">
+            Take our survey
+          </a>
+        </p>
+      )}
     </section>
   );
 }

--- a/client/src/plus/deep-dives/survey/index.scss
+++ b/client/src/plus/deep-dives/survey/index.scss
@@ -77,8 +77,12 @@
   }
 
   .survey-success {
+    align-items: center;
+    display: flex;
     font-size: typography.$xl-font-size;
+    justify-content: center;
     line-height: 150%;
+    min-height: 250px;
     text-align: center;
   }
 


### PR DESCRIPTION
Do not show the take survey call to action once the survey has been submitted.
Add min-height to success container.

We can, and probably should, abstract this. But perhaps ok for now?