### PR TITLE
fix copy-icon accessibility on dark-mode

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -518,6 +518,7 @@ pre {
     top: 0.75rem;
     width: 1.25rem;
     opacity: 0.4;
+    filter: invert(var(--invert-value));
 
     &:hover,
     &:focus {

--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -268,6 +268,9 @@ $screen-md: 769px;
 $screen-lg: 1200px;
 $screen-xl: 1441px;
 
+$invert-0: 0;
+$invert-1: 1;
+
 /*
  * z-index scale
  */

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -239,6 +239,7 @@
   --text-primary-green: #{$mdn-color-light-theme-green-60};
   --text-primary-blue: #{$mdn-color-light-theme-blue-60};
   --text-primary-yellow: #{$mdn-color-light-theme-yellow-60};
+  --invert-value: #{$invert-0};
 }
 
 @mixin dark-theme {
@@ -430,6 +431,7 @@
   --text-primary-green: #{$mdn-color-dark-theme-green-30};
   --text-primary-blue: #{$mdn-color-dark-theme-blue-30};
   --text-primary-yellow: #{$mdn-color-dark-theme-yellow-30};
+  --invert-value: #{$invert-1};
 }
 
 body,


### PR DESCRIPTION


Inverting the colours for copy-icon svg so that there's no need of using two svg's for both the themes.

---

Probable fix for #5414
