### PR TITLE
Fix:Rerender loop on auto update enabled

### DIFF
--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -29,6 +29,7 @@ function Settings() {
 
   const [estimate, setEstimate] = useState<StorageEstimate | null>(null);
   const [settings, setSettings] = useState<SettingsData>();
+  // Workaround to avoid "Error: Too many re-renders." (https://github.com/mdn/yari/pull/5744).
   const updateTriggered = useRef(false);
 
   useEffect(() => {

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -2,7 +2,7 @@ import { Switch } from "../ui/atoms/switch";
 import { SettingsData, STATE, UpdateStatus } from "./mdn-worker";
 import useInterval from "@use-it/interval";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import UpdateButton from "./update";
 import ClearButton from "./clear";
 import { Spinner } from "../ui/atoms/spinner";
@@ -29,6 +29,7 @@ function Settings() {
 
   const [estimate, setEstimate] = useState<StorageEstimate | null>(null);
   const [settings, setSettings] = useState<SettingsData>();
+  const updateTriggered = useRef(false);
 
   useEffect(() => {
     const init = async () => {
@@ -76,8 +77,13 @@ function Settings() {
     }
   };
 
-  if (settings?.autoUpdates && status?.state === STATE.updateAvailable) {
+  if (
+    settings?.autoUpdates &&
+    status?.state === STATE.updateAvailable &&
+    !updateTriggered.current
+  ) {
     update();
+    updateTriggered.current = true;
   }
 
   const usage = estimate && displayEstimate(estimate);


### PR DESCRIPTION
## Summary

- On autoupdate enabled a case was hit where the settings state would fall into a rerender loop (http://localhost:3000/en-US/offline-settings):
  ```
   Error: Too many re-renders. React limits the number of renders to prevent an infinite loop.
   ```
    <img width="1005" alt="image" src="https://user-images.githubusercontent.com/495429/159729261-5f9b2871-0bb0-4d7e-a6f4-4f274ce2bafb.png">

- Added useRef to guard against rerender loop.


## How did you test this change?

- In offline settings tab enabled auto-update. And wait for update to begin.
- After update complete click clear data, state should fall into STATE.updateAvailable. This won't now spin off into a rerender loop. 

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
