### PR TITLE
Removes z-index declaration to avoid footer covering search results on 404 page

### DIFF
--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -13,7 +13,6 @@
   color: $text-color-inverted;
   padding: ($base-spacing * 2) $base-spacing;
   position: relative;
-  z-index: $bring-to-front;
 
   .content-container {
     margin: 0 auto;


### PR DESCRIPTION
Fixes #4949
Cleans up #4950

Remove `z-index` declaration from `src/ui/organisms/footer.scss` to avoid footer covering search results as it will have a higher value in the stacking context.