### PR TITLE
fix: sidebar starts to grow when it scrolls off page

### DIFF
--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -14,11 +14,10 @@ function CalculateSidebarOnScroll() {
       let sidebar = document.getElementById("sidebar-quicklinks");
       if (sidebar) {
         let sidebarTop = sidebar.getBoundingClientRect().top;
-        let sidebarTopString = sidebarTop.toString();
-        let sidebarTopPx = sidebarTopString + "px";
+        let visibleHeaderHeight = sidebarTop > 0 ? sidebarTop : 0;
         document.documentElement.style.setProperty(
           "--visible-height-of-header",
-          sidebarTopPx
+          `${visibleHeaderHeight}px`
         );
       }
     }


### PR DESCRIPTION
When scrolling the page to the very bottom, the height of the sidebar starts to grow:

https://user-images.githubusercontent.com/23465488/156199087-74e25870-1b8c-4a6d-8257-5fcd1e3b814c.mp4

This happens because `visible-height-of-header` CSS variable becomes less than zero when the sidebar starts scrolling off the page.

This PR prevents `visible-height-of-header` CSS variable to be less than zero and fixes incorrect behavior.