### PR TITLE
Ability to define sampleId in different languages. fix EmbedLiveSample macros.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -31,6 +31,7 @@ const { gather: gatherGitHistory } = require("./git-history");
 const { buildSPAs } = require("./spas");
 const { renderCache: renderKumascriptCache } = require("../kumascript");
 const LANGUAGES_RAW = require("../content/languages.json");
+const { safeDecodeURIComponent } = require("../kumascript/src/api/util");
 
 const LANGUAGES = new Map(
   Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
@@ -630,7 +631,7 @@ async function buildLiveSamplePageFromURL(url) {
     document.metadata.slug,
     document.rawBody
   )) {
-    if (sampleIDObject.id.toLowerCase() === sampleID) {
+    if (sampleIDObject.id.toLowerCase() === safeDecodeURIComponent(sampleID)) {
       const liveSamplePage = kumascript.buildLiveSamplePage(
         document.url,
         document.metadata.title,


### PR DESCRIPTION
resolves #4436 – has detailed description

Now it's possible to use other than `en` language for the EmbedLiveSample `smapleId`. Tested with:
```
<div>{{EmbedLiveSample('Пример_на_русском', 500, 300)}}</div>
```

UPD: Was added as part of other PR https://github.com/Gregoor/yari/commit/c1db1d2c0babd2c4e4e8a4a33585f8272eddc756  from my review https://github.com/mdn/yari/pull/3973#pullrequestreview-726148274 
