### PR TITLE
Restore allow list + override it on stage + add whats included to teaser

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -161,6 +161,9 @@ jobs:
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true
 
+          # This disables the Plus geo-fencing.
+          REACT_APP_PLUS_IS_AVAILABLE_OVERRIDE: true
+
           # This adds the ability to sign in (stage only for now)
           REACT_APP_DISABLE_AUTH: false
 

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -39,6 +39,9 @@ export const VALID_LOCALES = new Set([
 export const ENABLE_PLUS = Boolean(
   JSON.parse(process.env.REACT_APP_ENABLE_PLUS || "false")
 );
+export const PLUS_IS_AVAILABLE_OVERRIDE = JSON.parse(
+  process.env.REACT_APP_PLUS_IS_AVAILABLE_OVERRIDE || "null"
+);
 export const MDN_PLUS_SUBSCRIBE_5M_URL = `${process.env.REACT_APP_MDN_PLUS_SUBSCRIBE_URL}?plan=${process.env.REACT_APP_MDN_PLUS_5M_PLAN}`;
 export const MDN_PLUS_SUBSCRIBE_5Y_URL = `${process.env.REACT_APP_MDN_PLUS_SUBSCRIBE_URL}?plan=${process.env.REACT_APP_MDN_PLUS_5Y_PLAN}`;
 export const MDN_PLUS_SUBSCRIBE_10M_URL = `${process.env.REACT_APP_MDN_PLUS_SUBSCRIBE_URL}?plan=${process.env.REACT_APP_MDN_PLUS_10M_PLAN}`;

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -50,6 +50,12 @@ export const FXA_SETTINGS_URL = process.env.REACT_APP_FXA_SETTINGS_URL || "";
 export const DEFAULT_GEO_COUNTRY =
   process.env.REACT_APP_DEFAULT_GEO_COUNTRY || "United States";
 
+export const PLUS_ENABLED_COUNTRIES =
+  process.env.REACT_APP_PLUS_ENABLED_COUNTRIES?.split(",") || [
+    "United States",
+    "Canada",
+  ];
+
 export const IEX_DOMAIN =
   process.env.REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL ||
   "https://interactive-examples.mdn.mozilla.net";

--- a/client/src/plus/offer-overview/index.tsx
+++ b/client/src/plus/offer-overview/index.tsx
@@ -1,14 +1,18 @@
+import { useUserData } from "../../user-context";
+import { isPlusAvailable } from "../../utils";
 import "./index.scss";
 import OfferHero from "./offer-hero";
 import OfferOverviewFeatures from "./offer-overview-feature";
 import OfferOverviewSubscribe from "./offer-overview-subscribe";
 
 function OfferOverview() {
+  const userData = useUserData();
+  const plusAvailable = isPlusAvailable(userData);
   return (
     <div className="offer-overview">
-      <OfferHero />
+      <OfferHero plusAvailable={plusAvailable} />
       <OfferOverviewFeatures />
-      <OfferOverviewSubscribe />
+      {plusAvailable && <OfferOverviewSubscribe />}
     </div>
   );
 }

--- a/client/src/plus/offer-overview/offer-hero/index.tsx
+++ b/client/src/plus/offer-overview/offer-hero/index.tsx
@@ -2,7 +2,7 @@ import { CRUD_MODE } from "../../../constants";
 import Mandala from "../../../ui/molecules/mandala";
 import "./index.scss";
 
-function OfferHero() {
+function OfferHero({ plusAvailable }: { plusAvailable: boolean }) {
   const animate = !CRUD_MODE;
   return (
     <div className="dark offer-hero">
@@ -11,17 +11,25 @@ function OfferHero() {
           <h1>
             More MDN. <u>Your</u> MDN.
           </h1>
-          <h2>
-            Support MDN <u>and</u> make it your own. For just $5 a month.
-          </h2>
-          <div className="button-wrapper">
-            <a href="#subscribe" className="button-primary">
-              Get started
-            </a>
-            <a href="#features" className="button-secondary">
-              What's included
-            </a>
-          </div>
+          {(plusAvailable && (
+            <>
+              <h2>
+                Support MDN <u>and</u> make it your own. For just $5 a month.
+              </h2>
+              <div className="button-wrapper">
+                <a href="#subscribe" className="button-primary">
+                  Get started
+                </a>
+                <a href="#features" className="button-secondary">
+                  What's included
+                </a>
+              </div>
+            </>
+          )) || (
+            <h2>
+              Coming to <u>your</u> region soon.
+            </h2>
+          )}
         </div>
       </header>
       <div className="mandala-wrapper">

--- a/client/src/plus/offer-overview/offer-hero/index.tsx
+++ b/client/src/plus/offer-overview/offer-hero/index.tsx
@@ -26,9 +26,19 @@ function OfferHero({ plusAvailable }: { plusAvailable: boolean }) {
               </div>
             </>
           )) || (
-            <h2>
-              Coming to <u>your</u> region soon.
-            </h2>
+            <>
+              <h2>
+                Coming to <u>your</u> region soon.
+              </h2>
+              <div className="button-wrapper">
+                <a href="#features" className="button-primary">
+                  What's included
+                </a>
+                <a href="/en-US/plus/faq" className="button-secondary">
+                  Frequently asked questions
+                </a>
+              </div>
+            </>
           )}
         </div>
       </header>

--- a/client/src/ui/organisms/top-navigation-main/index.tsx
+++ b/client/src/ui/organisms/top-navigation-main/index.tsx
@@ -9,11 +9,12 @@ import { useUserData } from "../../../user-context";
 
 import "./index.scss";
 import { ENABLE_PLUS } from "../../../constants";
+import { isPlusAvailable } from "../../../utils";
 import { ThemeSwitcher } from "../../molecules/theme-switcher";
 
 export const TopNavigationMain = ({ isOpenOnMobile }) => {
   const userData = useUserData();
-  const isAuthenticated = userData && userData.isAuthenticated;
+  const plusAvailable = isPlusAvailable(userData);
 
   return (
     <div className="top-navigation-main">
@@ -22,12 +23,12 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Search id="top-nav-search" />
       <ThemeSwitcher />
 
-      {ENABLE_PLUS &&
-        ((isAuthenticated && (
-          <>
-            <UserMenu />
-          </>
-        )) || <AuthContainer />)}
+      {(ENABLE_PLUS && userData && userData.isAuthenticated && (
+        <>
+          <UserMenu />
+        </>
+      )) ||
+        (plusAvailable && <AuthContainer />) || <></>}
     </div>
   );
 };

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,4 +1,8 @@
-import { IEX_DOMAIN, PLUS_ENABLED_COUNTRIES } from "./constants";
+import {
+  IEX_DOMAIN,
+  PLUS_ENABLED_COUNTRIES,
+  PLUS_IS_AVAILABLE_OVERRIDE,
+} from "./constants";
 import { UserData } from "./user-context";
 const HOMEPAGE_RE = /^\/[A-Za-z-]*\/?(?:_homepage)?$/i;
 const DOCS_RE = /^\/[A-Za-z-]+\/docs\/.*$/i;
@@ -60,6 +64,9 @@ export function switchTheme(theme: string, set: (theme: string) => void) {
 }
 
 export function isPlusAvailable(userData: UserData | null) {
+  if (typeof PLUS_IS_AVAILABLE_OVERRIDE === "boolean") {
+    return PLUS_IS_AVAILABLE_OVERRIDE;
+  }
   if (!userData) {
     return false;
   }

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,4 +1,5 @@
-import { IEX_DOMAIN } from "./constants";
+import { IEX_DOMAIN, PLUS_ENABLED_COUNTRIES } from "./constants";
+import { UserData } from "./user-context";
 const HOMEPAGE_RE = /^\/[A-Za-z-]*\/?(?:_homepage)?$/i;
 const DOCS_RE = /^\/[A-Za-z-]+\/docs\/.*$/i;
 const PLUS_RE = /^\/[A-Za-z-]*\/?plus(?:\/?.*)$/i;
@@ -56,4 +57,11 @@ export function switchTheme(theme: string, set: (theme: string) => void) {
     set(theme);
     postToIEx(theme);
   }
+}
+
+export function isPlusAvailable(userData: UserData | null) {
+  if (!userData) {
+    return false;
+  }
+  return PLUS_ENABLED_COUNTRIES.includes(userData?.geo?.country);
 }

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -288,3 +288,10 @@ Determines if the MDN++ SPA should be reachable or not.
 If the `/api/v1/whoami` does not include a `geo.country` value, fall back on this.
 Setting this allows you to pretend the XHR request to `/api/v1/whoami` included
 this value for `geo.country`.
+
+### `REACT_APP_PLUS_IS_AVAILABLE_OVERRIDE`
+
+**Default: `null`**
+
+- Setting this to `true` allows everybody to access plus (disables geofencing).
+- Setting this to `false` shows everybody the "Coming to your region soon".


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/69.

### Problem

- Below the "Coming to your region soon." teaser, there were no buttons.
- The allow list was completely reverted for testing purposes.

### Solution

1. Restore the allow list.
2. Override it in on stage.
3. Add two buttons "What's included" and "Frequently asked questions" below the "Coming to your region soon." teaser.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="559" alt="image" src="https://user-images.githubusercontent.com/495429/159557725-2989bb35-bc2b-4cab-b339-cf4fb7f1b26b.png">

### After

<img width="559" alt="image" src="https://user-images.githubusercontent.com/495429/159557670-477d701e-46ab-4fc3-b1f1-1584b7417beb.png">

---

## How did you test this change?

1. Add `REACT_APP_PLUS_IS_AVAILABLE_OVERRIDE=false` to `.env`
2. Restart `yarn dev`
3. Open http://localhost:3000/en-US/plus/ locally.

**Note**: The FAQ page is added in https://github.com/mdn/yari/pull/5707, so not yet available in this branch.