### PR TITLE
chore(menus): add mobile-only overview items

### DIFF
--- a/client/src/ui/molecules/guides-menu/index.scss
+++ b/client/src/ui/molecules/guides-menu/index.scss
@@ -6,4 +6,18 @@
     font-weight: initial;
     font: var(--type-body-m);
   }
+
+  .desktop-only {
+    display: none;
+  }
+
+  @media screen and (min-width: $screen-md) {
+    .desktop-only {
+      display: inherit;
+    }
+
+    .mobile-only {
+      display: none;
+    }
+  }
 }

--- a/client/src/ui/molecules/guides-menu/index.tsx
+++ b/client/src/ui/molecules/guides-menu/index.tsx
@@ -15,7 +15,15 @@ export const GuidesMenu = ({ visibleSubMenuId, toggleMenu }) => {
     items: [
       {
         description: "Learn web development",
-        extraClasses: "apis-link-container",
+        hasIcon: true,
+        extraClasses: "apis-link-container mobile-only",
+        iconClasses: "submenu-icon learn",
+        label: "Overview / MDN Learning Area",
+        url: `/${locale}/docs/Learn`,
+      },
+      {
+        description: "Learn web development",
+        extraClasses: "apis-link-container desktop-only",
         hasIcon: true,
         iconClasses: "submenu-icon learn",
         label: "MDN Learning Area",

--- a/client/src/ui/molecules/reference-menu/index.scss
+++ b/client/src/ui/molecules/reference-menu/index.scss
@@ -1,6 +1,22 @@
 @use "sass:color";
 @use "../../vars" as *;
 
+.references {
+  .desktop-only {
+    display: none;
+  }
+
+  @media screen and (min-width: $screen-md) {
+    .desktop-only {
+      display: inherit;
+    }
+
+    .mobile-only {
+      display: none;
+    }
+  }
+}
+
 .html-link-container {
   a:hover,
   a:focus {

--- a/client/src/ui/molecules/reference-menu/index.tsx
+++ b/client/src/ui/molecules/reference-menu/index.tsx
@@ -14,6 +14,14 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
     id: "references",
     items: [
       {
+        description: "Web technology reference for developers",
+        hasIcon: true,
+        extraClasses: "apis-link-container mobile-only",
+        iconClasses: "submenu-icon",
+        label: "Overview / Web Technology",
+        url: `/${locale}/docs/Web`,
+      },
+      {
         description: "Structure of content on the web",
         extraClasses: "html-link-container",
         hasIcon: true,
@@ -55,7 +63,7 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
       },
       {
         description: "Web technology reference for developers",
-        extraClasses: "apis-link-container",
+        extraClasses: "apis-link-container desktop-only",
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Web Technology",


### PR DESCRIPTION
## Summary

Resolves https://github.com/mdn/foxfooding-mdn-plus/issues/59.

### Problem

- On mobile, the top-level menu items toggle the submenu.
- Both the References and Guides menus already have a submenu item that refer to the same page as the top-level item.
- Users that know the References / Guides links on desktop, cannot know how to get there on mobile.

### Solution

Now, we show an "Overview / ..." item and hide the existing
"..." item on mobile, whereas we keep "..." on desktop.

---

## Screenshots

Desktop does **not** change:

<img width="297" alt="image" src="https://user-images.githubusercontent.com/495429/159491262-76a9f282-b2f8-4f62-a39c-7249480f2e5d.png"> <img width="297" alt="image" src="https://user-images.githubusercontent.com/495429/159491311-e58de9a0-b806-4bdf-a9ba-bc6bb6b593e8.png">

### Before

<img width="174" alt="image" src="https://user-images.githubusercontent.com/495429/159490691-17b45ff6-b1bf-4a26-9ccd-a239857a1ee0.png"> <img width="174" alt="image" src="https://user-images.githubusercontent.com/495429/159490740-06fe2b24-257e-4b9e-9560-f7b71c2398b1.png">


### After

<img width="222" alt="image" src="https://user-images.githubusercontent.com/495429/159490849-3a6cbbad-b50b-4c3b-b440-c671895556f8.png"> <img width="235" alt="image" src="https://user-images.githubusercontent.com/495429/159490900-66a2649c-4e14-4055-be5c-7373dd929b1d.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-US/ locally.
2. Test using Firefox DevTools responsive mode.
