### PR TITLE
Warn when deleting a page without a redirect

### DIFF
--- a/tool/cli.js
+++ b/tool/cli.js
@@ -172,7 +172,7 @@ program
             } to: ${redirect}`
           )
         );
-      } else if (!redirect) {
+      } else {
         console.error(
           chalk.yellow(
             "Deleting without a redirect. Consider using the --redirect option with a related page instead."


### PR DESCRIPTION
This adds some yellow caution text when you delete a page without redirecting.

At some point I want to revisit this to make redirecting the default behavior (requiring authors to specify `--no-redirect` for such cases) but I need to get my head around the cli module a little better to do that.

cc: @wbamberg