### PR TITLE
Add redirect for contribution video

### DIFF
--- a/deployer/aws-lambda/tests/server.test.js
+++ b/deployer/aws-lambda/tests/server.test.js
@@ -206,6 +206,14 @@ describe("always check for fundamental redirects first", () => {
       );
     }
   });
+  it("should redirect Contribute link distributed by video", async () => {
+    expect.assertions(2 * 2);
+    for (const url of ["/mdn/contribute/", "/MDN/Contribute"]) {
+      const r = await get(url);
+      expect(r.statusCode).toBe(301);
+      expect(r.headers["location"]).toBe("/en-US/docs/MDN/Contribute");
+    }
+  });
 });
 
 describe("redirect double-slash prefix URIs", () => {

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -806,6 +806,10 @@ const SCL3_REDIRECT_PATTERNS = [
     "/en-US/docs/Glossary/speculative_parsing",
     { permanent: true }
   ),
+  // Redirect for URL in Contribute video
+  redirect(/MDN\/Contribute\/?$/i, "/en-US/docs/MDN/Contribute", {
+    permanent: true,
+  }),
 ];
 
 const zoneRedirects = [

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -229,6 +229,10 @@ SCL3_REDIRECT_URLS = list(
                 "/{en,EN}/optimizing_your_pages_for_speculative_{PARSING,parsing,parsing/}",
                 "/en-US/docs/Glossary/speculative_parsing"
             ),
+            url_test(
+                "{mdn,MDN}/{Contribute,contribute}",
+                "/en-US/docs/MDN/Contribute"
+            )
         )
     )
 )

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -250,7 +250,9 @@ const SCL3_REDIRECT_URLS = [].concat(
   url_test(
     "/EN/optimizing_your_pages_for_speculative_parsing",
     "/en-US/docs/Glossary/speculative_parsing"
-  )
+  ),
+  url_test("MDN/Contribute", "/en-US/docs/MDN/Contribute"),
+  url_test("mdn/contribute", "/en-US/docs/MDN/Contribute")
 );
 
 const GITHUB_IO_URLS = [].concat(

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -251,8 +251,8 @@ const SCL3_REDIRECT_URLS = [].concat(
     "/EN/optimizing_your_pages_for_speculative_parsing",
     "/en-US/docs/Glossary/speculative_parsing"
   ),
-  url_test("MDN/Contribute", "/en-US/docs/MDN/Contribute"),
-  url_test("mdn/contribute", "/en-US/docs/MDN/Contribute")
+  url_test("/MDN/Contribute", "/en-US/docs/MDN/Contribute"),
+  url_test("/mdn/contribute", "/en-US/docs/MDN/Contribute")
 );
 
 const GITHUB_IO_URLS = [].concat(


### PR DESCRIPTION
A video highlighting contribution process for MDN that was recently published includes a link to a 404-ing page. This redirects to the intended page.

I have no idea what I'm doing, so I basically copied from https://github.com/mdn/yari/pull/4845/.