### PR TITLE
fix(plus): avoid "Page not found" messages

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -3,6 +3,7 @@ import useSWR from "swr";
 import { CRUD_MODE } from "../../constants";
 import { TOC } from "../../document/organisms/toc";
 import { PageNotFound } from "../../page-not-found";
+import { Loading } from "../../ui/atoms/loading";
 import "./index.scss";
 
 interface StaticPageProps {
@@ -22,7 +23,7 @@ function StaticPage({
 }: StaticPageProps) {
   const baseURL = `/${locale.toLowerCase()}/${slug}`;
   const featureJSONUrl = `${baseURL}/index.json`;
-  const { data: { hyData } = {} } = useSWR<any>(
+  const { data: { hyData } = {}, error } = useSWR<any>(
     featureJSONUrl,
     async (url) => {
       const response = await fetch(url);
@@ -45,8 +46,10 @@ function StaticPage({
     document.title = pageTitle;
   }, [hyData, title]);
 
-  if (!hyData) {
+  if (error) {
     return <PageNotFound />;
+  } else if (!hyData) {
+    return <Loading />;
   }
 
   return (

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -24,51 +24,64 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
     />
   );
 
-  const routes = (
+  function Layout({ children }) {
+    return (
+      <PageContentContainer extraClasses="fullwidth">
+        {isServer ? (
+          loading
+        ) : (
+          <React.Suspense fallback={loading}>{children}</React.Suspense>
+        )}
+      </PageContentContainer>
+    );
+  }
+
+  return (
     <Routes>
       <Route
         path="/"
         element={
-          <React.Suspense fallback={loading}>
+          <Layout>
             <OfferOverview />
-          </React.Suspense>
+          </Layout>
         }
       />
       <Route
         path="collections/*"
         element={
-          <React.Suspense fallback={loading}>
+          <Layout>
             <div className="bookmarks girdle">
               <Collections />
             </div>
-          </React.Suspense>
+          </Layout>
         }
       />
       <Route
         path="notifications/*"
         element={
-          <React.Suspense fallback={loading}>
+          <Layout>
             <div className="notifications girdle">
               <Notifications />
             </div>
-          </React.Suspense>
+          </Layout>
         }
       />
       <Route
         path="docs/*"
         element={
-          <React.Suspense fallback={loading}>
+          <Layout>
             <PlusDocs {...props} />
-          </React.Suspense>
+          </Layout>
         }
       />
-      <Route path="*" element={<PageNotFound />} />
+      <Route
+        path="*"
+        element={
+          <Layout>
+            <PageNotFound />
+          </Layout>
+        }
+      />
     </Routes>
-  );
-
-  return (
-    <PageContentContainer extraClasses="fullwidth">
-      {isServer ? loading : routes}
-    </PageContentContainer>
   );
 }


### PR DESCRIPTION
## Summary

### Problem

1. When opening Plus pages for the first time, sometimes a "Page not found" message displays.
2. Same happens when opening Plus docs.

### Solution

1. Return the Plus `Routes` during SSR, but with a `Loading` message.
2. Differentiate loading errors from actualy loading.