### PR TITLE
Revert "Mark beta/nightly/planned browsers releases as preview"

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/browser-info.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/browser-info.tsx
@@ -12,3 +12,11 @@ export function BrowserName({ id }: { id: bcd.BrowserNames }) {
   }
   return <>{browserInfo[id].name}</>;
 }
+
+export function BrowserPreviewName({ id }: { id: bcd.BrowserNames }) {
+  const browserInfo = useContext(BrowserInfoContext);
+  if (!browserInfo) {
+    throw new Error("Missing browser info");
+  }
+  return <>{browserInfo[id].preview_name}</>;
+}

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -1,7 +1,5 @@
-import { useContext } from "react";
 import type bcd from "@mdn/browser-compat-data/types";
-import { BrowserInfoContext } from "./browser-info";
-import { asList, listFeatures, versionIsPreview } from "./utils";
+import { asList, listFeatures } from "./utils";
 
 // Also specifies the order in which the legend appears
 const LEGEND_LABELS = {
@@ -20,11 +18,7 @@ const LEGEND_LABELS = {
 };
 type LEGEND_KEY = keyof typeof LEGEND_LABELS;
 
-function getActiveLegendItems(
-  compat: bcd.Identifier,
-  name: string,
-  browserInfo: bcd.Browsers
-) {
+function getActiveLegendItems(compat: bcd.Identifier, name: string) {
   const legendItems = new Set<LEGEND_KEY>();
 
   for (const feature of listFeatures(compat, "", name)) {
@@ -42,9 +36,7 @@ function getActiveLegendItems(
       }
     }
 
-    for (const [browser, browserSupport] of Object.entries(
-      feature.compat.support
-    )) {
+    for (const browserSupport of Object.values(feature.compat.support)) {
       if (!browserSupport) {
         legendItems.add("no");
         continue;
@@ -54,9 +46,7 @@ function getActiveLegendItems(
         if (versionSupport.version_added) {
           if (versionSupport.flags && versionSupport.flags.length) {
             legendItems.add("no");
-          } else if (
-            versionIsPreview(versionSupport.version_added, browserInfo[browser])
-          ) {
+          } else if (versionSupport.version_added === "preview") {
             legendItems.add("preview");
           } else {
             legendItems.add("yes");
@@ -97,19 +87,13 @@ export function Legend({
   compat: bcd.Identifier;
   name: string;
 }) {
-  const browserInfo = useContext(BrowserInfoContext);
-
-  if (!browserInfo) {
-    throw new Error("Missing browser info");
-  }
-
   return (
     <section className="bc-legend">
       <h3 className="visually-hidden" id="Legend">
         Legend
       </h3>
       <dl className="bc-legend-items-container">
-        {getActiveLegendItems(compat, name, browserInfo).map(([key, label]) =>
+        {getActiveLegendItems(compat, name).map(([key, label]) =>
           ["yes", "partial", "no", "unknown", "preview"].includes(key) ? (
             <div className="bc-legend-item" key={key}>
               <dt className="bc-legend-item-dt" key={key}>

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -45,20 +45,3 @@ export function listFeatures(
   }
   return features;
 }
-
-export function versionIsPreview(
-  version: bcd.VersionValue | string | undefined,
-  browser: bcd.BrowserStatement
-): boolean {
-  if (version === "preview") {
-    return true;
-  }
-
-  if (browser && typeof version === "string" && browser.releases[version]) {
-    return ["beta", "nightly", "planned"].includes(
-      browser.releases[version].status
-    );
-  }
-
-  return false;
-}


### PR DESCRIPTION
Reverts mdn/yari#5311

This is breaking BCD on production. Apparently, we use filtered BCD data on prod that's why this wasn't caught. We'll work on fixing this. @queengooborg fyi