### PR TITLE
fix switch margin

### DIFF
--- a/client/src/ui/atoms/switch/index.scss
+++ b/client/src/ui/atoms/switch/index.scss
@@ -5,9 +5,9 @@
 
   input {
     opacity: 0;
-    width: 0;
+    width: 2rem;
     height: 0;
-    margin-right: 1.5rem;
+    margin: 0;
 
     &:checked + .slider {
       &:before {


### PR DESCRIPTION
We were relying on browser specific styles and it was broken in
webkit.

broken: ![webkit-broken](https://user-images.githubusercontent.com/3604775/157483545-639af48f-96c1-48d4-9704-a759e52d245c.png)
fixed: ![webkit-fixed](https://user-images.githubusercontent.com/3604775/157483555-2b1c7acc-4b0d-4b43-940f-385bc1d1f686.png)

