### PR TITLE
Fix translation dashboard showing "Fresher than English" for stale translations

### DIFF
--- a/client/src/translations/dashboard/index.tsx
+++ b/client/src/translations/dashboard/index.tsx
@@ -488,8 +488,9 @@ function DocumentsTable({
                 .split("commit/")[1]
                 .substring(0, 7);
               let status = "Untranslated";
-              let dateDiff = Number.POSITIVE_INFINITY;
               if (documentDetail.info.localeInfo) {
+                let dateDiff =
+                  documentDetail.info.dateDiff ?? Number.POSITIVE_INFINITY;
                 status = "Out of date";
 
                 if (dateDiff > 0) {


### PR DESCRIPTION
The "Date delta" columns of translation dashboard (e.g. `/ko/_translations/dashboard`) always show "Fresher than English" even for stale documents.

This PR fixes it by actually using `documentDetail.info.dateDiff`.