### PR TITLE
fix: new globe icon alignment

### DIFF
--- a/client/src/ui/molecules/language-toggle/index.scss
+++ b/client/src/ui/molecules/language-toggle/index.scss
@@ -44,9 +44,10 @@ ul.language-toggle {
         no-repeat;
       content: "";
       display: inline-block;
-      height: 29px;
+      height: 25px;
+      margin-right: math.div($base-spacing, 4);
       vertical-align: middle;
-      width: 28px;
+      width: 24px;
     }
 
     &::after {


### PR DESCRIPTION
Address the alignment, spacing, and size of the new globe icon.

## Before

![Screenshot 2021-08-03 at 11 34 11](https://user-images.githubusercontent.com/10350960/127993789-76f65319-fd36-44c0-9650-2132709f688e.png)


## After

![Screenshot 2021-08-03 at 11 33 59](https://user-images.githubusercontent.com/10350960/127993816-41803c1d-946b-49aa-b697-48c053affd59.png)


fix #4396
