### PR TITLE
fix(static-page): remove scrollTo effect

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -60,9 +60,7 @@ function StaticPage({
       revalidateOnFocus: CRUD_MODE,
     }
   );
-  React.useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
+
   React.useEffect(() => {
     document.title = hyData ? `${hyData.title} | ${title}` : title;
   }, [hyData, title]);


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5793.

### Problem

The right sidebar in the MDN Plus docs doesn't work. Clicking does not have the expected effect.

### Solution

Remove a `scrollTo()` call that was obviously triggered when the hash changes. :(

---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/docs/faq locally.
2. Click on the right sidebar links.