### PR TITLE
fix(page-not-found): show fallback link for moved pages

### DIFF
--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -39,16 +39,16 @@ export default function FallbackLink({ url }: { url: string }) {
         }
         // Otherwise, use the URL that gave the successful page (potentially
         // including any redirects) and append index.json to get the data needed
-        var jsonURL = response.url;
+        let jsonURL = response.url;
         if (!jsonURL.endsWith("/")) {
           jsonURL += "/";
         }
         jsonURL += "index.json";
-        var jsonResponse = await fetch(jsonURL);
+        const jsonResponse = await fetch(jsonURL);
         if (jsonResponse.ok) {
           const { doc } = await jsonResponse.json();
           return doc;
-        } else if (response.status === 404) {
+        } else if (jsonResponse.status === 404) {
           return null;
         }
       } else if (response.status === 404) {


### PR DESCRIPTION
## Summary

Fixes #5615

### Problem

Often, MDN links are given to users with their localization in the path from Firefox UI. Some UI links require redirects to work. If a user encounters a localized URL to a link that requires a redirect, the helpful Fallback link does not show up because the fallback checker looks at $path/index.json and the re-director does not know about the /index.json stuff.

### Solution

Instead of just looking for the English `index.json` file for the missing article, which is not typically redirected, the search proceeds in two stages:

1. Look for the English version of the article, which will follow the redirects.
2. If such an article exists, get its `index.json` file using the URL that gave a success for the article.

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/90582190/158398238-67b4dc8e-7a97-4458-9926-5a2e7e4a2649.png)

### After

<img width="1648" alt="image" src="https://user-images.githubusercontent.com/90582190/158398531-1e62ded2-672f-4375-b5c2-cbc9be3d50c0.png">

---

## How did you test this change?

Manually tested locally. Ensured the new code followed the redirect and didn't break previous file-not-found boxes. Also ran relevant local tests.
