### PR TITLE
fix(csp): allow style/image from google translate

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -89,7 +89,13 @@ const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
   "script-src": scriptSrcValues,
   "script-src-elem": scriptSrcValues,
-  "style-src": ["'report-sample'", "'self'", "'unsafe-inline'"],
+  "style-src": [
+    "'report-sample'",
+    "'self'",
+    "'unsafe-inline'",
+
+    "translate.googleapis.com",
+  ],
   "object-src": ["'none'"],
   "base-uri": ["'self'"],
   "connect-src": [
@@ -135,6 +141,7 @@ const CSP_DIRECTIVES = {
 
     "wikipedia.org",
 
+    "translate.google.com",
     "www.google-analytics.com",
     "www.gstatic.com",
   ],


### PR DESCRIPTION
This should fix Chrome's integrated translate feature on MDN.

## Summary

Fixes mdn/fred#976.

### Problem

Chrome has an integrated translate feature, and it didn't work on MDN, because our Content-Security-Policy (CSP) was preventing a Google Translate stylesheet to be injected into MDN.

### Solution

I have adjusted our CSP to allow specifically what this Chrome feature injects.

---

## Screenshots

(_None_.)

---

## How did you test this change?

(Didn't test, because CSP is not applied locally.)