### PR TITLE
fix:copy ~ change instance mentioning collections in the notifications dashboard

### DIFF
--- a/client/src/plus/notifications/notification-card.tsx
+++ b/client/src/plus/notifications/notification-card.tsx
@@ -84,7 +84,7 @@ export default function NotificationCard({ item, changedCallback, csrfToken }) {
                 onClickHandler={async () => {
                   await post(deleteUrl, csrfToken);
                   setToastData({
-                    mainText: `${item.title} removed from your collection`,
+                    mainText: `${item.title} removed from your notifications`,
                     shortText: "Article removed",
                     buttonText: "UNDO",
                     buttonHandler: async () => {

--- a/client/src/plus/notifications/notifications-tab.tsx
+++ b/client/src/plus/notifications/notifications-tab.tsx
@@ -125,7 +125,7 @@ export function NotificationsTab({
     const listWithDelete = list.filter((v) => v.id !== item.id);
     setList(listWithDelete);
     setToastData({
-      mainText: `${item.title} removed from your collection`,
+      mainText: `${item.title} removed from your notifications`,
       shortText: "Article removed",
       buttonText: "Undo",
       buttonHandler: async () => {

--- a/client/src/plus/notifications/watched-items-tab.tsx
+++ b/client/src/plus/notifications/watched-items-tab.tsx
@@ -117,7 +117,7 @@ export function WatchedTab({ selectedTerms, selectedFilter, selectedSort }) {
         watchedTab={true}
       />
 
-      {isLoading && <Loading message="Fetching your collection..." />}
+      {isLoading && <Loading message="Fetching your notifications..." />}
       {error && <DataError error={error} />}
       <ul className="notification-list">
         <div className="icon-card-list">


### PR DESCRIPTION
Correct instances where "collections" is used instead of "notifications".

fix #5741