### PR TITLE
add h2m support for sql code blocks

### DIFF
--- a/markdown/h2m/handlers/index.ts
+++ b/markdown/h2m/handlers/index.ts
@@ -220,6 +220,7 @@ export const handlers: QueryAndTransform[] = [
     "xml",
     "glsl",
     "python",
+    "sql",
     "example-good",
     "example-bad",
   ].flatMap((lang) =>


### PR DESCRIPTION
Fixes #4608 

Note that #4599 provided support for `brush: python`, so this PR simply adds support for `brush: sql`.