### PR TITLE
Unbreak inheritance diagrams (InheritanceDiagram.ejs)

### DIFF
--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -80,7 +80,7 @@ var viewbox = 'viewbox="-'+ offset + ' 0 '+ width + ' ' + height +'"';
 if (rtl) {
   viewbox = 'viewbox="510 0 '+ width + ' ' + height +'" transform="scale(-1 1)"';
 }
-result = '<div id="interfaceDiagram" style="display: inline-block; position: relative; padding-bottom: '+ padding +'%; vertical-align: middle; overflow: hidden;">' +
+result = '<div id="interfaceDiagram" style="display: inline-block; position: relative; width: 100%; padding-bottom: '+ padding +'%; vertical-align: middle; overflow: hidden;">' +
              '<svg style="display: inline-block; position: absolute; top: 0; left: 0;" '+ viewbox +' preserveAspectRatio="xMinYMin meet">';
 
 for (var i = 0; i < inheritanceChain.length; i++) {


### PR DESCRIPTION
https://github.com/mdn/yari/commit/00dc256 (https://github.com/mdn/yari/pull/4211) broke all inheritance diagrams, because it mistakenly removed the `width: 100%` CSS property on the `div` element Yari generates for inheritance diagrams (that change/PR was meant to just change `iframe` elements, and should not have touched the `div` element in `InheritanceDiagram.ejs`.

So this change reverts the part of https://github.com/mdn/yari/commit/00dc256 that changed `InheritanceDiagram.ejs`

Fixes https://github.com/mdn/content/issues/7700