### PR TITLE
Add h2 tint for increased scanability

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -41,6 +41,14 @@
       }
     }
   }
+  
+  h2 {
+    background: linear-gradient(
+      rgba(255,255,255,0.9), 
+      rgba(255,255,255,0.9)
+    ), var(--text-link);
+    padding-left: 0.2rem;
+  }
 
   a:not(.button) {
     color: var(--text-link);


### PR DESCRIPTION
The MDN redesign has reduced the scanability of technical reference articles. This PR aims to improve it by adding some light visual differentiators to the `h2` headings. These split up major sections of reference articles. Their visual similarity to `h3`s makes it hard to spot when using MDN as a quick reference.

Adding a light, themed tint behind the `h2`s makes a big difference in my opinion. These all handily pass WCAG contrast-ratio guidelines, and are much less distracting than borders or outlines.

**HTML**
<img width="801" alt="image" src="https://user-images.githubusercontent.com/1337003/156551184-a625a655-b193-4735-a0eb-17bd369eedb3.png">

**CSS**
<img width="797" alt="image" src="https://user-images.githubusercontent.com/1337003/156551498-98a80db6-1e8e-4695-b778-f78645245f60.png">

**JS**
<img width="682" alt="image" src="https://user-images.githubusercontent.com/1337003/156551773-2f8e1d5b-48e8-4cbf-94ae-ddda1f7bbbc3.png">
