### PR TITLE
fix(plus-menu): add mobile-only overview item

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.scss
+++ b/client/src/ui/molecules/plus-menu/index.scss
@@ -1,6 +1,14 @@
 @use "sass:color";
 @use "../../vars" as *;
 
-.mdn-plus .submenu-icon {
-  background-color: var(--plus-accent-color);
+.mdn-plus {
+  .submenu-icon {
+    background-color: var(--plus-accent-color);
+  }
+
+  @media screen and (min-width: $screen-md) {
+    .mobile-only {
+      display: none;
+    }
+  }
 }

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -17,6 +17,14 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
     id: "mdn-plus",
     items: [
       {
+        description: "More MDN. Your MDN.",
+        hasIcon: true,
+        extraClasses: "mobile-only",
+        iconClasses: "submenu-icon",
+        label: "Overview",
+        url: `/${locale}/plus`,
+      },
+      {
         description: "Your saved articles from across MDN",
         hasIcon: true,
         iconClasses: "submenu-icon bookmarks-icon",


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari-private/issues/944.

### Problem

On mobile, the top-level navigation items toggle their submenu. For this reason, the Guides and Learn menus have a submenu item that refers to the same location as the main item, but the Plus menu was missing such an item.

### Solution

Added an "Overview" item on mobile-only.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Desktop

<img width="309" alt="image" src="https://user-images.githubusercontent.com/495429/159337610-27f317a0-2eab-45d9-89af-15c5d1a109f4.png">

### Mobile

<img width="309" alt="image" src="https://user-images.githubusercontent.com/495429/159337708-7cc3b8e1-ca76-4c89-a19a-68ffb0f2e474.png">

---

## How did you test this change?

1. Checked desktop and mobile views using DevTools responsive mode (see above).