### PR TITLE
fix(bcd): improve titles for support behind flags

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import type bcd from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import { asList, getFirst, isTruthy, versionIsPreview } from "./utils";
+import { LEGEND_LABELS } from "./legend";
 
 // Yari builder will attach extra keys from the compat data
 // it gets from @mdn/browser-compat-data. These are "Yari'esque"
@@ -244,8 +245,10 @@ const CellText = React.memo(
 );
 
 function Icon({ name }: { name: string }) {
+  const title = LEGEND_LABELS[name] ?? name;
+
   return (
-    <abbr className="only-icon" title={name}>
+    <abbr className="only-icon" title={title}>
       <span>{name}</span>
       <i className={`icon icon-${name}`} />
     </abbr>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -159,6 +159,11 @@ const CellText = React.memo(
             isSupported: "preview",
             label: labelFromString(added, browser),
           };
+        } else if (currentSupport?.flags?.length) {
+          status = {
+            isSupported: "no",
+            label: labelFromString(added, browser),
+          };
         } else {
           status = {
             isSupported: "yes",

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -4,7 +4,7 @@ import { BrowserInfoContext } from "./browser-info";
 import { asList, listFeatures, versionIsPreview } from "./utils";
 
 // Also specifies the order in which the legend appears
-const LEGEND_LABELS = {
+export const LEGEND_LABELS = {
   yes: "Full support",
   partial: "Partial support",
   preview: "In development. Supported in a pre-release version.",


### PR DESCRIPTION
## Summary

Fixes #5429.

### Problem

When hovering about a feature that is only supported _behind a flag_,

- the title of the cross icon would say "Full support", and
- the title of the flag icon would say "disabled".

### Solution

1. The title on the cross icon now says "No support" to be consistent with the icon.
2. The title on the flag icon now says "User must explicitly enable this feature." like the legend.

---

## Screenshots

### Before

<img width="790" alt="Screenshot 2022-03-14 at 22 15 57" src="https://user-images.githubusercontent.com/495429/158262669-59c55bb0-b57a-4871-93b5-5806b74a8b5f.png">

<img width="790" alt="image" src="https://user-images.githubusercontent.com/495429/158262711-3efac3f9-c418-40d5-824a-99c1bc6c120c.png">


### After

<img width="790" alt="Screenshot 2022-03-14 at 22 16 57" src="https://user-images.githubusercontent.com/495429/158262808-36019d25-0b73-43c4-afeb-f3353337d07b.png">

<img width="790" alt="Screenshot 2022-03-14 at 22 17 06" src="https://user-images.githubusercontent.com/495429/158262821-7bd4fe33-0ee8-4ba4-8146-59b2c306c213.png">


---

## How did you test this change?

1. I opened http://localhost:3000/en-US/docs/Web/HTML/Element/menu#browser_compatibility locally.
2. I hovered over the icons for the feature row `<hr> creates a separator` and the `Firefox for Android` column.