### PR TITLE
fix: build SPAs for Plus docs + allow indexing Plus product page

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -123,6 +123,22 @@ async function buildSPAs(options) {
           noIndexing: true,
         },
         {
+          prefix: "plus/docs/collections",
+          pageTitle: `Collections | ${MDN_PLUS_TITLE}`,
+        },
+        {
+          prefix: "plus/docs/notifications",
+          pageTitle: `Notifications | ${MDN_PLUS_TITLE}`,
+        },
+        {
+          prefix: "plus/docs/offline",
+          pageTitle: `MDN Offline | ${MDN_PLUS_TITLE}`,
+        },
+        {
+          prefix: "plus/docs/faq",
+          pageTitle: `FAQ | ${MDN_PLUS_TITLE}`,
+        },
+        {
           prefix: "plus/notifications",
           pageTitle: `Notifications | ${MDN_PLUS_TITLE}`,
           noIndexing: true,

--- a/build/spas.js
+++ b/build/spas.js
@@ -111,7 +111,7 @@ async function buildSPAs(options) {
       const MDN_PLUS_TITLE = "MDN Plus";
       const SPAs = [
         { prefix: "search", pageTitle: "Search" },
-        { prefix: "plus", pageTitle: MDN_PLUS_TITLE, noIndexing: true },
+        { prefix: "plus", pageTitle: MDN_PLUS_TITLE },
         {
           prefix: "plus/collections",
           pageTitle: `Collections | ${MDN_PLUS_TITLE}`,

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1230,7 +1230,7 @@ test("plus page", () => {
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
   expect($("title").text()).toContain("Plus");
-  expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
+  expect($('meta[name="robots"]').attr("content")).toBe("index, follow");
 });
 
 test("plus collections page", () => {


### PR DESCRIPTION
## Summary


### Problem

1. No SPAs were built for the Plus docs.
2. The Plus product page had `<meta name="robots" content="noindex, nofollow">`.

### Solution

1. Build SPAs for all Plus docs.
2. Flip the indexing flag for the Plus product page.

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/plus/docs/features/offline#clear-stored-data locally.
2. The page loaded instantly, rather than briefly showing blank content.