### PR TITLE
Add missing parent element for sidebar item

### DIFF
--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -171,7 +171,9 @@ var text = mdn.localStringMap({
   <li class="toggle">
     <details <%=state('Useful_lists')%>>
       <summary><%=text['Useful_lists']%></summary>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Index"><%=text['Index']%></a></li>
+      <ol>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Index"><%=text['Index']%></a></li>
+      </ol>
     </details>
   </li>
   <li class="toggle">


### PR DESCRIPTION
without, has a slightly weird alignment to other sidebar items

before:

<img width="1903" alt="Screen Shot 2021-08-17 at 6 52 27 am" src="https://user-images.githubusercontent.com/351763/129628142-3e3e76d1-a003-47da-bc9d-aea391b74e0b.png">

after:

<img width="1903" alt="Screen Shot 2021-08-17 at 6 52 31 am" src="https://user-images.githubusercontent.com/351763/129628173-950fb618-2725-4a9e-a640-ad3414943e5f.png">
