### PR TITLE
fix(plus): assume available if subscriber

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -89,5 +89,9 @@ export function isPlusAvailable(userData: UserData | null) {
   if (!userData) {
     return false;
   }
-  return PLUS_ENABLED_COUNTRIES.includes(userData?.geo?.country);
+
+  return (
+    userData.isSubscriber ||
+    PLUS_ENABLED_COUNTRIES.includes(userData.geo?.country)
+  );
 }


### PR DESCRIPTION
## Summary

Enables Plus subscribers to continue using Plus outside of the US/CA.

### Problem

Previously, Plus features were disabled as soon as a user is outside of US/CA.

### Solution

Now, Plus subscribers will be able to continue using Plus features as long as they are logged in.

**Limitation**: It still won't be possible to login outside of US/CA.

---

## How did you test this change?

_Unable to test locally._
