### PR TITLE
Remove hit regions from Canvas Sidebar

### DIFF
--- a/kumascript/macros/CanvasSidebar.ejs
+++ b/kumascript/macros/CanvasSidebar.ejs
@@ -23,7 +23,6 @@ var text = mdn.localStringMap({
     'Basic_animations': 'Basic animations',
     'Advanced_animations': 'Advanced animations',
     'Pixel_manipulation': 'Pixel manipulation',
-    'Hitregions': 'Hit regions and accessibility',
     'Optimizing': 'Optimizing the canvas',
     'Finale': 'Finale',
     'Examples': 'Examples',
@@ -48,7 +47,6 @@ var text = mdn.localStringMap({
     'Basic_animations': '基本动画',
     'Advanced_animations': '高级动画',
     'Pixel_manipulation': '像素操作',
-    'Hitregions': '点击区域和无障碍访问',
     'Optimizing': 'canvas 的优化',
     'Finale': '终极',
     'Examples': '示例',
@@ -73,7 +71,6 @@ var text = mdn.localStringMap({
     'Basic_animations': 'Простые анимации',
     'Advanced_animations': 'Расширенные анимации',
     'Pixel_manipulation': 'Манипуляция пикселями',
-    'Hitregions': 'Достижение областей и доступность',
     'Optimizing': 'Оптимизация canvas',
     'Finale': 'Заключение',
     'Examples': 'Примеры',
@@ -98,7 +95,6 @@ var text = mdn.localStringMap({
     'Basic_animations': '基本的なアニメーション',
     'Advanced_animations': '高度なアニメーション',
     'Pixel_manipulation': 'ピクセル操作',
-    'Hitregions': 'ヒット領域とアクセシビリティ',
     'Optimizing': 'canvas の最適化',
     'Finale': '最後に',
     'Examples': '例',
@@ -123,7 +119,6 @@ var text = mdn.localStringMap({
     'Basic_animations': '기본 애니메이션',
     'Advanced_animations': '고급 애니메이션',
     'Pixel_manipulation': '픽셀 조작',
-    'Hitregions': '히트 영역 및 접근성',
     'Optimizing': 'Canvas 최적화하기',
     'Finale': 'Finale',
     'Examples': '예제',
@@ -154,7 +149,6 @@ var text = mdn.localStringMap({
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Basic_animations"><%=text['Basic_animations']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Advanced_animations"><%=text['Advanced_animations']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas"><%=text['Pixel_manipulation']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility"><%=text['Hitregions']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas"><%=text['Optimizing']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Tutorial/Finale"><%=text['Finale']%></a></li>
         </ol>


### PR DESCRIPTION
Hit Regions have been removed from spec, implementations, and MDN Web Docs.

This fixes mdn/content#3780.

cc/ @Elchi3 