### PR TITLE
Avoid confusing CI reporting

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -45,6 +45,7 @@ jobs:
         run: yarn test:client
 
       - name: Build and start server
+        id: server
         env:
           ENV_FILE: testing/.env
         run: |
@@ -79,7 +80,7 @@ jobs:
           diff -s testing/content/files/en-us/markdown/tool/h2m/index.md testing/content/files/en-us/markdown/tool/h2m/expected.md
 
       - name: Debug server's stdout and stderr if tests failed
-        if: failure()
+        if: failure() && steps.server.outcome != 'skipped'
         run: |
           echo "STDOUT..................................................."
           cat /tmp/stdout.log


### PR DESCRIPTION
If the tests fails before starting the server (for instance while running eslint), the step debugging the server output was producing weird errors due to output files not being found.

See https://github.com/mdn/yari/runs/4223370492?check_suite_focus=true for an example