### PR TITLE
chore(plus): move /plus/{collection => collections}

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -111,7 +111,7 @@ async function buildSPAs(options) {
         { prefix: "search", pageTitle: "Search" },
         { prefix: "plus", pageTitle: "Plus", noIndexing: true },
         {
-          prefix: "plus/collection",
+          prefix: "plus/collections",
           pageTitle: "Collection",
           noIndexing: true,
         },

--- a/client/src/plus/common/tabs.tsx
+++ b/client/src/plus/common/tabs.tsx
@@ -12,8 +12,8 @@ export enum TabVariant {
 const NOTIFICATIONS_URL = "/plus/notifications";
 const STARRED_URL = "/plus/notifications/starred";
 const WATCHING_URL = "/plus/notifications/watching";
-const COLLECTIONS_URL = "/plus/collection";
-const FREQUENTLY_VIEWED_URL = "/plus/collection/frequently_viewed";
+const COLLECTIONS_URL = "/plus/collections";
+const FREQUENTLY_VIEWED_URL = "/plus/collections/frequently_viewed";
 
 export const FILTERS = [
   {

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -36,7 +36,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
         }
       />
       <Route
-        path="collection/*"
+        path="collections/*"
         element={
           <React.Suspense fallback={loading}>
             <div className="bookmarks girdle">

--- a/client/src/ui/molecules/manage-upgrade-dialog/index.tsx
+++ b/client/src/ui/molecules/manage-upgrade-dialog/index.tsx
@@ -60,7 +60,7 @@ export function ManageOrUpgradeDialogCollections({ setShow }) {
         Manage your collection or upgrade to MDN Plus to unlock unlimited saves
       </p>
       <div className="watch-submenu-item is-button-row">
-        <Button type="secondary" href={`/${locale}/plus/collection`}>
+        <Button type="secondary" href={`/${locale}/plus/collections`}>
           Manage
         </Button>
         <Button href={`/${locale}/plus`}>Upgrade</Button>

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -33,7 +33,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
               hasIcon: true,
               iconClasses: "submenu-icon bookmarks-icon",
               label: "Collections",
-              url: `/${locale}/plus/collection`,
+              url: `/${locale}/plus/collections`,
             },
             {
               description: "Updates from the pages you’re watching",

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -65,7 +65,7 @@ export const UserMenu = () => {
       },
       {
         label: "Collections",
-        url: `/${locale}/plus/collection`,
+        url: `/${locale}/plus/collections`,
       },
       {
         url: FXA_SETTINGS_URL,

--- a/testing/integration/headless/map_301.py
+++ b/testing/integration/headless/map_301.py
@@ -991,12 +991,12 @@ MISC_REDIRECT_URLS = list(
     flatten(
         (
             url_test(
-                "/fr/{plus,plus/,plus/collection,plus/collection/,plus/deep-dives,plus/deep-dives/}",
+                "/fr/{plus,plus/,plus/collections,plus/collections/,plus/deep-dives,plus/deep-dives/}",
                 "/fr/",
                 status_code=302,
             ),
             url_test(
-                "/en-US/{plus,plus/,plus/collection,plus/collection/,plus/deep-dives,plus/deep-dives/}",
+                "/en-US/{plus,plus/,plus/collections,plus/collections/,plus/deep-dives,plus/deep-dives/}",
                 "/en-US/",
                 status_code=302,
             ),

--- a/testing/tests/headless.plus.bookmarks.spec.js
+++ b/testing/tests/headless.plus.bookmarks.spec.js
@@ -54,7 +54,7 @@ test.describe("Bookmarking pages", () => {
   });
 
   test("view your listing of all bookmarks", async ({ page }) => {
-    await page.goto(testURL("/en-US/plus/collection"));
+    await page.goto(testURL("/en-US/plus/collections"));
     await page.waitForLoadState("networkidle");
     await page.waitForSelector("text=You have not signed in");
 
@@ -62,7 +62,7 @@ test.describe("Bookmarking pages", () => {
     await page.click("text='Already a subscriber?'");
     await page.waitForLoadState("networkidle");
 
-    await page.goto(testURL("/en-US/plus/collection"));
+    await page.goto(testURL("/en-US/plus/collections"));
     await page.waitForSelector("text=Nothing saved yet.");
 
     // Open a bunch of pages
@@ -82,7 +82,7 @@ test.describe("Bookmarking pages", () => {
 
     const locator = page.locator(".pagination");
 
-    await page.goto(testURL("/en-US/plus/collection"));
+    await page.goto(testURL("/en-US/plus/collections"));
     await page.waitForSelector("h3:has-text('Collections')");
 
     await expect(locator).toBeVisible();

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1233,8 +1233,8 @@ test("plus page", () => {
   expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
 });
 
-test("plus bookmarks page", () => {
-  const builtFolder = path.join(buildRoot, "en-us", "plus", "collection");
+test("plus collections page", () => {
+  const builtFolder = path.join(buildRoot, "en-us", "plus", "collections");
   expect(fs.existsSync(builtFolder)).toBeTruthy();
   const htmlFile = path.join(builtFolder, "index.html");
   const html = fs.readFileSync(htmlFile, "utf-8");


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/66.

### Problem

The URLs for Notifications and Collections were inconsistent:

- `/plus/notifications` (plural)
- `/plus/collection` (singular)

### Solution

Pluralize the collection urls: `/plus/collections`

**Note**: The kuma API routes are still singular, because technically users can only manage a single collection. But from a user perspective, the "Frequently viewed articles" could be considered a second collection.

---

## How did you test this change?

1. Open http://localhost:3000/en-US/ locally.
2. Navigate to Collections via MDN Plus menu.
3. Navigate to Collections via User menu.
4. Searched for `collection` in VS Code with _Match Case_ and _Match Full Word_ to make sure I didn't miss any spot.