### PR TITLE
Point create/edit commands to Markdown files

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -546,7 +546,7 @@ function move(oldSlug, newSlug, locale, { dry = false } = {}) {
 }
 
 function fileForSlug(slug, locale) {
-  return getHTMLPath(getFolderPath({ slug, locale }));
+  return getMarkdownPath(getFolderPath({ slug, locale }));
 }
 
 function exists(slug, locale) {


### PR DESCRIPTION
This PR directs `yarn content create` and `yarn content edit` to `index.md` rather than `index.html` when creating new files or editing existing ones.  The function altered is used only for these two commands, so no other portions of code are affected.  Fixes #5298.