### PR TITLE
allow more open PRs from Dependabot for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 25
+    open-pull-requests-limit: 35
     ignore:
       # Need manual updates with "resolutions" in package.json
       # to property hoist versions from react-scripts


### PR DESCRIPTION
Problem:
<img width="1303" alt="Screen Shot 2021-08-19 at 12 55 06 PM" src="https://user-images.githubusercontent.com/26739/130111553-659f693c-305a-4392-b5ad-6f76f7f44fff.png">

Real problem :)
https://github.com/mdn/yari/pulls/app%2Fdependabot