### PR TITLE
fix callout rendering

### DIFF
--- a/markdown/m2h/handlers/index.js
+++ b/markdown/m2h/handlers/index.js
@@ -41,7 +41,11 @@ module.exports = {
     if (type) {
       const isCallout = type == "callout";
       if (isCallout) {
-        node.children.splice(0, 1);
+        if (node.children[0].children.length <= 1) {
+          node.children.splice(0, 1);
+        } else {
+          node.children[0].children.splice(0, 1);
+        }
       }
       return h(
         node,


### PR DESCRIPTION
```md

> **Callout:** **Fancy Title**
>
> Something important!
```

should be 

> ** Fancy Title**
>
> Something important!

But currently is rendered as 

> Something important!