### PR TITLE
Changing position of switch to left of icon

### DIFF
--- a/client/src/ui/molecules/theme-toggle/index.tsx
+++ b/client/src/ui/molecules/theme-toggle/index.tsx
@@ -28,13 +28,13 @@ export function ThemeToggle() {
 
   return (
     <div className="theme-toggle">
-      <Icon name="theme"></Icon>
       <Switch
         name="themeToggle"
         hiddenLabel={`toggle theme to ${dark ? "light" : "dark"} mode`}
         checked={dark}
         toggle={toggle}
       ></Switch>
+      <Icon name="theme"></Icon>
     </div>
   );
 }


### PR DESCRIPTION
I think the switch position should be on the left side of the icon as the distance between the switch and search button is very little and it looks weird.