### PR TITLE
delete InterfaceOverview.ejs now

### DIFF
--- a/kumascript/macros/InterfaceOverview.ejs
+++ b/kumascript/macros/InterfaceOverview.ejs
@@ -1,8 +1,0 @@
-<%
-// The InterfaceOverview macro is considered deprecated.
-// As of today, Aug 2021, no content in the en-US repo uses it.
-// The few translated-content files that were using it were buggy as
-// no output is displayed and we decided it wasn't worth even trying 
-// to recover that because no content should be using it anyway.
-mdn.deprecated();
-%>


### PR DESCRIPTION
Now that it's not used anywhere in mdn/content or mdn/translated-content. 
@teoli2003 r? 
