### PR TITLE
fix(sidebar): link appearing in new line after marker

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -99,6 +99,7 @@
     padding: 0.25rem;
     color: var(--text-secondary);
     hyphens: auto;
+    max-width: calc(100% - 1rem);
 
     &[aria-current="page"] {
       background: var(--border-secondary);


### PR DESCRIPTION
# The problem

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs


![Screenshot 2022-03-01 225003](https://user-images.githubusercontent.com/3090380/156191599-4a51cc1d-7cb7-4bb1-a7a1-b98050bf5051.png)

On the sidebar list, when there is a long page titles, the link's box appear in the next line after the list marker.

![image](https://user-images.githubusercontent.com/3090380/156192276-2d40b5ca-b60c-45b4-a825-ab2302ac02e2.png)

# The change

Add "max-width" to force the link's box not be rendered in the line after `::marker`

# Result

![Screenshot 2022-03-01 225043](https://user-images.githubusercontent.com/3090380/156191612-a5ca3516-b153-4de0-afe4-c7aa9560de79.png)

![image](https://user-images.githubusercontent.com/3090380/156192801-34fc38e6-c008-46a7-a8eb-30c50f8b4061.png)
