### PR TITLE
chore: add mark as idle workflow

### DIFF
--- a/.github/workflows/mark-as-idle-issues-pr.yml
+++ b/.github/workflows/mark-as-idle-issues-pr.yml
@@ -1,0 +1,8 @@
+name: mark-as-idle
+on:
+  schedule:
+    - cron: "49 11,23 * * *"
+
+jobs:
+  idle-issues-prs:
+    uses: mdn/workflows/.github/workflows/idle-issues.yml@v1

--- a/.github/workflows/mark-as-idle-issues-pr.yml
+++ b/.github/workflows/mark-as-idle-issues-pr.yml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   idle-issues-prs:
-    uses: mdn/workflows/.github/workflows/idle-issues.yml@v1
+    uses: mdn/workflows/.github/workflows/idle-issues.yml@main


### PR DESCRIPTION
Add the mark-as-idle workflow to Yari

fix #5000
