### PR TITLE
Browser compatibility table: revise preview legend copy

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -5,9 +5,9 @@ import { asList, listFeatures } from "./utils";
 const LEGEND_LABELS = {
   yes: "Full support",
   partial: "Partial support",
+  preview: "In development. Supported in a pre-release version.",
   no: "No support",
   unknown: "Compatibility unknown",
-  preview: "Supported in pre-release/beta channel",
   experimental: "Experimental. Expect behavior to change in the future.",
   "non-standard": "Non-standard. Check cross-browser support before using.",
   deprecated: "Deprecated. Not for use in new websites.",


### PR DESCRIPTION
A follow up to https://github.com/mdn/yari/pull/5207 that amends the text a bit ("channel" is a bit jargony) and places it with other parts of the legend that are more similar.