### PR TITLE
tighten typescript types on constants

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,10 +1,12 @@
-export const DISABLE_AUTH = JSON.parse(
-  process.env.REACT_APP_DISABLE_AUTH || "false"
+export const DISABLE_AUTH = Boolean(
+  JSON.parse(process.env.REACT_APP_DISABLE_AUTH || "false")
 );
 
-export const CRUD_MODE = JSON.parse(
-  process.env.REACT_APP_CRUD_MODE ||
-    JSON.stringify(process.env.NODE_ENV === "development")
+export const CRUD_MODE = Boolean(
+  JSON.parse(
+    process.env.REACT_APP_CRUD_MODE ||
+      JSON.stringify(process.env.NODE_ENV === "development")
+  )
 );
 
 export const CRUD_MODE_HOSTNAMES = (
@@ -34,9 +36,11 @@ export const VALID_LOCALES = new Set([
   "zh-TW",
 ]);
 
-export const ENABLE_PLUS = JSON.parse(
-  process.env.REACT_APP_ENABLE_PLUS ||
-    JSON.stringify(process.env.NODE_ENV === "development")
+export const ENABLE_PLUS = Boolean(
+  JSON.parse(
+    process.env.REACT_APP_ENABLE_PLUS ||
+      JSON.stringify(process.env.NODE_ENV === "development")
+  )
 );
 
 export const DEFAULT_GEO_COUNTRY =


### PR DESCRIPTION
TypeScript is smart but it can't predict the many return types of `JSON.parse()`. E.g. `JSON.parse('true') === true`.
But by using `Boolean()` around these, it means that it doesn't matter so much what the env var strings were. For example:
```js
Boolean(JSON.parse('1')) === true
```
By the way, by doing this, these variables now have a known type signature throughout where they're used which is quite a lot of places. 


