### PR TITLE
Fix a link in CSSRef.ejs

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -607,7 +607,7 @@ function buildSublist(pages, title) {
       <details>
           <summary>Lists and counters</summary>
           <ol>
-            <li><%-smartLink(`${cssURL}CSS_Lists_and_Counters/Using_CSS_counters`, null, "Using CSS counters", cssURL)%></li>
+            <li><%-smartLink(`${cssURL}CSS_Counter_Styles/Using_CSS_counters`, null, "Using CSS counters", cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Lists_and_Counters/Consistent_list_indentation`, null, "Consistent list indentation", cssURL)%></li>
           </ol>
       </details>


### PR DESCRIPTION
Fix a link to "Using CSS Counters", which the URL has been changed.