### PR TITLE
Fix links in CSSRef.ejs

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -706,8 +706,8 @@ function buildSublist(pages, title) {
   <li class="toggle">
     <ol>
       <li><%-smartLink(`${cssURL}CSS_Colors/Color_picker_tool`, null, text['Color_picker_tool'], cssURL)%></li>
-      <li><%-smartLink(`${cssURL}CSS_Background_and_Borders/Box-shadow_generator`, null, text['Box-shadow_generator'], cssURL)%></li>
-      <li><%-smartLink(`${cssURL}CSS_Background_and_Borders/Border-image_generator`, null, text['Border-image_generator'], cssURL)%></li>
+      <li><%-smartLink(`${cssURL}CSS_Backgrounds_and_Borders/Box-shadow_generator`, null, text['Box-shadow_generator'], cssURL)%></li>
+      <li><%-smartLink(`${cssURL}CSS_Backgrounds_and_Borders/Border-image_generator`, null, text['Border-image_generator'], cssURL)%></li>
     </ol>
   </li>
 


### PR DESCRIPTION
We moved these last week and now, when building the pages, we get:

> In CSSRef the smartLink to /en-US/docs/Web/CSS/CSS_Background_and_Borders/Box-shadow_generator is broken (redirects to /en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Box-shadow_generator)
> In CSSRef the smartLink to /en-US/docs/Web/CSS/CSS_Background_and_Borders/Border-image_generator is broken (redirects to /en-US/docs/Web/CSS/CSS_Backgrounds_and_Borders/Border-image_generator)


(And 1888 flaws, …)

cc/ @Elchi3 for a review from the content perspective.