### PR TITLE
Fix: Close edit menu on submit

### DIFF
--- a/client/src/plus/collections/collection-list-item.tsx
+++ b/client/src/plus/collections/collection-list-item.tsx
@@ -75,7 +75,13 @@ export function CollectionListItem({
               <ul className="dropdown-list" id="collection-item-dropdown">
                 {showEditButton && (
                   <li className="dropdown-item">
-                    <EditCollection item={item} onEditSubmit={onEditSubmit} />
+                    <EditCollection
+                      item={item}
+                      onEditSubmit={(e, item) => {
+                        setShow(false);
+                        onEditSubmit(e, item);
+                      }}
+                    />
                   </li>
                 )}
                 <li className="dropdown-item">

--- a/client/src/ui/atoms/limit-banner/index.tsx
+++ b/client/src/ui/atoms/limit-banner/index.tsx
@@ -20,7 +20,7 @@ export default function LimitBanner({ type = "collections" }) {
         {text[0]}
         <br />
         <a href={`/${locale}/plus`}>
-          <strong>Become an MDN Plus subscriber</strong>
+          <strong>Become an MDN Plus subscriber </strong>
         </a>
         {text[1]}
       </p>


### PR DESCRIPTION
## Summary

- Closes collection edit menu on edit form submission

Resolves https://github.com/mdn/foxfooding-mdn-plus/issues/49

Also fix a little spacing issue in limit reached banner

![Screenshot 2022-03-23 at 15 39 50](https://user-images.githubusercontent.com/7376416/159725320-efb96fdc-da2d-491f-86af-361462c54cd9.png)



### Testing

Open collections tab. 
Click edit kebab menu on an item in the list. 
Make changes and click save or remove.
Observe the edit menu is closing. 