### PR TITLE
fix: Slash not opening the small search input

### DIFF
--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -6,6 +6,7 @@ export type SearchProps = {
   onChangeInputValue: (value: string) => void;
   isFocused: boolean;
   onChangeIsFocused: (isFocused: boolean) => void;
+  onSlashFocus?: () => void;
 };
 
 export function useFocusOnSlash(

--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -9,7 +9,8 @@ export type SearchProps = {
 };
 
 export function useFocusOnSlash(
-  inputRef: React.RefObject<null | HTMLInputElement>
+  inputRef: React.RefObject<null | HTMLInputElement>,
+  { onFocus }: { onFocus?: () => void } = {}
 ) {
   useEffect(() => {
     function focusOnSearchMaybe(event) {
@@ -23,6 +24,7 @@ export function useFocusOnSlash(
         if (input && document.activeElement !== input) {
           event.preventDefault();
           input.focus();
+          onFocus?.();
         }
       }
     }
@@ -30,5 +32,5 @@ export function useFocusOnSlash(
     return () => {
       document.removeEventListener("keydown", focusOnSearchMaybe);
     };
-  }, [inputRef]);
+  }, [inputRef, onFocus]);
 }

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useCombobox } from "downshift";
 import useSWR from "swr";
@@ -173,6 +167,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     onCloseSearch,
     onResultPicked,
     defaultSelection,
+    onSlashFocus,
   } = props;
 
   const inputId = `${id}-q`;
@@ -296,12 +291,8 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     },
   });
 
-  const handleSlashFocus = useCallback(() => {
-    onChangeIsFocused(true);
-  }, [onChangeIsFocused]);
-
   useFocusOnSlash(inputRef, {
-    onFocus: handleSlashFocus,
+    onFocus: onSlashFocus,
   });
 
   useEffect(() => {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { useCombobox } from "downshift";
 import useSWR from "swr";
@@ -290,7 +296,13 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     },
   });
 
-  useFocusOnSlash(inputRef);
+  const handleSlashFocus = useCallback(() => {
+    onChangeIsFocused(true);
+  }, [onChangeIsFocused]);
+
+  useFocusOnSlash(inputRef, {
+    onFocus: handleSlashFocus,
+  });
 
   useEffect(() => {
     if (isFocused) {

--- a/client/src/ui/molecules/search/index.tsx
+++ b/client/src/ui/molecules/search/index.tsx
@@ -30,7 +30,7 @@ export function Search({
   hasOpened?: boolean;
   onCloseSearch?: () => void;
   onResultPicked?: () => void;
-  onChangeIsFocused?: (isFocused?: boolean) => void;
+  onChangeIsFocused?: (isFocused: boolean) => void;
 }) {
   const [value, setValue] = useQueryParamState();
   const [isFocused, setIsFocused] = useState(false);

--- a/client/src/ui/molecules/search/index.tsx
+++ b/client/src/ui/molecules/search/index.tsx
@@ -25,12 +25,14 @@ export function Search({
   onCloseSearch,
   onResultPicked,
   onChangeIsFocused = () => {},
+  onSlashFocus,
 }: {
   id: string;
   hasOpened?: boolean;
   onCloseSearch?: () => void;
   onResultPicked?: () => void;
   onChangeIsFocused?: (isFocused: boolean) => void;
+  onSlashFocus?: () => void;
 }) {
   const [value, setValue] = useQueryParamState();
   const [isFocused, setIsFocused] = useState(false);
@@ -64,6 +66,7 @@ export function Search({
         {...searchProps}
         onResultPicked={onResultPicked}
         onCloseSearch={onCloseSearch}
+        onSlashFocus={onSlashFocus}
       />
     </div>
   );

--- a/client/src/ui/organisms/top-navigation-main/index.tsx
+++ b/client/src/ui/organisms/top-navigation-main/index.tsx
@@ -20,13 +20,14 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
   const [showSearch, setShowSearch] = React.useState(false);
   const [hasOpened, setHasOpened] = React.useState<boolean | undefined>(false);
 
-  const handleShowSearch = React.useCallback(function handleShowSearch(
-    value: boolean
-  ) {
-    setShowSearch(value);
-    setHasOpened(value);
-  },
-  []);
+  function handleShowSearch() {
+    setShowSearch(true);
+    setHasOpened(true);
+  }
+
+  function handleSlashFocus() {
+    setShowSearch(true);
+  }
 
   return (
     <div
@@ -37,7 +38,8 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Search
         id="top-nav-search"
         hasOpened={hasOpened}
-        onChangeIsFocused={handleShowSearch}
+        onChangeIsFocused={setHasOpened}
+        onSlashFocus={handleSlashFocus}
         onCloseSearch={() => {
           setShowSearch(false);
         }}
@@ -46,7 +48,7 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Button
         type="action"
         icon="search"
-        onClickHandler={() => handleShowSearch(true)}
+        onClickHandler={handleShowSearch}
         extraClasses="toggle-search-button"
       >
         <span className="visually-hidden">Show search</span>

--- a/client/src/ui/organisms/top-navigation-main/index.tsx
+++ b/client/src/ui/organisms/top-navigation-main/index.tsx
@@ -20,10 +20,13 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
   const [showSearch, setShowSearch] = React.useState(false);
   const [hasOpened, setHasOpened] = React.useState<boolean | undefined>(false);
 
-  function handleShowSearch() {
-    setShowSearch(true);
-    setHasOpened(true);
-  }
+  const handleShowSearch = React.useCallback(function handleShowSearch(
+    value: boolean
+  ) {
+    setShowSearch(value);
+    setHasOpened(value);
+  },
+  []);
 
   return (
     <div
@@ -34,7 +37,7 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Search
         id="top-nav-search"
         hasOpened={hasOpened}
-        onChangeIsFocused={(isFocused) => setHasOpened(isFocused)}
+        onChangeIsFocused={handleShowSearch}
         onCloseSearch={() => {
           setShowSearch(false);
         }}
@@ -43,7 +46,7 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Button
         type="action"
         icon="search"
-        onClickHandler={handleShowSearch}
+        onClickHandler={() => handleShowSearch(true)}
         extraClasses="toggle-search-button"
       >
         <span className="visually-hidden">Show search</span>


### PR DESCRIPTION
Fix a bug were the search bar was not properly shown when pressing the <kbd>/</kbd> key. This happened only when the search bar was hidden.
![image](https://user-images.githubusercontent.com/39559632/156836701-19d66a6c-851a-4fb9-a016-32f2f4f2eb53.png)

Closes #5490.