### PR TITLE
fix(bcd): sort history by version

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -441,6 +441,9 @@ function _addSingleSpecialSection($) {
               }
             }
           }
+          info.sort((a, b) =>
+            _compareVersions(_getFirstVersion(b), _getFirstVersion(a))
+          );
         }
       }
     }
@@ -458,6 +461,60 @@ function _addSingleSpecialSection($) {
         },
       },
     ];
+  }
+
+  /**
+   * @param {object} support
+   * @returns {string}
+   */
+  function _getFirstVersion(support) {
+    if (typeof support.version_added === "string") {
+      return support.version_added;
+    } else if (typeof support.version_removed === "string") {
+      return support.version_removed;
+    } else {
+      return "0";
+    }
+  }
+
+  /**
+   * @param {string} a
+   * @param {string} b
+   */
+  function _compareVersions(a, b) {
+    const x = _splitVersion(a);
+    const y = _splitVersion(b);
+
+    return _compareNumberArray(x, y);
+  }
+
+  /**
+   * @param {number[]} a
+   * @param {number[]} b
+   * @return {number}
+   */
+  function _compareNumberArray(a, b) {
+    while (a.length || b.length) {
+      const x = a.shift() || 0;
+      const y = b.shift() || 0;
+      if (x !== y) {
+        return x - y;
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * @param {string} version
+   * @return {number[]}
+   */
+  function _splitVersion(version) {
+    if (version.startsWith("≤")) {
+      version = version.slice(1);
+    }
+
+    return version.split(".").map(Number);
   }
 
   function _buildSpecialSpecSection() {


### PR DESCRIPTION
Previously, we would simply expect that the BCD history is ordered
by version number, but this is not always the case.

Now, we reorder the BCD history ourselves, to be sure.

Partly fixes #5462.

---

## Screenshots

### Before

<img width="778" alt="Screenshot 2022-03-16 at 22 47 18" src="https://user-images.githubusercontent.com/495429/158696678-88e6d2ec-5373-476c-9828-3a61a494c666.png">

### After

<img width="778" alt="Screenshot 2022-03-16 at 22 47 27" src="https://user-images.githubusercontent.com/495429/158696700-5c21c6ca-5a02-4b92-93c8-3d4b6e9ac0db.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/CSS/appearance#browser_compatibility and http://localhost:3000/en-US/docs/Web/CSS/gradient/linear-gradient()#browser_compatibility locally.
