### PR TITLE
Fix broken link in GameSidebar

### DIFF
--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -589,7 +589,7 @@ const text = mdn.localStringMap({
             <ol>
               <li><a href="<%=webURL%>API/Canvas_API"><%=text["Canvas"]%></a></li>
               <li><a href="<%=webURL%>CSS"><%=text["CSS"]%></a></li>
-              <li><a href="<%=appsURL%>Fundamentals/User_notifications/Full_screen_api"><%=text["Full_Screen"]%></a></li>
+              <li><a href="<%=webURL%>API/Fullscreen_API><%=text["Full_Screen"]%></a></li>
               <li><a href="<%=webURL%>API/Gamepad_API"><%=text["Gamepad"]%></a></li>
               <li><a href="<%=webURL%>API/IndexedDB_API"><%=text["IndexedDB"]%></a></li>
               <li><a href="<%=webURL%>JavaScript"><%=text["JavaScript"]%></a></li>


### PR DESCRIPTION
Fixes mdn/content#8602

The Apps area is gone. Linked to the overview page of the API instead.

cc/ @Elchi3 for a review from the content-side point-of-view.