### PR TITLE
chore(document-extractor): trim underscores from id

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -632,6 +632,12 @@ function _addSectionProse($) {
       }
     }
   }
+
+  if (id) {
+    // Remove trailing underscores (https://github.com/mdn/yari/issues/5492).
+    id = id.replace(/_+$/g, "");
+  }
+
   const value = {
     id,
     title,


### PR DESCRIPTION
Fixes #5492.

## Result

```diff
-<h3 id="curly_braces_"><a href="#curly_braces_" title="Permalink to Curly braces ({ })">Curly braces (<code>{ }</code>)</a></h3>
+<h3 id="curly_braces"><a href="#curly_braces" title="Permalink to Curly braces ({ })">Curly braces (<code>{ }</code>)</a></h3>
```
