### PR TITLE
fix(bcd): hide the prefix symbol if feature has unprefixed full support as well

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -5,10 +5,10 @@ import {
   asList,
   getFirst,
   hasFullSupport,
-  hasNoSupport,
   hasNoteworthyNotes,
   isTruthy,
   requiresPrefix,
+  showMessageIndicatingNoSupport,
   versionIsPreview,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
@@ -394,7 +394,7 @@ function getNotes(
                 iconName: "footnote",
                 label: "Full support",
               }
-            : hasNoSupport(item)
+            : showMessageIndicatingNoSupport(item)
             ? {
                 iconName: "footnote",
                 label: "No support",

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -5,11 +5,11 @@ import {
   asList,
   getFirst,
   hasNoteworthyNotes,
+  isFullySupportedWithoutLimitation,
+  isNotSupportedAtAll,
+  isOnlySupportedWithAltName,
+  isOnlySupportedWithPrefix,
   isTruthy,
-  requiresAltName,
-  requiresPrefix,
-  showsMessageIndicatingFullSupport,
-  showsMessageIndicatingNoSupport,
   versionIsPreview,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
@@ -278,9 +278,9 @@ function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
   }
   return (
     <div className="bc-icons">
-      {requiresPrefix(support) && <Icon name="prefix" />}
+      {isOnlySupportedWithPrefix(support) && <Icon name="prefix" />}
       {hasNoteworthyNotes(supportItem) && <Icon name="footnote" />}
-      {requiresAltName(support) && <Icon name="altname" />}
+      {isOnlySupportedWithAltName(support) && <Icon name="altname" />}
       {supportItem.flags && <Icon name="disabled" />}
     </div>
   );
@@ -390,13 +390,13 @@ function getNotes(
           // If we encounter nothing else than the required `version_added` and
           // `release_date` properties, assume full support.
           // EDIT 1-5-21: if item.version_added doesn't exist, assume no support.
-          showsMessageIndicatingFullSupport(item) &&
+          isFullySupportedWithoutLimitation(item) &&
           !versionIsPreview(item.version_added, browser)
             ? {
                 iconName: "footnote",
                 label: "Full support",
               }
-            : showsMessageIndicatingNoSupport(item)
+            : isNotSupportedAtAll(item)
             ? {
                 iconName: "footnote",
                 label: "No support",

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -6,6 +6,7 @@ import {
   getFirst,
   hasNoteworthyNotes,
   isTruthy,
+  needsPrefix,
   versionIsPreview,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
@@ -274,7 +275,7 @@ function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
   }
   return (
     <div className="bc-icons">
-      {supportItem.prefix && <Icon name="prefix" />}
+      {needsPrefix(support) && <Icon name="prefix" />}
       {hasNoteworthyNotes(supportItem) && <Icon name="footnote" />}
       {supportItem.alternative_name && <Icon name="altname" />}
       {supportItem.flags && <Icon name="disabled" />}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -4,11 +4,12 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getFirst,
-  hasFullSupport,
   hasNoteworthyNotes,
   isTruthy,
+  requiresAltName,
   requiresPrefix,
-  showMessageIndicatingNoSupport,
+  showsMessageIndicatingFullSupport,
+  showsMessageIndicatingNoSupport,
   versionIsPreview,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
@@ -279,7 +280,7 @@ function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
     <div className="bc-icons">
       {requiresPrefix(support) && <Icon name="prefix" />}
       {hasNoteworthyNotes(supportItem) && <Icon name="footnote" />}
-      {supportItem.alternative_name && <Icon name="altname" />}
+      {requiresAltName(support) && <Icon name="altname" />}
       {supportItem.flags && <Icon name="disabled" />}
     </div>
   );
@@ -389,12 +390,13 @@ function getNotes(
           // If we encounter nothing else than the required `version_added` and
           // `release_date` properties, assume full support.
           // EDIT 1-5-21: if item.version_added doesn't exist, assume no support.
-          hasFullSupport(item) && !versionIsPreview(item.version_added, browser)
+          showsMessageIndicatingFullSupport(item) &&
+          !versionIsPreview(item.version_added, browser)
             ? {
                 iconName: "footnote",
                 label: "Full support",
               }
-            : showMessageIndicatingNoSupport(item)
+            : showsMessageIndicatingNoSupport(item)
             ? {
                 iconName: "footnote",
                 label: "No support",

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -6,7 +6,7 @@ import {
   getFirst,
   hasNoteworthyNotes,
   isTruthy,
-  needsPrefix,
+  requiresPrefix,
   versionIsPreview,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
@@ -275,7 +275,7 @@ function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
   }
   return (
     <div className="bc-icons">
-      {needsPrefix(support) && <Icon name="prefix" />}
+      {requiresPrefix(support) && <Icon name="prefix" />}
       {hasNoteworthyNotes(supportItem) && <Icon name="footnote" />}
       {supportItem.alternative_name && <Icon name="altname" />}
       {supportItem.flags && <Icon name="disabled" />}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -4,6 +4,8 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getFirst,
+  hasFullSupport,
+  hasNoSupport,
   hasNoteworthyNotes,
   isTruthy,
   requiresPrefix,
@@ -387,18 +389,12 @@ function getNotes(
           // If we encounter nothing else than the required `version_added` and
           // `release_date` properties, assume full support.
           // EDIT 1-5-21: if item.version_added doesn't exist, assume no support.
-          Object.keys(item).filter(
-            (x) => !["version_added", "release_date"].includes(x)
-          ).length === 0 &&
-          item.version_added &&
-          !versionIsPreview(item.version_added, browser)
+          hasFullSupport(item) && !versionIsPreview(item.version_added, browser)
             ? {
                 iconName: "footnote",
                 label: "Full support",
               }
-            : Object.keys(item).filter(
-                (x) => !["version_added", "release_date"].includes(x)
-              ).length === 0 && !item.version_added
+            : hasNoSupport(item)
             ? {
                 iconName: "footnote",
                 label: "No support",

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -71,9 +71,8 @@ export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
   );
 }
 
-function hasSpecialProperty(support: bcd.SimpleSupportStatement) {
+function hasLimitation(support: bcd.SimpleSupportStatement) {
   return (
-    support.version_removed ||
     support.partial_implementation ||
     support.alternative_name ||
     support.flags ||
@@ -90,9 +89,11 @@ export function requiresPrefix(support: bcd.SupportStatement | undefined) {
 }
 
 export function hasFullSupport(support: bcd.SimpleSupportStatement) {
-  return support.version_added && !hasSpecialProperty(support);
+  return (
+    support.version_added && !support.version_removed && !hasLimitation(support)
+  );
 }
 
 export function hasNoSupport(support: bcd.SimpleSupportStatement) {
-  return !support.version_added && !hasSpecialProperty(support);
+  return !support.version_added && !hasLimitation(support);
 }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -94,6 +94,8 @@ export function hasFullSupport(support: bcd.SimpleSupportStatement) {
   );
 }
 
-export function hasNoSupport(support: bcd.SimpleSupportStatement) {
+export function showMessageIndicatingNoSupport(
+  support: bcd.SimpleSupportStatement
+) {
   return !support.version_added && !hasLimitation(support);
 }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -71,18 +71,28 @@ export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
   );
 }
 
+function hasSpecialProperty(support: bcd.SimpleSupportStatement) {
+  return (
+    support.version_removed ||
+    support.partial_implementation ||
+    support.alternative_name ||
+    support.flags ||
+    support.prefix
+  );
+}
+
 export function requiresPrefix(support: bcd.SupportStatement | undefined) {
   return (
     support &&
     getFirst(support).prefix &&
-    !asList(support).some(
-      (item) =>
-        item.version_added &&
-        !item.version_removed &&
-        !item.partial_implementation &&
-        !item.alternative_name &&
-        !item.flags &&
-        !item.prefix
-    )
+    !asList(support).some((item) => hasFullSupport(item))
   );
+}
+
+export function hasFullSupport(support: bcd.SimpleSupportStatement) {
+  return support.version_added && !hasSpecialProperty(support);
+}
+
+export function hasNoSupport(support: bcd.SimpleSupportStatement) {
+  return !support.version_added && !hasSpecialProperty(support);
 }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -70,3 +70,16 @@ export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
     !support.partial_implementation
   );
 }
+
+export function needsPrefix(support: bcd.SupportStatement | undefined) {
+  return (
+    support &&
+    getFirst(support).prefix &&
+    !asList(support).some(
+      (item) =>
+        Object.keys(item).filter(
+          (x) => !["version_added", "release_date"].includes(x)
+        ).length === 0
+    )
+  );
+}

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -77,7 +77,8 @@ function hasLimitation(support: bcd.SimpleSupportStatement) {
     support.alternative_name ||
     support.flags ||
     support.prefix ||
-    support.version_removed
+    support.version_removed ||
+    support.notes
   );
 }
 

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -71,15 +71,18 @@ export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
   );
 }
 
-export function needsPrefix(support: bcd.SupportStatement | undefined) {
+export function requiresPrefix(support: bcd.SupportStatement | undefined) {
   return (
     support &&
     getFirst(support).prefix &&
     !asList(support).some(
       (item) =>
-        Object.keys(item).filter(
-          (x) => !["version_added", "release_date"].includes(x)
-        ).length === 0
+        item.version_added &&
+        !item.version_removed &&
+        !item.partial_implementation &&
+        !item.alternative_name &&
+        !item.flags &&
+        !item.prefix
     )
   );
 }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -82,30 +82,32 @@ function hasLimitation(support: bcd.SimpleSupportStatement) {
   );
 }
 
-export function requiresAltName(support: bcd.SupportStatement | undefined) {
+export function isOnlySupportedWithAltName(
+  support: bcd.SupportStatement | undefined
+) {
   return (
     support &&
     getFirst(support).alternative_name &&
-    !asList(support).some((item) => showsMessageIndicatingFullSupport(item))
+    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
   );
 }
 
-export function requiresPrefix(support: bcd.SupportStatement | undefined) {
+export function isOnlySupportedWithPrefix(
+  support: bcd.SupportStatement | undefined
+) {
   return (
     support &&
     getFirst(support).prefix &&
-    !asList(support).some((item) => showsMessageIndicatingFullSupport(item))
+    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
   );
 }
 
-export function showsMessageIndicatingFullSupport(
+export function isFullySupportedWithoutLimitation(
   support: bcd.SimpleSupportStatement
 ) {
   return support.version_added && !hasLimitation(support);
 }
 
-export function showsMessageIndicatingNoSupport(
-  support: bcd.SimpleSupportStatement
-) {
+export function isNotSupportedAtAll(support: bcd.SimpleSupportStatement) {
   return !support.version_added && !hasLimitation(support);
 }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -81,19 +81,29 @@ function hasLimitation(support: bcd.SimpleSupportStatement) {
   );
 }
 
+export function requiresAltName(support: bcd.SupportStatement | undefined) {
+  return (
+    support &&
+    getFirst(support).alternative_name &&
+    !asList(support).some((item) => showsMessageIndicatingFullSupport(item))
+  );
+}
+
 export function requiresPrefix(support: bcd.SupportStatement | undefined) {
   return (
     support &&
     getFirst(support).prefix &&
-    !asList(support).some((item) => hasFullSupport(item))
+    !asList(support).some((item) => showsMessageIndicatingFullSupport(item))
   );
 }
 
-export function hasFullSupport(support: bcd.SimpleSupportStatement) {
+export function showsMessageIndicatingFullSupport(
+  support: bcd.SimpleSupportStatement
+) {
   return support.version_added && !hasLimitation(support);
 }
 
-export function showMessageIndicatingNoSupport(
+export function showsMessageIndicatingNoSupport(
   support: bcd.SimpleSupportStatement
 ) {
   return !support.version_added && !hasLimitation(support);

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -76,7 +76,8 @@ function hasLimitation(support: bcd.SimpleSupportStatement) {
     support.partial_implementation ||
     support.alternative_name ||
     support.flags ||
-    support.prefix
+    support.prefix ||
+    support.version_removed
   );
 }
 
@@ -89,9 +90,7 @@ export function requiresPrefix(support: bcd.SupportStatement | undefined) {
 }
 
 export function hasFullSupport(support: bcd.SimpleSupportStatement) {
-  return (
-    support.version_added && !support.version_removed && !hasLimitation(support)
-  );
+  return support.version_added && !hasLimitation(support);
 }
 
 export function showMessageIndicatingNoSupport(


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes #5709

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

When a vendor prefix was added after full support already existed for compatibility reasons, it showed as if it was needed.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Stop showing vendor prefix symbol in un-expanded table if full support already existed. 

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->
https://developer.mozilla.org/en-US/docs/Web/CSS/flex-flow#browser_compatibility
![Screenshot from 2022-03-22 10-38-20](https://user-images.githubusercontent.com/29206584/159507909-01536814-a0b1-4e0f-b6fd-0088db9c3724.png)
https://developer.mozilla.org/en-US/docs/Web/API/Window#browser_compatibility
![Screenshot from 2022-03-22 10-38-27](https://user-images.githubusercontent.com/29206584/159507988-094ac0b4-b141-4601-bb22-3e4519d8cd97.png)

### After

<!-- Replace this line with your screenshot (or video). -->
http://localhost:3000/en-US/docs/Web/CSS/flex-flow#browser_compatibility
![Screenshot from 2022-03-22 10-38-31](https://user-images.githubusercontent.com/29206584/159508081-10c92c94-910d-4ff6-9874-1061fb73780a.png)
http://localhost:3000/en-US/docs/Web/API/Window#browser_compatibility
![Screenshot from 2022-03-22 10-38-34](https://user-images.githubusercontent.com/29206584/159508110-38d62d86-92db-47f1-a3c2-24f9db3bbef3.png)