### PR TITLE
Workflow to add needs triage label to new issues

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -1,0 +1,10 @@
+name: "Mark new issues with needs-triage label"
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label-new-issues:
+    uses: mdn/workflows/.github/workflows/new-issues.yml@main


### PR DESCRIPTION
New workflow to automatically add `needs-triage` to new issues

Depends on https://github.com/mdn/workflows/pull/4