### PR TITLE
Check all external urls in analyze pr

### DIFF
--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -233,6 +233,13 @@ def upload(ctx, directory: Path, **kwargs):
     is_flag=True,
 )
 @click.option(
+    "--check-external-links",
+    help="HTTP get each external link",
+    default=False,
+    show_default=True,
+    is_flag=True,
+)
+@click.option(
     "--diff-file",
     help=(
         "The path to the file that is a diff output. "

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -13,6 +13,7 @@ DEFAULT_CONFIG = {
     "prefix": None,
     "analyze_flaws": False,
     "analyze_dangerous_content": False,
+    "check_external_links": False,
     "repo": "mdn/content",
     "pr_number": None,
     "dry_run": False,

--- a/deployer/src/deployer/urlchecker.py
+++ b/deployer/src/deployer/urlchecker.py
@@ -1,0 +1,76 @@
+import concurrent.futures
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def requests_retry_session(
+    retries=3,
+    backoff_factor=0.3,
+    status_forcelist=(500, 502, 504),
+):
+    """Opinionated wrapper that creates a requests session with a
+    HTTPAdapter that sets up a Retry policy that includes connection
+    retries.
+
+    If you do the more naive retry by simply setting a number. E.g.::
+
+        adapter = HTTPAdapter(max_retries=3)
+
+    then it will raise immediately on any connection errors.
+    Retrying on connection errors guards better on unpredictable networks.
+    From http://docs.python-requests.org/en/master/api/?highlight=retries#requests.adapters.HTTPAdapter
+    it says: "By default, Requests does not retry failed connections."
+
+    The backoff_factor is documented here:
+    https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry
+    A default of retries=3 and backoff_factor=0.3 means it will sleep like::
+
+        [0.3, 0.6, 1.2]
+    """  # noqa
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+def check_urls(urls, verbose=False):
+    session = requests_retry_session(
+        backoff_factor=0.1,
+        retries=2,
+    )
+    results = {}
+    futures = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for url in urls:
+            futures[executor.submit(check_url, url, session, verbose)] = url
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            results[futures[future]] = result
+    return results
+
+
+operational_errors = (requests.exceptions.SSLError,)
+
+
+def check_url(url, session, verbose=False):
+    try:
+        response = session.get(url)
+        if verbose:
+            print(f"Checked {url:<100} => {response.status_code}")
+        return {
+            "status_code": response.status_code,
+        }
+    except operational_errors as error:
+        if verbose:
+            print(f"Checked {url:<100} =!> {error}")
+        return {"error": error}

--- a/deployer/src/deployer/urlchecker.py
+++ b/deployer/src/deployer/urlchecker.py
@@ -59,7 +59,13 @@ def check_urls(urls, verbose=False):
     return results
 
 
-operational_errors = (requests.exceptions.SSLError,)
+operational_errors = (
+    requests.exceptions.SSLError,
+    requests.exceptions.ReadTimeout,
+    requests.exceptions.ConnectionError,
+    requests.exceptions.RetryError,
+    requests.exceptions.TooManyRedirects,
+)
 
 
 def check_url(url, session, verbose=False):


### PR DESCRIPTION
I created https://github.com/mdn/content/pull/7620 to make a `build.zip` that has some built HTML that has a lot of external links. Then I tested this new code and it would have posted this:

<img width="896" alt="Screen Shot 2021-08-05 at 10 29 38 AM" src="https://user-images.githubusercontent.com/26739/128367576-6bd5dcb6-4f63-4f96-a333-6bdce78bc934.png">

The algorithm is pretty simple:

1. Find all `a[href]` that appears to be external
2. For each one, try to `requests.get()` open it, with a retry mechanism
3. If an "operational error" happens, record that instead of the `status_code`
4. Otherwise, record the `status_code` for each URL
5. When all the results are in, only mention those who got an `error` or a `status_code != 200`

