### PR TITLE
Only show Node in compat tables if there is data

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -16,18 +16,23 @@ export const PLATFORM_BROWSERS: { [key: string]: bcd.BrowserNames[] } = {
   "webextensions-mobile": ["firefox_android"],
 };
 
-function PlatformHeaders({ platforms }) {
+function PlatformHeaders({ platforms, browsers }) {
   return (
     <tr className="bc-platforms">
       <td />
       {platforms.map((platform) => {
-        const platformCount = Object.keys(PLATFORM_BROWSERS[platform]).length;
+        // Get the intersection of browsers in the `browsers` array and the
+        // `PLATFORM_BROWSERS[platform]`.
+        const browsersInPlatform = PLATFORM_BROWSERS[platform].filter(
+          (browser) => browsers.includes(browser)
+        );
+        const browserCount = Object.keys(browsersInPlatform).length;
         const platformId = platform.replace("webextensions-", "");
         return (
           <th
             key={platform}
             className={`bc-platform-${platformId}`}
-            colSpan={platformCount}
+            colSpan={browserCount}
           >
             <span>{platform}</span>
           </th>
@@ -55,7 +60,7 @@ function BrowserHeaders({ browsers }: { browsers }) {
 export function Headers({ platforms, browsers }) {
   return (
     <thead>
-      <PlatformHeaders platforms={platforms} />
+      <PlatformHeaders platforms={platforms} browsers={browsers} />
       <BrowserHeaders browsers={browsers} />
     </thead>
   );

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -4,7 +4,7 @@ import type bcd from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import { BrowserCompatibilityErrorBoundary } from "./error-boundary";
 import { FeatureRow } from "./feature-row";
-import { PLATFORM_BROWSERS, Headers } from "./headers";
+import { Headers, PLATFORM_BROWSERS } from "./headers";
 import { Legend } from "./legend";
 import { listFeatures } from "./utils";
 
@@ -34,24 +34,41 @@ const NEW_ISSUE_TEMPLATE = `
 </details>
 `;
 
+/**
+ * Return a list of platforms and browsers that are relevant for this category &
+ * data.
+ *
+ * If the category is "webextensions", only those are shown. In all other cases
+ * at least the entirety of the "desktop" and "mobile" platforms are shown. If
+ * the category is JavaScript, the entirety of the "server" category is also
+ * shown. In all other categories, if compat data has info about Deno / Node.js
+ * those are also shown. Deno is always shown if Node.js is shown.
+ */
 function gatherPlatformsAndBrowsers(
   category: string,
   data: bcd.Identifier
 ): [string[], bcd.BrowserNames[]] {
+  const hasNodeJSData = data.__compat && "nodejs" in data.__compat.support;
+  const hasDenoData = data.__compat && "deno" in data.__compat.support;
+
   let platforms = ["desktop", "mobile"];
-  if (
-    category === "javascript" ||
-    (data.__compat &&
-      (data.__compat.support.nodejs || data.__compat.support.deno))
-  ) {
+  if (category === "javascript" || hasNodeJSData || hasDenoData) {
     platforms.push("server");
   } else if (category === "webextensions") {
     platforms = ["webextensions-desktop", "webextensions-mobile"];
   }
-  return [
-    platforms,
-    platforms.map((platform) => PLATFORM_BROWSERS[platform] || []).flat(),
-  ];
+
+  const browsers = new Set(
+    platforms.map((platform) => PLATFORM_BROWSERS[platform] || []).flat()
+  );
+
+  // If there is no Node.js data for a category outside of "javascript", don't
+  // show it. It ended up in the browser list because there is data for Deno.
+  if (category !== "javascript" && !hasNodeJSData) {
+    browsers.delete("nodejs");
+  }
+
+  return [platforms, [...browsers]];
 }
 
 type CellIndex = [number, number];


### PR DESCRIPTION
With the addition of Deno in compat tables, the tables now often show
Node.js in places it previously wasnt shown. In all of these new places
it is shown, it just shows a bunch of question marks, because it doesn't
have data.

I brought this up on Matrix, and @ddbeck and me agreed that the best
path forward would likely be to show the Node.js column only if there is
data for Node in the BCD data.

﻿This commit changes the table, so that Node.js is only shown if the
category is "javascript", or there is compat data for Node for the given
BCD entry. Deno is shown just like it is now.
