### PR TITLE
chore(callouts): left align content

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -492,7 +492,7 @@ pre {
   border: 1px solid var(--border-primary);
   box-shadow: var(--shadow-01);
   display: flex;
-  text-align: center;
+  text-align: left;
   gap: 1rem;
   flex-direction: column;
   margin: 2rem 0;


### PR DESCRIPTION
## Summary

Fixes #5511 

Callouts should not be center-justified. 
It's hard to read as it is not consistent with current document flow.

---

## Screenshots


### Before
1. small callout
![small callout](https://user-images.githubusercontent.com/495429/157690072-05f66595-918b-4a00-8568-9ca018877002.png)

2. big callout
![big callout](https://i.imgur.com/CrPYnYh.png)

### After
1. small callout
![small callout](https://user-images.githubusercontent.com/495429/157690149-3f8baaf9-ffe4-4fa6-819a-a91e9520721d.png)

2. big callout
![big callout](https://i.imgur.com/J0PKpsK.png)

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
