### PR TITLE
fix(sidebar): clear useEffect() timeout

### DIFF
--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -28,16 +28,22 @@ export function SidebarContainer({ doc, children }) {
   const [classes, setClasses] = useState<string>("sidebar");
 
   useEffect(() => {
+    let timeoutID;
+
     if (isSidebarOpen) {
       setClasses("sidebar is-expanded");
     } else {
       setClasses("sidebar is-animating");
-      setTimeout(() => {
+      timeoutID = setTimeout(() => {
         setClasses("sidebar");
       }, 300);
     }
 
     _setScrollLock(isSidebarOpen);
+
+    if (timeoutID) {
+      return () => clearTimeout(timeoutID);
+    }
   }, [isSidebarOpen]);
 
   return (


### PR DESCRIPTION
Fixes an error in the browser console where a timeout was setting a class on an unrendered component.