### PR TITLE
Fix redirect error on users/fxa

### DIFF
--- a/client/pwa/src/service-worker.ts
+++ b/client/pwa/src/service-worker.ts
@@ -41,7 +41,11 @@ self.addEventListener("install", (e) => {
 self.addEventListener("fetch", (e) => {
   const preferOnline =
     new URLSearchParams(location.search).get("preferOnline") === "true";
-  if (preferOnline && !e.request.url.includes("/api/v1/")) {
+  if (
+    preferOnline &&
+    !e.request.url.includes("/api/v1/") &&
+    !e.request.url.includes("/users/fxa/")
+  ) {
     e.respondWith(
       (async () => {
         const res = await fetchWithExampleOverride(e.request);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

- Add users/fxa to skip handling for prefer online. 

### Problem
- The request was being made as a post then as res.ok was false (for opaqueredirect) it was being made again and failing. 

### Solution

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

- 1. Login on localhost. 2. Set service worker to 'prefer online' mode.  3. Logout (This should redirect without failing). 

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
