### PR TITLE
plus bookmarks page isn't rendering as SPA

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,6 +51,9 @@ jobs:
           yarn prepare-build
           yarn build
 
+          cat client/build/en-us/plus/bookmarks/index.html
+          cat client/build/en-us/plus/bookmarks/index.html | grep 'page-content-container plus' | grep div
+
           yarn start:static-server > /tmp/stdout.log 2> /tmp/stderr.log &
           sleep 1
           curl --retry-connrefused --retry 5 http://localhost:5000 > /dev/null

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -121,6 +121,8 @@ export function App(appProps) {
       </PageOrPageNotFound>
     );
 
+  console.log({ CRUD_MODE, ENABLE_PLUS });
+
   const routes = (
     <Routes>
       {/*

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -302,7 +302,12 @@ export function App(appProps) {
               path="*"
               element={
                 <StandardLayout>
-                  <PageNotFound />
+                  {/* <PageNotFound /> */}
+                  <div>
+                    FALLBACK PAGE NOT FOUN!!!!!
+                    <pre>{JSON.stringify(appProps)}</pre>
+                    <pre>{JSON.stringify({ CRUD_MODE, ENABLE_PLUS })}</pre>
+                  </div>
                 </StandardLayout>
               }
             />

--- a/testing/.env
+++ b/testing/.env
@@ -31,3 +31,6 @@ BUILD_SPEEDCURVE_LUX_ID=012345
 # The functional tests are done in a production'y way as if it had
 # to go into full production mode.
 BUILD_ALWAYS_ALLOW_ROBOTS=true
+
+# Always true for testing
+REACT_APP_ENABLE_PLUS=true

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1275,6 +1275,22 @@ test("plus page", () => {
   const $ = cheerio.load(html);
   expect($("title").text()).toContain("Plus");
   expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
+  expect($("main.plus").length).toBe(1);
+  // because, by default, it just loads the blank skeleton page
+  expect($("main.plus h1").length).toBe(0);
+});
+
+test("plus bookmarks page", () => {
+  const builtFolder = path.join(buildRoot, "en-us", "plus", "bookmarks");
+  expect(fs.existsSync(builtFolder)).toBeTruthy();
+  const htmlFile = path.join(builtFolder, "index.html");
+  const html = fs.readFileSync(htmlFile, "utf-8");
+  const $ = cheerio.load(html);
+  expect($("title").text()).toMatch(/Bookmarks/);
+  expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
+  expect($("main.plus").length).toBe(1);
+  // because, by default, it just loads the blank skeleton page
+  expect($("main.plus h1").length).toBe(0);
 });
 
 test("bcd table extraction followed by h3", () => {


### PR DESCRIPTION
Super strangely. When `spas.js` generates the file `client/build/en-us/plus/bookmarks/index.html` for some reason it's the `Page not found` component rendered in it. But only in CI (aka. Linux). 

In `client/build/en-us/plus/bookmarks/index.html` I get:
```
<main id="content" class="page-content-container plus" role="main">
</main>
```
but on Linux I get something different.
