### PR TITLE
Fix EmbedLiveSample when there are subheadings

### DIFF
--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -280,9 +280,7 @@ class HTMLTool {
       }
       return result;
     } else {
-      const result = collectClosestCode(
-        this.$(`#${minimalIDEscape(sampleID)}`)
-      );
+      const result = collectClosestCode(findSectionStart(this.$, sectionID));
       if (!result) {
         throw new KumascriptError(
           `unable to find any live code samples for "${sectionID}" within ${this.pathDescription}`


### PR DESCRIPTION
This fixes a regression introduced by commit 49f5317df4963018c8be94dfc5f50b6e56b1079c.

Fixes: mdn/content#8020
Fixes: mdn/content#8124