### PR TITLE
fix: Use buttons in edit collections article actions

### DIFF
--- a/client/src/ui/molecules/collection/menu.tsx
+++ b/client/src/ui/molecules/collection/menu.tsx
@@ -166,26 +166,6 @@ export function BookmarkMenu({
                 {bookmarked ? "Edit Collection" : "Add Collection"}
               </h2>
 
-              <div className="watch-submenu-mobile-buttons">
-                {doc && data?.bookmarked ? (
-                  <Button
-                    type="action"
-                    buttonType="submit"
-                    name="delete"
-                    value="true"
-                    icon="trash"
-                    isDisabled={isValidating}
-                  />
-                ) : null}
-                <Button
-                  buttonType="submit"
-                  type="action"
-                  icon="checkmark"
-                  isDisabled={isValidating}
-                  name="save"
-                />
-              </div>
-
               <div className="watch-submenu-item pad-y">
                 <label htmlFor="bookmark-name">Name:</label>
                 <input

--- a/client/src/ui/molecules/notifications-watch-menu/index.scss
+++ b/client/src/ui/molecules/notifications-watch-menu/index.scss
@@ -151,15 +151,14 @@
   padding: 1rem;
 
   &.is-button-row {
-    display: none;
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 1rem;
 
-    &.is-always-visible {
-      display: flex;
-      justify-content: flex-end;
-      padding-bottom: 0.25rem;
+    .button {
+      width: auto;
     }
   }
-
   &.has-dropdown {
     padding: 0 1rem 0.25rem;
   }
@@ -184,16 +183,6 @@
 
   @media screen and (min-width: $screen-md) {
     padding: 0 0.5rem 0 1rem;
-
-    &.is-button-row {
-      display: flex;
-      justify-content: flex-end;
-      padding-top: 1rem;
-
-      .button {
-        width: auto;
-      }
-    }
 
     &.pad-y {
       padding-top: 1rem;

--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -22,11 +22,6 @@
   margin: 0;
   padding: 0;
 
-  .button {
-    white-space: nowrap;
-    width: 100%;
-  }
-
   @media screen and (min-width: $screen-md) {
     display: flex;
     gap: 0.5rem;
@@ -67,6 +62,14 @@
         .button-wrap {
           justify-content: flex-start;
           padding: 1.5rem 1rem;
+        }
+      }
+      .watch-submenu-item {
+        padding-top: 0.5rem;
+        padding-bottom: 0.5rem;
+
+        .button {
+          width: auto;
         }
       }
 


### PR DESCRIPTION
## Summary

Article actions should be consistent with plus tab collection edit.

## Screenshots

### Before

![Screenshot 2022-03-16 at 14 05 39](https://user-images.githubusercontent.com/7376416/158596410-c90e4769-5c12-46d4-83c5-e437196634fc.png)

### After

![Screenshot 2022-03-16 at 14 00 11](https://user-images.githubusercontent.com/7376416/158596138-aebb261d-43e7-409b-a91e-ba290d0cdebc.png)

