### PR TITLE
fix(loading-error): wrap in standard-page layout

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -249,30 +249,32 @@ function RenderDocumentBody({ doc }) {
 
 function LoadingError({ error }) {
   return (
-    <div className="page-content-container loading-error">
-      <h3>Loading Error</h3>
-      {error instanceof window.Response ? (
+    <div className="standard-page">
+      <div className="page-content-container loading-error">
+        <h3>Loading Error</h3>
+        {error instanceof window.Response ? (
+          <p>
+            <b>{error.status}</b> on <b>{error.url}</b>
+            <br />
+            <small>{error.statusText}</small>
+          </p>
+        ) : (
+          <p>
+            <code>{error.toString()}</code>
+          </p>
+        )}
         <p>
-          <b>{error.status}</b> on <b>{error.url}</b>
-          <br />
-          <small>{error.statusText}</small>
+          <button
+            className="button"
+            type="button"
+            onClick={() => {
+              window.location.reload();
+            }}
+          >
+            Try reloading the page
+          </button>
         </p>
-      ) : (
-        <p>
-          <code>{error.toString()}</code>
-        </p>
-      )}
-      <p>
-        <button
-          className="button"
-          type="button"
-          onClick={() => {
-            window.location.reload();
-          }}
-        >
-          Try reloading the page
-        </button>
-      </p>
+      </div>
     </div>
   );
 }

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -250,7 +250,7 @@ function RenderDocumentBody({ doc }) {
 function LoadingError({ error }) {
   return (
     <div className="standard-page">
-      <div className="page-content-container loading-error">
+      <div id="content" className="page-content-container loading-error">
         <h3>Loading Error</h3>
         {error instanceof window.Response ? (
           <p>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/43.

### Problem

Loading errors were shown outside of any layout.

### Solution

Wrap the `LoadingError` root node in a `<div>`, reusing the layout for standard pages.

---

## Screenshots

### Before

<img width="767" alt="image" src="https://user-images.githubusercontent.com/495429/159515959-53a0c510-0f0a-4a37-8b84-68ec42541c77.png">

### After

<img width="767" alt="image" src="https://user-images.githubusercontent.com/495429/159516222-ec8677c3-db99-4c1a-a79c-3783193000a0.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/404-city locally.