### PR TITLE
Make h2m support some more languages

### DIFF
--- a/markdown/h2m/handlers/index.ts
+++ b/markdown/h2m/handlers/index.ts
@@ -216,6 +216,10 @@ export const handlers: QueryAndTransform[] = [
     "cpp",
     "java",
     "bash",
+    "php",
+    "xml",
+    "glsl",
+    "python",
     "example-good",
     "example-bad",
   ].flatMap((lang) =>


### PR DESCRIPTION
Yari's syntax supports some extra languages that h2m didn't know about, so h2m would complain that code blocks marked up with those language codes were unconvertible.

This PR teaches h2m about these language codes, so they make it into the Markdown info string, and get syntax highlighting.

These are some pages that use these language identifiers:

* php: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler/Web-based_protocol_handlers#example_3
* xml: https://developer.mozilla.org/en-US/docs/Web/API/XSLTProcessor/Basic_Example
* glsl: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_model_view_projection#webglbox_draw
* python: https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction (but note that this page will currently fail in Markdown due to a live sample issue)