### PR TITLE
Fix problem where word-wrap wasn't wrapping text as intended in Firefox and Edge

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/atoms/_bc-table.scss
@@ -55,10 +55,12 @@
   .bc-table-row-header {
     padding: math.div($base-spacing, 2) math.div($base-spacing, 4);
     display: flex;
+    display: -webkit-flex;
 
     code {
       text-decoration: none;
       white-space: normal;
+      word-wrap: anywhere;
     }
   }
 


### PR DESCRIPTION
Fixes #4514

- adds `-webkit` vendor prefix for Firefox and Edge (Since I wasn't sure if there was already some auto-prefixer in place happening during build time)
- updates `word-wrap: break-word` to `word-wrap: anywhere` for `.bc-table-row-header code` since that is what works to allow the text to break onto the next line in Firefox and Edge. Using `break-word` works in Chrome but fails in Firefox/Edge, thus introducing `anywhere` solves the problem.

Screenshot in Firefox (`hyphens: auto` won't appear as they aren't supported)

<img width="1279" alt="Screen Shot 2021-09-08 at 4 00 16 PM" src="https://user-images.githubusercontent.com/48612525/132597337-3e422364-60fb-444f-a1a7-27199de0b15f.png">
