### PR TITLE
chore(plus): add feedback link to user menu

### DIFF
--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -79,6 +79,10 @@ export const UserMenu = () => {
         label: "Help",
       },
       {
+        url: "https://github.com/mdn/MDN-feedback",
+        label: "Feedback",
+      },
+      {
         component: SignOut,
         extraClasses: "signout-container",
       },


### PR DESCRIPTION
Adds a feedback link to the user menu pointing at the feedback repo on GitHub. I did not test this locally as my Kuma instance seems buggy but, technically it "should just work" 😄 

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/53.