### PR TITLE
Replaces all pre-existing h4 tags in notecards with <strong>

### DIFF
--- a/build/format-notecards.js
+++ b/build/format-notecards.js
@@ -1,21 +1,14 @@
+// Remove h4s from any existing notecards and transform them
+// from <div class="note notecard"><h4>Note:</h4>foobar</div> to
+// <div class="note notecard"><p><strong>Note:</strong>foobar</p></div>
 function formatNotecards($) {
-  $(".note.notecard").each(() => {
-    const $h4 = $("h4");
-    const id = $h4.attr("id");
-    const $p = $("p");
-    const $replacer = $(`<strong>${$h4.text()}:</strong>`);
-
-    if ($h4.length) {
-      $h4.empty();
-      $h4.replaceWith($replacer);
-      $p.prepend($replacer);
-      // if the h4 has id="note" add it as <strong id="note">
-      if (id === "note") {
-        $replacer.attr("id", id);
-      }
-    }
-
-    return;
+  $(".note.notecard h4").each((_, element) => {
+    const h4 = $(element);
+    const text = h4.text();
+    const p = $("p:first", h4.parents("div.notecard"));
+    p.html(`<strong>${text}:</strong> ${p.html()}`);
+    h4.empty();
+    h4.remove();
   });
 }
 

--- a/build/format-notecards.js
+++ b/build/format-notecards.js
@@ -2,12 +2,11 @@
 // from <div class="note notecard"><h4>Note:</h4>foobar</div> to
 // <div class="note notecard"><p><strong>Note:</strong>foobar</p></div>
 function formatNotecards($) {
-  $(".note.notecard h4").each((_, element) => {
+  $("div.notecard h4").each((_, element) => {
     const h4 = $(element);
     const text = h4.text();
     const p = $("p:first", h4.parents("div.notecard"));
     p.html(`<strong>${text}:</strong> ${p.html()}`);
-    h4.empty();
     h4.remove();
   });
 }

--- a/build/format-notecards.js
+++ b/build/format-notecards.js
@@ -1,0 +1,22 @@
+function formatNotecards($) {
+  $(".note.notecard").each(() => {
+    const $h4 = $("h4");
+    const id = $h4.attr("id");
+    const $p = $("p");
+    const $replacer = $(`<strong>${$h4.text()}:</strong>`);
+
+    if ($h4.length) {
+      $h4.empty();
+      $h4.replaceWith($replacer);
+      $p.prepend($replacer);
+      // if the h4 has id="note" add it as <strong id="note">
+      if (id === "note") {
+        $replacer.attr("id", id);
+      }
+    }
+
+    return;
+  });
+}
+
+module.exports = { formatNotecards };

--- a/build/format-notecards.js
+++ b/build/format-notecards.js
@@ -11,7 +11,7 @@ function formatNotecards($) {
     // Return filtered collection of elements that are
     // text nodes and remove the node while were at it,
     // also trimming away any leading/trailing space
-    var textNodes = div
+    const textNodes = div
       .contents()
       .filter((_, element) => {
         return element.nodeType === 3;

--- a/build/format-notecards.js
+++ b/build/format-notecards.js
@@ -5,8 +5,28 @@ function formatNotecards($) {
   $("div.notecard h4").each((_, element) => {
     const h4 = $(element);
     const text = h4.text();
-    const p = $("p:first", h4.parents("div.notecard"));
-    p.html(`<strong>${text}:</strong> ${p.html()}`);
+    const div = h4.parent("div.notecard");
+    const p = $("p:first", div);
+
+    // Return filtered collection of elements that are
+    // text nodes and remove the node while were at it,
+    // also trimming away any leading/trailing space
+    var textNodes = div
+      .contents()
+      .filter((_, element) => {
+        return element.nodeType === 3;
+      })
+      .remove()
+      .text()
+      .trim();
+
+    if (!textNodes.length) {
+      p.html(`<strong>${text}:</strong> ${p.html()}`);
+    } else {
+      div.append(`<p>${p.html()}</p>`);
+      p.html(`<strong>${text}:</strong> ${textNodes}`);
+    }
+
     h4.remove();
   });
 }

--- a/build/index.js
+++ b/build/index.js
@@ -547,9 +547,6 @@ async function buildDocument(document, documentOptions = {}) {
   // raw HTML has been fixed to always have it in there already.
   injectNotecardOnWarnings($);
 
-  // Remove h4s from any existing notecards and transform them
-  // from <div class="note notecard"><h4>Note:</h4>foobar</div> to
-  // <div class="note notecard"><p><strong>Note:</strong>foobar</p></div>
   formatNotecards($);
 
   // Turn the $ instance into an array of section blocks. Most of the

--- a/build/index.js
+++ b/build/index.js
@@ -26,6 +26,7 @@ const { normalizeBCDURLs, extractBCDData } = require("./bcd-urls");
 const { checkImageReferences, checkImageWidths } = require("./check-images");
 const { getPageTitle } = require("./page-title");
 const { syntaxHighlight } = require("./syntax-highlight");
+const { formatNotecards } = require("./format-notecards");
 const buildOptions = require("./build-options");
 const { gather: gatherGitHistory } = require("./git-history");
 const { buildSPAs } = require("./spas");
@@ -545,6 +546,11 @@ async function buildDocument(document, documentOptions = {}) {
   // We might want to delete this injection in 2021 some time when all content's
   // raw HTML has been fixed to always have it in there already.
   injectNotecardOnWarnings($);
+
+  // Remove h4s from any existing notecards and transform them
+  // from <div class="note notecard"><h4>Note:</h4>foobar</div> to
+  // <div class="note notecard"><p><strong>Note:</strong>foobar</p></div>
+  formatNotecards($);
 
   // Turn the $ instance into an array of section blocks. Most of the
   // section blocks are of type "prose" and their value is a string blob

--- a/client/src/document/molecules/_notecards.scss
+++ b/client/src/document/molecules/_notecards.scss
@@ -8,7 +8,6 @@
 @mixin set-notecard-icon($icon) {
   h3,
   h4,
-  strong,
   &.inline {
     &::before {
       background: transparent url($icon) 0 0 no-repeat;
@@ -18,8 +17,7 @@
 
 @mixin set-notecard-icon-only($icon) {
   h3,
-  h4,
-  strong {
+  h4 {
     &::before {
       background-image: url($icon);
     }
@@ -46,8 +44,7 @@
   }
 
   h3,
-  h4,
-  #note {
+  h4 {
     /* 
      * Because we also allow h3, we need to undo some of its styling here.
      * This relates specifically to `background-color`, `color`, 
@@ -70,7 +67,6 @@
 
   h3,
   h4,
-  #note,
   &.inline {
     &::before {
       background-repeat: no-repeat;
@@ -83,12 +79,6 @@
       top: 2px;
       width: 20px;
     }
-  }
-
-  /* Mimic an <h4> block-level context for <strong> 
-  tags with <h4 id="note"> otherwise leave them alone */
-  #note {
-    display: block;
   }
 
   p {

--- a/client/src/document/molecules/_notecards.scss
+++ b/client/src/document/molecules/_notecards.scss
@@ -8,6 +8,7 @@
 @mixin set-notecard-icon($icon) {
   h3,
   h4,
+  strong,
   &.inline {
     &::before {
       background: transparent url($icon) 0 0 no-repeat;
@@ -17,7 +18,8 @@
 
 @mixin set-notecard-icon-only($icon) {
   h3,
-  h4 {
+  h4,
+  strong {
     &::before {
       background-image: url($icon);
     }
@@ -44,7 +46,8 @@
   }
 
   h3,
-  h4 {
+  h4,
+  #note {
     /* 
      * Because we also allow h3, we need to undo some of its styling here.
      * This relates specifically to `background-color`, `color`, 
@@ -67,6 +70,7 @@
 
   h3,
   h4,
+  #note,
   &.inline {
     &::before {
       background-repeat: no-repeat;
@@ -79,6 +83,12 @@
       top: 2px;
       width: 20px;
     }
+  }
+
+  /* Mimic an <h4> block-level context for <strong> 
+  tags with <h4 id="note"> otherwise leave them alone */
+  #note {
+    display: block;
   }
 
   p {

--- a/testing/content/files/en-us/web/check_notecards/index.html
+++ b/testing/content/files/en-us/web/check_notecards/index.html
@@ -1,0 +1,25 @@
+---
+title: 'A page representing some edge cases of div.notecard that we might encounter'
+slug: Web/Check_notecards
+---
+
+<p>This page exists to test the formatNotecards utility for transforming notecards from h4 to strong</p>
+
+<div class="notecard note">
+  <h4>Some heading</h4>
+  No paragraph here.
+  <p>Paragraph 2</p>
+</div>
+
+<div class="notecard warning">
+  <h4>Some heading</h4>
+  <p>Paragraph 1</p>
+  <p>Paragraph 2</p>
+</div>
+
+<div class="notecard extra">
+  <h4>Some heading</h4>
+  <p>Paragraph 1</p>
+  <span>Foo bar</span>
+  <p>Paragraph 2</p>
+</div>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1687,7 +1687,7 @@ test("translated content broken links can fall back to en-us", () => {
   );
 });
 
-test("notecards are being transformed by formatNotecards correctly", () => {
+test("notecards are correctly transformed by the formatNotecards utility", () => {
   const builtFolder = path.join(
     buildRoot,
     "en-us",
@@ -1707,13 +1707,10 @@ test("notecards are being transformed by formatNotecards correctly", () => {
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
 
-  // There shouldnt be any div.notecard h4 elements
   expect($("div.notecard h4").length).toBe(0);
-  // when a h4 has its immediate adjacent sibiling as a text node
   expect($("div.notecard.note").html()).toBe(
     "<p><strong>Some heading:</strong> No paragraph here.</p><p>Paragraph 2</p>"
   );
-  // when a h4's immediate adjacent sibling is a <p> tag
   expect($("div.notecard.warning").html()).toBe(
     "<p><strong>Some heading:</strong> Paragraph 1</p><p>Paragraph 2</p>"
   );

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1698,7 +1698,7 @@ test("notecards are correctly transformed by the formatNotecards utility", () =>
 
   const jsonFile = path.join(builtFolder, "index.json");
   const { doc } = JSON.parse(fs.readFileSync(jsonFile));
-  expect(doc.flaws.length).toBe(undefined);
+  expect(doc.flaws.length).toBeFalsy();
   expect(doc.title).toBe(
     "A page representing some edge cases of div.notecard that we might encounter"
   );

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1687,6 +1687,41 @@ test("translated content broken links can fall back to en-us", () => {
   );
 });
 
+test("notecards are being transformed by formatNotecards correctly", () => {
+  const builtFolder = path.join(
+    buildRoot,
+    "en-us",
+    "docs",
+    "web",
+    "check_notecards"
+  );
+
+  const jsonFile = path.join(builtFolder, "index.json");
+  const { doc } = JSON.parse(fs.readFileSync(jsonFile));
+  expect(doc.flaws.length).toBe(undefined);
+  expect(doc.title).toBe(
+    "A page representing some edge cases of div.notecard that we might encounter"
+  );
+
+  const htmlFile = path.join(builtFolder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+  const $ = cheerio.load(html);
+
+  // There shouldnt be any div.notecard h4 elements
+  expect($("div.notecard h4").length).toBe(0);
+  // when a h4 has its immediate adjacent sibiling as a text node
+  expect($("div.notecard.note").html()).toBe(
+    "<p><strong>Some heading:</strong> No paragraph here.</p><p>Paragraph 2</p>"
+  );
+  // when a h4's immediate adjacent sibling is a <p> tag
+  expect($("div.notecard.warning").html()).toBe(
+    "<p><strong>Some heading:</strong> Paragraph 1</p><p>Paragraph 2</p>"
+  );
+  expect($("div.notecard.extra").html()).toBe(
+    "<p><strong>Some heading:</strong> Paragraph 1</p><span>Foo bar</span><p>Paragraph 2</p>"
+  );
+});
+
 test("homepage links and flaws", () => {
   const builtFolder = path.join(
     buildRoot,


### PR DESCRIPTION
Fixes #4394

Replaces h4s for notecards that have it, otherwise leaves them be.

Page in screenshot: http://localhost:3000/en-US/docs/Glossary/HTML5

<img width="1267" alt="Screen Shot 2021-08-04 at 1 01 35 AM" src="https://user-images.githubusercontent.com/48612525/128144671-f659a2ea-74ee-4a89-b709-d89010169389.png">

