### PR TITLE
chore(plus-docs): order features as on the product page

### DIFF
--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -9,12 +9,12 @@ function PlusDocsNav() {
       heading="MDN Plus"
       items={[
         {
-          slug: "plus/docs/features/collections",
-          title: "Collections",
-        },
-        {
           slug: "plus/docs/features/notifications",
           title: "Notifications",
+        },
+        {
+          slug: "plus/docs/features/collections",
+          title: "Collections",
         },
         {
           slug: "plus/docs/features/offline",


### PR DESCRIPTION
# Summary

### Problem

The feature order is different between the MDN Plus product page and the MDN Plus docs:

- Product page: Notifications, Collections, MDN Offline
- Docs: Collections, Notifications, MDN Offline

### Solution

Order the features in the MDN Plus docs the same as on the product page.

---

## Screenshots

### Before

<img width="689" alt="image" src="https://user-images.githubusercontent.com/495429/160153191-549bf8c6-6457-4409-8474-fa576e23fd22.png">

### After

<img width="689" alt="image" src="https://user-images.githubusercontent.com/495429/160153147-e08a2666-ab6a-4d50-9dbd-e00dfa19dd4a.png">


---

## How did you test this change?

1. Open http://localhost:3000/en-US/plus/docs/features/notifications locally.
2. Verify the order of the left TOC.
