### PR TITLE
fix(live-samples): make Copied! message visible + use theme

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -533,16 +533,15 @@ pre {
   }
 
   .copy-icon-message {
-    background: $mdn-color-dark-grey-90;
+    background: var(--text-primary);
     border-radius: var(--elem-radius);
-    color: white;
+    color: var(--text-invert);
     font-size: 0.8125rem;
     opacity: 1;
     padding: 0.125rem;
     position: absolute;
     right: 0.25rem;
     top: 15px;
-    z-index: -1000;
   }
 
   .example-good,


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary
Fixes #5537 

Code section "Copied!" message is not visible for multiline code sections.
Change the message foreground and background colors according to theme.

### Problem
The message was staying behind the code section due to z-index set to -1000. 
Colors are hardcoded so they don't change as per theme.

### Solution
Remove z-index property from the CSS rule `..copy-icon-message`.
Also set color using CSS vars.

---

## Screenshots

### Before
The message was not visible.

### After
1. Light Theme:
![Light theme](https://camo.githubusercontent.com/2fb687c0d773ba4f31c3f29f029fedd9b2fdee791def7b29c9f4ed1fc5dbbed5/68747470733a2f2f692e696d6775722e636f6d2f6e5144634f666e2e706e67)

2. Dark Theme:
![Dark theme](https://camo.githubusercontent.com/60ec55b956c4ae12aa78176a3ba4dde7a661a9c70a0c0a51edfbd2f5852b375a/68747470733a2f2f692e696d6775722e636f6d2f583070644c694e2e706e67)
