### PR TITLE
fix: always close article actions menu after choosing a language

### DIFF
--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -13,9 +13,11 @@ import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
 
 export function LanguageMenu({
+  toggleArticleActionsMenu,
   translations,
   native,
 }: {
+  toggleArticleActionsMenu: () => void;
   translations: Translation[];
   native: string;
 }) {
@@ -73,6 +75,8 @@ export function LanguageMenu({
 
       navigate(localeURL);
       window.scrollTo(0, 0);
+
+      toggleArticleActionsMenu();
       setIsOpen(false);
     }
   }

--- a/client/src/ui/molecules/language-menu/index.tsx
+++ b/client/src/ui/molecules/language-menu/index.tsx
@@ -13,11 +13,11 @@ import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
 
 export function LanguageMenu({
-  toggleArticleActionsMenu,
+  onClose,
   translations,
   native,
 }: {
-  toggleArticleActionsMenu: () => void;
+  onClose: () => void;
   translations: Translation[];
   native: string;
 }) {
@@ -76,8 +76,8 @@ export function LanguageMenu({
       navigate(localeURL);
       window.scrollTo(0, 0);
 
-      toggleArticleActionsMenu();
       setIsOpen(false);
+      onClose();
     }
   }
 

--- a/client/src/ui/organisms/article-actions/index.tsx
+++ b/client/src/ui/organisms/article-actions/index.tsx
@@ -71,7 +71,7 @@ export const ArticleActions = ({
               {!MDN_APP && translations && !!translations.length && (
                 <li className="article-actions-entry">
                   <LanguageMenu
-                    toggleArticleActionsMenu={toggleArticleActionsMenu}
+                    onClose={toggleArticleActionsMenu}
                     translations={translations}
                     native={native}
                   />

--- a/client/src/ui/organisms/article-actions/index.tsx
+++ b/client/src/ui/organisms/article-actions/index.tsx
@@ -25,7 +25,7 @@ export const ArticleActions = ({
   const translations = doc.other_translations || [];
   const { native } = doc;
 
-  function toggleArticleActionsMenu(event) {
+  function toggleArticleActionsMenu() {
     setShowArticleActionsMenu(!showArticleActionsMenu);
   }
 
@@ -70,7 +70,11 @@ export const ArticleActions = ({
               )}
               {!MDN_APP && translations && !!translations.length && (
                 <li className="article-actions-entry">
-                  <LanguageMenu translations={translations} native={native} />
+                  <LanguageMenu
+                    toggleArticleActionsMenu={toggleArticleActionsMenu}
+                    translations={translations}
+                    native={native}
+                  />
                 </li>
               )}
             </>


### PR DESCRIPTION
Before we had a scenario where, on mobile, after having selected a languages, the article menu would not close.
This change ensures that both the language drop-down and the articles menu is always closed after a selection.

fix #5343
