### PR TITLE
fix(typography): use regular font size in notecards

### DIFF
--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -13,7 +13,6 @@
   &,
   p,
   li {
-    font: var(--type-body-m);
     color: var(--text-secondary);
   }
 


### PR DESCRIPTION
Currently, the copy of the first paragraph in notecards is much smaller than the rest of the notecard.
This change ensures that it is always consistent.

<details>
<summary>Before</summary>

![Screenshot of the notecard before, showing the smaller copy in the first paragraph](https://user-images.githubusercontent.com/10350960/157239067-a8849b03-95c3-401b-9f4c-fa7f64300751.png)

</details>

<details>
<summary>After</summary>

![Screenshot of notecard with consistent sizing](https://user-images.githubusercontent.com/10350960/157239303-69f4fd49-9dff-4204-b89d-fde6d9d4b43d.png)

</details>

fix #5517
