### PR TITLE
fix(sidebar): links overflow

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -13,6 +13,10 @@
     font-size: $medium-font-size;
     margin-bottom: $base-spacing;
   }
+  
+  li {
+    word-break: break-all;
+  }
 
   ol {
     list-style: none;


### PR DESCRIPTION
Fixes #5031, #5105, #4973, #4635, #2221

Changes proposed in this pull request:

- Fix content overflow of links within sidebar component keeping icon and link inline
- Add  property ```word-break: break-all``` to ```.sidebar li``` class