### PR TITLE
feat(CLI): Make it possible to use an absolute URL when providing a redirect during a deletion

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -580,7 +580,10 @@ function remove(
 ) {
   const root = getRoot(locale);
   const url = buildURL(locale, slug);
-  const redirectUrl = redirect && buildURL(locale, redirect);
+  let redirectUrl = redirect;
+  if (redirect && !redirect.match("^http(s)?://")) {
+    redirectUrl = buildURL(locale, redirect);
+  }
 
   const roots = [CONTENT_ROOT];
   if (CONTENT_TRANSLATED_ROOT) {
@@ -599,7 +602,7 @@ function remove(
 
   if (dry) {
     if (redirectUrl) {
-      Redirect.add(locale, [[url, buildURL(locale, redirectUrl)]], { dry });
+      Redirect.add(locale, [[url, redirectUrl]], { dry });
     }
     return docs;
   }


### PR DESCRIPTION
## Summary

#5813

### Problem
See https://github.com/mdn/yari/issues/5813

This would help add redirects for deleted content which now lives outside of MDN (e.g. Fx DevTools)

### Solution

I added a check to switch case when the URL is absolute (vs when it's not where it uses the existing logic)

---

### Before
![image](https://user-images.githubusercontent.com/2413436/160121055-ca5d7574-bac7-4241-ae56-54bfa426613a.png)

### After
![image](https://user-images.githubusercontent.com/2413436/160120195-24ce49f6-5b61-4615-9aee-9fe3cb037c17.png)
---

## How did you test this change?

I ran the following command from `yari`s directory:

`yarn tool delete Tools/3D_View fr --redirect https://firefox-source-docs.mozilla.org/devtools-user/3d_view/index.html` 

and then manually check the redirects file and ran 
`yarn tool validate-redirects fr --strict` (resp. w/ `yarn content` under `content`)
