### PR TITLE
Corrections around the capture of ”/” keypress used to focus the search input

### DIFF
--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -14,7 +14,7 @@ export function useFocusOnSlash(
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
       if (
-        event.code === "Slash" &&
+        event.key === "/" &&
         !["TEXTAREA", "INPUT"].includes(event.target.tagName)
       ) {
         if (input && document.activeElement !== input) {

--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -14,7 +14,7 @@ export function useFocusOnSlash(
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
       if (
-        event.key === "/" &&
+        event.key === "/" && !event.ctrlKey && !event.metaKey &&
         !["TEXTAREA", "INPUT"].includes(event.target.tagName)
       ) {
         if (input && document.activeElement !== input) {

--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -14,7 +14,9 @@ export function useFocusOnSlash(
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
       if (
-        event.key === "/" && !event.ctrlKey && !event.metaKey &&
+        event.key === "/" &&
+        !event.ctrlKey &&
+        !event.metaKey &&
         !["TEXTAREA", "INPUT"].includes(event.target.tagName)
       ) {
         if (input && document.activeElement !== input) {


### PR DESCRIPTION
Fixes #4719, fixes #4718.

1. Checks that the character produced by pressing the key is `/`, instead of checking that the physical key is the one labelled `/` on US-keyboards.
2. Excludes the key combos that include either Ctrl or Meta (⌘ on Mac), e.g. `⌘/` or `^⇧/`, as they are more likely to be some preëxisting keyboard shortcut than a way to output “/”.