### PR TITLE
fix(toolbar/flaws): avoid #_flaws navigation in useEffect

### DIFF
--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -120,9 +120,10 @@ export function ToggleDocumentFlaws({
 }) {
   const location = useLocation();
   const navigate = useNavigate();
-  const [show, toggle] = useReducer((v) => !v, location.hash === FLAWS_HASH);
   const rootElement = useRef<HTMLDivElement>(null);
   const isInitialRender = useRef(true);
+
+  const show = location.hash === FLAWS_HASH;
 
   useEffect(() => {
     if (isInitialRender.current && show && rootElement.current) {
@@ -131,14 +132,13 @@ export function ToggleDocumentFlaws({
     isInitialRender.current = false;
   }, [show]);
 
-  useEffect(() => {
-    const hasShowHash = window.location.hash === FLAWS_HASH;
-    if (show && !hasShowHash) {
-      navigate(location.pathname + location.search + FLAWS_HASH);
-    } else if (!show && hasShowHash) {
+  function toggle() {
+    if (show) {
       navigate(location.pathname + location.search);
+    } else {
+      navigate(location.pathname + location.search + FLAWS_HASH);
     }
-  }, [location, navigate, show]);
+  }
 
   const flawsCounts = Object.entries(doc.flaws)
     .map(([name, actualFlaws]) => ({

--- a/client/src/document/toolbar/flaws.tsx
+++ b/client/src/document/toolbar/flaws.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { annotate, annotationGroup } from "rough-notation";
 import { RoughAnnotation } from "rough-notation/lib/model";


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes #5591.

### Problem

`location` changes after a history back(`#_flaws` -> ` `); this causes the effect I removed in this PR to fire. But the `show` state remains `true`. Thus, `show && !hasShowHash === true`, which in turn pushes `#_flaws` to browsing history stack again and again, neutralizing user-made history stack popping (i.e. history back button).

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

We can consider `location` itself as a (global) state, especially since it's managed by `react-router`. By removing local `show` state, we don't have to worry about discrepancy between local (`show`) and global states (`location`) the effect block is trying to solve at all. There will be no local state at all.

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## How did you test this change?

Ran locally:

1. History back/forward closes or opens the toolbar. I can exit the document by history backs.
2. Navigating to a document with `#_flaws`, and the toolbar is open from the start.

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
