### PR TITLE
feat: allow search box to be triggered via NumpadDivide

### DIFF
--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -14,7 +14,7 @@ export function useFocusOnSlash(
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
       if (
-        event.code === "Slash" &&
+        event.key === "/" &&
         !["TEXTAREA", "INPUT"].includes(event.target.tagName)
       ) {
         if (input && document.activeElement !== input) {


### PR DESCRIPTION
The search input field can now be focussed via pressing the similar looking `NumpadDivide` <kbd>/</kbd> (since it has the same `key` property (unlike the `code` property) as `Slash` <kbd>/</kbd>) **as well** as the Slash.

#### Additional info: 

<img src = "https://user-images.githubusercontent.com/68165727/134724587-aa2c9bad-2812-40f4-b99e-6e35fa93887c.png" width=340>

^ for e.g currently the key numbered "2" does not trigger the search box, while the one numbered "1" does


This can make it easier to focus the search input field (for e.g when someone presses the NumpadDivide on the keyboard instead, since the user might not know to press the character with the required code value (Slash) by simply viewing the placeholder text "Press / to focus").

Additionally, the `code` property ignores the user's keyboard layout, so it might be better to use the `key` property here instead in the perhaps unlikely case there's a layout where the slash is swapped with some other key.