### PR TITLE
Deprecate the {{anch}} macro

### DIFF
--- a/kumascript/macros/anch.ejs
+++ b/kumascript/macros/anch.ejs
@@ -1,4 +1,15 @@
 <%
+
+// The anch macro should not be used anymore!
+// Please use markdown links instead!
+
+// See https://github.com/mdn/content/pull/13802 for en-US removal
+// This macro can be removed once translated-content removed all {{anch}} calls
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
+
 // Inserts a link to an in-page section, given the section name.
 //
 // Parameters:


### PR DESCRIPTION
### Summary

{{anch}} shouldn't be used anymore. Use markdown instead.

### Problem

We shouldn't maintain outdated wiki macros. However, the macro can only be removed entirely if translations removed all calls to it, so let them know by raising a deprecation error.

### Solution

Encourage translators fix pages with {{anch}} calls by presenting a MacroDeprecatedError.

### How did you test this change?

Put the {{anch}} macro on a page and see a flaw like "MacroDeprecatedError from anch. Fixable 👍🏼" appearing.

### Related

https://github.com/mdn/content/pull/13802