### PR TITLE
fix(bcd): Use partial support symbol in the timeline of notes

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -51,11 +51,8 @@ function getSupportClassName(
   } else {
     className = "no";
   }
-  if (partial_implementation && !version_removed) {
-    className = "partial";
-  }
-  if (partial_implementation && version_removed) {
-    className = "removed-partial";
+  if (partial_implementation) {
+    className = version_removed ? "removed-partial" : "partial";
   }
 
   return className;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -195,9 +195,18 @@ const CellText = React.memo(
       status = {
         isSupported: "partial",
         label:
-          typeof added === "string"
-            ? labelFromString(added, browser)
-            : "Partial",
+          typeof added === "string" ? (
+            typeof removed === "string" ? (
+              <>
+                {labelFromString(added, browser)}&#8202;&ndash;&#8202;
+                {labelFromString(removed, browser)}
+              </>
+            ) : (
+              labelFromString(added, browser)
+            )
+          ) : (
+            "Partial"
+          ),
       };
     }
 

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -191,6 +191,7 @@ const CellText = React.memo(
         title = "Partial support";
         label = status.label || "Partial";
         break;
+
       case "removed-partial":
         if (timeline) {
           title = "Partial support";

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -29,7 +29,8 @@ interface CompatStatementExtended extends bcd.CompatStatement {
 
 function getSupportClassName(
   support: SupportStatementExtended | undefined,
-  browser: bcd.BrowserStatement
+  browser: bcd.BrowserStatement,
+  timeline: boolean
 ): string {
   if (!support) {
     return "unknown";
@@ -51,7 +52,7 @@ function getSupportClassName(
   } else {
     className = "no";
   }
-  if (partial_implementation && !version_removed) {
+  if (partial_implementation && (!version_removed || timeline)) {
     className = "partial";
   }
 
@@ -122,9 +123,11 @@ const CellText = React.memo(
   ({
     support,
     browser,
+    timeline,
   }: {
     support: bcd.SupportStatement | undefined;
     browser: bcd.BrowserStatement;
+    timeline: boolean;
   }) => {
     const currentSupport = getCurrentSupport(support);
 
@@ -183,7 +186,12 @@ const CellText = React.memo(
           </>
         ),
       };
-    } else if (currentSupport && currentSupport.partial_implementation) {
+    }
+    if (
+      currentSupport &&
+      currentSupport.partial_implementation &&
+      (!removed || timeline)
+    ) {
       status = {
         isSupported: "partial",
         label:
@@ -221,7 +229,7 @@ const CellText = React.memo(
         label = "?";
         break;
     }
-    const supportClassName = getSupportClassName(support, browser);
+    const supportClassName = getSupportClassName(support, browser, timeline);
 
     return (
       <div className="bcd-cell-text-wrapper">
@@ -417,10 +425,11 @@ function getNotes(
                 <dt
                   className={`bc-supports-${getSupportClassName(
                     item,
-                    browser
+                    browser,
+                    true
                   )} bc-supports`}
                 >
-                  <CellText support={item} browser={browser} />
+                  <CellText support={item} browser={browser} timeline={true} />
                 </dt>
                 {supportNotes.map(({ iconName, label }, i) => {
                   return (
@@ -459,7 +468,7 @@ function CompatCell({
   onToggle: () => void;
   locale: string;
 }) {
-  const supportClassName = getSupportClassName(support, browserInfo);
+  const supportClassName = getSupportClassName(support, browserInfo, false);
   // NOTE: 1-5-21, I've forced hasNotes to return true, in order to
   // make the details view open all the time.
   // Whenever the support statement is complex (array with more than one entry)
@@ -475,7 +484,7 @@ function CompatCell({
   const notes = getNotes(browserInfo, support!);
   const content = (
     <>
-      <CellText {...{ support }} browser={browserInfo} />
+      <CellText {...{ support }} browser={browserInfo} timeline={false} />
       {showNotes && (
         <dl className="bc-notes-list bc-history bc-history-mobile">{notes}</dl>
       )}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -30,7 +30,7 @@ interface CompatStatementExtended extends bcd.CompatStatement {
 function getSupportClassName(
   support: SupportStatementExtended | undefined,
   browser: bcd.BrowserStatement,
-  timeline: boolean
+  timeline: boolean = false
 ): string {
   if (!support) {
     return "unknown";
@@ -123,11 +123,11 @@ const CellText = React.memo(
   ({
     support,
     browser,
-    timeline,
+    timeline = false,
   }: {
     support: bcd.SupportStatement | undefined;
     browser: bcd.BrowserStatement;
-    timeline: boolean;
+    timeline?: boolean;
   }) => {
     const currentSupport = getCurrentSupport(support);
 
@@ -477,7 +477,7 @@ function CompatCell({
   onToggle: () => void;
   locale: string;
 }) {
-  const supportClassName = getSupportClassName(support, browserInfo, false);
+  const supportClassName = getSupportClassName(support, browserInfo);
   // NOTE: 1-5-21, I've forced hasNotes to return true, in order to
   // make the details view open all the time.
   // Whenever the support statement is complex (array with more than one entry)
@@ -493,7 +493,7 @@ function CompatCell({
   const notes = getNotes(browserInfo, support!);
   const content = (
     <>
-      <CellText {...{ support }} browser={browserInfo} timeline={false} />
+      <CellText {...{ support }} browser={browserInfo} />
       {showNotes && (
         <dl className="bc-notes-list bc-history bc-history-mobile">{notes}</dl>
       )}

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -80,6 +80,10 @@
       td {
         border-left-width: 0;
       }
+      .icon.icon-removed-partial {
+        // override icon
+        mask-image: url("../../../assets/icons/partial.svg");
+      }
     }
   }
 
@@ -95,6 +99,11 @@
       background: var(--background-primary);
     }
   }
+  .bc-supports.bc-supports-removed-partial {
+    .bcd-cell-text-copy {
+      color: var(--text-primary-yellow);
+    }
+  }
 
   .icon-wrap {
     .bc-support-level {
@@ -104,6 +113,16 @@
   .bc-support {
     > button > .icon-wrap {
       display: block;
+    }
+    .icon.icon-removed-partial {
+      // override icon
+      mask-image: url("../../../assets/icons/no.svg");
+      background-color: var(--icon-critical);
+    }
+  }
+  .bc-support.bc-supports-removed-partial {
+    .bcd-cell-text-copy {
+      color: var(--text-primary-red);
     }
   }
   .bc-feature-depth-2 {


### PR DESCRIPTION
## Summary

Use partial support symbol in the timeline of notes

### Problem

There is a "No support" symbol in historical notes for partially supported technologies.

### Solution

Remove that symbol while keeping it for non timeline view of removed notes

---

## Screenshots

### Before

Page: https://developer.mozilla.org/en-US/docs/Web/API/Document#browser_compatibility
![Screenshot from 2022-04-21 09-25-47](https://user-images.githubusercontent.com/29206584/164468717-58ba64b6-9b80-4bf5-ad80-0b6ad744033d.png)

Page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video#browser_compatibility
![Screenshot from 2022-04-21 09-28-32](https://user-images.githubusercontent.com/29206584/164468789-c39428d7-c8d4-47e0-943f-bad41d38a2b8.png)

### After

Page: http://localhost:3000/en-US/docs/Web/API/Document#browser_compatibility
![Screenshot from 2022-04-21 09-27-46](https://user-images.githubusercontent.com/29206584/164468869-837584b0-0f9e-461e-a66f-6577799031e1.png)

Page: http://localhost:3000/en-US/docs/Web/HTML/Element/video#browser_compatibility
![Screenshot from 2022-04-21 09-29-37](https://user-images.githubusercontent.com/29206584/164468891-5280e955-5095-4a7e-8191-792e61120a96.png)