### PR TITLE
Add ability to draw diagram for inheritance chain of any length

### DIFF
--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -52,17 +52,10 @@ function rectWithText(x, y, fill, interfaceName, reverse) {
 }
 
 function lineWithTriangle(x, y, reverse) {
-  let str = '';
-  let linePoints = `x1="${x+10}" y1="${y+14}" x2="${x+30}" y2="${y+14}"`;
-
-  if (reverse) {
-    linePoints = `x1="${x-10}" y1="${y+14}" x2="${x-30}" y2="${y+14}"`;
-  }
-
-  str += triangle(x, y + 14, reverse);
-  str += `<line ${linePoints} stroke="#D4DDE4"/>`;
-
-  return str;
+  const length = reverse ? -30 : 30;
+  return `
+  <line x1="${x}" y1="${y}" x2="${x+length}" y2="${y}" stroke="#D4DDE4""/>
+  ${triangle(x, y, reverse)}`;
 }
 
 function connectingLineWithTriangle() {
@@ -98,7 +91,7 @@ function drawDiagram(inheritanceChain) {
     if (i < 4) {
       str += rectWithText(xpos, ypos, fill, inheritanceChain[i]);
       if (i != inheritanceChain.length - 1 && i != 3) {
-        str += lineWithTriangle(xpos, ypos);
+        str += lineWithTriangle(xpos, ypos + 14);
         xpos += 30;
       }
     // second row
@@ -106,7 +99,7 @@ function drawDiagram(inheritanceChain) {
       height = 80; // need more space
       str += rectWithText(xpos, ypos, fill, inheritanceChain[i], true);
       if (i != inheritanceChain.length - 1) {
-        str += lineWithTriangle(xpos, ypos, true);
+        str += lineWithTriangle(xpos, ypos + 14, true);
         xpos -= 30;
       }
       if (xpos < 0) {

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -35,7 +35,7 @@ function getInheritance(inh) {
 getInheritance(inh);
 
 function rectWithText(x, y, fill, interfaceName, reverse) {
-  const rectWidth = interfaceName.length * 8 < 75 ? 75 : interfaceName.length * 8;
+  const rectWidth = calculateRectWidth(interfaceName);
   if (reverse) {
     xpos -= rectWidth;
     x = xpos;
@@ -68,6 +68,10 @@ function connectingLineWithTriangle(x, y, reverse) {
 function triangle(x, y, reverse) {
   const width = reverse ? -10 : 10;
   return `<polyline points="${x},${y} ${x+width},${y-5} ${x+width},${y+5} ${x},${y}" stroke="#D4DDE4" fill="#fff"/>`;
+}
+
+function calculateRectWidth(text) {
+  return text.length * 8 < 75 ? 75 : text.length * 8;
 }
 
 function drawDiagram(inheritanceChain) {

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -9,6 +9,7 @@
     - http://localhost:3000/en-US/docs/Web/API/SVGTextPositioningElement
     - http://localhost:3000/en-US/docs/Web/API/WheelEvent
     - http://localhost:3000/en-US/docs/Web/API/USB/connect_event
+    - http://localhost:3000/en-US/docs/Web/API/SVGTSpanElement
 */
 
 const data = web.getJSONData("InterfaceData")[0];

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -58,18 +58,11 @@ function lineWithTriangle(x, y, reverse) {
   ${triangle(x, y, reverse)}`;
 }
 
-function connectingLineWithTriangle() {
-  let str = '';
-
-  str += triangle(xpos, ypos + 14);
-  xpos += 10;
-  str += `<line x1="${xpos}" y1="${ypos+14}" x2="${xpos+8}" y2="${ypos+14}" stroke="#D4DDE4"/>`;
-  xpos += 8;
-  str += `<line x1="${xpos}" y1="${ypos+14}" x2="${xpos}" y2="${ypos+59}" stroke="#D4DDE4"/>`;
-  ypos = 60;
-  str += `<line x1="${xpos}" y1="${ypos}" x2="${xpos-17}" y2="${ypos}" stroke="#D4DDE4"/>`;
-
-  return str;
+function connectingLineWithTriangle(x, y, reverse) {
+  const width = reverse ? -17 : 17;
+  return `
+  <polyline points="${x},${y} ${x+width},${y} ${x+width},${y+45} ${x},${y+45}" stroke="#D4DDE4" fill="none"/>
+  ${triangle(x, y, reverse)}`;
 }
 
 function triangle(x, y, reverse) {
@@ -83,8 +76,7 @@ function drawDiagram(inheritanceChain) {
     const fill = (inheritanceChain[i] == mainInterfaceName) ? '#F4F7F8': '#fff';
     // we are going to the second row with a connecting line
     if (i === 4) {
-      str += connectingLineWithTriangle();
-      xpos -= 18;
+      str += connectingLineWithTriangle(xpos, ypos + 14);
       ypos = 47;
     }
     // first row

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -16,9 +16,10 @@ const href = `/${env.locale}/docs/Web/API/`;
 const mainInterfaceName = $0 || env.slug.replace('Web/API/','').split('/')[0];
 
 let height = 40;
-let offset = 0;
-let xpos = 1;
-let ypos = 1;
+let xpos = 0;
+let ypos = 0;
+let left = 0;
+let right = 0;
 
 let inheritanceChain = [mainInterfaceName];
 let inh = data[mainInterfaceName] != undefined ? data[mainInterfaceName].inh : '';
@@ -69,38 +70,53 @@ function calculateRectWidth(text) {
   return text.length * 8 < 75 ? 75 : text.length * 8;
 }
 
+function moveBy(number, delta, reverse) {
+  return number + (reverse ? -delta : delta);
+}
+
+function includeInRange(number, start, end) {
+  return [
+    Math.min(start, number),
+    Math.max(end, number)
+  ];
+}
+
 function drawDiagram(inheritanceChain) {
   let str = '';
+  let reverse = false;
+
   for (let i = 0; i < inheritanceChain.length; i++) {
     const fill = (inheritanceChain[i] == mainInterfaceName) ? '#F4F7F8': '#fff';
     const rectWidth = calculateRectWidth(inheritanceChain[i]);
-    // we are going to the second row with a connecting line
-    if (i === 4) {
-      str += connectingLineWithTriangle(xpos, ypos + 14);
-      ypos = 47;
-    }
-    // first row
-    if (i < 4) {
-      str += rectWithText(xpos, ypos, fill, inheritanceChain[i]);
-      xpos += rectWidth;
-      if (i != inheritanceChain.length - 1 && i != 3) {
-        str += lineWithTriangle(xpos, ypos + 14);
-        xpos += 30;
-      }
-    // second row
-    } else {
-      height = 80; // need more space
-      str += rectWithText(xpos, ypos, fill, inheritanceChain[i], true);
-      xpos -= rectWidth;
-      if (i != inheritanceChain.length - 1) {
-        str += lineWithTriangle(xpos, ypos + 14, true);
-        xpos -= 30;
-      }
-      if (xpos < 0) {
-        // prevent cut off in case of a really long chain (see e.g. SVGTextPositioningElement)
-        offset = 1 + Math.abs(xpos);
+    // Minumum space required to continue the current row
+    let reqSpace = rectWidth;
+    if (i > 0) reqSpace += 30;
+    // If the rect from the next iteration won't fit in the row, we need to be
+    // sure that at least the connectingLineWithTriangle will fit
+    if (i < inheritanceChain.length - 1) reqSpace += 17;
+    const reqBounds = includeInRange(
+      moveBy(xpos, reqSpace, reverse), left, right
+    );
+    // Will the current drawing items fit inside the viewbox? Subtract the
+    // stroke width from the viewbox width to prevent stroke cut off.
+    const canContinueRow = reqBounds[1] - reqBounds[0] <= 650 - 2;
+
+    if (i > 0) {
+      if (canContinueRow) {
+        str += lineWithTriangle(xpos, ypos + 14, reverse);
+        xpos = moveBy(xpos, 30, reverse);
+      } else {
+        str += connectingLineWithTriangle(xpos, ypos + 14, reverse);
+        [left, right] = includeInRange(moveBy(xpos, 17, reverse), left, right);
+        ypos += 46;
+        height += 46;
+        reverse = !reverse;
       }
     }
+
+    str += rectWithText(xpos, ypos, fill, inheritanceChain[i], reverse);
+    xpos = moveBy(xpos, rectWidth, reverse);
+    [left, right] = includeInRange(xpos, left, right);
   }
   return str;
 }
@@ -108,8 +124,8 @@ function drawDiagram(inheritanceChain) {
 let output = '';
 
 if (inheritanceChain.length > 1) {
-  let diagram = drawDiagram(inheritanceChain); // needs to run first to calculate offset and height
-  output = `<svg viewbox="-${offset} 0 650 ${height}" preserveAspectRatio="xMinYMin meet">`;
+  let diagram = drawDiagram(inheritanceChain); // needs to run first to calculate left and height
+  output = `<svg viewbox="${left-1} -1 650 ${height+2}" preserveAspectRatio="xMinYMin meet">`;
   output += diagram;
   output +='</svg>';
 }

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -36,12 +36,7 @@ getInheritance(inh);
 
 function rectWithText(x, y, fill, interfaceName, reverse) {
   const rectWidth = calculateRectWidth(interfaceName);
-  if (reverse) {
-    xpos -= rectWidth;
-    x = xpos;
-  } else {
-    xpos += rectWidth;
-  }
+  if (reverse) x -= rectWidth;
   return `
   <a style="text-decoration: none;" xlink:href="${href+interfaceName}">
     <rect x="${x}" y="${y}" width="${rectWidth}" height="25" fill="${fill}" stroke="#D4DDE4" stroke-width="2px" />
@@ -78,6 +73,7 @@ function drawDiagram(inheritanceChain) {
   let str = '';
   for (let i = 0; i < inheritanceChain.length; i++) {
     const fill = (inheritanceChain[i] == mainInterfaceName) ? '#F4F7F8': '#fff';
+    const rectWidth = calculateRectWidth(inheritanceChain[i]);
     // we are going to the second row with a connecting line
     if (i === 4) {
       str += connectingLineWithTriangle(xpos, ypos + 14);
@@ -86,6 +82,7 @@ function drawDiagram(inheritanceChain) {
     // first row
     if (i < 4) {
       str += rectWithText(xpos, ypos, fill, inheritanceChain[i]);
+      xpos += rectWidth;
       if (i != inheritanceChain.length - 1 && i != 3) {
         str += lineWithTriangle(xpos, ypos + 14);
         xpos += 30;
@@ -94,6 +91,7 @@ function drawDiagram(inheritanceChain) {
     } else {
       height = 80; // need more space
       str += rectWithText(xpos, ypos, fill, inheritanceChain[i], true);
+      xpos -= rectWidth;
       if (i != inheritanceChain.length - 1) {
         str += lineWithTriangle(xpos, ypos + 14, true);
         xpos -= 30;

--- a/kumascript/macros/InheritanceDiagram.ejs
+++ b/kumascript/macros/InheritanceDiagram.ejs
@@ -53,16 +53,13 @@ function rectWithText(x, y, fill, interfaceName, reverse) {
 
 function lineWithTriangle(x, y, reverse) {
   let str = '';
-  let polylinePoints = `${x},${y+14} ${x+10},${y+9} ${x+10},${y+19} ${x},${y+14}`;
   let linePoints = `x1="${x+10}" y1="${y+14}" x2="${x+30}" y2="${y+14}"`;
 
   if (reverse) {
-    polylinePoints = `${x},${y+14} ${x-10},${y+9} ${x-10},${y+19} ${x},${y+14}`;
     linePoints = `x1="${x-10}" y1="${y+14}" x2="${x-30}" y2="${y+14}"`;
   }
 
-  str += `<polyline points="${polylinePoints}" stroke="#D4DDE4" fill="none"/>`;
-  x -= 10;
+  str += triangle(x, y + 14, reverse);
   str += `<line ${linePoints} stroke="#D4DDE4"/>`;
 
   return str;
@@ -71,7 +68,7 @@ function lineWithTriangle(x, y, reverse) {
 function connectingLineWithTriangle() {
   let str = '';
 
-  str += `<polyline points="${xpos},${ypos+14} ${xpos+10},${ypos+9} ${xpos+10},${ypos+19} ${xpos},${ypos+14}" stroke="#D4DDE4" fill="none"/>`;
+  str += triangle(xpos, ypos + 14);
   xpos += 10;
   str += `<line x1="${xpos}" y1="${ypos+14}" x2="${xpos+8}" y2="${ypos+14}" stroke="#D4DDE4"/>`;
   xpos += 8;
@@ -80,6 +77,11 @@ function connectingLineWithTriangle() {
   str += `<line x1="${xpos}" y1="${ypos}" x2="${xpos-17}" y2="${ypos}" stroke="#D4DDE4"/>`;
 
   return str;
+}
+
+function triangle(x, y, reverse) {
+  const width = reverse ? -10 : 10;
+  return `<polyline points="${x},${y} ${x+width},${y-5} ${x+width},${y+5} ${x},${y}" stroke="#D4DDE4" fill="#fff"/>`;
 }
 
 function drawDiagram(inheritanceChain) {


### PR DESCRIPTION
Currently, the maximum number of rows when drawing an inheritance diagram is 2 and the maximum number of rectangles in a row is 4. Therefore, in some cases, the inheritance diagram doesn't fit in the svg viewbox:

- https://developer.mozilla.org/en-US/docs/Web/API/SVGTextElement
- https://developer.mozilla.org/en-US/docs/Web/API/SVGTSpanElement
- https://developer.mozilla.org/en-US/docs/Web/API/BackgroundFetchUpdateUIEvent

This PR adds the ability to draw a diagram for inheritance chain of any length.

This became possible by checking whether the connecting line and rectangle fit in the viewbox before drawing.

What was done to achieve the result:

- Added a utility function for drawing triangles.
- `lineWithTriangle()`, `connectingLineWithTriangle()`, `rectWithText()` functions are now pure.
- Connecting lines are now drawn from the apex of the triangle.
- Added `calculateRectWidth()` function to be able to determine the width of the rectangle before drawing it.
- Added `left` and `right` variables to control the overall width of drawn items and do not allow the size of this area to be larger than the width of the viewbox.
- Added `moveBy()` function to move `xpos` relative to the drawing direction.
- Added `includeInRange()` function to have a convenient way to expand the left and right borders during the drawing process.

Also a new test page with a very long inheritance chain was added to the header.

To test the macro you can also add this line:

```js
inheritanceChain = new Array(30).fill().map(() => "X".repeat(4 + Math.round(Math.random() * 20)));
```

before this line:

```js
let diagram = drawDiagram(inheritanceChain); // needs to run first to calculate left and height
```

to generate a very long inheritance chain with random text in rectangles. You will get something like this:

<img width="811" alt="Screenshot 2022-02-07 204234" src="https://user-images.githubusercontent.com/23465488/152857278-aee27071-00a0-4aac-88d4-f710383c86fe.png">

The macro was tested manually on all pages that have an inheritance diagram.
