### PR TITLE
Remove limitation of 20 displayed unhandled elements to h2m conversion report

### DIFF
--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -36,7 +36,7 @@ function saveProblemsReport(problems: Map<any, any>) {
   const report = [
     `# Report from ${now.toLocaleString()}`,
 
-    "## Top 20 unhandled elements",
+    "## All unhandled elements",
     ...Array.from(
       Array.from(problems)
         .flatMap(([, { invalid, unhandled }]) => [
@@ -50,7 +50,6 @@ function saveProblemsReport(problems: Map<any, any>) {
         )
     )
       .sort(([, c1], [, c2]) => (c1 > c2 ? -1 : 1))
-      .slice(0, 20)
       .map(([label, count]) => `- ${label} (${count})`),
 
     "## Details per Document",


### PR DESCRIPTION
As mentioned with @wbamberg a few times, it's useful not to have a limit at 20 in order to display unhandled elements. As a matter of facts, there are likely several "one-offs" (e.g. for French, after a first pass I still had 15 w/ a single occurrence)

This short PR removes this limitation.
@wbamberg let me know if this does not work for you.