### PR TITLE
Replace tools.ietf.org with datatracker.ietf.org

### DIFF
--- a/kumascript/macros/RFC.ejs
+++ b/kumascript/macros/RFC.ejs
@@ -12,7 +12,7 @@
 // it, and the default text shown has ", section $2" appended to it.
 //
 
-var link = "https://tools.ietf.org/html/rfc" + $0;
+var link = "https://datatracker.ietf.org/doc/html/rfc" + $0;
 var text = "";
 
 var commonl10n = web.getJSONData('L10n-Common');

--- a/testing/content/files/jsondata/SpecData.json
+++ b/testing/content/files/jsondata/SpecData.json
@@ -941,7 +941,7 @@
   },
   "HSTS": {
     "name": "HTTP Strict Transport Security (HSTS)",
-    "url": "https://tools.ietf.org/html/rfc6797",
+    "url": "https://datatracker.ietf.org/doc/html/rfc6797",
     "status": "RFC"
   },
   "HTML Editing": {
@@ -1581,7 +1581,7 @@
   },
   "vCard": {
     "name": "vCard Format Specification",
-    "url": "https://tools.ietf.org/html/rfc6350",
+    "url": "https://datatracker.ietf.org/doc/html/rfc6350",
     "status": "RFC"
   },
   "Vibration API": {


### PR DESCRIPTION
tools.ietf.org is a HTTP Redirect to datatracker.ietf.org
