### PR TITLE
Safari iOS is now a WebExtensions browser

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -13,7 +13,7 @@ export const PLATFORM_BROWSERS: { [key: string]: bcd.BrowserNames[] } = {
   ],
   server: ["deno", "nodejs"],
   "webextensions-desktop": ["chrome", "edge", "firefox", "opera", "safari"],
-  "webextensions-mobile": ["firefox_android"],
+  "webextensions-mobile": ["firefox_android", "safari_ios"],
 };
 
 function PlatformHeaders({ platforms, browsers }) {


### PR DESCRIPTION
Over in BCD, @jdatapple has submitted compat data for WebExtensions on iOS. 
In order for MDN to show a column for Safari iOS in the WebExtension docs, we need to add safari to the "webExtensions-mobile" browsers. See for example https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs#browser_compatibility where we currently have no Safari iOS in the mobile column. This PR adds Safari iOS

See also https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes#Web-Extensions