### PR TITLE
Support svg syntax highlighting

### DIFF
--- a/markdown/h2m/handlers/index.ts
+++ b/markdown/h2m/handlers/index.ts
@@ -211,6 +211,7 @@ export const handlers: QueryAndTransform[] = [
     "html",
     "css",
     "json",
+    "svg",
     "plain",
     "cpp",
     "java",


### PR DESCRIPTION
We support syntax highlighting for SVG when code blocks have the classes `"brush: svg"`. See for example https://developer.mozilla.org/en-US/docs/Web/CSS/filter#brightness.

Because this isn't documented (https://developer.mozilla.org/en-US/docs/MDN/Guidelines/CSS_style_guide#code_syntax_highlighting), it never made it into the converter, so the converter treats code blocks with an `"svg"` class as unconvertible.

This change just tells the converter about this class, so it will be accepted and written into the GFM info string like any other language identifier.
