### PR TITLE
Make Specifications macro generate spec URL for ARIA docs based on title

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -323,12 +323,14 @@ function _addSingleSpecialSection($) {
 
   let dataQuery = null;
   let specialSectionType = null;
+  let isSpecSectionForAria;
   if ($.find("div.bc-data").length) {
     specialSectionType = "browser_compatibility";
     dataQuery = $.find("div.bc-data").attr("id");
   } else if ($.find("div.bc-specs").length) {
     specialSectionType = "specifications";
     dataQuery = $.find("div.bc-specs").attr("data-bcd-query");
+    isSpecSectionForAria = dataQuery.startsWith("aria-") ? true : false;
   }
 
   // Some old legacy documents haven't been re-rendered yet, since it
@@ -361,7 +363,7 @@ function _addSingleSpecialSection($) {
     }
     return _buildSpecialBCDSection();
   } else if (specialSectionType === "specifications") {
-    if (data === undefined) {
+    if (data === undefined && !isSpecSectionForAria) {
       return [
         {
           type: specialSectionType,
@@ -458,13 +460,16 @@ function _addSingleSpecialSection($) {
     // Collect spec_urls from a BCD feature.
     // Can either be a string or an array of strings.
     let specURLs = [];
-
-    for (const [key, compat] of Object.entries(data)) {
-      if (key === "__compat" && compat.spec_url) {
-        if (Array.isArray(compat.spec_url)) {
-          specURLs = compat.spec_url;
-        } else {
-          specURLs.push(compat.spec_url);
+    if (isSpecSectionForAria) {
+      specURLs.push(`https://w3c.github.io/aria/#${dataQuery}`);
+    } else {
+      for (const [key, compat] of Object.entries(data)) {
+        if (key === "__compat" && compat.spec_url) {
+          if (Array.isArray(compat.spec_url)) {
+            specURLs = compat.spec_url;
+          } else {
+            specURLs.push(compat.spec_url);
+          }
         }
       }
     }

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -14,6 +14,7 @@ Example calls
 */
 
 var query = $0 || env['browser-compat'];
+query = !query && env['title'].startsWith('aria-') ? env['title'] : query;
 if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");
 }


### PR DESCRIPTION
This change makes the Specifications macro generate a spec URL for all articles for ARIA attributes based on the article title, rather than by doing a BCD query.

This makes it possible to just put a `{{Specifications}}` macro call in all the ARIA docs, and have it automatically do the right thing.

Otherwise, without this change, we’d need to add data to BCD for all the ARIA attributes. It’s not clear that we’d ever actually want to do that — but anyway, this change is forward-compatible in that if we ever did add all the ARIA attributes to BCD, this change won’t break anything (instead it would end up just being redundant, and so we could remove it at that time).