### PR TITLE
build(deps): bump @mdn/browser-compat-data from 4.0.1 to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "@caporal/core": "2.0.2",
     "@fast-csv/parse": "4.3.6",
-    "@mdn/browser-compat-data": "4.0.1",
+    "@mdn/browser-compat-data": "4.0.2",
     "accept-language-parser": "1.5.0",
     "browser-specs": "^2.9.0",
     "chalk": "4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2551,10 +2551,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@mdn/browser-compat-data@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.0.1.tgz#267a8d48cb0a3c5f7726111c8cf36a7120452268"
-  integrity sha512-Q3w8hkRE/3ATasymBUACDphIDKFS3OxKSJsPlnVwKxbbxF94lXF771P7ltgOZ6HhaC5zBZomuIfjBIYrj3SFYg==
+"@mdn/browser-compat-data@4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.0.2.tgz#54431f690853e11b61f93b29ded25978f78c38e0"
+  integrity sha512-XGLqWi1uOil0L4TJs9KOTMRl9FdEtRQLvBDaB7++AFnFf9G0QYihiUNRJ4eXZa53KI9VORsEi3Fj8p3N+m/Gdw==
 
 "@mdn/dinocons@^0.3.5":
   version "0.3.5"


### PR DESCRIPTION
In case dependabot is slow or not proposing this today, here's a PR to bump BCD to 4.0.2. 

It's not a major / breaking release but a change for about 15 (important / high traffic) pages was made. So, we want this to go out soon.
See https://github.com/mdn/browser-compat-data/releases/tag/v4.0.2

Closes https://github.com/mdn/content/issues/8542

cc @escattone 