### PR TITLE
Update to @mdn/browser-compat-data v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@caporal/core": "2.0.2",
     "@fast-csv/parse": "4.3.6",
-    "@mdn/browser-compat-data": "3.3.14",
+    "@mdn/browser-compat-data": "4.0.0",
     "accept-language-parser": "1.5.0",
     "browser-specs": "^2.7.0",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2546,10 +2546,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@mdn/browser-compat-data@3.3.14":
-  version "3.3.14"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-3.3.14.tgz#b72a37c654e598f9ae6f8335faaee182bebc6b28"
-  integrity sha512-n2RC9d6XatVbWFdHLimzzUJxJ1KY8LdjqrW6YvGPiRmsHkhOUx74/Ct10x5Yo7bC/Jvqx7cDEW8IMPv/+vwEzA==
+"@mdn/browser-compat-data@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.0.0.tgz#a947660f0601fc2cf208fbddff6a94fec9fcc675"
+  integrity sha512-Yn5Xf+LyH+KZ0wz0XXzD1C7uGKF29RMrcXLaRHwzH3Uo5fRtnPTdWJIyT8kCrvxt8Wq8MQpMDByk/AufmPWL1A==
 
 "@mdn/dinocons@^0.3.4":
   version "0.3.4"


### PR DESCRIPTION
Dependabot won't roll majors automatically AFAIK, so here I am doing it
manually.
