### PR TITLE
Redirect mozilla-teach-speakers

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1180,6 +1180,13 @@ const MISC_REDIRECT_PATTERNS = [
     prependLocale: false,
     permanent: false,
   }),
+  redirect(
+    /^communities\/mozilla-tech-speakers\/?$/i,
+    "https://community.mozilla.org/en/groups/tech-speakers/",
+    {
+      permanent: false,
+    }
+  ),
   localeRedirect(/^account\/?$/i, "/settings", {
     permanent: false,
   }),

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -990,6 +990,11 @@ MISC_REDIRECT_URLS = [
     url_test(
         "/en-US/events/", "https://community.mozilla.org/events/", status_code=302
     ),
+    url_test(
+        "/communities/mozilla-tech-speakers",
+        "https://community.mozilla.org/en/groups/tech-speakers",
+        status_code=302
+    ),
     url_test("/fr/account", "/fr/settings", status_code=302),
     url_test("/en-US/account", "/en-US/settings", status_code=302),
     url_test("/en-US/account/", "/en-US/settings", status_code=302),

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -1205,6 +1205,13 @@ const MISC_REDIRECT_URLS = [].concat(
   url_test("/en-US/events/", "https://community.mozilla.org/events/", {
     statusCode: 302,
   }),
+  url_test(
+    "/communities/mozilla-tech-speakers",
+    "https://community.mozilla.org/en/groups/tech-speakers/",
+    {
+      statusCode: 302,
+    }
+  ),
   url_test("/fr/account", "/fr/settings", { statusCode: 302 }),
   url_test("/en-US/account", "/en-US/settings", { statusCode: 302 }),
   url_test("/en-US/account/", "/en-US/settings", { statusCode: 302 }),


### PR DESCRIPTION
We have a [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1660250) request to redirect this slug to the new home of the tech-speakers website.