### PR TITLE
docs(README): fix clone instruction indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ Before you can start working with Yari, you need to:
 1.  Clone the forked repositories to your computer using the following commands
     (replace `[your account]` with the account you forked the repositories to):
 
-    ```shell
-    git clone https://github.com/[your_account]/content.git
-    git clone https://github.com/[your_account]/yari.git
-    ```
+        git clone https://github.com/[your_account]/content.git
+        git clone https://github.com/[your_account]/yari.git
 
     Take a note of the file path to the location where you've cloned that
     repo before moving on.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Before you can start working with Yari, you need to:
 1.  Clone the forked repositories to your computer using the following commands
     (replace `[your account]` with the account you forked the repositories to):
 
-            git clone https://github.com/[your_account]/content.git
-            git clone https://github.com/[your_account]/yari.git
+```shell
+git clone https://github.com/[your_account]/content.git
+git clone https://github.com/[your_account]/yari.git
+```
 
-        Take a note of the file path to the location where you've cloned that
-        repo before moving on.
+Take a note of the file path to the location where you've cloned that
+repo before moving on.
 
     <!-- markdownlint-enable list-marker-space -->
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Before you can start working with Yari, you need to:
     git clone https://github.com/[your_account]/yari.git
     ```
 
- Take a note of the file path to the location where you've cloned that
-repo before moving on.
+    Take a note of the file path to the location where you've cloned that
+    repo before moving on.
 
 <!-- markdownlint-enable list-marker-space -->
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ git clone https://github.com/[your_account]/content.git
 git clone https://github.com/[your_account]/yari.git
 ```
 
-Take a note of the file path to the location where you've cloned that
-repo before moving on.
+        Take a note of the file path to the location where you've cloned that
+        repo before moving on.
 
     <!-- markdownlint-enable list-marker-space -->
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/[your_account]/content.git
 git clone https://github.com/[your_account]/yari.git
 ```
 
-Take a note of the file path to the location where you've cloned that
+ Take a note of the file path to the location where you've cloned that
 repo before moving on.
 
 <!-- markdownlint-enable list-marker-space -->

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Before you can start working with Yari, you need to:
 1.  Clone the forked repositories to your computer using the following commands
     (replace `[your account]` with the account you forked the repositories to):
 
-```shell
-git clone https://github.com/[your_account]/content.git
-git clone https://github.com/[your_account]/yari.git
-```
+    ```shell
+    git clone https://github.com/[your_account]/content.git
+    git clone https://github.com/[your_account]/yari.git
+    ```
 
  Take a note of the file path to the location where you've cloned that
 repo before moving on.

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ git clone https://github.com/[your_account]/content.git
 git clone https://github.com/[your_account]/yari.git
 ```
 
-        Take a note of the file path to the location where you've cloned that
-        repo before moving on.
+Take a note of the file path to the location where you've cloned that
+repo before moving on.
 
-    <!-- markdownlint-enable list-marker-space -->
+<!-- markdownlint-enable list-marker-space -->
 
 To run Yari locally, you'll first need to install its dependencies and build the
 app locally. Do this like so:


### PR DESCRIPTION
A portion of the README that isn't code is marked as code. This is a minor adjustment to that. 😬 

|Main|This PR|
|---|---|
|<img width="855" alt="image" src="https://user-images.githubusercontent.com/9947422/157746003-33d390e8-6590-4be1-8741-d8ff623067de.png">|<img width="1028" alt="image" src="https://user-images.githubusercontent.com/9947422/157746104-fe51cc8b-5dcb-4f60-9351-33bab45e5806.png">|