### PR TITLE
Deprecate the {{manch}} anchor

### DIFF
--- a/kumascript/macros/manch.ejs
+++ b/kumascript/macros/manch.ejs
@@ -1,1 +1,7 @@
+// This macro is no more used. Use a regular Markdown link instead.
+// Remove this file when there are no more {{manch}} calls in translated-content
+// See also https://github.com/mdn/content/pull/13802
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 <code><a href="<%-page.uri + '#' + $0 + '()'%>"><%-$0%>()</a></code>


### PR DESCRIPTION


The {{manch}} macro brings nothing more since we migrated to Markdown. A regular Markdown link should be used instead.

@SphinxKnight detected it (while removing {{anch}} from fr/ and removed its 3-4 occurrences in en-US. It is now only used in translated-content.
