### PR TITLE
build(workflows): fetch full translated-content git history

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
+          # See matching warning for mdn/content checkout step
+          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -78,6 +78,8 @@ jobs:
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
+          # See matching warning for mdn/content checkout step
+          fetch-depth: 0
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -78,6 +78,8 @@ jobs:
         with:
           repository: mdn/translated-content
           path: mdn/translated-content
+          # See matching warning for mdn/content checkout step
+          fetch-depth: 0
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Summary

Fixes #5594

### Problem

The last modified date is currently incorrect for localized docs. As @alattalatta pointed out, this is due to the build workflows not fetching all of the git history with https://github.com/actions/checkout.

### Solution

This PR is quite naive as it uses the same depth as mdn/content. Regarding the current warning, mdn/content has 8437 commits on main while mdn/translated content has 4922 commits so I'd think this is as acceptable.
If this is not, that means another way of computing the last edit should be found


## How did you test this change?

Not yet, I need to setup `act` on my machine.