### PR TITLE
Fix some nits of the offline settings page

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -138,7 +138,7 @@ async function buildSPAs(options) {
           noIndexing: true,
         },
         {
-          prefix: "offline-settings",
+          prefix: "plus/offline-settings",
           pageTitle: `Offline settings | ${MDN_PLUS_TITLE}`,
           noIndexing: true,
         },

--- a/build/spas.js
+++ b/build/spas.js
@@ -138,7 +138,7 @@ async function buildSPAs(options) {
           noIndexing: true,
         },
         {
-          prefix: "plus/offline-settings",
+          prefix: "plus/offline",
           pageTitle: `Offline settings | ${MDN_PLUS_TITLE}`,
           noIndexing: true,
         },

--- a/build/spas.js
+++ b/build/spas.js
@@ -137,6 +137,11 @@ async function buildSPAs(options) {
           pageTitle: `Watch list | ${MDN_PLUS_TITLE}`,
           noIndexing: true,
         },
+        {
+          prefix: "offline-settings",
+          pageTitle: `Offline settings | ${MDN_PLUS_TITLE}`,
+          noIndexing: true,
+        },
         { prefix: "about", pageTitle: "About MDN" },
         { prefix: "community", pageTitle: "Contribute to MDN" },
       ];

--- a/build/spas.js
+++ b/build/spas.js
@@ -139,7 +139,7 @@ async function buildSPAs(options) {
         },
         {
           prefix: "plus/offline",
-          pageTitle: `Offline settings | ${MDN_PLUS_TITLE}`,
+          pageTitle: `MDN Offline | ${MDN_PLUS_TITLE}`,
           noIndexing: true,
         },
         { prefix: "about", pageTitle: "About MDN" },

--- a/client/pwa/README.md
+++ b/client/pwa/README.md
@@ -1,6 +1,6 @@
-# MDN offline
+# MDN Offline
 
-This is MDN's ServiceWorker that powers MDN offline. It's not being build by
+This is MDN's ServiceWorker that powers MDN Offline. It's not being build by
 default for local development. And for now it requires a running instance of
 [kuma](https://github.com/mdn/kuma) to work. We might add support for local
 development and update this README.

--- a/client/pwa/package.json
+++ b/client/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mdn-worker",
   "version": "1.0.0",
-  "description": "MDN offline service worker",
+  "description": "MDN Offline service worker",
   "license": "MPL-2.0",
   "author": "MDN Web Docs",
   "main": "service-worker.ts",

--- a/client/src/offline-settings/index.tsx
+++ b/client/src/offline-settings/index.tsx
@@ -12,7 +12,7 @@ const SettingsApp = React.lazy(() => import("./settings"));
 export function OfflineSettings() {
   const locale = useLocale();
   const user = useUserData();
-  const pageTitle = "Offline Settings";
+  const pageTitle = "Offline settings";
 
   return (
     <>

--- a/client/src/offline-settings/index.tsx
+++ b/client/src/offline-settings/index.tsx
@@ -12,7 +12,7 @@ const SettingsApp = React.lazy(() => import("./settings"));
 export function OfflineSettings() {
   const locale = useLocale();
   const user = useUserData();
-  const pageTitle = "Offline settings";
+  const pageTitle = "MDN Offline";
 
   return (
     <>

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import UpdateButton from "./update";
 import ClearButton from "./clear";
 import { Spinner } from "../ui/atoms/spinner";
+import { MDN_PLUS_TITLE } from "../constants";
 
 function displayEstimate({ usage = 0, quota = Infinity }: StorageEstimate) {
   const usageInMib = Math.round(usage / (1024 * 1024));
@@ -35,7 +36,7 @@ export default function SettingsApp({ ...appProps }) {
 }
 
 function Settings() {
-  document.title = "Settings | MDN";
+  document.title = `Offline settings | ${MDN_PLUS_TITLE}`;
   const [status, setStatus] = useState<UpdateStatus>();
   const [saving, setSaving] = useState<boolean>(true);
 

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -145,20 +145,6 @@ function Settings() {
               update={update}
             />
           </li>
-          {window?.location.hash === "#debug" && (
-            <li>
-              <h4>Debug</h4>
-              <span>{JSON.stringify(status, null, 2)}</span>
-            </li>
-          )}
-          {usage && (
-            <li>
-              <h4>Storage used</h4>
-              <span>
-                MDN offline currently uses <b>{usage}</b>
-              </span>
-            </li>
-          )}
           <li>
             <h4>Enable auto-update</h4>
             <span>
@@ -176,6 +162,20 @@ function Settings() {
               ></Switch>
             )}
           </li>
+          {window?.location.hash === "#debug" && (
+            <li>
+              <h4>Debug</h4>
+              <span>{JSON.stringify(status, null, 2)}</span>
+            </li>
+          )}
+          {usage && (
+            <li>
+              <h4>Storage used</h4>
+              <span>
+                MDN offline currently uses <b>{usage}</b>
+              </span>
+            </li>
+          )}
           <li>
             <ClearButton
               disabled={saving}

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -172,7 +172,7 @@ function Settings() {
             <li>
               <h4>Storage used</h4>
               <span>
-                MDN offline currently uses <b>{usage}</b>
+                MDN Offline currently uses <b>{usage}</b>
               </span>
             </li>
           )}

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -19,7 +19,7 @@ export default function SettingsApp({ ...appProps }) {
 
   return (
     <section className="field-group">
-      {/* <h3>Offline settings</h3> */}
+      {/* <h3>MDN Offline</h3> */}
       {serviceWorkerAvailable ? (
         <Settings />
       ) : (
@@ -36,7 +36,7 @@ export default function SettingsApp({ ...appProps }) {
 }
 
 function Settings() {
-  document.title = `Offline settings | ${MDN_PLUS_TITLE}`;
+  document.title = `MDN Offline | ${MDN_PLUS_TITLE}`;
   const [status, setStatus] = useState<UpdateStatus>();
   const [saving, setSaving] = useState<boolean>(true);
 

--- a/client/src/offline-settings/update.tsx
+++ b/client/src/offline-settings/update.tsx
@@ -9,13 +9,11 @@ export default function UpdateButton({
   update: () => void;
   disabled?: boolean;
 }) {
-  const current = `Last updated: ${
-    updateStatus?.currentDate
-      ? Intl.DateTimeFormat([], { dateStyle: "medium" }).format(
-          Date.parse(updateStatus.currentDate)
-        )
-      : "never"
-  }`;
+  const current =
+    updateStatus?.currentDate &&
+    `Last updated: ${Intl.DateTimeFormat([], { dateStyle: "medium" }).format(
+      Date.parse(updateStatus.currentDate)
+    )}`;
   let button: JSX.Element | null = null;
   let info: string | undefined;
   let progress = (updateStatus?.progress || 0) * 100;
@@ -27,20 +25,39 @@ export default function UpdateButton({
     button = <button disabled>Up to date</button>;
   }
   if (updateStatus?.state === STATE.updateAvailable) {
-    info = "Update available";
-    button = (
-      <button className="button" onClick={update} disabled={disabled}>
-        {" "}
-        Update now
-      </button>
-    );
+    if (updateStatus?.currentDate) {
+      info = "Update available";
+      button = (
+        <button className="button" onClick={update} disabled={disabled}>
+          {" "}
+          Update now
+        </button>
+      );
+    } else {
+      info =
+        "Start using MDN Offline by downloading the latest version of MDN Web Docs";
+      button = (
+        <button className="button" onClick={update} disabled={disabled}>
+          {" "}
+          Download
+        </button>
+      );
+    }
   }
   if (updateStatus?.state === STATE.downloading) {
-    info = "Update in progress…";
+    if (updateStatus?.currentDate) {
+      info = "Update in progress…";
+    } else {
+      info = "Download in progress…";
+    }
     button = <button disabled={disabled}>Downloading…</button>;
   }
   if (updateStatus?.state === STATE.unpacking) {
-    info = "Update in progress…";
+    if (updateStatus?.currentDate) {
+      info = "Update in progress…";
+    } else {
+      info = "Download in progress…";
+    }
     button = (
       <button disabled={disabled}>
         Unpacking…{" "}
@@ -52,7 +69,11 @@ export default function UpdateButton({
     );
   }
   if (updateStatus?.state === STATE.cleaning) {
-    info = "Update in progress…";
+    if (updateStatus?.currentDate) {
+      info = "Update in progress…";
+    } else {
+      info = "Download in progress…";
+    }
     button = <button disabled>Cleaning…</button>;
   }
   if (updateStatus?.state === STATE.clearing) {

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -56,7 +56,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
         }
       />
       <Route
-        path="/offline-settings"
+        path="/offline"
         element={
           <React.Suspense fallback={loading}>
             <OfflineSettings {...props} />

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -6,6 +6,7 @@ import { PageContentContainer } from "../ui/atoms/page-content";
 import { PageNotFound } from "../page-not-found";
 import Notifications from "./notifications";
 import { MDN_PLUS_TITLE } from "../constants";
+import { OfflineSettings } from "../offline-settings";
 
 const OfferOverview = React.lazy(() => import("./offer-overview"));
 const Collections = React.lazy(() => import("./collections"));
@@ -51,6 +52,14 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
             <div className="notifications girdle">
               <Notifications />
             </div>
+          </React.Suspense>
+        }
+      />
+      <Route
+        path="/offline-settings"
+        element={
+          <React.Suspense fallback={loading}>
+            <OfflineSettings {...props} />
           </React.Suspense>
         }
       />

--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
@@ -57,7 +57,7 @@ export type OfferDetailsProps = {
 const PLUS_FEATURES = [
   ["notifications", "Page notifications"],
   ["collections", "Collections of articles"],
-  ["offline", "MDN offline"],
+  ["offline", "MDN Offline"],
 ];
 
 const CORE: OfferDetailsProps = {

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -65,6 +65,7 @@ export const UserMenu = () => {
       {
         label: "MDN Offline",
         url: "/en-US/plus/offline",
+        extraClasses: "submenu-header",
       },
       {
         url: FXA_SETTINGS_URL,

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -63,7 +63,7 @@ export const UserMenu = () => {
         url: `/${locale}/plus/collections`,
       },
       {
-        label: "Offline settings",
+        label: "MDN Offline",
         url: "/en-US/plus/offline",
       },
       {

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -64,7 +64,7 @@ export const UserMenu = () => {
       },
       {
         label: "Offline settings",
-        url: "/en-US/offline-settings",
+        url: "/en-US/plus/offline-settings",
       },
       {
         url: FXA_SETTINGS_URL,

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -64,7 +64,7 @@ export const UserMenu = () => {
       },
       {
         label: "Offline settings",
-        url: "/en-US/plus/offline-settings",
+        url: "/en-US/plus/offline",
       },
       {
         url: FXA_SETTINGS_URL,

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -65,7 +65,6 @@ export const UserMenu = () => {
       {
         label: "MDN Offline",
         url: "/en-US/plus/offline",
-        extraClasses: "submenu-header",
       },
       {
         url: FXA_SETTINGS_URL,

--- a/copy/plus/features/offline.md
+++ b/copy/plus/features/offline.md
@@ -33,7 +33,7 @@ Open the user menu -> offline settings -> clear data
 
 ## Supported Features
 
-Some insight into what can be expected from using MDN offline
+Some insight into what can be expected from using MDN Offline
 
 ### Browsing Content
 


### PR DESCRIPTION
## Summary

Reopens https://github.com/mdn/yari/pull/5763, targeting `main` instead of merged `mdn-offline`.

### Problem

1. The `document.title` of the Offline settings was not consistent.
2. The Offline settings was not in the `/plus` path and so it didn't have the Plus design.
3. The path `/plus/offline` is not taken yet, so we can use that instead of `/plus/offline-settings`.

### Solution

1. Use _Offline settings_ consistently.
2. Move the Offline settings route into the `Plus` routes.
3. Rename the Offline settings path to `offline`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="999" alt="image" src="https://user-images.githubusercontent.com/495429/159883436-9059b68a-8caa-4d69-97bf-fca111d88b41.png">


### After

<img width="999" alt="image" src="https://user-images.githubusercontent.com/495429/159884093-3978e01d-e570-4002-ba82-7df821971adb.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/offline locally.