### PR TITLE
fix(static-page): avoid wrong hydration

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -58,21 +58,16 @@ function StaticPage({
   );
 
   React.useEffect(() => {
-    document.title = hyData?.title ? `${hyData.title} | ${title}` : title;
+    document.title = hyData ? `${hyData.title} | ${title}` : title;
   }, [hyData, title]);
-
-  const isLoaded = hyData && hyData.title && hyData.toc && hyData.sections;
 
   if (error) {
     return <PageNotFound />;
-  } else if (!isLoaded) {
+  } else if (!hyData) {
     return <Loading />;
   }
 
   const toc = hyData.toc?.length && <TOC toc={hyData.toc} />;
-  const sections = hyData.sections.map((section) => (
-    <section dangerouslySetInnerHTML={{ __html: section }}></section>
-  ));
 
   return (
     <>
@@ -99,7 +94,11 @@ function StaticPage({
         </SidebarContainer>
         <div className="toc">{toc || null}</div>
         <main id="content" className="main-content" role="main">
-          <article className="main-page-content">{sections}</article>
+          <article className="main-page-content">
+            {hyData.sections.map((section) => (
+              <section dangerouslySetInnerHTML={{ __html: section }}></section>
+            ))}
+          </article>
         </main>
       </div>
     </>

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -27,6 +27,8 @@ interface StaticPageProps {
   sidebarHeader?: ReactElement;
 }
 
+const isServer = typeof window === "undefined";
+
 function StaticPage({
   extraClasses = "",
   locale,
@@ -50,7 +52,7 @@ function StaticPage({
       return await response.json();
     },
     {
-      initialData,
+      initialData: isServer ? initialData : undefined,
       revalidateOnFocus: CRUD_MODE,
     }
   );

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback } from "react";
+import React, { ReactElement } from "react";
 import useSWR from "swr";
 import { CRUD_MODE } from "../../constants";
 import { SidebarContainer } from "../../document/organisms/sidebar";
@@ -38,15 +38,9 @@ function StaticPage({
 }: StaticPageProps) {
   const { isSidebarOpen, setIsSidebarOpen } = useUIStatus();
   const baseURL = `/${locale}/${slug}`;
-
-  const getJsonUrl = useCallback(() => {
-    const baseURL = `/${locale}/${slug}`;
-    const featureJSONUrl = `${baseURL.toLowerCase()}/index.json`;
-    return featureJSONUrl;
-  }, [locale, slug]);
-
+  const featureJSONUrl = `${baseURL.toLowerCase()}/index.json`;
   const { data: { hyData } = {}, error } = useSWR<{ hyData: StaticPageDoc }>(
-    getJsonUrl(),
+    featureJSONUrl,
     async (url) => {
       const response = await fetch(url);
       if (!response.ok) {

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -56,16 +56,21 @@ function StaticPage({
   );
 
   React.useEffect(() => {
-    document.title = hyData ? `${hyData.title} | ${title}` : title;
+    document.title = hyData?.title ? `${hyData.title} | ${title}` : title;
   }, [hyData, title]);
+
+  const isLoaded = hyData && hyData.title && hyData.toc && hyData.sections;
 
   if (error) {
     return <PageNotFound />;
-  } else if (!hyData) {
+  } else if (!isLoaded) {
     return <Loading />;
   }
 
   const toc = hyData.toc?.length && <TOC toc={hyData.toc} />;
+  const sections = hyData.sections.map((section) => (
+    <section dangerouslySetInnerHTML={{ __html: section }}></section>
+  ));
 
   return (
     <>
@@ -92,11 +97,7 @@ function StaticPage({
         </SidebarContainer>
         <div className="toc">{toc || null}</div>
         <main id="content" className="main-content" role="main">
-          <article className="main-page-content">
-            {hyData.sections.map((section) => (
-              <section dangerouslySetInnerHTML={{ __html: section }}></section>
-            ))}
-          </article>
+          <article className="main-page-content">{sections}</article>
         </main>
       </div>
     </>

--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -1,4 +1,4 @@
-import { useParams, useLocation } from "react-router-dom";
+import { Link, useParams, useLocation } from "react-router-dom";
 import { MDN_PLUS_TITLE } from "../../constants";
 import StaticPage from "../../homepage/static-page";
 import "./index.scss";
@@ -51,16 +51,16 @@ function RelatedTopics({
 
             return (
               <li className="document-toc-item">
-                <a
-                  href={itemPathname}
+                <Link
                   className="document-toc-link"
                   aria-current={
                     itemPathname.toLowerCase() ===
                     locationPathname.toLowerCase()
                   }
+                  to={itemPathname}
                 >
                   {title}
-                </a>
+                </Link>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary

Fixes #5796.

### Problem

It appears that MDN Plus Docs page are sometimes hydrated with the wrong data.

### Solution

Avoid using existing hydration data in client context.

---

## How did you test this change?

To test, I have deployed this branch to stage (https://github.com/mdn/yari/actions/runs/2036537637).
