### PR TITLE
fix: inline images by default in main content

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -27,6 +27,10 @@ a.page-not-created {
 .main-page-content {
   padding: math.div($base-spacing, 2) $base-spacing $base-spacing;
 
+  img {
+    display: inline-block;
+  }
+
   figure {
     margin-bottom: $base-spacing;
   }


### PR DESCRIPTION
Set images in the main content to `inline-block` by default.

fix #5029
