### PR TITLE
Home page: made mandala visible

### DIFF
--- a/client/src/ui/molecules/mandala/index.scss
+++ b/client/src/ui/molecules/mandala/index.scss
@@ -25,7 +25,7 @@
   }
   svg {
     font-size: 1.5rem;
-    font-weight: 100;
+    font-weight: 300;
   }
 
   svg > text {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

There is a rotating mandala on the [home page](https://developer.mozilla.org/en-US/). But it is barely visible.

### Solution
Changed font-weight from `lighter` to `normal`. 
Also added/set flags `animate` and `animateColors`.

## Screenshots

### Before
It was not visible before.

### After
View following image in fullscreen or in a new tab to see all the details:
![visible mandala](https://i.imgur.com/Z6kIAOY.png?1)


## How did you test this change?
Tested in Google chrome on Windows 10. 
And tested on all small smartphones available in Device Toolbar in Chrome dev tools.

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
