### PR TITLE
chore(plus/collections): use singular for tab

### DIFF
--- a/client/src/plus/common/tabs.tsx
+++ b/client/src/plus/common/tabs.tsx
@@ -63,7 +63,7 @@ export const TAB_INFO: Record<TabVariant, TabDefinition> = {
   },
 
   [TabVariant.COLLECTIONS]: {
-    label: "Collections",
+    label: "Collection",
     pageTitle: `Collections | ${MDN_PLUS_TITLE}`,
     path: COLLECTIONS_URL,
   },


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/89.

### Problem

The MDN Plus feature is called "Collections", but the tab should still be called "Collection".

### Solution

Rename tab.

---

## Screenshots

### Before

<img width="663" alt="image" src="https://user-images.githubusercontent.com/495429/159946093-29380c4a-ac88-427c-bd4a-ef0ddeb036d1.png">

### After

<img width="663" alt="image" src="https://user-images.githubusercontent.com/495429/159946018-629e5e9f-1242-4449-8b66-654a8fad117b.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/collections locally.