### PR TITLE
fix:copy ~ fix button copy for collections

### DIFF
--- a/client/src/ui/molecules/collection/edit-collection.tsx
+++ b/client/src/ui/molecules/collection/edit-collection.tsx
@@ -83,7 +83,7 @@ export function EditCollection({
                   name="delete"
                   value="true"
                 >
-                  Remove Bookmark
+                  Delete
                 </Button>
               </div>
             </form>

--- a/client/src/ui/molecules/collection/menu.tsx
+++ b/client/src/ui/molecules/collection/menu.tsx
@@ -221,7 +221,7 @@ export function BookmarkMenu({
                     value="true"
                     isDisabled={isValidating}
                   >
-                    Remove Collection
+                    Delete
                   </Button>
                 ) : (
                   <Button onClickHandler={cancelHandler} type="secondary">

--- a/copy/plus/features/collections.md
+++ b/copy/plus/features/collections.md
@@ -55,7 +55,7 @@ Add notes from **Collections**
 Remove a saved page from **an article page**
 
 1. Select **Saved** at the top of the page.
-2. Select **Remove collection**.
+2. Select **Delete**.
 
 Remove a saved page from **Collections**
 


### PR DESCRIPTION
Updates the button copy for collections.

On the dashboard, it replaces "Remove Bookmark" with "Delete"
On a page pop-up, it replaces "Remove collection" with "Delete"
Also updates the reference in the docs

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/77