### PR TITLE
fix(plus): rework document titles

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -107,12 +107,34 @@ async function buildSPAs(options) {
       if (!fs.statSync(path.join(root, locale)).isDirectory()) {
         continue;
       }
+
+      const MDN_PLUS_TITLE = "MDN Plus";
       const SPAs = [
         { prefix: "search", pageTitle: "Search" },
-        { prefix: "plus", pageTitle: "Plus", noIndexing: true },
+        { prefix: "plus", pageTitle: MDN_PLUS_TITLE, noIndexing: true },
         {
           prefix: "plus/collections",
-          pageTitle: "Collection",
+          pageTitle: `Collections | ${MDN_PLUS_TITLE}`,
+          noIndexing: true,
+        },
+        {
+          prefix: "plus/collections/frequently_viewed",
+          pageTitle: `Frequently viewed articles | ${MDN_PLUS_TITLE}`,
+          noIndexing: true,
+        },
+        {
+          prefix: "plus/notifications",
+          pageTitle: `Notifications | ${MDN_PLUS_TITLE}`,
+          noIndexing: true,
+        },
+        {
+          prefix: "plus/notifications/starred",
+          pageTitle: `Starred | ${MDN_PLUS_TITLE}`,
+          noIndexing: true,
+        },
+        {
+          prefix: "plus/notifications/watched",
+          pageTitle: `Watch list | ${MDN_PLUS_TITLE}`,
           noIndexing: true,
         },
         { prefix: "about", pageTitle: "About MDN" },

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -36,6 +36,8 @@ export const VALID_LOCALES = new Set([
   "zh-TW",
 ]);
 
+export const MDN_PLUS_TITLE = "MDN Plus";
+
 export const PLUS_IS_ENABLED = Boolean(
   JSON.parse(
     (typeof window !== "undefined"

--- a/client/src/plus/collections/collections-tab.tsx
+++ b/client/src/plus/collections/collections-tab.tsx
@@ -10,7 +10,7 @@ import {
   updateDeleteCollectionItem,
 } from "../common/api";
 import { showMoreButton } from "../common/plus-tabs";
-import { TabVariant, SORTS, TAB_INFO } from "../common/tabs";
+import { SORTS } from "../common/tabs";
 import SearchFilter from "../search-filter";
 import { CollectionListItem } from "./collection-list-item";
 
@@ -24,8 +24,6 @@ export function CollectionsTab({
   const [list, setList] = useState<Array<any>>([]);
   const [subscriptionLimitReached, setSubscriptionLimitReached] =
     useState(false);
-
-  document.title = TAB_INFO[TabVariant.COLLECTIONS].pageTitle || "MDN Plus";
 
   const { data, error, isLoading, hasMore } = useCollectionsApiEndpoint(
     offset,

--- a/client/src/plus/collections/frequently-viewed-tab.tsx
+++ b/client/src/plus/collections/frequently-viewed-tab.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { BookmarkData } from ".";
 import { useUIStatus } from "../../ui-context";
 import { useFrequentlyViewedData } from "../common/api";
-import { TabVariant, SORTS, TAB_INFO } from "../common/tabs";
+import { SORTS } from "../common/tabs";
 import SearchFilter from "../search-filter";
 import { CollectionListItem } from "./collection-list-item";
 
@@ -11,9 +11,6 @@ export function FrequentlyViewedTab({ selectedTerms }) {
   const [list, setList] = useState<Array<any>>([]);
 
   const { data, setFrequentlyViewed } = useFrequentlyViewedData(selectedTerms);
-
-  document.title =
-    TAB_INFO[TabVariant.FREQUENTLY_VIEWED].pageTitle || "MDN Plus";
 
   useEffect(() => {
     if (data) {

--- a/client/src/plus/collections/index.tsx
+++ b/client/src/plus/collections/index.tsx
@@ -17,6 +17,7 @@ import { BookmarkData } from "./types";
 import { useUserData } from "../../user-context";
 import { TabVariant, TAB_INFO, useCurrentTab } from "../common/tabs";
 import { PlusTabs } from "../common/plus-tabs";
+import { MDN_PLUS_TITLE } from "../../constants";
 
 dayjs.extend(relativeTime);
 
@@ -50,6 +51,14 @@ function CollectionsLayout() {
     setSelectedSort("");
     setSelectedFilter("");
   }, [currentTab, setSelectedTerms, setSelectedSort, setSelectedFilter]);
+
+  useEffect(() => {
+    document.title = TAB_INFO[currentTab].pageTitle || MDN_PLUS_TITLE;
+
+    return () => {
+      document.title = MDN_PLUS_TITLE;
+    };
+  }, [currentTab]);
 
   const tabsForRoute = [
     TAB_INFO[TabVariant.COLLECTIONS],

--- a/client/src/plus/common/tabs.tsx
+++ b/client/src/plus/common/tabs.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
+import { MDN_PLUS_TITLE } from "../../constants";
 
 export enum TabVariant {
   NOTIFICATIONS,
@@ -37,33 +38,39 @@ export const SORTS = [
   },
 ];
 
-export const TAB_INFO = {
+interface TabDefinition {
+  pageTitle: string;
+  label: string;
+  path: string;
+}
+
+export const TAB_INFO: Record<TabVariant, TabDefinition> = {
   [TabVariant.NOTIFICATIONS]: {
-    pageTitle: "Notifications",
+    pageTitle: `Notifications | ${MDN_PLUS_TITLE}`,
     label: "All notifications",
     path: NOTIFICATIONS_URL,
   },
 
   [TabVariant.STARRED]: {
     label: "Starred",
-    pageTitle: "My Starred Pages",
+    pageTitle: `Starred | ${MDN_PLUS_TITLE}`,
     path: STARRED_URL,
   },
   [TabVariant.WATCHING]: {
     label: "Watch list",
-    pageTitle: "My Watched Pages",
+    pageTitle: `Watch list | ${MDN_PLUS_TITLE}`,
     path: WATCHING_URL,
   },
 
   [TabVariant.COLLECTIONS]: {
     label: "Collections",
-    pageTitle: "Collections",
+    pageTitle: `Collections | ${MDN_PLUS_TITLE}`,
     path: COLLECTIONS_URL,
   },
 
   [TabVariant.FREQUENTLY_VIEWED]: {
     label: "Frequently viewed articles",
-    pageTitle: "Frequently viewed articles",
+    pageTitle: `Frequently viewed articles | ${MDN_PLUS_TITLE}`,
     path: FREQUENTLY_VIEWED_URL,
   },
 };

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -5,21 +5,21 @@ import { Loading } from "../ui/atoms/loading";
 import { PageContentContainer } from "../ui/atoms/page-content";
 import { PageNotFound } from "../page-not-found";
 import Notifications from "./notifications";
+import { MDN_PLUS_TITLE } from "../constants";
 
 const OfferOverview = React.lazy(() => import("./offer-overview"));
 const Collections = React.lazy(() => import("./collections"));
 const PlusDocs = React.lazy(() => import("./plus-docs"));
 
 export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
-  const defaultPageTitle = "MDN Plus";
   React.useEffect(() => {
-    document.title = pageTitle || defaultPageTitle;
+    document.title = pageTitle || MDN_PLUS_TITLE;
   }, [pageTitle]);
 
   const isServer = typeof window === "undefined";
   const loading = (
     <Loading
-      message={`Loading ${pageTitle || defaultPageTitle}…`}
+      message={`Loading ${pageTitle || MDN_PLUS_TITLE}…`}
       minHeight={800}
     />
   );

--- a/client/src/plus/notifications/notifications-tab.tsx
+++ b/client/src/plus/notifications/notifications-tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { useUIStatus } from "../../ui-context";
 import {
   useNotificationsApiEndpoint,
@@ -13,10 +13,11 @@ import { showMoreButton } from "../common/plus-tabs";
 import SearchFilter from "../search-filter";
 import NotificationCardListItem from "./notification-card-list-item";
 import SelectedNotificationsBar from "./notification-select";
-import { TAB_INFO, TabVariant, FILTERS, SORTS } from "../common/tabs";
+import { TAB_INFO, FILTERS, SORTS, useCurrentTab } from "../common/tabs";
 import { useVisibilityChangeListener } from "./utils";
 import { DataError } from "../common";
 import { Loading } from "../../ui/atoms/loading";
+import { useLocale } from "../../hooks";
 
 export function NotificationsTab({
   selectedTerms,
@@ -28,6 +29,8 @@ export function NotificationsTab({
   const { setToastData } = useUIStatus();
   const [selectAllChecked, setSelectAllChecked] = useState(false);
   const [list, setList] = useState<Array<any>>([]);
+  const locale = useLocale();
+  const currentTab = useCurrentTab(locale);
 
   const [editOptions, setEditOptions] = useState({
     starEnabled: false,
@@ -46,16 +49,16 @@ export function NotificationsTab({
 
   useVisibilityChangeListener();
 
+  const unreadCount = useMemo(
+    () => data?.items?.filter((v) => v.read === false).length ?? 0,
+    [data]
+  );
+
+  document.title = TAB_INFO[currentTab].pageTitle;
   useEffect(() => {
-    let unread;
-    document.title = TAB_INFO[TabVariant.NOTIFICATIONS].pageTitle;
-    if (data && data.items) {
-      unread = data.items.filter((v) => v.read === false).length;
-    }
-    if (!!unread) {
-      document.title = document.title + ` (${unread})`;
-    }
-  }, [data]);
+    document.title =
+      TAB_INFO[currentTab].pageTitle + (unreadCount ? ` (${unreadCount})` : "");
+  }, [currentTab, unreadCount]);
 
   const listRef = useRef<Array<any>>([]);
 
@@ -230,8 +233,6 @@ export function StarredNotificationsTab({
   selectedFilter,
   selectedSort,
 }) {
-  document.title = TAB_INFO[TabVariant.STARRED].pageTitle || "MDN Plus";
-
   return (
     <NotificationsTab
       starred={true}

--- a/client/src/plus/notifications/watched-items-tab.tsx
+++ b/client/src/plus/notifications/watched-items-tab.tsx
@@ -4,6 +4,7 @@ import { Loading } from "../../ui/atoms/loading";
 import { DataError } from "../common";
 import { useWatchedItemsApiEndpoint, unwatchItemsByUrls } from "../common/api";
 import { showMoreButton } from "../common/plus-tabs";
+import { TabVariant, TAB_INFO } from "../common/tabs";
 import WatchedCardListItem from "../icon-card";
 import SearchFilter from "../search-filter";
 import SelectedNotificationsBar from "./notification-select";
@@ -15,6 +16,8 @@ export function WatchedTab({ selectedTerms, selectedFilter, selectedSort }) {
     useState(false);
   const [list, setList] = useState<Array<any>>([]);
   const listRef = useRef<Array<any>>([]);
+
+  document.title = TAB_INFO[TabVariant.WATCHING].pageTitle;
 
   const { data, error, isLoading, hasMore } = useWatchedItemsApiEndpoint(
     offset,

--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -1,4 +1,5 @@
 import { useParams } from "react-router-dom";
+import { MDN_PLUS_TITLE } from "../../constants";
 import StaticPage from "../../homepage/static-page";
 import { Button } from "../../ui/atoms/button";
 
@@ -10,7 +11,7 @@ function PlusDocs({ ...props }) {
       {...{
         locale,
         slug: `plus/docs/${slug}`,
-        title: "MDN Plus",
+        title: MDN_PLUS_TITLE,
         sidebarHeader: (
           <Button href={`/${locale}/plus`}>← Back to Overview</Button>
         ),


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/80.

### Problem

Example: When visiting https://developer.allizom.org/en-US/plus, the browser tab quickly shows "Plus" before updating to "MDN Plus". This is because the SPA has an initial title, which is overwritten in the Plus component.

### Solution

1. All MDN Plus pages should have the `| MDN Plus` suffix.
2. The SSR title should be equivalent to the dynamically set title.
3. The "Offline settings" should have the title _Offline Settings | MDN Plus_.

---

## How did you test this change?

_This cannot be tested locally, because the SPA title doesn't apply there._