### PR TITLE
Display dev toolbar on any display width

### DIFF
--- a/client/src/document/toolbar/index.scss
+++ b/client/src/document/toolbar/index.scss
@@ -2,13 +2,9 @@
 @import "~@mdn/minimalist/sass/vars/layout";
 
 .toolbar {
-  display: none;
-
-  @media #{$mq-small-desktop-and-up} {
-    display: block;
-    margin: 0 auto;
-    padding: $base-unit $base-spacing;
-  }
+  display: block;
+  margin: 0 auto;
+  padding: $base-unit $base-spacing;
 
   .toolbar-first-row {
     display: flex;


### PR DESCRIPTION
Fixes https://github.com/mdn/mdn-minimalist/issues/795.  This PR removes the media query that makes the toolbar for developers only display on larger widths.  I've explained why I am making this change in the linked issue.