### PR TITLE
fix(search): allow submitting non-empty query via button

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -417,7 +417,9 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           // When something *is* entered, the onKeyDown event is triggered
           // on the <input> and within that handler you can
           // access `event.key === 'Enter'` as a signal to submit the form.
-          e.preventDefault();
+          if (!inputValue.trim()) {
+            e.preventDefault();
+          }
         },
       })}
     >


### PR DESCRIPTION
Previously, the search form could only be submitted by pressing
the Enter key while having focus in the input field, and any
regular submits via the submit button were prevented.

This was meant to prevent submitting the form without a query term,
but it also prevented submitting it *with* a non-empty query term.

Fixes #5359.