### PR TITLE
Display error rather than generate flaw for {{CSSSyntax}}

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const util = require("util");
 
 const fm = require("front-matter");
 const glob = require("glob");
@@ -220,7 +221,11 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
   }
 
   if (filePath.includes(" ")) {
-    throw new Error("Folder contains whitespace which is not allowed.");
+    throw new Error(
+      `Folder contains whitespace which is not allowed (${util.inspect(
+        filePath
+      )})`
+    );
   }
   if (filePath.includes("\u200b")) {
     throw new Error(

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -430,12 +430,11 @@ if (name === "preview-wiki-content") {
 }
 
 if (!formattedSyntax) {
-  formattedSyntax = "<span style=\"color:red;\">" +
-    `No syntax found in DB for '${name}'` + "</span>";
+  out = "<div class=\"notecard warning\"><h4>No syntax available</h4><p>No value found in the database.</p></div>";
+} else {
+    const rtlLocales = ['ar', 'he', 'fa'];
+    const rtl = rtlLocales.includes(env.locale);
+    const out = `<pre${rtl ? ' dir="rtl"' : ""}>${formattedSyntax}</pre>`
 }
-
-const rtlLocales = ['ar', 'he', 'fa'];
-const rtl = rtlLocales.includes(env.locale);
-const out = `<pre${rtl ? ' dir="rtl"' : ""}>${formattedSyntax}</pre>`
 
 %><%- out %>

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -430,7 +430,8 @@ if (name === "preview-wiki-content") {
 }
 
 if (!formattedSyntax) {
-    throw new Error(`No syntax found in DB for '${name}'`);
+  formattedSyntax = "<span style=\"color:red;\">" +
+    `No syntax found in DB for '${name}'` + "</span>";
 }
 
 const rtlLocales = ['ar', 'he', 'fa'];


### PR DESCRIPTION
In `{{CSSInfo}}` (as well as in `{{Specification}}` and `{{Compat}}`, although the mechanism is different), when the structured data is missing, an error message is displayed.

In `{{CSSSyntax}}`, an exception is thrown, the name of the macro is displayed in the page, and a flaw is generated.

The behavior of `{{CSSInfo}}` is better: there is nothing wrong in the page (as the macro flaw hints) and the message helps diagnose and to fix the actual problem.

This PR fixes this.

cc/ @peterbe: do you think you can still squeeze this review? The only issue in macros preventing me to go down to 0 for MacroExecutionError flaws :-)