### PR TITLE
Add sidebar for WebHID API

### DIFF
--- a/kumascript/macros/GroupData.json
+++ b/kumascript/macros/GroupData.json
@@ -1773,6 +1773,18 @@
         "HTMLCanvasElement: webglcontextcreationerror"
       ]
     },
+    "WebHID API": {
+      "overview": ["WebHID API"],
+      "interfaces": [
+        "HID",
+        "HIDDevice",
+        "HIDInputReportEvent",
+        "HIDConnectionEvent"
+      ],
+      "methods": [],
+      "properties": ["Navigator.hid"],
+      "events": []
+    },
     "Web MIDI API": {
       "overview": ["Web MIDI API"],
       "interfaces": [


### PR DESCRIPTION
_WebHID API_ has no proper sidebar, although it calls the sidebar macro. In addition, this API doesn't appear in the [API list](https://developer.mozilla.org/en-US/docs/Web/API).

The reason for these flaws is that it doesn't have an entry in `GroupData.json`.

This PR fixes this.

cc/ @rachelandrew for a review from the content point-of-view.