### PR TITLE
Fix: make `Asynchronous JavaScript overview` page accessible from sidebar

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -123,6 +123,7 @@ var text = mdn.localStringMap({
         'Object_building_practice' : 'Object building practice',
         'Assessment_Adding_features_to_our_bouncing_balls_demo' : 'Assessment: Adding features to our bouncing balls demo',
       'Asynchronous_JavaScript': 'Asynchronous JavaScript',
+        'Asynchronous_JavaScript_overview':'Asynchronous JavaScript overview',
         'Introducing_asynchronous_JavaScript': 'Introducing asynchronous JavaScript',
         'How_to_use_promises': 'How to use promises',
         'Implementing_a_promise-based_API': 'Implementing a promise-based API',
@@ -1992,6 +1993,7 @@ var text = mdn.localStringMap({
     <details <%=currentPageIsUnder('JavaScript/Asynchronous')%>>
         <summary><%=text['Asynchronous_JavaScript']%></summary>
         <ol>
+          <li><a href="<%=baseURL%>JavaScript/Asynchronous"><%=text['Asynchronous_JavaScript_overview']%></a></li>
           <li><a href="<%=baseURL%>JavaScript/Asynchronous/Introducing"><%=text['Introducing_asynchronous_JavaScript']%></a></li>
           <li><a href="<%=baseURL%>JavaScript/Asynchronous/Promises"><%=text['How_to_use_promises']%></a></li>
           <li><a href="<%=baseURL%>JavaScript/Asynchronous/Implementing_a_promise-based_API"><%=text['Implementing_a_promise-based_API']%></a></li>


### PR DESCRIPTION

## Summary
Fixes #5584
### Problem
[Asynchronous JavaScript overview](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous) page is not accessible from the sidebar

### Solution
Added the page to `LearnSidebar.ejs` 

---

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/6881345/157958026-c536bc52-59c0-4153-aa73-807056114417.png)


### After
![image](https://user-images.githubusercontent.com/6881345/157957982-47ac072d-2595-4739-8df1-d66288bbc61e.png)


