### PR TITLE
chore(render): restore overview heading

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -208,15 +208,12 @@ export function Document(props /* TODO: define a TS interface for this */) {
   );
 }
 
-/** These prose sections should be rendered WITHOUT a heading. */
-const PROSE_NO_HEADING = ["short_description", "overview"];
-
 function RenderDocumentBody({ doc }) {
   return doc.body.map((section, i) => {
     if (section.type === "prose") {
       // Only exceptional few should use the <Prose/> component,
       // as opposed to <ProseWithHeading/>.
-      if (!section.value.id || PROSE_NO_HEADING.includes(section.value.id)) {
+      if (!section.value.id) {
         return (
           <Prose
             key={section.value.id || `prose${i}`}


### PR DESCRIPTION
Previously, "Overview" headings were not rendered. This caused the
corresponding table-of-contents item to not work.

Now, we render these headings again, provided they have an ID.

Closes #5476.

## Before

![image](https://user-images.githubusercontent.com/495429/156832214-73895407-cd83-4fe9-9c17-498f24514a39.png)

## After

![image](https://user-images.githubusercontent.com/495429/156832158-16df4e40-ab63-4ef3-a828-512a35320fb6.png)
