### PR TITLE
fix(collections): handle remove from edit dialog properly

### DIFF
--- a/client/src/plus/collections/collections-tab.tsx
+++ b/client/src/plus/collections/collections-tab.tsx
@@ -61,8 +61,19 @@ export function CollectionsTab({
     item: BookmarkData
   ) => {
     let formData;
+
     const form = e.target as HTMLFormElement;
     formData = new FormData(form);
+
+    // Determine if delete was clicked.
+    const submitter = (e.nativeEvent as SubmitEvent)
+      .submitter as HTMLButtonElement;
+
+    let isDeleted = submitter.name === "delete" && submitter.value === "true";
+    if (submitter) {
+      formData.append(submitter.name, submitter.value);
+    }
+
     const res = await updateCollectionItem(
       item,
       new URLSearchParams([...(formData as any)]),
@@ -72,13 +83,21 @@ export function CollectionsTab({
     const limitReached =
       (await res.json())?.subscription_limit_reached || false;
     setSubscriptionLimitReached(limitReached);
-    const newList = list.map((v) => {
-      if (v.id === item.id) {
-        v.title = formData.get("name") ?? v.title;
-        v.notes = formData.get("notes") ?? v.notes;
-      }
-      return v;
-    });
+
+    let newList;
+    if (isDeleted) {
+      // Remove locally.
+      newList = list.filter((v) => v.id !== item.id);
+    } else {
+      // Update locally.
+      newList = list.map((v) => {
+        if (v.id === item.id) {
+          v.title = formData.get("name") ?? v.title;
+          v.notes = formData.get("notes") ?? v.notes;
+        }
+        return v;
+      });
+    }
     setList(newList);
   };
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Resolves https://github.com/mdn/foxfooding-mdn-plus/issues/48

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When the collections tab was refactored the save data handler didn't bind to the button/value combo of the submit button. This meant that the 'delete' wasn't being passed to the api in the edit collectiond dialog. This fixes the issue

## How did you test this change?

Locally load _http://localhost:3000/en-US/plus/collection_  the collections tab. Select from the edit menut -> Edit -> Then 'Remove' . The collection should be removed

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
