### PR TITLE
fix: Horizontal scrollbar thicker than vertical

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -177,6 +177,7 @@ u {
 
 *::-webkit-scrollbar {
   width: 12px;
+  height: 12px;
   background-color: var(--scrollbar-bg, auto);
 }
 


### PR DESCRIPTION
## Problem
Visit page https://developer.mozilla.org/en-US/docs/Web/API/MediaSource 
Scroll all the way down.
Notice the horizontal scrollbar looks thicker than the vertical one:

![thickhorizontal](https://i.imgur.com/bUQ7C3u.png)

### Solution
Set scrollbar height to `12px`.
```css
::-webkit-scrollbar {
  width: 12px;
  height: 12px;   /* <---- */
  background-color: auto;
  background-color: var(--scrollbar-bg,auto);
}
```

## Screenshots

### After
![fixed](https://i.imgur.com/ZIMZi9v.png)

## How did you test this change?
On Chrome 99.0 on Windows 10.


