### PR TITLE
consolidate on 'Quick_links' (not 'Quick_Links')

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -2,32 +2,26 @@ const cheerio = require("cheerio");
 const { packageBCD } = require("./resolve-bcd");
 const specs = require("browser-specs");
 
-/** Extract and mutate the $ if it as a "Quick_Links" section.
+/** Extract and mutate the $ if it as a "Quick_links" section.
  * But only if it exists.
  *
  * If you had this:
  *
  *   const $ = cheerio.load(`
- *      <div id="Quick_Links">Stuff</div>
+ *      <div id="Quick_links">Stuff</div>
  *      <h2>Headline<h2>
  *      <p>Text</p>
  *    `)
  *   const sidebar = extractSidebar($);
  *   console.log(sidebar);
- *   // '<div id="Quick_Links">Stuff</div>'
+ *   // '<div id="Quick_links">Stuff</div>'
  *   console.log($.html());
  *   // '<h2>Headline<h2>\n<p>Text</p>'
  *
  * ...give or take some whitespace.
  */
 function extractSidebar($) {
-  // Have to use both spellings because unfortunately, some sidebars don't come
-  // from macros but have it hardcoded into the content. Perhaps it was the
-  // result of someone once rendering out some sidebar macros.
-  // We could consolidate it to just exactly one spelling (`quick_links`) but
-  // that would require having to fix 29 macros and hundreds of translated content.
-  // By selecting for either spelling we're being defensive and safe.
-  const search = $("#Quick_Links, #Quick_links");
+  const search = $("#Quick_links");
   if (!search.length) {
     return "";
   }

--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -237,7 +237,7 @@ function buildIFList(interfaces, title) {
 }
 
 // output
-output = '<section class="Quick_links" id="Quick_Links"><ol>';
+output = '<section id="Quick_links"><ol>';
 if (group && webAPIGroups[0][group] && webAPIGroups[0][group].overview) {
   output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
 }

--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -411,7 +411,7 @@ var text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li><a href="<%=baseURL%>WebExtensions"><strong><%=text['WebExtensions']%></strong></a></li>
     <li class="toggle">

--- a/kumascript/macros/AddonSidebarMain.ejs
+++ b/kumascript/macros/AddonSidebarMain.ejs
@@ -52,7 +52,7 @@ var text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li><a href="<%=baseURL%>WebExtensions"><strong><%=text['WebExtensions']%></strong></a></li>
     <li><a href="<%=baseURL%>Themes"><strong><%=text['Themes']%></strong></a></li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -396,7 +396,7 @@ function buildSublist(pages, title) {
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 
 <ol>
   <li><strong><%=text['Learn_CSS']%></strong></li>

--- a/kumascript/macros/CSSTutorialTOC.ejs
+++ b/kumascript/macros/CSSTutorialTOC.ejs
@@ -3,7 +3,7 @@ var l = env.locale;
 
 if(l === "ru"){
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol><li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/What_is_CSS">Что такое CSS?</a></li>
     <li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/Why_use_CSS">Зачем нужен CSS?</a></li>
 	<li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/How_CSS_works">Как работает CSS</a></li>
@@ -28,7 +28,7 @@ if(l === "ru"){
 <%
 } else {
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol><li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/What_is_CSS">What is CSS?</a></li>
    	<li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/Why_use_CSS">Why use CSS?</a></li>
 	<li><a href="/<%- l %>/docs/Web/Guide/CSS/Getting_Started/How_CSS_works">How CSS works</a></li>

--- a/kumascript/macros/CanvasSidebar.ejs
+++ b/kumascript/macros/CanvasSidebar.ejs
@@ -142,7 +142,7 @@ var text = mdn.localStringMap({
   }
 });
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/API/Canvas_API"><strong><%=text['Canvas_API']%></strong></a></li>
   <li class="toggle">

--- a/kumascript/macros/DefaultAPISidebar.ejs
+++ b/kumascript/macros/DefaultAPISidebar.ejs
@@ -102,7 +102,7 @@ function convertEvent(eventName) {
 }
 
 // output
-output = '<section class="Quick_links" id="Quick_Links"><ol>';
+output = '<section id="Quick_links"><ol>';
 
 if (webAPIGroups[0][group].overview) {
   output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';

--- a/kumascript/macros/EditorGuideQuicklinks.ejs
+++ b/kumascript/macros/EditorGuideQuicklinks.ejs
@@ -21,7 +21,7 @@ switch (env.locale) {
     default: break;
 }
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
 <ol>
  <li><a href="#" title="#"><%-s_guide%></a>
  <%-await template("ListSubpages", ["/en-US/docs/MDN/Contribute/Editor", 1, 0, 1])%>

--- a/kumascript/macros/FirefoxSidebar.ejs
+++ b/kumascript/macros/FirefoxSidebar.ejs
@@ -318,7 +318,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li class="toggle">
         <details>

--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -571,7 +571,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li class="toggle">
         <details>

--- a/kumascript/macros/HTMLRef.ejs
+++ b/kumascript/macros/HTMLRef.ejs
@@ -60,14 +60,14 @@ var resultGuide = [];
 var resultAPI = [];
 
  if (s_html_href) {  %>
-  <section class="Quick_links" id="Quick_Links">
+  <section id="Quick_links">
   <ol>
-   <% if (found_tag) { 
+   <% if (found_tag) {
         for( aPage in resultGuide) { // Tutorials and guides matching
   %>
             <li><a href="<%-resultGuide[aPage].url%>"><%-resultGuide[aPage].title%></a></li>
   <%    }
-        for (slugLeaf in resultHTML) { // HTML entities matching 
+        for (slugLeaf in resultHTML) { // HTML entities matching
             if (resultHTML[slugLeaf] === "heading_elements") { // Special case for <h1>…<h6>
   %>
             <li><%- await template("HTMLelement", ["Heading_elements", "<code>&lt;h1&gt;-&lt;h6&gt;</code>"]) %></li>
@@ -77,11 +77,11 @@ var resultAPI = [];
   %>
             <li><%- await template("HTMLelement", [resultHTML[slugLeaf]]) %></li>
   <%        }
-        } 
-        for (slugLeaf in resultAPI) { // HTML-DOM interfaces matching 
+        }
+        for (slugLeaf in resultAPI) { // HTML-DOM interfaces matching
   %>
             <li><%- await template("domxref", [resultAPI[slugLeaf]]) %></li>
-  <%    } 
+  <%    }
     } %>
     <% if (env.slug.includes("/HTML/Element/input")) { %>
    <li><details open><summary><%-text['Input_types']%></summary>
@@ -288,11 +288,11 @@ var resultAPI = [];
  <ol>
   <li class="html5"><%-await template("HTMLElement", ["wbr"])%></li>
  </ol>
- </li><li>X Y Z 
+ </li><li>X Y Z
  <ol>
   <li><s class="obsoleteElement"><%-await template("HTMLElement", ["xmp"])%></s></li>
  </ol>
-    </li>  
+    </li>
    </ol>
    </details></li>
    </ol>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -112,7 +112,7 @@ var text = mdn.localStringMap({
   }
 });
 %>
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/HTML"><strong><em>HTML</em></strong></a></li>
   <li><strong><%=text['Tutorials']%></strong></li>

--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -174,7 +174,7 @@ var text = mdn.localStringMap({
 %>
 
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li><a href="/<%=locale%>/docs/Web/HTTP"><strong><em><%=text['HTTP']%></em></strong></a></li>
     <li><strong><%=text['Guides']%></strong></li>

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -225,7 +225,7 @@ var len = 0;
 
 // Output
 
-output  = '<section class="Quick_links" id="Quick_Links"><ol>';
+output  = '<section id="Quick_links"><ol>';
 output += '<li><strong><a href="'+slug_stdlib+'">'+text['stdlib']+'</a></strong></li>';
 
     for (object in result) {

--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -397,7 +397,7 @@ var text = mdn.localStringMap({
   },
 });
 %>
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/JavaScript"><strong><em>JavaScript</em></strong></a></li>
   <li><a href="/<%=locale%>/docs/Web/JavaScript/Tutorials"><strong><%=text['Tutorials']%></strong></a></li>

--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1825,7 +1825,7 @@ var text = mdn.localStringMap({
 });
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 
 <ol>
   <li data-default-state="<%=currentPageIsUnder('Getting_started_with_the_web')%>"><a href="<%=baseURL%>Getting_started_with_the_web"><strong><%=text['Complete_beginners']%></strong></a></li>
@@ -2276,4 +2276,3 @@ var text = mdn.localStringMap({
 </ol>
 
 </section>
-

--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -409,7 +409,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
   <ol>
     <li><a href="<%=baseURL%>About"><%=text['About_MDN']%></a></li>
     <li class="toggle">

--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -41,14 +41,14 @@ for (aPage in pageList) {
 }
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
     <ol>
         <li><strong><a href="<%=s_mathml_ref_href%>"><%=s_mathml_ref_title%></a></strong>
 
         <% for (aPage in result) { %>
             <li><a href="<%-result[aPage].url%>"><%-safe_tags(result[aPage].title)%></a></li>
         <% } %>
-        
-        </li>  
+
+        </li>
     </ol>
 </section>

--- a/kumascript/macros/QuickLinksWithSubpages.ejs
+++ b/kumascript/macros/QuickLinksWithSubpages.ejs
@@ -9,6 +9,6 @@
 //
 //  $0  Optional; the page whose subpages are to be included.
 %>
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 <%-await template("ListSubpages", [$0, 2, 0, 1])%>
 </section>

--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -45,23 +45,23 @@ if (found_tag != undefined && found_tag != null && found_tag.length) {
 var resultAPI = [];
 
  if (s_svg_href) {  %>
-  <section class="Quick_links" id="Quick_Links">
+  <section id="Quick_links">
   <ol>
-   <% if (found_tag) {        
-/*       
+   <% if (found_tag) {
+/*
         for( aPage in resultGuide) { // Tutorials and guides matching
   %>
             <li><a href="<%-resultGuide[aPage].url%>"><%-resultGuide[aPage].title%></a></li>
   <%    }
 */
-        for (aTitle in resultSVG) { // SVG entities matching 
+        for (aTitle in resultSVG) { // SVG entities matching
   %>
             <li><%- await template("SVGElement", [resultSVG[aTitle]]) %></li>
-  <%    } 
-        for (aTitle in resultAPI) { // SVG-DOM interfaces matching 
+  <%    }
+        for (aTitle in resultAPI) { // SVG-DOM interfaces matching
   %>
             <li><%- await template("domxref", [resultAPI[aTitle]]) %></li>
-  <%    } 
+  <%    }
     } %>
    <li><details><summary><%-s_svg_ref_title%></summary><ol>
  <li>A
@@ -206,7 +206,7 @@ var resultAPI = [];
    <ol>
      <li><%-await template("SVGElement", ["view"])%></li>
      <li><%-await template("SVGElement", ["vkern"])%></li>
-   </ol>   
+   </ol>
  </li>
    </ol></li></details>
    </ol>

--- a/kumascript/macros/ServiceWorkerSidebar.ejs
+++ b/kumascript/macros/ServiceWorkerSidebar.ejs
@@ -44,7 +44,7 @@ var text = mdn.localStringMap({
   }
 });
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/API/Service_Worker_API"><strong><%=text['Service_Worker_API']%></strong></a></li>
   <li class="toggle">

--- a/kumascript/macros/ToolsSidebar.ejs
+++ b/kumascript/macros/ToolsSidebar.ejs
@@ -461,7 +461,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
     <ol>
         <li><a href="<%=baseURL%>Page_Inspector"><%=text['Page_Inspector']%></a></li>
         <li><a href="<%=baseURL%>Web_Console"><%=text['Web_Console']%></a></li>

--- a/kumascript/macros/WebAssemblySidebar.ejs
+++ b/kumascript/macros/WebAssemblySidebar.ejs
@@ -20,7 +20,7 @@ var text = mdn.localStringMap({
 });
 %>
 
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 
 <ol>
   <li data-default-state="open"><a href="<%=baseURL%>"><strong><%=text['WebAssembly_home_page']%></strong></a>

--- a/kumascript/macros/WebGLSidebar.ejs
+++ b/kumascript/macros/WebGLSidebar.ejs
@@ -105,7 +105,7 @@ var text = mdn.localStringMap({
   }
 });
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/API/WebGL_API"><strong><%=text['WebGL_API']%></strong></a></li>
   <li class="toggle">

--- a/kumascript/macros/WebRTCSidebar.ejs
+++ b/kumascript/macros/WebRTCSidebar.ejs
@@ -52,7 +52,7 @@ var text = mdn.localStringMap({
   }
 });
 %>
-<section id="Quick_Links">
+<section id="Quick_links">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/API/WebRTC_API"><strong><%=text['WebRTC_API']%></strong></a></li>
   <li class="toggle">

--- a/kumascript/tests/macros/HTTPSidebar.test.js
+++ b/kumascript/tests/macros/HTTPSidebar.test.js
@@ -31,12 +31,6 @@ const locales = {
 };
 
 function checkSidebarDom(dom, locale) {
-  const section = dom.querySelector("section");
-  assert(
-    section.classList.contains("Quick_links"),
-    "Section does not contain Quick_links class"
-  );
-
   const summaries = dom.querySelectorAll("summary");
   assert.equal(summaries[0].textContent, locales[locale].ResourcesURI);
 }

--- a/kumascript/tests/macros/WebAssemblySidebar.test.js
+++ b/kumascript/tests/macros/WebAssemblySidebar.test.js
@@ -4,7 +4,7 @@
 const { assert, itMacro, describeMacro, beforeEachMacro } = require("./utils");
 
 const expected = `\
-<section class="Quick_links" id="Quick_Links">
+<section id="Quick_links">
 
 <ol>
   <li data-default-state="open"><a href="/en-US/docs/WebAssembly"><strong>WebAssembly home page</strong></a>

--- a/kumascript/tests/macros/addonsidebar.test.js
+++ b/kumascript/tests/macros/addonsidebar.test.js
@@ -97,7 +97,7 @@ function checkSidebarResult(html, locale, isUnderWebExtAPI = false) {
   // Lint the HTML
   expect(lintHTML(html)).toBeFalsy();
   const dom = JSDOM.fragment(html);
-  const section = dom.querySelector("section.Quick_links");
+  const section = dom.querySelector("section#Quick_links");
   // Check the basics
   expect(section).toBeTruthy();
   // Check the total number of top-level list items that can be toggled

--- a/kumascript/tests/macros/firefoxsidebar.test.js
+++ b/kumascript/tests/macros/firefoxsidebar.test.js
@@ -14,12 +14,6 @@ const locales = {
 };
 
 function checkSidebarDom(dom, locale) {
-  const section = dom.querySelector("section");
-  assert(
-    section.classList.contains("Quick_links"),
-    "Section does not contain Quick_links class"
-  );
-
   const summaries = dom.querySelectorAll("summary");
   assert.equal(
     summaries[0].textContent,

--- a/kumascript/tests/macros/gamessidebar.test.js
+++ b/kumascript/tests/macros/gamessidebar.test.js
@@ -15,12 +15,6 @@ const locales = {
 };
 
 function checkSidebarDom(dom, locale) {
-  const section = dom.querySelector("section");
-  assert(
-    section.classList.contains("Quick_links"),
-    "Section does not contain Quick_links class"
-  );
-
   const summaries = dom.querySelectorAll("summary");
   assert.equal(summaries[0].textContent, locales[locale].Introduction);
 }

--- a/kumascript/tests/macros/mdnsidebar.test.js
+++ b/kumascript/tests/macros/mdnsidebar.test.js
@@ -15,12 +15,6 @@ const locales = {
 };
 
 function checkSidebarDom(dom, locale) {
-  const section = dom.querySelector("section");
-  assert(
-    section.classList.contains("Quick_links"),
-    "Section does not contain Quick_links class"
-  );
-
   const summaries = dom.querySelectorAll("summary");
   assert.equal(summaries[0].textContent, locales[locale].About_MDN);
 }

--- a/kumascript/tests/macros/toolssidebar.test.js
+++ b/kumascript/tests/macros/toolssidebar.test.js
@@ -15,12 +15,6 @@ const locales = {
 };
 
 function checkSidebarDom(dom, locale) {
-  const section = dom.querySelector("section");
-  assert(
-    section.classList.contains("Quick_links"),
-    "Section does not contain Quick_links class"
-  );
-
   const listItems = dom.querySelectorAll("li");
   assert.equal(listItems[0].textContent, locales[locale].Page_Inspector);
 }


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/2454
Depends on https://github.com/mdn/translated-content/pull/2138 being merged. 

Now there's only exactly 1 single way to spell it and it's: `Quick_links`