### PR TITLE
fix: improve visibility of copy to clipboard icon

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -38,7 +38,7 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
         span.textContent = "Copy to Clipboard";
 
         button.setAttribute("type", "button");
-        button.setAttribute("class", "copy-icon");
+        button.setAttribute("class", "icon copy-icon");
         span.setAttribute("class", "visually-hidden");
         liveregion.classList.add("copy-icon-message", "visually-hidden");
         liveregion.setAttribute("role", "alert");

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -506,20 +506,18 @@ pre {
   position: relative;
 
   .copy-icon {
-    background-image: url("../assets/clippy.svg");
-    background-repeat: no-repeat;
-    background-position: 61% 45%;
-    background-size: 1rem;
     border-radius: var(--elem-radius);
     cursor: pointer;
-    height: 33px;
+    height: 1.25rem;
+    mask-image: url("../assets/clippy.svg");
+    mask-size: cover;
     margin: 0;
     padding: 0.25rem;
     position: absolute;
     right: 0.5rem;
     top: 0.75rem;
-    width: 33px;
-    opacity: 0;
+    width: 1.25rem;
+    opacity: 0.5;
 
     &:focus {
       opacity: 1;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -517,23 +517,11 @@ pre {
     right: 0.5rem;
     top: 0.75rem;
     width: 1.25rem;
-    opacity: 0.5;
+    opacity: 0.4;
 
+    &:hover,
     &:focus {
       opacity: 1;
-    }
-  }
-
-  &:hover {
-    .copy-icon {
-      @media screen and (min-width: $screen-md) {
-        opacity: 0.4;
-
-        &:hover,
-        &:focus {
-          opacity: 1;
-        }
-      }
     }
   }
 


### PR DESCRIPTION
The copy to clipboard icon is was not visible on light and dark modes.
The icon would only become visible on hover and even then, it was hard to
see in dark mode due to size and color.

<details>
<summary>Before</summary>

![Screenshot showing the invisible icon in dark mode](https://user-images.githubusercontent.com/10350960/157027512-f365ee2f-9626-4352-a99a-072a5bbd5825.png)

![Screenshot showing the invisible icon in light mode](https://user-images.githubusercontent.com/10350960/157027791-028b3412-6f54-4e86-bf48-a6ef425dbf22.png)
</details>

<details>
<summary>Afrter</summary>

![Screenshot showing restored icon in light mode](https://user-images.githubusercontent.com/10350960/157028288-57e1bbf1-ba17-45f0-8557-0777a3e063d3.png)

![Screenshot showing restored icon in dark mode](https://user-images.githubusercontent.com/10350960/157028406-fd7c39a9-2e69-4657-a88c-24e0f5083836.png)

This is the default state. When hovered, the icon will go to 100% opacity.

</details>

fix #5446
fix #5516
