### PR TITLE
Specify folder that contains whitespace

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const util = require("util");
 
 const fm = require("front-matter");
 const glob = require("glob");
@@ -220,7 +221,11 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
   }
 
   if (filePath.includes(" ")) {
-    throw new Error("Folder contains whitespace which is not allowed.");
+    throw new Error(
+      `Folder contains whitespace which is not allowed (${util.inspect(
+        filePath
+      )})`
+    );
   }
   if (filePath.includes("\u200b")) {
     throw new Error(


### PR DESCRIPTION
Fixes #4453

I renamed a folder to have a space in it. Now...
```
▶ BUILD_FOLDERSEARCH=webassembly/exist yarn build
yarn run v1.22.10
$ cross-env NODE_ENV=production node build/cli.js
CONTENT_ROOT:            /Users/peterbe/dev/MOZILLA/MDN/content/files
CONTENT_TRANSLATED_ROOT: not set
Error: Folder contains whitespace which is not allowed ('/Users/peterbe/dev/MOZILLA/MDN/content/files/en-us/webassembly/existing c to wasm/index.html')
```
