### PR TITLE
fix(plus-docs): add key to RelatedTopics

### DIFF
--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -50,7 +50,7 @@ function RelatedTopics({
             const itemPathname = `/${locale}/${slug}`;
 
             return (
-              <li className="document-toc-item">
+              <li key={itemPathname} className="document-toc-item">
                 <Link
                   className="document-toc-link"
                   aria-current={


### PR DESCRIPTION
The RelatedTopics component does not properly set a key on a loop.