### PR TITLE
Markdown: relaxing the requirement for callouts to begin with an h4

### DIFF
--- a/markdown/h2m/handlers/cards.ts
+++ b/markdown/h2m/handlers/cards.ts
@@ -47,16 +47,11 @@ export const cards: QueryAndTransform[] = [
   [
     (node) =>
       node.tagName == "div" &&
-      ((node.properties.className as string[]) || "").includes("callout") &&
-      node.children[0].tagName == "h4",
+      ((node.properties.className as string[]) || "").includes("callout"),
     (node, t) =>
       h("blockquote", [
-        h("paragraph", [
-          h("strong", [h("text", "Callout:")]),
-          h("text", " "),
-          h("strong", [h("text", toText(node.children[0]))]),
-        ]),
-        ...asArray(t(node.children.slice(1) as any)),
+        h("paragraph", [h("strong", [h("text", "Callout:")]), h("text", " ")]),
+        ...asArray(t(node.children as any)),
       ]),
   ],
 ];

--- a/markdown/h2m/handlers/cards.ts
+++ b/markdown/h2m/handlers/cards.ts
@@ -50,7 +50,7 @@ export const cards: QueryAndTransform[] = [
       ((node.properties.className as string[]) || "").includes("callout"),
     (node, t) =>
       h("blockquote", [
-        h("paragraph", [h("strong", [h("text", "Callout:")]), h("text", " ")]),
+        h("paragraph", [h("strong", [h("text", "Callout:")])]),
         ...asArray(t(node.children as any)),
       ]),
   ],

--- a/markdown/m2h/handlers/index.js
+++ b/markdown/m2h/handlers/index.js
@@ -41,7 +41,7 @@ module.exports = {
     if (type) {
       const isCallout = type == "callout";
       if (isCallout) {
-        node.children[0].children.splice(0, 1);
+        node.children.splice(0, 1);
       }
       return h(
         node,


### PR DESCRIPTION
In Markdown we support "notes", "warnings", and "callouts", which are all little highlighted boxes containing content.

There are lots of details about this in here: https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#notes_warnings_and_callouts. The different between callouts and the other two is that notes and warnings must start with "**Note:**" or "**Warning:**", while callouts don't start with any fixed text, and people can write anything they like in there.

In the current callout implementation, the h2m tool requires that a callout starts with an H4 heading (for example, see the "Looking to become a front-end web developer?" bit in https://developer.mozilla.org/en-US/docs/Web/JavaScript). Having looked at some content I think this is too restrictive. For example, see "Download this example" in https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Media_objects - logically it makes sense for this to be a callout, but doesn't make sense for it to contain a heading.

So this change is supposed to relax that requirement.

Now if a `<div>` contains `class="callout"`, then h2m should write a blockquote, adding a first paragraph of `**Callout:**` followed by the contents of the `<div>`. Then on the other side, if a blockquote starts with `**Callout:**`, m2h removes that first paragraph and converts the rest.

Example HTML:

```html
<div class="callout">
<p>I'm just a paragrapgh containing a link: <a href="https://www.w3.org/TR/selectors/#overview">Selectors in the Selectors Level 4 specification</a>.</p>
</div>


<div class="callout">
<h4>I've got a heading</h4>
<p>Then a paragraph containing a link: <a href="https://www.w3.org/TR/selectors/#overview">Selectors in the Selectors Level 4 specification</a>.</p>
</div>


<div class="callout">
<p><strong>I'm strong</strong></p>
<h4>And I've got a heading</h4>

<p>Then a paragraph containing a link: <a href="https://www.w3.org/TR/selectors/#overview">Selectors in the Selectors Level 4 specification</a>.</p>
</div>

<div class="callout">
<p>I've just got some paragraphs</p>
<p><strong>I'm strong</strong></p>
<p>Then a paragraph containing a link: <a href="https://www.w3.org/TR/selectors/#overview">Selectors in the Selectors Level 4 specification</a>.</p>
</div>
```

Converts to this Markdown:

```

> **Callout:**
>
> I'm just a paragrapgh containing a link: [Selectors in the Selectors Level 4 specification](https://www.w3.org/TR/selectors/#overview).

> **Callout:**
>
> #### I've got a heading
>
> Then a paragraph containing a link: [Selectors in the Selectors Level 4 specification](https://www.w3.org/TR/selectors/#overview).

> **Callout:**
>
> **I'm strong**
>
> #### And I've got a heading
>
> Then a paragraph containing a link: [Selectors in the Selectors Level 4 specification](https://www.w3.org/TR/selectors/#overview).

> **Callout:**
>
> I've just got some paragraphs
>
> **I'm strong**
>
> Then a paragraph containing a link: [Selectors in the Selectors Level 4 specification](https://www.w3.org/TR/selectors/#overview).
```

...which renders like:

<img width="722" alt="Screen Shot 2021-07-29 at 3 08 32 PM" src="https://user-images.githubusercontent.com/432915/127572864-9bcbb3fb-0929-4862-a469-6966840ab3dc.png">
