### PR TITLE
Fix inheritanceDiagram getting a scrollbar

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -282,7 +282,6 @@ a.page-not-created {
 
   iframe {
     max-width: 100%;
-    width: 100%;
   }
 
   iframe:not(.sample-code-frame) {


### PR DESCRIPTION
- Fixes #4569 and mdn/content#8412
- `width: 100%` for the example iframes is being applied here https://github.com/mdn/mdn-minimalist/blob/main/sass/atoms/_examples.scss#L10 so taking off this property from here fixed the scrollbar issue on `InheritanceDiagram`


- Another way to tackle this would be removing height and width properties or even just the height property here(https://github.com/mdn/yari/blob/main/kumascript/macros/InheritanceDiagram.ejs), but then this would lead to more refactoring and removing height and width arguments passed to all the instances of `InheritanceDiagram` macro just for the diagram to cover 100% of the parent a be visible a bit bigger!!