### PR TITLE
Add support for 'spec-urls' frontmatter key

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -322,6 +322,7 @@ function _addSingleSpecialSection($) {
   }
 
   let dataQuery = null;
+  let specURLsString = "";
   let specialSectionType = null;
   if ($.find("div.bc-data").length) {
     specialSectionType = "browser_compatibility";
@@ -329,13 +330,14 @@ function _addSingleSpecialSection($) {
   } else if ($.find("div.bc-specs").length) {
     specialSectionType = "specifications";
     dataQuery = $.find("div.bc-specs").attr("data-bcd-query");
+    specURLsString = $.find("div.bc-specs").attr("data-spec-urls");
   }
 
   // Some old legacy documents haven't been re-rendered yet, since it
   // was added, so the `div.bc-data` tag doesn't have a `id="bcd:..."`
   // attribute. If that's the case, bail and fail back on a regular
   // prose section :(
-  if (!dataQuery) {
+  if (!dataQuery && specURLsString === "") {
     // I wish there was a good place to log this!
     const [proseSections] = _addSectionProse($);
     return proseSections;
@@ -361,7 +363,7 @@ function _addSingleSpecialSection($) {
     }
     return _buildSpecialBCDSection();
   } else if (specialSectionType === "specifications") {
-    if (data === undefined) {
+    if (data === undefined && specURLsString === "") {
       return [
         {
           type: specialSectionType,
@@ -455,18 +457,28 @@ function _addSingleSpecialSection($) {
   }
 
   function _buildSpecialSpecSection() {
-    // Collect spec_urls from a BCD feature.
-    // Can either be a string or an array of strings.
+    // Collect spec URLs from a BCD feature, a 'spec-urls' value, or both;
+    // For a BCD feature, it can either be a string or an array of strings.
     let specURLs = [];
 
-    for (const [key, compat] of Object.entries(data)) {
-      if (key === "__compat" && compat.spec_url) {
-        if (Array.isArray(compat.spec_url)) {
-          specURLs = compat.spec_url;
-        } else {
-          specURLs.push(compat.spec_url);
+    if (data) {
+      // If 'data' is non-null, that means we have data for a BCD feature
+      // that we can extract spec URLs from.
+      for (const [key, compat] of Object.entries(data)) {
+        if (key === "__compat" && compat.spec_url) {
+          if (Array.isArray(compat.spec_url)) {
+            specURLs = compat.spec_url;
+          } else {
+            specURLs.push(compat.spec_url);
+          }
         }
       }
+    }
+
+    if (specURLsString !== "") {
+      // If specURLsString is non-empty, then it has the string contents of
+      // the document’s 'spec-urls' frontmatter key: one or more URLs.
+      specURLs.push(...specURLsString.split(",").map((url) => url.trim()));
     }
 
     // Use BCD specURLs to look up more specification data

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -14,10 +14,11 @@ Example calls
 */
 
 var query = $0 || env['browser-compat'];
-if (!query) {
-  throw new Error("No first query argument or 'browser-compat' front-matter value passed");
+var specURLs = env['spec-urls'] || "";
+if (!query && !specURLs) {
+  throw new Error("No first query argument or 'browser-compat' or 'spec-urls' front-matter value passed");
 }
-var output = `<div class="bc-specs" data-bcd-query="${query}">
+var output = `<div class="bc-specs" data-bcd-query="${query}" data-spec-urls="${specURLs}">
   If you're able to see this, something went wrong on this page.
 </div>`;
 %>


### PR DESCRIPTION
Fixes https://github.com/mdn/yari/issues/4704 • Related: https://github.com/mdn/yari/pull/5277

This change adds support for listing specs in the **Specifications** section based on the value of the `spec-urls` frontmatter key — instead of or in addition to listing specs based on the value of the `browser-compat` frontmatter key, or the value of the parameter passed to the `Specifications` macro.