### PR TITLE
Deprecate the {{index}} macro

### DIFF
--- a/kumascript/README.md
+++ b/kumascript/README.md
@@ -1,1 +1,12 @@
-The home of Kumascript for Yari. More to be written some other day.
+# Kumascript in Yari
+
+## Signaling macro deprecation
+
+If a macro should no longer be used and is marked for removal, add the following to the top of the relevant macro:
+
+```js
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated();
+```
+
+It is also useful to add a code comment to the macro detailing what the blockers are for removal. See the following pull request for reference: [Deprecate the {{index}} macro](https://github.com/mdn/yari/pull/5607)

--- a/kumascript/macros/Index.ejs
+++ b/kumascript/macros/Index.ejs
@@ -1,4 +1,12 @@
 <%
+
+// Index pages are no longer used.
+// Remove this file when there are no more {{index}} calls in translated-content
+// See also https://github.com/mdn/content/pull/13770
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 // Builds an index / inventory table for a section
 //
 // Parameters:


### PR DESCRIPTION
### Summary

Index pages are no longer a thing in our content.

### Problem

We shouldn't maintain outdated wiki macros. However, the macro can only be removed entirely if translations removed all calls to it, so let them know by raising a deprecation error.

### Solution

Encourage translators to remove index pages with a MacroDeprecatedError.

### How did you test this change?

Put the {{index}} macro on a page and see a flaw like "MacroDeprecatedError from index. Fixable 👍🏼" appearing.

### Related

https://github.com/mdn/content/pull/13770