### PR TITLE
(fix:kumascript) fix jsref

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -221,7 +221,7 @@ var len = 0;
 
 // Output
 
-output  = '<section class="Quick_links" id="Quick_Links"><ol>';
+output  = '<section class="Quick_links" id="Quick_links"><ol>';
 const link = web.smartLink(slug_stdlib, null, text['stdlib'], slug_stdlib, slug_stdlib, "JSRef");
 output += `<li><strong>${link}</strong></li>`;
 


### PR DESCRIPTION
The `id` attribute value should be `Quick_links` and not `Quick_Links`

fix #5180
