### PR TITLE
Themes menu item link to extension workshop

### DIFF
--- a/kumascript/macros/AddonSidebarMain.ejs
+++ b/kumascript/macros/AddonSidebarMain.ejs
@@ -55,7 +55,7 @@ var text = mdn.localStringMap({
 <section id="Quick_links">
   <ol>
     <li><a href="<%=baseURL%>WebExtensions"><strong><%=text['WebExtensions']%></strong></a></li>
-    <li><a href="<%=baseURL%>Themes"><strong><%=text['Themes']%></strong></a></li>
+    <li><a href="https://extensionworkshop.com/documentation/themes/"><strong><%=text['Themes']%></strong></a></li>
     <li><a href="https://discourse.mozilla.org/c/add-ons"><strong><%=text['Community_and_Support']%></strong></a></li>
     <li class="toggle">
       <details>


### PR DESCRIPTION
Correct the feedback reported in  [Content bug: /docs/Mozilla/Add-ons/Themes 404's #11214](https://github.com/mdn/content/issues/11214): the add-on sidebar menu item  "Themes" is linked to a non-existent MDN page not to the themes page on extension workshop.