### PR TITLE
fix(notifications): improve watch submenu

### DIFF
--- a/client/src/ui/molecules/collection/menu.tsx
+++ b/client/src/ui/molecules/collection/menu.tsx
@@ -126,7 +126,7 @@ export function BookmarkMenu({
 
   return (
     <DropdownMenuWrapper
-      className="watch-menu open-on-focus-within"
+      className="watch-menu"
       isOpen={show}
       setIsOpen={setShow}
     >

--- a/client/src/ui/molecules/notifications-watch-menu/index.scss
+++ b/client/src/ui/molecules/notifications-watch-menu/index.scss
@@ -236,11 +236,6 @@
     border-top-width: 0;
   }
 
-  &:focus {
-    outline: 1px solid var(--button-secondary-border-focus);
-    box-shadow: var(--focus-effect);
-  }
-
   &-wrap {
     display: grid;
     grid-template-columns: 16px 1fr;
@@ -250,6 +245,15 @@
     gap: 0.5rem;
     padding: 0.8125rem var(--gutter-padding);
     text-align: left;
+  }
+
+  &:focus &-wrap {
+    outline: 1px solid var(--button-secondary-border-focus);
+    box-shadow: var(--focus-effect);
+  }
+
+  &:hover &-wrap {
+    background-color: var(--border-secondary);
   }
 
   &-status {
@@ -264,10 +268,6 @@
   &-text {
     font: var(--type-body-m);
     grid-area: text;
-  }
-
-  &:hover {
-    background-color: var(--border-secondary);
   }
 }
 

--- a/client/src/ui/molecules/notifications-watch-menu/index.scss
+++ b/client/src/ui/molecules/notifications-watch-menu/index.scss
@@ -209,7 +209,7 @@
 
 .watch-submenu-button {
   background-color: transparent;
-  border-top: 1px solid var(--border-primary);
+  border-bottom: 1px solid var(--border-primary);
   padding: 0;
   color: var(--text-primary);
   cursor: pointer;

--- a/client/src/ui/molecules/notifications-watch-menu/index.tsx
+++ b/client/src/ui/molecules/notifications-watch-menu/index.tsx
@@ -99,7 +99,7 @@ export const NotificationsWatchMenu = ({ doc }) => {
   const watchIcon = watching ? "eye-filled" : canWatchMore ? "eye" : "padlock";
   return (
     <DropdownMenuWrapper
-      className="watch-menu open-on-focus-within"
+      className="watch-menu"
       isOpen={show}
       setIsOpen={setShow}
     >


### PR DESCRIPTION
Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/34.

https://user-images.githubusercontent.com/495429/159053932-0d7a2316-6ca2-45a9-8f7e-d282111f3280.mov

# Problem 1: Outline of "Watch page" is sometimes missing bottom-edge.

The problem here is that the `border-top` of the "Not watching" button was shown on top of the `outline`-"bottom" of the "Watch page" button.

See also: https://stackoverflow.com/q/11802399

## Solution
1. Prefer `border-bottom` over `border-top`.
2. Move the `outline` (on focus) and `background-color` (on hover) effects to the `&-wrap` element inside the button.

# Problem 2: Menu closes when clicking on "Notifications".

The problem is that only buttons and input elements are focusable in those menus, because other elements like text ("Notifications") shouldn't be focusable. However, `open-on-focus-within` keeps the menu open **only as long as an element inside it has focus**.

## Solution
1. Remove `open-on-focus-within` class from the menus in question.