### PR TITLE
feat(theme): add bgcolor to notes

### DIFF
--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -20,6 +20,22 @@
       $mdn-color-light-theme-green-30,
       $alpha: -0.6
     )};
+  --background-information: #{color.adjust(
+      $mdn-theme-light-icon-information,
+      $alpha: -0.9
+    )};
+  --background-warning: #{color.adjust(
+      $mdn-theme-light-icon-warning,
+      $alpha: -0.9
+    )};
+  --background-critical: #{color.adjust(
+      $mdn-theme-light-icon-critical,
+      $alpha: -0.9
+    )};
+  --background-success: #{color.adjust(
+      $mdn-theme-light-icon-success,
+      $alpha: -0.9
+    )};
 
   --border-primary: #{$mdn-theme-light-border-primary};
   --border-secondary: #{$mdn-theme-light-border-secondary};

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -1,8 +1,10 @@
 .notecard {
+  --note-background: var(--background-information);
   --note-theme: var(--icon-information);
   position: relative;
   padding: 1rem 1rem 1rem 3rem;
   margin: 1rem 0;
+  background-color: var(--note-background);
   border: 1px solid var(--border-secondary);
   border-radius: var(--elem-radius);
   border-left: 4px solid var(--note-theme);
@@ -44,6 +46,7 @@
   }
 
   &.warning {
+    --note-background: var(--background-warning);
     --note-theme: var(--icon-warning);
 
     &:before {
@@ -54,6 +57,7 @@
   &.deprecated,
   &.error,
   &.negative {
+    --note-background: var(--background-critical);
     --note-theme: var(--icon-critical);
 
     &:before {
@@ -62,6 +66,7 @@
   }
 
   &.success {
+    --note-background: var(--background-success);
     --note-theme: var(--icon-success);
 
     &:before {


### PR DESCRIPTION
Previously, notes (e.g. warnings) had a background color, which helped to
easily recognize them in articles. This got lost as part of the redesign.

This simply adds background colors to notes again.

Closes #5367.