### PR TITLE
Remove no-more-documented mixins on InterfaceData

### DIFF
--- a/kumascript/macros/InterfaceData.json
+++ b/kumascript/macros/InterfaceData.json
@@ -2229,11 +2229,6 @@
       "impl": [
         "GlobalEventHandlers",
         "WindowEventHandlers",
-        "GlobalCrypto",
-        "SpeechSynthesisGetter",
-        "WindowModal",
-        "OnErrorEventHandlerForWindow",
-        "ChromeWindow",
         "WindowOrWorkerGlobalScope"
       ]
     },


### PR DESCRIPTION
These mixins have been either removed from spec or from MDN. 

They lead to 5 flaws in each and every Window.* pages! (and there are a lot of them!)

cc/ @Elchi3 for the review from content.

(Removal of GlobalCrypto from spec: https://github.com/w3c/webcrypto/pull/200 ) 