### PR TITLE
Support giving spec URL as {{Specifications(...)}} argument

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -342,8 +342,17 @@ function _addSingleSpecialSection($) {
     const [proseSections] = _addSectionProse($);
     return proseSections;
   }
-  const query = dataQuery.replace(/^bcd:/, "");
-  const { browsers, data } = packageBCD(query);
+  let query = dataQuery.replace(/^bcd:/, "");
+  let browsers;
+  let data;
+
+  if (dataQuery && dataQuery.trim().match("^http[s]?://")) {
+    specURLsString = [specURLsString, dataQuery.trim()]
+      .filter((urls) => urls)
+      .join(", ");
+  } else {
+    ({ browsers, data } = packageBCD(query));
+  }
 
   if (specialSectionType === "browser_compatibility") {
     if (data === undefined) {

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -4,12 +4,14 @@ Placeholder to render a specification section with spec_urls from BCD
 
 Parameters
 
-$0 – A query string indicating for which feature to retrieve specification URLs for.
+$0 – Either (a) a query string indicating which feature to retrieve spec
+     URLs for, or else (2) one or more spec URLs, separated by commas.
 
 Example calls
 
 {{Specifications}}
-{{Specifications("html.element.abbr")}}
+{{Specifications("api.isSecureContext")}}
+{{Specifications("https://w3c.github.io/webappsec-secure-contexts/")}}
 
 */
 


### PR DESCRIPTION
Related: https://github.com/mdn/content/pull/13273#issuecomment-1051378612 • This changes allows authors to give the Specifications macro a spec URL as an argument; like this:

```
{{Specifications("https://w3c.github.io/webappsec-secure-contexts/")}}
```

cc @wbamberg