### PR TITLE
fix(menu): avoid links with trailing slash

### DIFF
--- a/client/src/ui/molecules/guides-menu/index.tsx
+++ b/client/src/ui/molecules/guides-menu/index.tsx
@@ -72,7 +72,7 @@ export const GuidesMenu = ({ visibleSubMenuId, toggleMenu }) => {
       </button>
 
       <Link
-        to={`/${locale}/docs/Learn/`}
+        to={`/${locale}/docs/Learn`}
         className="top-level-entry"
         // @ts-ignore
         onClick={() => document?.activeElement?.blur()}

--- a/client/src/ui/molecules/reference-menu/index.tsx
+++ b/client/src/ui/molecules/reference-menu/index.tsx
@@ -59,7 +59,7 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Web Technology",
-        url: `/${locale}/docs/Web/`,
+        url: `/${locale}/docs/Web`,
       },
     ],
   };
@@ -81,7 +81,7 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
       </button>
 
       <Link
-        to={`/${locale}/docs/Web/`}
+        to={`/${locale}/docs/Web`}
         className="top-level-entry"
         // @ts-ignore
         onClick={() => document?.activeElement?.blur()}


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/40 as a workaround.

### Problem

When navigating from the Notifications list to `/Web/` or `/Learn/`, we're getting a _Page not found_ error, even though yari doesn't even try to fetch the `index.json`. This did not affect links to `/Learn` (without a trailing slash).

### Solution

Remove the trailing slashes from those links, especially as `/Web/` redirects to `/Web`.

---

## How did you test this change?

1. Tested that the links still work.
2. Couldn't verify that it fixes the problem, but I'm very confident, as the _Guides_ menu (itself linking to `/Learn/`) has an item _MDN Learning Area_ that links to `/Learn` (without a trailing slash).