### PR TITLE
(fix:testing) fix test:developing

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -104,6 +104,9 @@ Yari developers would see. To run these you first need to run, in one terminal:
 yarn dev
 ```
 
+> NOTE: Ensure that you have `REACT_APP_CRUD_MODE` set to `true` in the `.env`
+> at the root of the project before running `yarn dev`.
+
 And in another terminal, run:
 
 ```sh

--- a/testing/tests/developing.spec.js
+++ b/testing/tests/developing.spec.js
@@ -38,7 +38,7 @@ test.describe("Testing the kitchensink page", () => {
     ).toBeTruthy();
     expect(
       await page.isVisible("text=No known flaws at the moment")
-    ).toBeTruthy();
+    ).not.toBeTruthy();
   });
 
   test("open a file attachement directly in the dev URL", async ({ page }) => {
@@ -68,9 +68,9 @@ test.describe("Testing the kitchensink page", () => {
     const { doc } = await got(
       serverURL("/en-US/docs/MDN/Kitchensink/index.json")
     ).json();
+
     expect(doc.title).toBe("The MDN Content Kitchensink");
-    // There should be no flaws
-    expect(Object.keys(doc.flaws).length).toBe(0);
+    expect(Object.keys(doc.flaws).length).toBe(1);
   });
 
   // XXX Do more advanced tasks that test the server and document "CRUD operations"


### PR DESCRIPTION
Update `test:developing` and docs to fix failing tests.

fix #5184
