### PR TITLE
h2m: support hidden class in code blocks

### DIFF
--- a/markdown/h2m/handlers/index.ts
+++ b/markdown/h2m/handlers/index.ts
@@ -230,6 +230,7 @@ export const handlers: QueryAndTransform[] = [
               "brush",
               "example-good",
               "example-bad",
+              "hidden",
               "no-line-numbers",
               "line-numbers",
               "notranslate",
@@ -250,7 +251,9 @@ export const handlers: QueryAndTransform[] = [
                 lang: lang.startsWith("example") ? "plain" : lang,
                 meta: asArray(node.properties.className)
                   .filter(
-                    (c) => typeof c == "string" && c.startsWith("example-")
+                    (c) =>
+                      typeof c == "string" &&
+                      (c.startsWith("example-") || c === "hidden")
                   )
                   .join(" "),
               }


### PR DESCRIPTION
Fixes https://github.com/mdn/yari/issues/4308.

I think adding "hidden" to `canHaveClass` means h2m will treat this as convertible, and the change in `filter` will make it actually write the hidden class into the GFM info string.

It might be better to change the conditional in `filter` to look in a list of allowed classnames, but I wasn't sure where I ought to put that. So I just extended the conditional.

I don't know what the array of classnames at lines 209-220 is doing.

With this change, something like this: https://github.com/mdn/content/blob/609ec8e90205f8db69e6755287de11448828f0cb/files/en-us/web/css/background-blend-mode/index.html#L62-L80

...will give us Markdown like this:

```
\```
html hidden
<div id="div"></div>
<select id="select">
    <option>normal</option>
    <option>multiply</option>
    <option selected>screen</option>
    <option>overlay</option>
    <option>darken</option>
    <option>lighten</option>
    <option>color-dodge</option>
    <option>color-burn</option>
    <option>hard-light</option>
    <option>soft-light</option>
    <option>difference</option>
    <option>exclusion</option>
    <option>hue</option>
    <option>saturation</option>
    <option>color</option>
    <option>luminosity</option>
</select>
\```
```

...and the code blocks are hidden properly in the rendered page.
