### PR TITLE
chore(icons): replace badges.svg with icon classes

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -179,10 +179,10 @@
   /* icons in sidebars */
   .icon-experimental,
   .icon-nonstandard {
-    color: var(--icon-information);
+    background-color: var(--icon-information);
   }
 
   .icon-deprecated {
-    color: var(--icon-critical);
+    background-color: var(--icon-critical);
   }
 }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -169,6 +169,7 @@
 
   .icon {
     background-size: 14px;
+    mask-size: 14px;
     height: 14px;
     width: 14px;
     margin-right: -0.25rem;

--- a/kumascript/macros/DeprecatedBadge.ejs
+++ b/kumascript/macros/DeprecatedBadge.ejs
@@ -10,6 +10,6 @@ var titleAttrValue = mdn.localString({
     "ja"   : "これは非推奨の API です。まだ動作しているかもしれませんが、もう使用するべきではありません。"
 });
 %>
-<abbr class="only-icon icon icon-deprecated" title="Deprecated">
-    <span>Deprecated</span>
+<abbr class="icon icon-deprecated" title="Deprecated">
+    <span class="visually-hidden">Deprecated</span>
 </abbr>

--- a/kumascript/macros/DeprecatedBadge.ejs
+++ b/kumascript/macros/DeprecatedBadge.ejs
@@ -10,6 +10,6 @@ var titleAttrValue = mdn.localString({
     "ja"   : "これは非推奨の API です。まだ動作しているかもしれませんが、もう使用するべきではありません。"
 });
 %>
-<svg class="icon icon-deprecated" tabindex="0">
-    <use xlink:href="/assets/badges.svg#icon-deprecated"></use>
-</svg>
+<abbr class="only-icon icon icon-deprecated" title="Deprecated">
+    <span>Deprecated</span>
+</abbr>

--- a/kumascript/macros/DeprecatedBadge.ejs
+++ b/kumascript/macros/DeprecatedBadge.ejs
@@ -10,6 +10,6 @@ var titleAttrValue = mdn.localString({
     "ja"   : "これは非推奨の API です。まだ動作しているかもしれませんが、もう使用するべきではありません。"
 });
 %>
-<abbr class="icon icon-deprecated" title="Deprecated">
+<abbr class="icon icon-deprecated" title="Deprecated. Not for use in new websites.">
     <span class="visually-hidden">Deprecated</span>
 </abbr>

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -12,6 +12,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This is an experimental API that should not be used in production code."
 });
 %>
-<abbr class="only-icon icon icon-experimental" title="Experimental">
-    <span>Experimental</span>
+<abbr class="icon icon-experimental" title="Experimental">
+    <span class="visually-hidden">Experimental</span>
 </abbr>

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -12,6 +12,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This is an experimental API that should not be used in production code."
 });
 %>
-<svg class="icon icon-experimental" tabindex="0">
-    <use xlink:href="/assets/badges.svg#icon-experimental"></use>
-</svg>
+<abbr class="only-icon icon icon-experimental" title="Experimental">
+    <span>Experimental</span>
+</abbr>

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -12,6 +12,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This is an experimental API that should not be used in production code."
 });
 %>
-<abbr class="icon icon-experimental" title="Experimental">
+<abbr class="icon icon-experimental" title="Experimental. Expect behavior to change in the future.">
     <span class="visually-hidden">Experimental</span>
 </abbr>

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -13,6 +13,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This API has not been standardized."
 });
 %>
-<svg class="icon icon-nonstandard" tabindex="0">
-    <use xlink:href="/assets/badges.svg#icon-nonstandard"></use>
-</svg>
+<abbr style="mask-size: 14px;" class="only-icon icon icon-nonstandard" title="Non-Standard">
+    <span>Non-Standard</span>
+</abbr>

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -13,6 +13,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This API has not been standardized."
 });
 %>
-<abbr style="mask-size: 14px;" class="only-icon icon icon-nonstandard" title="Non-Standard">
-    <span>Non-Standard</span>
+<abbr class="icon icon-nonstandard" title="Non-Standard">
+    <span class="visually-hidden">Non-Standard</span>
 </abbr>

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -13,6 +13,6 @@ var titleAttrValue = mdn.localString({
     "en-US": "This API has not been standardized."
 });
 %>
-<abbr class="icon icon-nonstandard" title="Non-Standard">
+<abbr class="icon icon-nonstandard" title="Non-standard. Check cross-browser support before using.">
     <span class="visually-hidden">Non-Standard</span>
 </abbr>

--- a/kumascript/tests/macros/Deprecated.test.js
+++ b/kumascript/tests/macros/Deprecated.test.js
@@ -8,9 +8,9 @@ describeMacro("Deprecated_Inline", function () {
   itMacro("No arguments (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(),
-      `<svg class="icon icon-deprecated" tabindex="0">
-    <use xlink:href="/assets/badges.svg#icon-deprecated"></use>
-</svg>`
+      `<abbr class="only-icon icon icon-deprecated" title="Deprecated">
+    <span>Deprecated</span>
+</abbr>`
     );
   });
   itMacro('"semver" string only (en-US)', function (macro) {

--- a/kumascript/tests/macros/Deprecated.test.js
+++ b/kumascript/tests/macros/Deprecated.test.js
@@ -8,7 +8,7 @@ describeMacro("Deprecated_Inline", function () {
   itMacro("No arguments (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(),
-      `<abbr class="icon icon-deprecated" title="Deprecated">
+      `<abbr class="icon icon-deprecated" title="Deprecated. Not for use in new websites.">
     <span class="visually-hidden">Deprecated</span>
 </abbr>`
     );

--- a/kumascript/tests/macros/Deprecated.test.js
+++ b/kumascript/tests/macros/Deprecated.test.js
@@ -8,8 +8,8 @@ describeMacro("Deprecated_Inline", function () {
   itMacro("No arguments (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call(),
-      `<abbr class="only-icon icon icon-deprecated" title="Deprecated">
-    <span>Deprecated</span>
+      `<abbr class="icon icon-deprecated" title="Deprecated">
+    <span class="visually-hidden">Deprecated</span>
 </abbr>`
     );
   });

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -43,8 +43,8 @@ const expectedHTML = `<div class="index">
         <li>
             <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
-              <abbr class="only-icon icon icon-experimental" title="Experimental">
-                <span>Experimental</span>
+              <abbr class="icon icon-experimental" title="Experimental">
+                <span class="visually-hidden">Experimental</span>
               </abbr>
             </span>
         </li>

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -43,7 +43,7 @@ const expectedHTML = `<div class="index">
         <li>
             <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
-              <abbr class="icon icon-experimental" title="Experimental">
+              <abbr class="icon icon-experimental" title="Experimental. Expect behavior to change in the future.">
                 <span class="visually-hidden">Experimental</span>
               </abbr>
             </span>

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -43,9 +43,9 @@ const expectedHTML = `<div class="index">
         <li>
             <a href='/en-US/docs/Web/API/A2TestInterface_overview'>A2TestInterface</a>
             <span class='indexListBadges'>
-              <svg class="icon icon-experimental" tabindex="0">
-                <use xlink:href="/assets/badges.svg#icon-experimental"></use>
-              </svg>
+              <abbr class="only-icon icon icon-experimental" title="Experimental">
+                <span>Experimental</span>
+              </abbr>
             </span>
         </li>
         <li>

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -349,16 +349,16 @@ function checkInterfaceItem(actual, expected, config) {
     // and the text contents omits the CTA
     const methodLink = actual.querySelector("a");
     expect(methodLink).toBeNull();
-    const methodName = actual.querySelector("svg");
+    const methodName = actual.querySelector("abbr, svg");
     expect(actual.textContent).toContain(methodName.textContent);
   }
 
   // Test that the badges are what we expect
-  const badgeClasses = actual.querySelectorAll("svg");
+  const badgeClasses = actual.querySelectorAll("abbr, svg");
   expect(badgeClasses.length).toEqual(expected.badges.length);
   for (const badgeClass of badgeClasses) {
     badgeClass.classList.forEach((value) => {
-      if (value !== "icon") {
+      if (value !== "icon" && value !== "only-icon") {
         expect(expected.badges).toContain(value);
       }
     });

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -349,16 +349,16 @@ function checkInterfaceItem(actual, expected, config) {
     // and the text contents omits the CTA
     const methodLink = actual.querySelector("a");
     expect(methodLink).toBeNull();
-    const methodName = actual.querySelector("abbr, svg");
+    const methodName = actual.querySelector(".icon");
     expect(actual.textContent).toContain(methodName.textContent);
   }
 
   // Test that the badges are what we expect
-  const badgeClasses = actual.querySelectorAll("abbr, svg");
+  const badgeClasses = actual.querySelectorAll(".icon");
   expect(badgeClasses.length).toEqual(expected.badges.length);
   for (const badgeClass of badgeClasses) {
     badgeClass.classList.forEach((value) => {
-      if (value !== "icon" && value !== "only-icon") {
+      if (value !== "icon") {
         expect(expected.badges).toContain(value);
       }
     });


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes the remainder of number 3 (deprecated icon is different in badges.svg) from #5571 and just seems nicer
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Also fix #5844

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

Stop using badges.svg.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Uses the same type of code used for the BCD

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screenshot from 2022-03-16 12-13-53](https://user-images.githubusercontent.com/29206584/158636591-04451467-523c-4a17-8457-a285ca86dd41.png)

<!-- Replace this line with your screenshot (or video). -->

### After

![Screenshot from 2022-03-16 12-13-46](https://user-images.githubusercontent.com/29206584/158636622-821358be-e999-49c4-906c-460c9fe34309.png)

<!-- Replace this line with your screenshot (or video). -->