### PR TITLE
fix(layout): move :target below sticky header

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -66,7 +66,7 @@
   --form-elem-height: 2rem;
 
   /* Major Components */
-  --sticky-header-height: 2rem;
+  --sticky-header-height: 0;
   --top-nav-height: 4rem;
   --icon-size: 1rem;
 }

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -66,8 +66,13 @@
   --form-elem-height: 2rem;
 
   /* Major Components */
+  --sticky-header-height: 2rem;
   --top-nav-height: 4rem;
   --icon-size: 1rem;
+}
+
+:target {
+  scroll-margin-top: var(--sticky-header-height);
 }
 
 body {

--- a/client/src/ui/organisms/article-actions-container/index.scss
+++ b/client/src/ui/organisms/article-actions-container/index.scss
@@ -66,3 +66,9 @@
     }
   }
 }
+
+@media screen and (max-width: $screen-md) {
+  :root {
+    --sticky-header-height: 2rem;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #5620.

### Problem

Previously, when the sticky breadcrumbs were shown on mobile, the currently targeted heading was covered by these.

### Solution

By adding a `scroll-margin-top` to `:target` elements (as suggested by @e3dio), the browser will show the targeted heading below the sticky breadcrumbs.

---

## Screenshots

### Before

<img width="769" alt="Screenshot 2022-03-15 at 12 51 15" src="https://user-images.githubusercontent.com/495429/158372120-d1a2d5c2-9cc2-45a4-bf34-8805ad1dc697.png">

### After

<img width="769" alt="Screenshot 2022-03-15 at 12 51 39" src="https://user-images.githubusercontent.com/495429/158372166-2ce1b119-5ea5-4b9f-9e92-a9a79afcdd99.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/CSS/:target#examples locally.