### PR TITLE
fix regression of embedlivesample fallback algorithm

### DIFF
--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -251,8 +251,8 @@ class HTMLTool {
     return this.$.html(result);
   }
 
-  extractLiveSampleObject(sampleID) {
-    const sectionID = sampleID.substr("frame_".length);
+  extractLiveSampleObject(iframeID) {
+    const sectionID = iframeID.substr("frame_".length);
     if (hasHeading(this.$, sectionID)) {
       const result = Object.create(null);
       const sample = this.getSection(sectionID);
@@ -280,7 +280,10 @@ class HTMLTool {
       }
       return result;
     } else {
-      const result = collectClosestCode(findSectionStart(this.$, sectionID));
+      // We're here because we can't find the sectionID, so instead we're going
+      // to find the live-sample iframe by its id (iframeID, NOT sectionID), and
+      // then collect the closest blocks of code for the live sample.
+      const result = collectClosestCode(findSectionStart(this.$, iframeID));
       if (!result) {
         throw new KumascriptError(
           `unable to find any live code samples for "${sectionID}" within ${this.pathDescription}`

--- a/kumascript/src/api/util.js
+++ b/kumascript/src/api/util.js
@@ -108,7 +108,7 @@ function* collectLevels($el) {
     }
     level = getLevel($header);
     $prev = $header;
-    yield $header.add($header.nextUntil(nextHigherLevel));
+    yield $header.clone().add($header.nextUntil(nextHigherLevel).clone());
   }
 }
 

--- a/kumascript/src/live-sample.js
+++ b/kumascript/src/live-sample.js
@@ -69,13 +69,6 @@ function buildLiveSamplePages(uri, title, $, rawBody) {
   // document or else collect flaws
   if (typeof $ == "string") {
     $ = cheerio.load($);
-  } else {
-    // Let's create a deep copy, since the CheerioAPI object may
-    // be modified during the course of collecting the live sample
-    // code blocks. I couldn't find a better way to create a deep
-    // copy of the CheerioAPI object.
-    // https://stackoverflow.com/questions/55172833/how-do-you-clone-a-cheerio-object
-    $ = cheerio.load($.html());
   }
   return $("iframe")
     .filter((i, iframe) => {

--- a/kumascript/src/live-sample.js
+++ b/kumascript/src/live-sample.js
@@ -69,6 +69,13 @@ function buildLiveSamplePages(uri, title, $, rawBody) {
   // document or else collect flaws
   if (typeof $ == "string") {
     $ = cheerio.load($);
+  } else {
+    // Let's create a deep copy, since the CheerioAPI object may
+    // be modified during the course of collecting the live sample
+    // code blocks. I couldn't find a better way to create a deep
+    // copy of the CheerioAPI object.
+    // https://stackoverflow.com/questions/55172833/how-do-you-clone-a-cheerio-object
+    $ = cheerio.load($.html());
   }
   return $("iframe")
     .filter((i, iframe) => {


### PR DESCRIPTION
Fixes #4883 

#### Testing
I modified `files/en-us/web/css/_colon_active/index.md` locally. I removed the argument to both of its `EmbedLiveSample` macro calls (so they both became simply `EmbedLiveSample()`), and then reloaded http://localhost:5000/en-US/docs/web/css/:active.