### PR TITLE
(fix:a11y) restore underlines for links in main content

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -8,6 +8,18 @@
   padding: 3rem 1rem 1rem;
   overflow-wrap: break-word;
 
+  a {
+    &:link,
+    &:visited {
+      text-decoration: underline;
+    }
+
+    &:hover,
+    &:focus {
+      text-decoration: none;
+    }
+  }
+
   h1,
   h2,
   h3,
@@ -45,11 +57,6 @@
   a:not(.button) {
     color: var(--text-link);
     width: fit-content;
-
-    &:hover,
-    &:focus {
-      text-decoration: underline;
-    }
 
     &:active {
       background-color: var(--text-link);


### PR DESCRIPTION
Restore underlines for `:link` and `:visited` states for links in the main document content.

## Before

![Screenshot showing JavaScript landing page without underlines for links](https://user-images.githubusercontent.com/10350960/157640591-1ad1c4be-8e07-4447-84bd-7e9b434bb9a2.png)


## After

![Screenshot showing JavaScript landing page with underlines for links](https://user-images.githubusercontent.com/10350960/157640612-73009ac8-21b5-4f04-8951-833b5e439314.png)


fix #5394
