### PR TITLE
fix(notecards): adjust icon position

### DIFF
--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -31,7 +31,7 @@
 
   &:before {
     position: absolute;
-    top: 1.3rem;
+    top: 1.5rem;
     left: 1rem;
     display: block;
     width: 1rem;


### PR DESCRIPTION
This PR resolves a second issue mentioned in #5522. It makes the icon align with the first line of the text.