### PR TITLE
Fix URL for "Visual formatting model"

### DIFF
--- a/kumascript/macros/CSS_key_concepts.ejs
+++ b/kumascript/macros/CSS_key_concepts.ejs
@@ -45,7 +45,7 @@ switch(env.locale) {
  <a href="/ja/docs/Web/CSS/inheritance" title="継承">継承</a>、
  <a href="/ja/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model" title="ボックスモデル">ボックス</a>、
  <a href="/ja/docs/Web/CSS/Layout_mode" title="レイアウトモード">レイアウトモード</a>、
- <a href="/ja/docs/Web/Guide/CSS/Visual_formatting_model" title="視覚整形モデル">視覚整形モデル</a>、
+ <a href="/ja/docs/Web/CSS/Visual_formatting_model" title="視覚整形モデル">視覚整形モデル</a>、
  <a href="/ja/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing" title="マージンの相殺">マージンの相殺</a>、
  値 (<a href="/ja/docs/Web/CSS/initial_value" title="初期値">初期値</a>、
  <a href="/ja/docs/Web/CSS/computed_value" title="計算値">計算値</a>、
@@ -99,7 +99,7 @@ switch(env.locale) {
  <a href="/en-US/docs/Web/CSS/inheritance" title="inheritance">inheritance</a>,
  the <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model" title="Box model">box</a>,
  <a href="/en-US/docs/Web/CSS/Layout_mode" title="CSS layout modes">layout modes</a> and
- <a href="/en-US/docs/Web/Guide/CSS/Visual_formatting_model" title="Visual formatting model">visual formatting models</a>,
+ <a href="/en-US/docs/Web/CSS/Visual_formatting_model" title="Visual formatting model">visual formatting models</a>,
  and <a href="/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing" title="Margin collapsing">margin collapsing</a>,
  or the <a href="/en-US/docs/Web/CSS/initial_value" title="initial value">initial</a>,
  <a href="/en-US/docs/Web/CSS/computed_value" title="computed value">computed</a>,


### PR DESCRIPTION
The link to "Visual formatting model" includes an old URL. Update it.