### PR TITLE
fix(plus-docs): make breadcrumbs span full width

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -70,7 +70,7 @@ function StaticPage({
   const toc = hyData.toc?.length && <TOC toc={hyData.toc} />;
 
   return (
-    <div className={`document-page container ${extraClasses}`}>
+    <>
       <div className="article-actions-container">
         <div className="container">
           <Button
@@ -101,7 +101,7 @@ function StaticPage({
           </article>
         </main>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/client/src/plus/plus-docs/index.scss
+++ b/client/src/plus/plus-docs/index.scss
@@ -1,8 +1,9 @@
 @use "../../ui/vars" as *;
 
-.plus-docs {
-  // Workaround: Remove when PlusDocs are no longer wrapped in [Plus]Layout.
-  padding: 0rem;
+.plus {
+  .article-actions-container {
+    display: flex;
+  }
 
   .main-page-content {
     em {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5787.

### Problem

The breadcrumbs on the MDN Plus docs didn't span the full width.

### Solution

Make sure it does. 🤷 

---

## Screenshots

### Before

<img width="1902" alt="image" src="https://user-images.githubusercontent.com/495429/159970080-a203aa14-b211-4d96-a39c-aceffc366d6c.png">

### After

<img width="1902" alt="image" src="https://user-images.githubusercontent.com/495429/159970023-ba7f54cc-0832-440b-91f2-eb281481a767.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/docs/features/offline locally.
2. Switch between `main` and this branch to verify only the breadcrumb (article-actions-container) changes.