### PR TITLE
Esc should just hide the search results, not blur

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -388,7 +388,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           onBlur: () => onChangeIsFocused(false),
           onKeyDown(event) {
             if (event.key === "Escape" && inputRef.current) {
-              inputRef.current.blur();
+              toggleMenu();
             } else if (
               event.key === "Enter" &&
               inputValue.trim() &&


### PR DESCRIPTION
Part of #4407

To test:

1. Type something in the search so you see results
2. Press <kbd>Esc</kbd>

What it used to do: Blur the whole input field

What it should do: just hide the search results