### PR TITLE
fix css syntax range definition notation

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -218,7 +218,7 @@ let operators = [
         })
     },
     {
-        regexp: /\[|\]/g,
+        regexp: /(\[|\])(?![^<]*>)/g,
         title: mdn.localString({
             "en-US": "Brackets: enclose several entities, combinators, and multipliers to transform them as a single component",
             "de"   : "Eckige Klammern: umschließen mehrere Entitäten, Kombinatoren und Multiplikatoren, um diese als eine gesamte Komponente zu behandeln"
@@ -333,7 +333,7 @@ async function formatSyntax(rawSyntax) {
     });
     formattedSyntax = await string.asyncReplace(
         formattedSyntax,
-        /<([a-z0-9()'-]+?)>/gi,
+        /<([a-z0-9()'-]+?( \[-?(\d+|∞),(\d+|∞)\])?)>/gi,
         buildLink
     );
 


### PR DESCRIPTION
Formal syntax for [range restrictions and range definition notation](https://www.w3.org/TR/css-values-4/#numeric-ranges) is broken. Currently grouping brackets are matching the range notation within data types and the regex that matches the data types doesn't match the bracketed range notation.

This PR prevents bracket groups from matching within data type angle brackets and adds the bracketed range notation to the data type regex.

**Examples where syntax currently breaks:**

https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-clip-margin#formal_syntax
https://drafts.csswg.org/css-overflow/#overflow-clip-margin
`<visual-box> || [0,∞]>`
should be:
`<visual-box> || <length [0,∞]>`


https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#formal_syntax
https://drafts.csswg.org/css-fonts/#font-weight-prop

`<font-weight-absolute> = normal | bold | [1,1000]>`
should be:
`<font-weight-absolute> = [normal | bold | <number [1,1000]>]`

https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timing-function#formal_syntax
https://drafts.csswg.org/css-easing-1/#typedef-cubic-bezier-easing-function

`<cubic-bezier-timing-function> = ease | ease-in | ease-out | ease-in-out | cubic-bezier([0,1]>, <number>, [0,1]>, <number>)`
should be
`<cubic-bezier-easing-function> = ease | ease-in | ease-out | ease-in-out | cubic-bezier(<number [0,1]>, <number>, <number [0,1]>, <number>)`

