### PR TITLE
fix(bcd): show correct title for unknown support

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -127,8 +127,8 @@ const CellText = React.memo(
   }) => {
     const currentSupport = getFirst(support);
 
-    const added = currentSupport && currentSupport.version_added;
-    const removed = currentSupport && currentSupport.version_removed;
+    const added = currentSupport?.version_added ?? null;
+    const removed = currentSupport?.version_removed ?? null;
 
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
 


### PR DESCRIPTION
## Summary

Fixes #5613. 

### Problem

Previously, the title would say "Full support" for features where the support is in fact unknown.

This was because the "unknown" state expected `added === null`, but got `undefined`, which didn't match.

### Solution

The solution was to fallback `added` to `null`.

Now, the title shows: "Compatibility unknown; please update this."

---

## Screenshots

### Before

<img width="761" alt="Screenshot 2022-03-14 at 21 02 41" src="https://user-images.githubusercontent.com/495429/158255406-b7266a35-2e96-4d69-b335-2d68eacc7da9.png">


### After

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/495429/158255467-5fea32d5-3166-4676-93e9-e05bb4180494.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/API/Window#browser_compatibility locally
2. Hovered over a cell with unknown support.