### PR TITLE
Sort preview URLs in PR companion

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -89,6 +89,7 @@ def post_about_deployment(build_directory: Path, **config):
     for doc in get_built_docs(build_directory):
         url = mdn_url_to_dev_url(config["prefix"], doc["mdn_url"])
         links.append(f"- <{url}>")
+    links.sort()
 
     heading = "## Preview URLs\n\n"
     if links:


### PR DESCRIPTION
**Untested!** Just a guess that this would do the trick.

Problem: It is quite annoying to find a particular preview URL when the list is not sorted alphabetically. See e.g. https://github.com/mdn/content/pull/8274#issuecomment-905175316