### PR TITLE
Removes flex declaration from .bc-table-row-header code selector

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -21,7 +21,6 @@
 
 .bc-table-row-header {
   code {
-    display: flex;
     overflow: hidden;
   }
 


### PR DESCRIPTION
Fixes [#819](https://github.com/mdn/mdn-minimalist/issues/819) in [mdn/minimalist](https://github.com/mdn/mdn-minimalist)

This proposed change removes display: flex from the .bc-table-row-header code selector. This resolves the issue of `<code>` elements nested in .bc-table-row-header to occupy an entire line creating a very hard to read cell

_screenshot of a bcd table cell on [addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) before any changes were made_

<img width="204" alt="Screen Shot 2021-11-08 at 9 26 10 PM" src="https://user-images.githubusercontent.com/48612525/140868332-3af723f7-602d-405c-b1aa-efca4cc2c660.png">


After removing the `display: flex` declaration from the `.bc-table-row-header code` selector within `/ingredients/browser-compatibility-table/index.scss`, the formatting looks good again and doesn't seem to negatively affect any other cells. 

<img width="202" alt="Screen Shot 2021-11-08 at 9 31 09 PM" src="https://user-images.githubusercontent.com/48612525/140868050-96450f01-5c84-43e3-9e3b-5e1f84671abc.png">

I'm inclined to believe there weren't any other elements in the BCD tables that relied on `.bc-table-row-header code { display: flex }` so removing it seems to have benefited the BCD tables without sacrificing any elements losing out on styling from the flex layout (from my quick inspection).