### PR TITLE
fix:locale active es locale

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -58,6 +58,7 @@ const LOCALE_ALIASES = new Map([
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
 const ACTIVE_LOCALES = new Set([
   "en-us",
+  "es",
   "fr",
   "ja",
   "ko",


### PR DESCRIPTION
Activate `es` locale as tier one locale

fix #5162
