### PR TITLE
Fix MacroWrongXRefError from CSSRef macro

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -343,12 +343,10 @@ const badges = {
   DeprecatedBadge : await template("DeprecatedBadge"),
 }
 
-function smartLink(...args) {
-  while (args.length < 5) {
-    args.push(undefined);
-  }
-  args.push("CSSRef");
-  return web.smartLink(...args);
+function smartLink(href, title, content, subpath) {
+  let basepath = subpath;
+  let ignoreFlawMacro = "CSSRef";
+  return web.smartLink(href, title, content, subpath, basepath, ignoreFlawMacro);
 }
 
 function buildSublist(pages, title) {


### PR DESCRIPTION
This fixes macro flaws that appear on every page that CSSRef is used.

> wrong xref macro used (consider changing which macro you use)