### PR TITLE
Alter Empty state starred + notifcations tab

### DIFF
--- a/client/src/plus/notifications/notifications-tab.tsx
+++ b/client/src/plus/notifications/notifications-tab.tsx
@@ -164,6 +164,29 @@ export function NotificationsTab({
     const updated = list.filter((v) => !v.checked);
     setList(updated);
   };
+  let empty_text = !starred ? (
+    <>
+      <p>You have no more notifications to review! ✨</p>{" "}
+      <p>
+        {" "}
+        Want more? Try watching one of these pages to receive notifications for
+        content and/or compatibility updates:{" "}
+        <a href="/en-US/docs/Web/CSS/overscroll-behavior">
+          <code>overscroll-behavior</code>
+        </a>
+        ,{" "}
+        <a href="/en-US/docs/Web/API/MIDIPort">
+          <code>MIDIPort</code>
+        </a>
+        , or{" "}
+        <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupBy">
+          <code>Array.prototype.groupBy()</code>
+        </a>
+      </p>
+    </>
+  ) : (
+    <p>You have no starred notifications ✨</p>
+  );
 
   return (
     <>
@@ -188,24 +211,7 @@ export function NotificationsTab({
       {isLoading && <Loading message="Waiting for data" />}
       {error && <DataError error={error} />}
       {!isLoading && !list.length && (
-        <div className="empty-card">
-          <p>You've no more notifications to review! ✨</p>{" "}
-          <p>
-            {" "}
-            Want more? Try watching one of these pages:{" "}
-            <a href="/en-US/docs/Web/CSS/overscroll-behavior">
-              <code>overscroll-behavior</code>
-            </a>
-            ,{" "}
-            <a href="/en-US/docs/Web/API/MIDIPort">
-              <code>MIDIPort</code>
-            </a>
-            , or{" "}
-            <a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupBy">
-              <code>Array.prototype.groupBy()</code>
-            </a>
-          </p>
-        </div>
+        <div className="empty-card">{empty_text}</div>
       )}
       <ul className="notification-list">
         <div className="icon-card-list">


### PR DESCRIPTION
## Summary

- Adjust copy of notifcations empty state.
- Add no starred notifications custom copy. 

Resolves https://github.com/mdn/foxfooding-mdn-plus/issues/56#

## Screenshots
![Screenshot 2022-03-22 at 15-48-56 MDN Web Docs](https://user-images.githubusercontent.com/7376416/159510187-d53c44ec-ade5-43af-bbda-29bde4b8496e.png)
![Screenshot 2022-03-22 at 15-49-04 MDN Web Docs](https://user-images.githubusercontent.com/7376416/159510197-25a743d5-639a-4ecb-9a43-80c555585923.png)



<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
