### PR TITLE
Make "MDN Plus" a link in the banner + make Plus links refer to "Choose a plan" section when on product page

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -81,8 +81,10 @@ function PlusLaunchAnnouncementBanner({
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
-        <span className="mdn-plus">MDN Plus</span> is here! Support MDN{" "}
-        <em>and</em> make it your own.{" "}
+        <a href="/en-US/plus/" className="mdn-plus">
+          MDN Plus
+        </a>{" "}
+        is here! Support MDN <em>and</em> make it your own.{" "}
         <a
           href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
           target="_blank"

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -5,6 +5,7 @@ import { useGA } from "../ga-context";
 import { useUserData } from "../user-context";
 import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
 import { isPlusAvailable } from "../utils";
+import { usePlusUrl } from "../plus/utils";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.
@@ -78,10 +79,12 @@ function PlusLaunchAnnouncementBanner({
 }: {
   onDismissed: () => void;
 }) {
+  const plusUrl = usePlusUrl();
+
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
-        <a href="/en-US/plus/" className="mdn-plus">
+        <a href={plusUrl} className="mdn-plus">
           MDN Plus
         </a>{" "}
         is here! Support MDN <em>and</em> make it your own.{" "}

--- a/client/src/plus/utils.ts
+++ b/client/src/plus/utils.ts
@@ -1,7 +1,11 @@
 import { useLocation } from "react-router-dom";
 import { useLocale } from "../hooks";
 
-export function usePlusUrl() {
+/**
+ * Returns the URL of the Plus product page, or, if we're
+ * already there, the hash of the "Choose a plan" section.
+ */
+export function usePlusUrl(): string {
   const { pathname } = useLocation();
   const locale = useLocale();
 

--- a/client/src/plus/utils.ts
+++ b/client/src/plus/utils.ts
@@ -1,0 +1,19 @@
+import { useLocation } from "react-router-dom";
+import { useLocale } from "../hooks";
+
+export function usePlusUrl() {
+  const { pathname } = useLocation();
+  const locale = useLocale();
+
+  function normalizedUrl(url: string): string {
+    return url.replace(/\/$/, "").toLowerCase();
+  }
+
+  let target = `/${locale}/plus/`;
+
+  if (normalizedUrl(target) === normalizedUrl(pathname)) {
+    target = "#subscribe";
+  }
+
+  return target;
+}

--- a/client/src/ui/atoms/subscribe-link/index.tsx
+++ b/client/src/ui/atoms/subscribe-link/index.tsx
@@ -1,7 +1,6 @@
-import { useLocale } from "../../../hooks";
-
 import "./index.scss";
 import { Button } from "../button";
+import { usePlusUrl } from "../../../plus/utils";
 
 /**
  *
@@ -9,11 +8,10 @@ import { Button } from "../button";
  * @returns {JSX.Element} - The anchor link with the appropriate URL
  */
 export const SubscribeLink = () => {
-  const locale = useLocale();
-  const endPoint = `/${locale}/plus`;
+  const href = usePlusUrl();
 
   return (
-    <Button href={endPoint} extraClasses="mdn-plus-subscribe-link">
+    <Button href={href} extraClasses="mdn-plus-subscribe-link">
       Get MDN Plus
     </Button>
   );

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -7,10 +7,13 @@ import { Link } from "react-router-dom";
 import { Submenu } from "../submenu";
 
 import "./index.scss";
+import { usePlusUrl } from "../../../plus/utils";
 
 export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
   const locale = useLocale();
   const userData = useUserData();
+
+  const plusUrl = usePlusUrl();
 
   const isAuthenticated = userData && userData.isAuthenticated;
 
@@ -26,7 +29,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
               extraClasses: "mobile-only",
               iconClasses: "submenu-icon",
               label: "Overview",
-              url: `/${locale}/plus`,
+              url: plusUrl,
             },
             {
               description: "Your saved articles from across MDN",
@@ -69,7 +72,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         {plusMenu.label}
       </button>
 
-      <Link to={`/${locale}/plus/`} className="top-level-entry">
+      <Link to={plusUrl} className="top-level-entry">
         {plusMenu.label}
       </Link>
 

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -21,16 +21,16 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
     label: "MDN Plus",
     id: "mdn-plus",
     items: [
+      {
+        description: "More MDN. Your MDN.",
+        hasIcon: true,
+        extraClasses: "mobile-only",
+        iconClasses: "submenu-icon",
+        label: "Overview",
+        url: plusUrl,
+      },
       ...(isAuthenticated
         ? [
-            {
-              description: "More MDN. Your MDN.",
-              hasIcon: true,
-              extraClasses: "mobile-only",
-              iconClasses: "submenu-icon",
-              label: "Overview",
-              url: plusUrl,
-            },
             {
               description: "Your saved articles from across MDN",
               hasIcon: true,


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5821.
Fixes https://github.com/mdn/yari/issues/5820.

PS: This also fixes the issue that the "Overview" item in the mobile Plus menu was only available to subscribers.

### Problem

1. "MDN Plus" in the banner looks like a link, but doesn't actually link to the MDN Plus product page.
2. "Get MDN Plus" doesn't have any effect on the MDN Plus product page.
3. "MDN Plus" in the Plus menu doesn't have any effect on the MDN Plus product page.

### Solution

- (1.) Convert "MDN Plus" in the banner into a link.
- (2./3.) Make "Get MDN Plus" (and "MDN Plus") link to the Plans section, if we're on the product page.

---

## How did you test this change?

1. Open http://localhost:3000/en-US/ locally.
2. Make sure that both "MDN Plus" (in the banner) and "Get MDN Plus" (in the toolbar) link to the (top of the) MDN Plus product page.
4. Follow one of the links.
5. Make sure that both link to the plans section (`#subscribe`) now.