### PR TITLE
chore(plus/offer-overview): add feature titles

### DIFF
--- a/client/src/plus/offer-overview/offer-overview-feature/index.scss
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.scss
@@ -44,9 +44,19 @@
       a {
         justify-content: start;
       }
+
+      h1 {
+        color: var(--plus-accent-color);
+        font: 700 12px/120% Inter;
+        letter-spacing: 1.5px;
+        text-transform: uppercase;
+        margin-bottom: 0;
+      }
+
       h2 {
         margin-top: 1rem;
       }
+
       text-align: center;
       align-items: center;
       max-width: 40rem;

--- a/client/src/plus/offer-overview/offer-overview-feature/index.scss
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.scss
@@ -44,17 +44,19 @@
       a {
         justify-content: start;
       }
-
-      h1 {
+      h2 {
         color: var(--plus-accent-color);
         font: 700 12px/120% Inter;
         letter-spacing: 1.5px;
         text-transform: uppercase;
-        margin-bottom: 0;
+        margin-bottom: 1rem;
+        margin-top: 0;
       }
 
-      h2 {
-        margin-top: 1rem;
+      h3 {
+        font-size: 1.75rem;
+        font-weight: 400;
+        margin-top: 0;
       }
 
       text-align: center;

--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -28,49 +28,55 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h2>Notifications</h2>
-        <h3>
-          Development in real time:
-          <br />
-          Get custom alerts
-        </h3>
-        <p>
-          The Web doesn't have a changelog, but MDN can help. Follow pages and
-          get customizable notifications when documentation changes, CSS
-          features launch, and APIs ship.
-        </p>
-        <Button href="./docs/features/notifications">Learn more →</Button>
+        <section aria-labelledby="notifications-section-title">
+          <h2 id="notifications-section-title">Notifications</h2>
+          <h3>
+            Development in real time:
+            <br />
+            Get custom alerts
+          </h3>
+          <p>
+            The Web doesn't have a changelog, but MDN can help. Follow pages and
+            get customizable notifications when documentation changes, CSS
+            features launch, and APIs ship.
+          </p>
+          <Button href="./docs/features/notifications">Learn more →</Button>
+        </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature
         id="collections"
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h2>Collections</h2>
-        <h3>
-          Build your perfect library. <br />
-          Or let us build it for you.
-        </h3>
-        <p>
-          No more haphazard hunting through the vast virtual library: unleash
-          your inner curator and collect your favorite articles in one place for
-          convenient consultation.
-        </p>
-        <Button href="./docs/features/collections">Learn more →</Button>
+        <section aria-labelledby="collections-section-title">
+          <h2 id="collections-section-title">Collections</h2>
+          <h3>
+            Build your perfect library. <br />
+            Or let us build it for you.
+          </h3>
+          <p>
+            No more haphazard hunting through the vast virtual library: unleash
+            your inner curator and collect your favorite articles in one place
+            for convenient consultation.
+          </p>
+          <Button href="./docs/features/collections">Learn more →</Button>
+        </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature
         id="offline"
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h2>MDN Offline</h2>
-        <h3>MDN's entire library at your fingertips: offline</h3>
-        <p>
-          Taking your projects beyond the nearest wifi signal? Say goodbye to
-          inaccessible pages or cluttered tabs. With MDN Plus, have the fully
-          navigable resources of MDN at your disposal even when offline.
-        </p>
-        <Button href="./docs/features/offline">Learn more →</Button>
+        <section aria-labelledby="offline-section-title">
+          <h2 id="offline-section-title">MDN Offline</h2>
+          <h3>MDN's entire library at your fingertips: offline</h3>
+          <p>
+            Taking your projects beyond the nearest wifi signal? Say goodbye to
+            inaccessible pages or cluttered tabs. With MDN Plus, have the fully
+            navigable resources of MDN at your disposal even when offline.
+          </p>
+          <Button href="./docs/features/offline">Learn more →</Button>
+        </section>
       </OfferOverviewFeature>
     </section>
   );

--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -28,12 +28,12 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h1>Notifications</h1>
-        <h2>
+        <h2>Notifications</h2>
+        <h3>
           Development in real time:
           <br />
           Get custom alerts
-        </h2>
+        </h3>
         <p>
           The Web doesn't have a changelog, but MDN can help. Follow pages and
           get customizable notifications when documentation changes, CSS
@@ -46,11 +46,11 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h1>Collections</h1>
-        <h2>
+        <h2>Collections</h2>
+        <h3>
           Build your perfect library. <br />
           Or let us build it for you.
-        </h2>
+        </h3>
         <p>
           No more haphazard hunting through the vast virtual library: unleash
           your inner curator and collect your favorite articles in one place for
@@ -63,8 +63,8 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
-        <h1>MDN Offline</h1>
-        <h2>MDN's entire library at your fingertips: offline</h2>
+        <h2>MDN Offline</h2>
+        <h3>MDN's entire library at your fingertips: offline</h3>
         <p>
           Taking your projects beyond the nearest wifi signal? Say goodbye to
           inaccessible pages or cluttered tabs. With MDN Plus, have the fully

--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -28,6 +28,7 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
+        <h1>Notifications</h1>
         <h2>
           Development in real time:
           <br />
@@ -45,6 +46,7 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
+        <h1>Collections</h1>
         <h2>
           Build your perfect library. <br />
           Or let us build it for you.
@@ -61,6 +63,7 @@ export default function OfferOverviewFeatures() {
         img="/assets/notifications_light.png"
         imgAlt=""
       >
+        <h1>MDN Offline</h1>
         <h2>MDN's entire library at your fingertips: offline</h2>
         <p>
           Taking your projects beyond the nearest wifi signal? Say goodbye to


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/71.

### Problem

Previously, the Plus product page only described and visualized the features, without actually **naming** them.

### Solution

We add a title on top of each feature description, similar to the title on the Plus docs.

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/495429/159694089-3fdb8dd1-b961-4e2b-a570-588e0876cb1d.png)

### After

![image](https://user-images.githubusercontent.com/495429/159707903-9c5e6fa2-6be5-44fe-a53e-38bbb6de3ab7.png)

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/plus/ locally.
