### PR TITLE
Make spec-name lookup fall back to SpecData if not in browser-specs

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -1,6 +1,7 @@
 const cheerio = require("cheerio");
 const { packageBCD } = require("./resolve-bcd");
 const specs = require("browser-specs");
+const web = require("../kumascript/src/api/web.js");
 
 /** Extract and mutate the $ if it as a "Quick_links" section.
  * But only if it exists.
@@ -501,6 +502,14 @@ function _addSingleSpecialSection($) {
         };
         if (spec) {
           specificationsData.title = spec.title;
+        } else {
+          const specList = web.getJSONData("SpecData");
+          const titleFromSpecData = Object.keys(specList).find(
+            (key) => specList[key]["url"] === specURL.split("#")[0]
+          );
+          if (titleFromSpecData) {
+            specificationsData.title = titleFromSpecData;
+          }
         }
 
         return specificationsData;


### PR DESCRIPTION
When building Specifications sections, if a spec URL is not found in browser-specs, fall back to looking up the spec title in `SpecData.json`. Related: https://github.com/mdn/content/pull/13170#discussion_r812657490