### PR TITLE
Fix:Service worker intercepting fxa requests.

### DIFF
--- a/client/pwa/src/fetch-interceptors.ts
+++ b/client/pwa/src/fetch-interceptors.ts
@@ -246,7 +246,7 @@ class DefaultApiInterceptor implements FetchInterceptor {
   }
 
   handles(path: string): boolean {
-    return path.startsWith("/api/v1/");
+    return path.startsWith("/api/v1/") || path.startsWith("/users/fxa/");
   }
 
   async onGet(req: Request): Promise<Response> {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes logging out/logging in issues when service worker is running. 

### Problem

The service worker was trying to service requests going to /users/fxa out of the cache. (This wasn't detected locally as the requests are sent directly to api server localhost:8000 and not proxied).

### Solution

Add path prefix /users/fxa to the api interceptor that directly forwards the request upstream. 

## How did you test this change?

Tested locally.
