### PR TITLE
Update Russian translation of FirefoxSidebar

### DIFF
--- a/kumascript/macros/FirefoxSidebar.ejs
+++ b/kumascript/macros/FirefoxSidebar.ejs
@@ -79,13 +79,13 @@ const text = mdn.localStringMap({
     "Firefox_documentation": "Firefox documentation",
   },
   "ru": {
-    "Firefox_releases": "Firefox releases",
-      "Firefox_release_notes_developer": "Firefox release notes for developers",
-      "Experimental_features_firefox": "Experimental features in Firefox",
+    "Firefox_releases": "Выпуски Firefox",
+      "Firefox_release_notes_developer": "Примечания к выпускам Firefox для разработчиков",
+      "Experimental_features_firefox": "Экспериментальные функции Firefox",
     "Add-ons": "Дополнения",
       "Browser_extensions": "Расширения браузера",
       "Themes": "Темы",
-    "Firefox_documentation": "Firefox documentation",
+    "Firefox_documentation": "Документация Firefox",
   },
   "zh-CN": {
     "Firefox_releases": "Firefox 发行说明",


### PR DESCRIPTION
Adds remaining Russian translations for the new Firefox sidebar. Related to mdn/translated-content#4706

Ping @mdn/yari-content-ru and @schalkneethling for review