### PR TITLE
Trim "≤" sign from version when searching for browser release date

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -426,7 +426,11 @@ function _addSingleSpecialSection($) {
             info = [info];
           }
           for (const infoEntry of info) {
-            const added = infoEntry.version_added;
+            const added =
+              typeof infoEntry.version_added === "string" &&
+              infoEntry.version_added.startsWith("≤")
+                ? infoEntry.version_added.slice(1)
+                : infoEntry.version_added;
             if (browserReleaseData.has(browser)) {
               if (browserReleaseData.get(browser).has(added)) {
                 infoEntry.release_date = browserReleaseData


### PR DESCRIPTION
When building a BCD document section, the support statement object don't receive the browser release date if the version is ranged.

The effect is that some of the browser compatibility table cells don't receive the `title` attribute with the browser version release date. Thus, the user get no tooltip when the cursor is over that cell.

For example, the `@mdn/browser-compat-data` says that the `api.CanvasRenderingContext2D.beginPath` method was added to Opera in "≤12.1" version (https://github.com/mdn/browser-compat-data/blob/main/api/CanvasRenderingContext2D.json).

Here is how it looks like in the browser (https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D):

<img width="829" alt="02" src="https://user-images.githubusercontent.com/23465488/150408184-71623c61-d914-4a77-9901-98c4c7b37630.png">

This PR fixes the bug. After applying the fix:

<img width="829" alt="03" src="https://user-images.githubusercontent.com/23465488/150408214-220e3dab-dbc3-422a-b2fa-d4729b8cfb98.png">
