### PR TITLE
(fix:testing) bump nodejs to v14

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v2.5.1
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Cache node_modules
         uses: actions/cache@v2.1.7


### PR DESCRIPTION
Bumps Nodejs version to version 14 for `performance.yml` as this is a requirement for the latest version of `@lhci/cli`

fix #5327
