### PR TITLE
cache node_modules in CI by unique workflows

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/npm-publish.yml') }}
 
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: |
             node_modules
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/performance.yml') }}
 
       - name: Install all yarn packages
         if: steps.cached-node_modules.outputs.cache-hit != 'true'


### PR DESCRIPTION
This solves the same issue as this: https://github.com/mdn/content/issues/8014

What can happen is that you get a race condition on 2 different GHA workflows that try to store or use the same Cache key and thus failing. 
Besides, making each possible cache key in the `actions/cache` per workflow is a good idea because it assures that the caching is unique for the whole workflow. 