### PR TITLE
feat(search): allow items to be opened in new tab

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -379,7 +379,13 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
                   index: i,
                 })}
               >
-                {resultsWithHighlighting[i]}
+                <a
+                  href={item.url}
+                  onClick={(event: React.MouseEvent) => event.preventDefault()}
+                  tabIndex={-1}
+                >
+                  {resultsWithHighlighting[i]}
+                </a>
               </div>
             )),
             <div

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -381,7 +381,15 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
               >
                 <a
                   href={item.url}
-                  onClick={(event: React.MouseEvent) => event.preventDefault()}
+                  onClick={(event: React.MouseEvent) => {
+                    if (event.ctrlKey || event.metaKey) {
+                      // Open in new tab, don't navigate current tab.
+                      event.stopPropagation();
+                    } else {
+                      // Open in same tab, navigate via combobox.
+                      event.preventDefault();
+                    }
+                  }}
                   tabIndex={-1}
                 >
                   {resultsWithHighlighting[i]}

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -88,7 +88,6 @@
   }
 
   .search-results {
-    color: var(--text-primary);
     border: 1px solid var(--border-secondary);
     border-radius: var(--elem-radius);
     box-shadow: var(--shadow-01);
@@ -97,6 +96,12 @@
     top: 42px;
     width: 100%;
     z-index: var(--z-index-search-results);
+
+    &,
+    a[href],
+    mark {
+      color: var(--text-primary);
+    }
 
     .indexing-warning {
       color: var(--icon-warning);
@@ -148,7 +153,6 @@
 
     mark {
       background-color: var(--mark-color);
-      color: var(--text-primary);
     }
 
     small {

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -102,10 +102,6 @@
       color: var(--icon-warning);
     }
 
-    div {
-      padding: 0.5rem;
-    }
-
     .nothing-found {
       font-style: italic;
     }
@@ -117,6 +113,7 @@
 
     .result-item {
       border-bottom: 1px solid var(--border-secondary);
+      padding: 0.5rem;
       word-break: break-word;
       background: var(--background-secondary);
       font: var(--type-body-m);


### PR DESCRIPTION
## Summary

Fixes #5424.

### Problem

Search results could not be opened in a new tab (using middle-click or right-click).

### Solution

This PR wraps all search results in a link to support this use case.

---

## Screenshots

(No changes, but I'm attaching screenshots just for reassurance.)

### Before

<img width="273" alt="Screenshot 2022-03-13 at 17 22 26" src="https://user-images.githubusercontent.com/495429/158069086-4403d96e-0624-4a86-8717-7ccaa05d6704.png">

### After

<img width="273" alt="Screenshot 2022-03-13 at 17 20 58" src="https://user-images.githubusercontent.com/495429/158069029-6df2c0b5-5274-4d96-b829-5906bbaf64a1.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/HTML/Element/acronym locally.
2. Typed "dialog" in the search field.
3. Clicked right on the first item and "Open in new tab".
4. The article opened in a new tab, without navigating the current tab to that article.