### PR TITLE
fix:link ~ hard code locale for faw link

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -49,7 +49,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "FAQ",
-        url: `/${locale}/plus/docs/faq`,
+        url: `/en-US/plus/docs/faq`,
       },
     ],
   };


### PR DESCRIPTION
This was reported by Florian. We now hardcode the locale for the FAQ link in the Plus menu