### PR TITLE
fix(collections): make fva search case-insensitive

### DIFF
--- a/client/src/plus/common/api.tsx
+++ b/client/src/plus/common/api.tsx
@@ -242,7 +242,11 @@ export function useFrequentlyViewedData(searchTerms: string) {
   const [data, setData] = useState(entries);
   useEffect(() => {
     if (searchTerms) {
-      setData(entries.filter((val) => val.title.includes(searchTerms)));
+      const lowerSearchTerms = searchTerms.toLowerCase();
+      const filteredEntries = entries.filter((val) =>
+        val.title.toLowerCase().includes(lowerSearchTerms)
+      );
+      setData(filteredEntries);
     } else {
       setData(entries);
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/42.

### Problem

When searching the "Frequently viewed articles", the results were filtered using case-sensitive comparison, e.g. "api" didn't return "Screen Capture API".

### Solution

This changes the filtering to use lowercase versions of both search terms and document title.

---

## Screenshots

### Before

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/495429/159543031-8b91b5ca-85cb-41eb-9579-bd80c1e687c6.png">

### After

<img width="1429" alt="image" src="https://user-images.githubusercontent.com/495429/159543080-3330e8a3-d19d-46ad-8c23-dfdabc9d0de5.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/collection/frequently_viewed locally
2. Search for "walker" (because the list contained the "TreeWalker" article with a different casing).
