### PR TITLE
chore: remove babel-loader from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "fiori:build": "cd client && build-storybook",
     "fiori:start": "cd client && start-storybook -p 6006",
     "md": "ts-node markdown/cli.ts",
+    "prepare": "husky install",
     "prepare-build": "yarn build:client && yarn build:ssr && yarn tool optimize-client-build && yarn tool google-analytics-code && yarn tool spas && yarn tool gather-git-history && yarn tool build-robots-txt && yarn tool popularities",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",
@@ -26,13 +27,12 @@
     "test": "yarn prettier-check && yarn test:client && yarn test:kumascript && yarn test:content && yarn test:testing",
     "test:client": "cd client && tsc --noEmit && react-scripts test --env=jest-environment-jsdom-sixteen",
     "test:content": "jest content",
-    "test:headless": "playwright test headless",
     "test:developing": "playwright test developing",
+    "test:headless": "playwright test headless",
     "test:kumascript": "jest kumascript --env=node",
     "test:testing": "jest --rootDir testing",
     "tool": "node tool/cli.js",
-    "watch:ssr": "cd ssr && webpack --mode=production --watch",
-    "prepare": "husky install"
+    "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -130,7 +130,6 @@
     "@types/react": "^17.0.34",
     "@types/react-dom": "^17.0.11",
     "@types/react-modal": "^3.13.1",
-    "babel-loader": "8.1.0",
     "benchmark": "2.1.4",
     "braces": "^3.0.2",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
From the logs:

```
There might be a problem with the project dependency tree.
It is likely not a bug in Create React App, but something you need to fix locally.

The react-scripts package provided by Create React App requires a dependency:

  "babel-loader": "8.1.0"

Don't try to install it manually: your package manager does it automatically.
```
