### PR TITLE
remove link rewrites for fxsitecompat.com

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -485,21 +485,6 @@ async function buildDocument(document, documentOptions = {}) {
     throw error;
   }
 
-  // Some hyperlinks are not easily fixable and we should never include them
-  // because they're potentially evil.
-  $("a[href]").each((i, a) => {
-    // See https://github.com/mdn/kuma/issues/7647
-    // Ideally we should manually remove this from all sources
-    // but that's not immediately feasible. So at least make sure we never
-    // present the link in any rendered HTML.
-    if (
-      a.attribs.href.startsWith("http") &&
-      a.attribs.href.includes("fxsitecompat.com")
-    ) {
-      $(a).attr("href", "https://github.com/mdn/kuma/issues/7647");
-    }
-  });
-
   // If fixFlaws is on and the doc has fixable flaws, this returned
   // raw HTML string will be different.
   try {


### PR DESCRIPTION
As of https://github.com/mdn/content/pull/7591 there's no more links to `fxsitecompat.com` or `fxsitecompat.dev` in any of the mdn/content. 
There's still some in the translated-content. See https://github.com/mdn/translated-content/issues/1634
But even if we allow some of them in the translated content, it's no longer horrible because the new domain is a redirect to a URLs that will always respond with `410 Gone`. It used to be worse. It used to redirect to a domain squatters site with "seedy" banner ads. 

So I think we can finally delete this added complexity, once [the content updates](https://github.com/mdn/content/pull/7591) and it'll make the build marginally faster. 