### PR TITLE
Disable watch/save and hide collection/notification management actions when offline

### DIFF
--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import useSWR from "swr";
 
@@ -77,4 +77,24 @@ export function useOnClickOutside(ref, handler) {
     // ... passing it into this hook.
     [ref, handler]
   );
+}
+
+export function useOnlineStatus(): { isOnline: boolean; isOffline: boolean } {
+  const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
+  const isOffline = useMemo(() => !isOnline, [isOnline]);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+    };
+  }, []);
+
+  return { isOnline, isOffline };
 }

--- a/client/src/plus/collections/collection-list-item.tsx
+++ b/client/src/plus/collections/collection-list-item.tsx
@@ -8,6 +8,7 @@ import { docCategory } from "../../utils";
 import { _getIconLabel } from "../common";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import { useOnlineStatus } from "../../hooks";
 
 dayjs.extend(relativeTime);
 
@@ -23,6 +24,7 @@ export function CollectionListItem({
   handleDelete: (item: BookmarkData) => Promise<void>;
 }) {
   const [show, setShow] = React.useState(false);
+  const { isOnline } = useOnlineStatus();
 
   const iconClass = docCategory({ pathname: item.url })?.split("-")[1];
   const iconLabel = _getIconLabel(item.url);
@@ -45,46 +47,50 @@ export function CollectionListItem({
         >
           {`Added ${dayjs(item.created).fromNow().toString()}`}
         </time>
-        <DropdownMenuWrapper
-          className="dropdown is-flush-right"
-          isOpen={show}
-          setIsOpen={(value, event) => {
-            if (
-              !document.querySelector(".modal-content")?.contains(event.target)
-            ) {
-              setShow(value);
-            }
-          }}
-        >
-          <Button
-            type="action"
-            icon="ellipses"
-            ariaControls="collection-list-item-dropdown"
-            ariaHasPopup={"menu"}
-            ariaExpanded={show || undefined}
-            onClickHandler={() => {
-              setShow(!show);
+        {isOnline && (
+          <DropdownMenuWrapper
+            className="dropdown is-flush-right"
+            isOpen={show}
+            setIsOpen={(value, event) => {
+              if (
+                !document
+                  .querySelector(".modal-content")
+                  ?.contains(event.target)
+              ) {
+                setShow(value);
+              }
             }}
-          />
-          <DropdownMenu>
-            <ul className="dropdown-list" id="collection-item-dropdown">
-              {showEditButton && (
+          >
+            <Button
+              type="action"
+              icon="ellipses"
+              ariaControls="collection-list-item-dropdown"
+              ariaHasPopup={"menu"}
+              ariaExpanded={show || undefined}
+              onClickHandler={() => {
+                setShow(!show);
+              }}
+            />
+            <DropdownMenu>
+              <ul className="dropdown-list" id="collection-item-dropdown">
+                {showEditButton && (
+                  <li className="dropdown-item">
+                    <EditCollection item={item} onEditSubmit={onEditSubmit} />
+                  </li>
+                )}
                 <li className="dropdown-item">
-                  <EditCollection item={item} onEditSubmit={onEditSubmit} />
+                  <Button
+                    type="action"
+                    title="Delete"
+                    onClickHandler={() => handleDelete(item)}
+                  >
+                    Delete
+                  </Button>
                 </li>
-              )}
-              <li className="dropdown-item">
-                <Button
-                  type="action"
-                  title="Delete"
-                  onClickHandler={() => handleDelete(item)}
-                >
-                  Delete
-                </Button>
-              </li>
-            </ul>
-          </DropdownMenu>
-        </DropdownMenuWrapper>
+              </ul>
+            </DropdownMenu>
+          </DropdownMenuWrapper>
+        )}
       </div>
       {item.notes && <p className="icon-card-description">{item.notes}</p>}
     </article>

--- a/client/src/plus/icon-card/index.tsx
+++ b/client/src/plus/icon-card/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useOnlineStatus } from "../../hooks";
 import { Button } from "../../ui/atoms/button";
 import { DropdownMenu, DropdownMenuWrapper } from "../../ui/molecules/dropdown";
 import { Checkbox } from "../../ui/molecules/notifications-watch-menu/atoms/checkbox";
@@ -12,6 +13,7 @@ export default function WatchedCardListItem({
   toggleSelected,
 }) {
   const [show, setShow] = React.useState(false);
+  const { isOnline } = useOnlineStatus();
 
   const iconClass = docCategory({ pathname: item.url })?.split("-")[1];
   const iconLabel = _getIconLabel(item.url);
@@ -19,11 +21,13 @@ export default function WatchedCardListItem({
   return (
     <li className="icon-card">
       <div className="icon-card-title-wrap">
-        <Checkbox
-          name="selected"
-          checked={item.checked}
-          onChange={(e) => toggleSelected(item, e.target.value)}
-        />
+        {isOnline && (
+          <Checkbox
+            name="selected"
+            checked={item.checked}
+            onChange={(e) => toggleSelected(item, e.target.value)}
+          />
+        )}
         <div className={`icon-card-icon ${iconClass || ""}`}>
           <span>{iconLabel}</span>
         </div>
@@ -37,31 +41,36 @@ export default function WatchedCardListItem({
             <a href={item.url}>{item.title}</a>
           </h2>
         </div>
-        <DropdownMenuWrapper
-          className="dropdown is-flush-right"
-          isOpen={show}
-          setIsOpen={setShow}
-        >
-          <Button
-            type="action"
-            icon="ellipses"
-            ariaControls="watch-card-dropdown"
-            ariaHasPopup={"menu"}
-            ariaExpanded={show || undefined}
-            onClickHandler={() => {
-              setShow(!show);
-            }}
-          />
-          <DropdownMenu>
-            <ul className="dropdown-list" id="watch-card-dropdown">
-              <li className="dropdown-item">
-                <Button type="action" onClickHandler={() => onUnwatched(item)}>
-                  Unwatch
-                </Button>
-              </li>
-            </ul>
-          </DropdownMenu>
-        </DropdownMenuWrapper>
+        {isOnline && (
+          <DropdownMenuWrapper
+            className="dropdown is-flush-right"
+            isOpen={show}
+            setIsOpen={setShow}
+          >
+            <Button
+              type="action"
+              icon="ellipses"
+              ariaControls="watch-card-dropdown"
+              ariaHasPopup={"menu"}
+              ariaExpanded={show || undefined}
+              onClickHandler={() => {
+                setShow(!show);
+              }}
+            />
+            <DropdownMenu>
+              <ul className="dropdown-list" id="watch-card-dropdown">
+                <li className="dropdown-item">
+                  <Button
+                    type="action"
+                    onClickHandler={() => onUnwatched(item)}
+                  >
+                    Unwatch
+                  </Button>
+                </li>
+              </ul>
+            </DropdownMenu>
+          </DropdownMenuWrapper>
+        )}
       </div>
       {/* <p className="icon-card-description">This is a note, lets keep it. </p> */}
     </li>

--- a/client/src/plus/notifications/index.scss
+++ b/client/src/plus/notifications/index.scss
@@ -19,10 +19,22 @@
   align-items: center;
   border: 1px solid var(--border-secondary);
   background-color: var(--background-primary);
-  display: grid;
-  grid-template-columns: auto auto 1fr 2rem;
+  display: flex;
+  justify-content: space-between;
+
+  & > div {
+    display: flex;
+    align-items: center;
+  }
+
+  .desktop-only {
+    display: hidden;
+  }
+
   @media screen and (min-width: $screen-md) {
-    grid-template-columns: auto auto 1fr 10ch auto;
+    .desktop-only {
+      display: inherit;
+    }
   }
 
   padding: 0.5rem;

--- a/client/src/plus/notifications/notification-card-list-item.tsx
+++ b/client/src/plus/notifications/notification-card-list-item.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import React from "react";
+import { useOnlineStatus } from "../../hooks";
 import { Button } from "../../ui/atoms/button";
 import { DropdownMenu, DropdownMenuWrapper } from "../../ui/molecules/dropdown";
 import { Checkbox } from "../../ui/molecules/notifications-watch-menu/atoms/checkbox";
@@ -11,25 +12,30 @@ export default function NotificationCardListItem({
   handleDelete,
 }) {
   const [show, setShow] = React.useState(false);
+  const { isOnline } = useOnlineStatus();
 
   return (
     <li
       className={`notification-card ${!item.read ? "unread" : ""}`}
       key={item.id}
     >
-      <Checkbox
-        name="selected"
-        checked={item.checked}
-        onChange={(e) => toggleSelected(item, e.target.value)}
-      />
-      <Button
-        type="action"
-        extraClasses="notification-card-star"
-        icon={item.starred ? "star-filled" : "star"}
-        onClickHandler={() => toggleStarred(item)}
-      >
-        <span className="visually-hidden">Toggle Starring</span>
-      </Button>
+      {isOnline && (
+        <>
+          <Checkbox
+            name="selected"
+            checked={item.checked}
+            onChange={(e) => toggleSelected(item, e.target.value)}
+          />
+          <Button
+            type="action"
+            extraClasses="notification-card-star"
+            icon={item.starred ? "star-filled" : "star"}
+            onClickHandler={() => toggleStarred(item)}
+          >
+            <span className="visually-hidden">Toggle Starring</span>
+          </Button>
+        </>
+      )}
 
       <a href={item.url} className="notification-card-description">
         <h2 className="notification-card-title">{item.title}</h2>
@@ -43,31 +49,33 @@ export default function NotificationCardListItem({
         {dayjs(item.created).fromNow().toString()}
       </time>
 
-      <DropdownMenuWrapper
-        className="dropdown is-flush-right"
-        isOpen={show}
-        setIsOpen={setShow}
-      >
-        <Button
-          type="action"
-          icon="ellipses"
-          ariaControls="watch-card-dropdown"
-          ariaHasPopup={"menu"}
-          ariaExpanded={show || undefined}
-          onClickHandler={() => {
-            setShow(!show);
-          }}
-        />
-        <DropdownMenu>
-          <ul className="dropdown-list" id="watch-card-dropdown">
-            <li className="dropdown-item">
-              <Button type="action" onClickHandler={() => handleDelete(item)}>
-                Delete
-              </Button>
-            </li>
-          </ul>
-        </DropdownMenu>
-      </DropdownMenuWrapper>
+      {isOnline && (
+        <DropdownMenuWrapper
+          className="dropdown is-flush-right"
+          isOpen={show}
+          setIsOpen={setShow}
+        >
+          <Button
+            type="action"
+            icon="ellipses"
+            ariaControls="watch-card-dropdown"
+            ariaHasPopup={"menu"}
+            ariaExpanded={show || undefined}
+            onClickHandler={() => {
+              setShow(!show);
+            }}
+          />
+          <DropdownMenu>
+            <ul className="dropdown-list" id="watch-card-dropdown">
+              <li className="dropdown-item">
+                <Button type="action" onClickHandler={() => handleDelete(item)}>
+                  Delete
+                </Button>
+              </li>
+            </ul>
+          </DropdownMenu>
+        </DropdownMenuWrapper>
+      )}
     </li>
   );
 }

--- a/client/src/plus/notifications/notification-card-list-item.tsx
+++ b/client/src/plus/notifications/notification-card-list-item.tsx
@@ -19,63 +19,70 @@ export default function NotificationCardListItem({
       className={`notification-card ${!item.read ? "unread" : ""}`}
       key={item.id}
     >
-      {isOnline && (
-        <>
-          <Checkbox
-            name="selected"
-            checked={item.checked}
-            onChange={(e) => toggleSelected(item, e.target.value)}
-          />
-          <Button
-            type="action"
-            extraClasses="notification-card-star"
-            icon={item.starred ? "star-filled" : "star"}
-            onClickHandler={() => toggleStarred(item)}
-          >
-            <span className="visually-hidden">Toggle Starring</span>
-          </Button>
-        </>
-      )}
+      <div>
+        {isOnline && (
+          <>
+            <Checkbox
+              name="selected"
+              checked={item.checked}
+              onChange={(e) => toggleSelected(item, e.target.value)}
+            />
+            <Button
+              type="action"
+              extraClasses="notification-card-star"
+              icon={item.starred ? "star-filled" : "star"}
+              onClickHandler={() => toggleStarred(item)}
+            >
+              <span className="visually-hidden">Toggle Starring</span>
+            </Button>
+          </>
+        )}
 
-      <a href={item.url} className="notification-card-description">
-        <h2 className="notification-card-title">{item.title}</h2>
-        <p className="notification-card-text">{item.text}</p>
-      </a>
+        <a href={item.url} className="notification-card-description">
+          <h2 className="notification-card-title">{item.title}</h2>
+          <p className="notification-card-text">{item.text}</p>
+        </a>
+      </div>
 
-      <time
-        className="notification-card-created"
-        dateTime={dayjs(item.created).toISOString()}
-      >
-        {dayjs(item.created).fromNow().toString()}
-      </time>
-
-      {isOnline && (
-        <DropdownMenuWrapper
-          className="dropdown is-flush-right"
-          isOpen={show}
-          setIsOpen={setShow}
+      <div>
+        <time
+          className="notification-card-created desktop-only"
+          dateTime={dayjs(item.created).toISOString()}
         >
-          <Button
-            type="action"
-            icon="ellipses"
-            ariaControls="watch-card-dropdown"
-            ariaHasPopup={"menu"}
-            ariaExpanded={show || undefined}
-            onClickHandler={() => {
-              setShow(!show);
-            }}
-          />
-          <DropdownMenu>
-            <ul className="dropdown-list" id="watch-card-dropdown">
-              <li className="dropdown-item">
-                <Button type="action" onClickHandler={() => handleDelete(item)}>
-                  Delete
-                </Button>
-              </li>
-            </ul>
-          </DropdownMenu>
-        </DropdownMenuWrapper>
-      )}
+          {dayjs(item.created).fromNow().toString()}
+        </time>
+
+        {isOnline && (
+          <DropdownMenuWrapper
+            className="dropdown is-flush-right"
+            isOpen={show}
+            setIsOpen={setShow}
+          >
+            <Button
+              type="action"
+              icon="ellipses"
+              ariaControls="watch-card-dropdown"
+              ariaHasPopup={"menu"}
+              ariaExpanded={show || undefined}
+              onClickHandler={() => {
+                setShow(!show);
+              }}
+            />
+            <DropdownMenu>
+              <ul className="dropdown-list" id="watch-card-dropdown">
+                <li className="dropdown-item">
+                  <Button
+                    type="action"
+                    onClickHandler={() => handleDelete(item)}
+                  >
+                    Delete
+                  </Button>
+                </li>
+              </ul>
+            </DropdownMenu>
+          </DropdownMenuWrapper>
+        )}
+      </div>
     </li>
   );
 }

--- a/client/src/plus/notifications/notification-select.tsx
+++ b/client/src/plus/notifications/notification-select.tsx
@@ -1,3 +1,4 @@
+import { useOnlineStatus } from "../../hooks";
 import { Button } from "../../ui/atoms/button";
 import { Checkbox } from "../../ui/molecules/notifications-watch-menu/atoms/checkbox";
 
@@ -11,43 +12,53 @@ export default function SelectedNotificationsBar({
   onUnwatchSelected,
   watchedTab,
 }) {
+  const { isOnline } = useOnlineStatus();
+
   return (
-    <form className="select-all-toolbar">
-      <Checkbox name="select-all" onChange={onSelectAll} checked={isChecked} />
-      {!watchedTab && (
-        <>
-          <Button
-            type="secondary"
-            isDisabled={!buttonStates.starEnabled}
-            onClickHandler={onStarSelected}
-          >
-            Star
-          </Button>
-          <Button
-            type="secondary"
-            isDisabled={!buttonStates.unstarEnabled}
-            onClickHandler={onUnstarSelected}
-          >
-            Unstar
-          </Button>
-          <Button
-            type="secondary"
-            isDisabled={!buttonStates.deleteEnabled}
-            onClickHandler={onDeleteSelected}
-          >
-            Delete
-          </Button>
-        </>
+    <>
+      {isOnline && (
+        <form className="select-all-toolbar">
+          <Checkbox
+            name="select-all"
+            onChange={onSelectAll}
+            checked={isChecked}
+          />
+          {!watchedTab && (
+            <>
+              <Button
+                type="secondary"
+                isDisabled={!buttonStates.starEnabled}
+                onClickHandler={onStarSelected}
+              >
+                Star
+              </Button>
+              <Button
+                type="secondary"
+                isDisabled={!buttonStates.unstarEnabled}
+                onClickHandler={onUnstarSelected}
+              >
+                Unstar
+              </Button>
+              <Button
+                type="secondary"
+                isDisabled={!buttonStates.deleteEnabled}
+                onClickHandler={onDeleteSelected}
+              >
+                Delete
+              </Button>
+            </>
+          )}
+          {watchedTab && (
+            <Button
+              type="secondary"
+              isDisabled={!buttonStates.unwatchEnabled}
+              onClickHandler={onUnwatchSelected}
+            >
+              Unwatch
+            </Button>
+          )}
+        </form>
       )}
-      {watchedTab && (
-        <Button
-          type="secondary"
-          isDisabled={!buttonStates.unwatchEnabled}
-          onClickHandler={onUnwatchSelected}
-        >
-          Unwatch
-        </Button>
-      )}
-    </form>
+    </>
   );
 }

--- a/client/src/ui/molecules/collection/menu.tsx
+++ b/client/src/ui/molecules/collection/menu.tsx
@@ -8,6 +8,7 @@ import { BookmarkedData } from ".";
 import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 import { ManageOrUpgradeDialogCollections } from "../manage-upgrade-dialog";
 import { useUIStatus } from "../../../ui-context";
+import { useOnlineStatus } from "../../../hooks";
 
 const menuId = "watch-submenu";
 
@@ -44,6 +45,7 @@ export function BookmarkMenu({
     new URLSearchParams([["url", doc?.mdn_url || data?.bookmarked?.url || ""]])
   );
   const ui = useUIStatus();
+  const { isOffline } = useOnlineStatus();
   const [show, setShow] = React.useState(false);
   const [name, setName] = React.useState<string>(
     data?.bookmarked?.title || doc?.title || ""
@@ -133,9 +135,9 @@ export function BookmarkMenu({
       {doc ? (
         <Button
           type="action"
+          isDisabled={isOffline || !data}
           icon={saveIcon}
           extraClasses={`bookmark-button small ${saved ? "highlight" : ""}`}
-          isDisabled={!data}
           onClickHandler={() => {
             setShow((v) => !v);
           }}
@@ -148,6 +150,7 @@ export function BookmarkMenu({
         <Button
           icon="edit"
           type="action"
+          isDisabled={isOffline}
           title="Edit"
           onClickHandler={() => {
             setShow((v) => !v);

--- a/client/src/ui/molecules/notifications-watch-menu/index.tsx
+++ b/client/src/ui/molecules/notifications-watch-menu/index.tsx
@@ -5,7 +5,7 @@ import { NotificationsWatchMenuStart } from "./menu-start";
 
 import "./index.scss";
 import useSWR from "swr";
-import { useCSRFMiddlewareToken } from "../../../hooks";
+import { useCSRFMiddlewareToken, useOnlineStatus } from "../../../hooks";
 import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 import { ManageOrUpgradeDialogNotifications } from "../manage-upgrade-dialog";
 import { useUIStatus } from "../../../ui-context";
@@ -28,6 +28,7 @@ export const NotificationsWatchMenu = ({ doc }) => {
   const apiURL = `/api/v1/plus/watching/?url=${slug}`;
   const csrfMiddlewareToken = useCSRFMiddlewareToken();
   const ui = useUIStatus();
+  const { isOffline } = useOnlineStatus();
 
   const { data, mutate } = useSWR<WatchModeData>(
     apiURL,
@@ -107,6 +108,7 @@ export const NotificationsWatchMenu = ({ doc }) => {
         <Button
           type="action"
           id="watch-menu-button"
+          isDisabled={isOffline}
           icon={watchIcon}
           extraClasses={`small watch-menu ${watching ? "highlight" : ""}`}
           ariaHasPopup={"menu"}


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari-private/issues/940 by greying out the menu items, instead of showing a toast when the action fails (which we might want to do additionally).

### Problem

Watch/Save actions are not available when offline, but this is not indicated in the UI.

### Solution

- Added a ~~`useOffline()`~~ `useOnlineStatus()` hook that returns two `isOnline` and `isOffline` flags.
- Used the `isOffline` flag to disable the buttons responsible for the Watch/Save menus.
- Used the `isOnline` flag to show some toolbars/buttons/dropdowns on the Collections/Notifications page conditionally.

---

## Screenshots

### Before

<img width="471" alt="image" src="https://user-images.githubusercontent.com/495429/159312444-53bc61bb-53d4-40a1-a08b-53a18d37ce49.png">

### After

<img width="471" alt="image" src="https://user-images.githubusercontent.com/495429/159312383-798b16d6-2890-4619-bc6f-28cce4bbc784.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/API/Navigator/onLine in Edge.
2. Set Network > (Throttling) to Offline in the DevTools.