### PR TITLE
fix: margin bottom on p tags got lost in translation

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -158,6 +158,10 @@ a.page-not-created {
     max-width: 85ch;
   }
 
+  p {
+    margin-bottom: $base-spacing;
+  }
+
   a {
     text-decoration: underline;
 


### PR DESCRIPTION
I guess the rule that set the bottom for paragraph tags in content was lost during the merge of the latest minimalist release.
This fixes that.

fix #4929