### PR TITLE
fix(document): link to source, not rendered blob

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -34,7 +34,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
   const { github_url, folder } = doc.source;
   return (
     <a
-      href={github_url}
+      href={`${github_url}?plain=1`}
       title={`Folder: ${folder} (Opens in a new tab)`}
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
## Summary

There is a "Found a problem with this page?" at the end of each article, and it links to the article's source.

### Problem

Previously, we would link to the so-called "rendered blob", which doesn't *really* show the source, just another *rendered* version.

### Solution

Now, we link to the so-called "source blob", i.e. the raw markdown.

---

## How did you test this change?

- I opened http://localhost:3000/en-US/docs/Learn locally.
- Then I verified that "Source on GitHub" now links to: https://github.com/mdn/content/blob/main/files/en-us/learn/index.md?plain=1
- And it no longer links to: https://github.com/mdn/content/blob/main/files/en-us/learn/index.md