### PR TITLE
fix:banner ~ adds mdn plus launch banner

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -2,7 +2,9 @@ import * as React from "react";
 
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
 import { useGA } from "../ga-context";
+import { useUserData } from "../user-context";
 import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
+import { isPlusAvailable } from "../utils";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.
@@ -106,7 +108,9 @@ export default function ActiveBanner({
   id: string;
   onDismissed: () => void;
 }) {
-  if (id === PLUS_LAUNCH_ANNOUNCEMENT) {
+  const userData = useUserData();
+
+  if (id === PLUS_LAUNCH_ANNOUNCEMENT && isPlusAvailable(userData)) {
     return <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />;
   }
   throw new Error(`Unrecognized banner to display (${id})`);

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -112,9 +112,11 @@ export default function ActiveBanner({
 
   if (id === PLUS_LAUNCH_ANNOUNCEMENT) {
     return (
-      isPlusAvailable(userData) && (
-        <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
-      )
+      <>
+        {isPlusAvailable(userData) && (
+          <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
+        )}
+      </>
     );
   }
   throw new Error(`Unrecognized banner to display (${id})`);

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -79,7 +79,8 @@ function PlusLaunchAnnouncementBanner({
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
-        MDN Plus is here! Support MDN <u>and</u> make it your own.{" "}
+        <span className="mdn-plus">MDN Plus</span> is here! Support MDN{" "}
+        <em>and</em> make it your own.{" "}
         <a
           href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
           target="_blank"

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -79,7 +79,7 @@ function PlusLaunchAnnouncementBanner({
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
-        ✨{" "}
+        MDN Plus is here! Support MDN <u>and</u> make it your own.{" "}
         <a
           href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
           target="_blank"
@@ -88,7 +88,7 @@ function PlusLaunchAnnouncementBanner({
         >
           Learn more
         </a>{" "}
-        about MDN Plus.
+        ✨
       </p>
     </Banner>
   );

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -110,8 +110,12 @@ export default function ActiveBanner({
 }) {
   const userData = useUserData();
 
-  if (id === PLUS_LAUNCH_ANNOUNCEMENT && isPlusAvailable(userData)) {
-    return <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />;
+  if (id === PLUS_LAUNCH_ANNOUNCEMENT) {
+    return (
+      isPlusAvailable(userData) && (
+        <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
+      )
+    );
   }
   throw new Error(`Unrecognized banner to display (${id})`);
 }

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
 import { useGA } from "../ga-context";
-import { REDESIGN_ANNOUNCEMENT } from "./ids";
+import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.
@@ -71,24 +71,24 @@ function SendCTAEventToGA(eventCategory: string) {
   });
 }
 
-function RedesignAnnouncementBanner({
+function PlusLaunchAnnouncementBanner({
   onDismissed,
 }: {
   onDismissed: () => void;
 }) {
   return (
-    <Banner id={REDESIGN_ANNOUNCEMENT} onDismissed={onDismissed}>
+    <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
         ✨{" "}
         <a
-          href="https://hacks.mozilla.org/2022/02/a-new-year-a-new-mdn/"
+          href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => SendCTAEventToGA(REDESIGN_ANNOUNCEMENT)}
+          onClick={() => SendCTAEventToGA(PLUS_LAUNCH_ANNOUNCEMENT)}
         >
           Learn more
         </a>{" "}
-        about MDN Web Docs' new design.
+        about MDN Plus.
       </p>
     </Banner>
   );
@@ -105,8 +105,8 @@ export default function ActiveBanner({
   id: string;
   onDismissed: () => void;
 }) {
-  if (id === REDESIGN_ANNOUNCEMENT) {
-    return <RedesignAnnouncementBanner onDismissed={onDismissed} />;
+  if (id === PLUS_LAUNCH_ANNOUNCEMENT) {
+    return <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />;
   }
   throw new Error(`Unrecognized banner to display (${id})`);
 }

--- a/client/src/banners/banner.scss
+++ b/client/src/banners/banner.scss
@@ -37,6 +37,23 @@
 
   a {
     min-height: 0;
-    color: #f16b8c;
+    color: var(--color-announcement-banner-accent);
+
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+  }
+
+  em {
+    font-style: normal;
+    font-weight: 600;
+    text-decoration: underline var(--color-announcement-banner-accent) 0.15rem;
+  }
+
+  .mdn-plus {
+    color: var(--color-announcement-banner-accent);
+    font-size: 1.2rem;
+    font-weight: 700;
   }
 }

--- a/client/src/banners/ids.ts
+++ b/client/src/banners/ids.ts
@@ -3,3 +3,4 @@
 export const PLUS_IDv1 = "plus_banner_v1";
 export const PLUS_IDv2 = "plus_banner_v2";
 export const REDESIGN_ANNOUNCEMENT = "redesign_announcement";
+export const PLUS_LAUNCH_ANNOUNCEMENT = "plus_launch_announcement";

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -10,20 +10,20 @@ import { CRUD_MODE } from "../constants";
 // <ActiveBanner>, at least the CSS will be ready.
 import "./banner.scss";
 
-import { REDESIGN_ANNOUNCEMENT } from "./ids";
+import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
 
 const ActiveBanner = React.lazy(() => import("./active-banner"));
 
-export const hasActiveBanners = false;
+export const hasActiveBanners = true;
 
 export function Banner() {
-  if (CRUD_MODE || !isEmbargoed(REDESIGN_ANNOUNCEMENT)) {
+  if (CRUD_MODE || !isEmbargoed(PLUS_LAUNCH_ANNOUNCEMENT)) {
     return (
       <React.Suspense fallback={null}>
         <ActiveBanner
-          id={REDESIGN_ANNOUNCEMENT}
+          id={PLUS_LAUNCH_ANNOUNCEMENT}
           onDismissed={() => {
-            setEmbargoed(REDESIGN_ANNOUNCEMENT, 7);
+            setEmbargoed(PLUS_LAUNCH_ANNOUNCEMENT, 7);
           }}
         />
       </React.Suspense>

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -311,6 +311,7 @@ body,
   --mdn-background-dark: #{$mdn-theme-dark-background-primary};
   --mdn-background-light: #{$mdn-theme-light-background-primary};
   --mdn-background-light-grey: #{$mdn-color-light-grey-30};
+  --color-announcement-banner-accent: #{$mdn-color-light-theme-pink-40};
 }
 
 :root,


### PR DESCRIPTION
Adds MDN Plus launch banner

![Screenshot of the MDN Plus launch banner. The banner contains the words, "MDN Plus is here! Support MDN and make it your own. Learn more"](https://user-images.githubusercontent.com/10350960/159879957-d101d145-7578-4ea2-b7d9-a6f15a45a8c3.png)
