### PR TITLE
fix(offer-overview): override docs locale for now

### DIFF
--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -40,7 +40,7 @@ export default function OfferOverviewFeatures() {
             get customizable notifications when documentation changes, CSS
             features launch, and APIs ship.
           </p>
-          <Button href="./docs/features/notifications">Learn more →</Button>
+          <Button href="/en-US/docs/features/notifications">Learn more →</Button>
         </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature
@@ -59,7 +59,7 @@ export default function OfferOverviewFeatures() {
             your inner curator and collect your favorite articles in one place
             for convenient consultation.
           </p>
-          <Button href="./docs/features/collections">Learn more →</Button>
+          <Button href="/en-US/docs/features/collections">Learn more →</Button>
         </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature
@@ -75,7 +75,7 @@ export default function OfferOverviewFeatures() {
             inaccessible pages or cluttered tabs. With MDN Plus, have the fully
             navigable resources of MDN at your disposal even when offline.
           </p>
-          <Button href="./docs/features/offline">Learn more →</Button>
+          <Button href="/en-US/docs/features/offline">Learn more →</Button>
         </section>
       </OfferOverviewFeature>
     </section>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/64.

### Problem

When switching to the MDN Plus overview from a non-English article, the "Learn more" buttons lead nowhere.

### Solution

For now, I hard-coded the `en-US` locale on the "Learn more" links.

The better, but less trivial solution would be to properly fallback to the English version.

---

## How did you test this change?

1. Open http://localhost:3000/en-US/docs/Web locally.
2. Switch to French version.
3. Click on "MDN Plus" in the top menu.
4. Click on "Learn more".