### PR TITLE
Make git ops work for h2m replace when targeting translated-content

### DIFF
--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -7,6 +7,7 @@ import { Document } from "../content";
 import { saveFile } from "../content/document";
 import { VALID_LOCALES } from "../libs/constants";
 import { execGit } from "../content";
+import { getRoot } from "../content/utils";
 
 import { h2m } from "./h2m";
 const { prettyAST } = require("./utils");
@@ -179,11 +180,16 @@ program
 
           if (options.mode == "replace" || options.mode == "keep") {
             if (options.mode == "replace") {
-              execGit([
-                "mv",
-                doc.fileInfo.path,
-                doc.fileInfo.path.replace(/\.html$/, ".md"),
-              ]);
+              const gitRoot = getRoot(options.locale);
+              execGit(
+                [
+                  "mv",
+                  doc.fileInfo.path,
+                  doc.fileInfo.path.replace(/\.html$/, ".md"),
+                ],
+                {},
+                gitRoot
+              );
             }
             saveFile(
               doc.fileInfo.path.replace(/\.html$/, ".md"),


### PR DESCRIPTION
Git was complaining my local mdn/translated-content was out of the git repo when I ran `yarn md h2m web/javascript --locale fr --mode replace`.
In other words, I needed this (and  https://github.com/mdn/yari/pull/4251) for https://github.com/mdn/translated-content/pull/1835

The fix uses an existing utils fonction :)


