### PR TITLE
Fix issue 5164: Adapt sidebar navigation

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -36,8 +36,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'Debugging HTML',
         'Assessment_marking_up_a_letter': 'Assessment: Marking up a letter',
         'Assessment_structuring_a_page_of_content': 'Assessment: Structuring a page of content',
-      'Multimedia_and_embedding': 'Multimedia and embedding',
-        'Multimedia_and_embedding_overview': 'Multimedia and embedding overview',
+      'Multimedia_and_Embedding': 'Multimedia and Embedding',
+        'Multimedia_and_Embedding_overview': 'Multimedia and Embedding overview',
         'Images_in_HTML': 'Images in HTML',
         'Video_and_audio_content': 'Video and audio content',
         'Other_embedding_technologies': 'From object to iframe — other embedding technologies',
@@ -47,7 +47,7 @@ var text = mdn.localStringMap({
       'HTML_tables' : 'HTML tables',
         'HTML_tables_overview' : 'HTML tables overview',
         'HTML_table_basics' : 'HTML table basics',
-        'HTML_table_advanced' : 'HTML Table advanced features and accessibility',
+        'HTML_table_advanced' : 'HTML table advanced features and accessibility',
         'Assessment_Structuring_planet_data' : 'Assessment: Structuring planet data',
     'CSS_styling_the_Web': 'CSS — Styling the Web',
       'CSS_first_steps': 'CSS first steps',
@@ -56,7 +56,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'Getting started with CSS',
         'How_CSS_is_structured': 'How CSS is structured',
         'How_CSS_works': 'How CSS works',
-        'Using_your_new_knowledge': 'Using your new knowledge',
+        'Assessment: Styling a biography pageiography_page': 'Assessment: Styling a biography page',
       'CSS_building_blocks': 'CSS building blocks',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -65,12 +65,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Handling different text directions',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Values and units',
+        'CSS_values_and_units': 'CSS values and units',
         'Sizing_items_in_CSS': 'Sizing items in CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Styling tables',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organizing your CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': 'Styling text',
         'Styling_text_overview': 'Styling text overview',
         'Fundamental_text_and_font_styling': 'Fundamental text and font styling',
@@ -86,12 +89,12 @@ var text = mdn.localStringMap({
         'Grids' : 'Grids',
         'Floats': 'Floats',
         'Positioning': 'Positioning',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension' : 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension' : 'Assessment: Fundamental layout comprehension',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — Dynamic client-side scripting',
       'JavaScript_first_steps': 'JavaScript first steps',
         'JavaScript_first_steps_overview': 'JavaScript first steps overview',
@@ -297,8 +300,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'Fehlersuche in HTML',
         'Assessment_marking_up_a_letter': 'Aufgabe: Formatierung eines Briefes',
         'Assessment_structuring_a_page_of_content': 'Aufgabe: Strukturieren einer Webseite',
-      'Multimedia_and_embedding': 'Multimediainhalte einbinden',
-        'Multimedia_and_embedding_overview': 'Multimediainhalte einbinden — Übersicht',
+      'Multimedia_and_Embedding': 'Multimediainhalte einbinden',
+        'Multimedia_and_Embedding_overview': 'Multimediainhalte einbinden — Übersicht',
         'Images_in_HTML': 'Bilder in eine Webseite einbinden',
         'Video_and_audio_content': 'Video- und Audioinhalte',
         'Other_embedding_technologies': 'Von object zu iframe — weitere Einbindungsmöglichkeiten',
@@ -317,7 +320,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'Getting started with CSS',
         'How_CSS_is_structured': 'How CSS is structured',
         'How_CSS_works': 'How CSS works',
-        'Using_your_new_knowledge': 'Using your new knowledge',
+        'Assessment: Styling a biography pageiography_page': 'Assessment: Styling a biography page',
       'CSS_building_blocks': 'CSS building blocks',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -326,12 +329,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Handling different text directions',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Values and units',
+        'CSS_values_and_units': 'CSS values and units',
         'Sizing_items_in_CSS': 'Sizing items in CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Styling tables',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organizing your CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': 'Gestaltung von Text',
         'Styling_text_overview': 'Gestaltung von Text — Übersicht',
         'Fundamental_text_and_font_styling': 'Texte gestalten',
@@ -346,12 +352,12 @@ var text = mdn.localStringMap({
         'Grids' : 'Grid',
         'Floats': 'Float',
         'Positioning': 'Positionierung',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension': 'Assessment: Fundamental layout comprehension',
    'JavaScript_dynamic_client-side_scripting': 'JavaScript — dynamische, benutzerseitige Programmiersprache',
       'JavaScript_first_steps': 'Erste Schritte in JavaScript',
         'JavaScript_first_steps_overview': 'Erste Schritte in JavaScript — Übersicht',
@@ -548,8 +554,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'Depurando HTML',
         'Assessment_marking_up_a_letter': 'Avaliação: Marcando uma carta',
         'Assessment_structuring_a_page_of_content': 'Avaliação: Estruturação de uma página de conteúdo',
-      'Multimedia_and_embedding': 'Multimídia e incorporação',
-        'Multimedia_and_embedding_overview': 'Visão geral sobre Multimídia e incorporação',
+      'Multimedia_and_Embedding': 'Multimídia e incorporação',
+        'Multimedia_and_Embedding_overview': 'Visão geral sobre Multimídia e incorporação',
         'Images_in_HTML': 'Imagens em HTML',
         'Video_and_audio_content': 'Conteúdos em Vídeo e áudio',
         'Other_embedding_technologies': 'De objeto a iframe — outras tecnologias de incorporação',
@@ -568,7 +574,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'Iniciando com CSS',
         'How_CSS_is_structured': 'como CSS é estruturado',
         'How_CSS_works': 'Como CSS funciona',
-        'Using_your_new_knowledge': 'Usando seu novo Conhecimento',
+        'Styling_a_biography_page': 'Avaliação: Estilização de uma página biográfica',
       'CSS_building_blocks': 'CSS building blocks',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -577,12 +583,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Tratamento de diferentes direções de texto',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Valores e unidades',
+        'CSS_values_and_units': 'Valores e unidades CSS',
         'Sizing_items_in_CSS': 'Dimensionando itens em CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Estilização de tabelas',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organize seu CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': 'Estilização de textos',
         'Styling_text_overview': 'Visão geral da Estilização de textos',
         'Fundamental_text_and_font_styling': 'Fundamentos da estilização de textos e fontes',
@@ -598,12 +607,12 @@ var text = mdn.localStringMap({
         'Grids' : 'Grids',
         'Floats': '"Floats" - Flutuando elementos',
         'Positioning': 'Posicionamento',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension': 'Assessment: Fundamental layout comprehension',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — Uma linguagem de script dinâmica para aplicações cliente',
       'JavaScript_first_steps': 'Primeiros passos com JavaScript',
         'JavaScript_first_steps_overview': 'Visão geral dos Primeiros passos com JavaScript',
@@ -801,8 +810,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'Отладка HTML',
         'Assessment_marking_up_a_letter': 'Задание: Выделение символа',
         'Assessment_structuring_a_page_of_content': 'Задание: Структура страницы',
-      'Multimedia_and_embedding': 'Мультимедиа и встраивание',
-        'Multimedia_and_embedding_overview': 'Мультимедиа и встраивание',
+      'Multimedia_and_Embedding': 'Мультимедиа и встраивание',
+        'Multimedia_and_Embedding_overview': 'Мультимедиа и встраивание',
         'Images_in_HTML': 'Изображения в HTML',
         'Video_and_audio_content': 'Видео и аудио контент',
         'Other_embedding_technologies': 'От object до iframe — другие технологии встраивания',
@@ -816,7 +825,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'Getting started with CSS',
         'How_CSS_is_structured': 'How CSS is structured',
         'How_CSS_works': 'How CSS works',
-        'Using_your_new_knowledge': 'Using your new knowledge',
+        'Styling_a_biography_page': 'Assessment: Styling a biography page',
       'CSS_building_blocks': 'CSS building blocks',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -825,12 +834,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Handling different text directions',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Values and units',
+        'CSS_values_and_units': 'CSS values and units',
         'Sizing_items_in_CSS': 'Sizing items in CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Styling tables',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organizing your CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': 'Стилизирование текста',
         'Styling_text_overview': 'Стилизирование текста',
         'Fundamental_text_and_font_styling': 'Основы стилизирования текста и шрифта',
@@ -845,12 +857,12 @@ var text = mdn.localStringMap({
         'Grids' : 'Сетки',
         'Floats': 'Float',
         'Positioning': 'Позиционирование',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension': 'Assessment: Fundamental layout comprehension',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — динамический клиентский скриптинг',
       'JavaScript_first_steps': 'Первые шаги в JavaScript',
         'JavaScript_first_steps_overview': 'Первые шаги в JavaScript',
@@ -1032,8 +1044,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'HTML 除错',
         'Assessment_marking_up_a_letter': '作业：标记字母',
         'Assessment_structuring_a_page_of_content': '作业：构建出有内容的网页',
-      'Multimedia_and_embedding': '多媒体与嵌入',
-        'Multimedia_and_embedding_overview': '多媒体与嵌入概述',
+      'Multimedia_and_Embedding': '多媒体与嵌入',
+        'Multimedia_and_Embedding_overview': '多媒体与嵌入概述',
         'Images_in_HTML': 'HTML 中的图片',
         'Video_and_audio_content': '视频和音频内容',
         'Other_embedding_technologies': '从对象到 iframe — 其他嵌入技术',
@@ -1052,7 +1064,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': '让我们开始CSS之旅',
         'How_CSS_is_structured': '如何让构建CSS',
         'How_CSS_works': 'CSS如何运行',
-        'Using_your_new_knowledge': '运用你的新知识',
+        'Styling_a_biography_page': '作业：传记页的风格设计',
       'CSS_building_blocks': 'CSS 构建基础',
         'CSS_building_blocks_overview': 'CSS构建基础概览',
         'Cascade_and_inheritance': '层叠与继承',
@@ -1061,12 +1073,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': '背景与边框',
         'Handling_different_text_directions': '处理不同方向的文本',
         'Overflowing_content': '溢出的内容',
-        'Values_and_units': '值与单位',
+        'CSS_values_and_units': 'CSS值和单位',
         'Sizing_items_in_CSS': '在CSS中调整大小',
         'Images_media_and_form_elements': '图像、媒体和表单元素',
         'Styling_tables': '样式化表格',
         'Debugging_CSS': '调试CSS',
         'Organizing_your_CSS': '组织你的CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': '样式化文字',
         'Styling_text_overview': '样式化文字概述',
         'Fundamental_text_and_font_styling': '基础文字与字体样式化',
@@ -1081,12 +1096,12 @@ var text = mdn.localStringMap({
         'Grids' : '网格',
         'Floats': '浮动',
         'Positioning': '定位',
-        'Multiple-column_Layout': '多列布局',
+        'Multiple-column_layout': '多栏式布局',
         'Responsive_design': '响应式布局',
         'Media_queries': '媒体查询',
-        'Legacy_Layout_Methods': '传统的布局方法',
-        'Supporting_Older_Browsers': '支持旧的浏览器',
-        'Fundamental_Layout_Comprehension': '基础布局练习',
+        'Legacy_layout_methods': '传统的布局方法',
+        'Supporting_older_browsers': '支持旧版浏览器',
+        'Fundamental_layout_comprehension': '作业：基本的布局理解力',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — 用户端动态脚本',
       'JavaScript_first_steps': 'JavaScript 第一步',
         'JavaScript_first_steps_overview': 'JavaScript 第一步概述',
@@ -1290,8 +1305,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'HTML 除錯',
         'Assessment_marking_up_a_letter': '親和度：設個字母',
         'Assessment_structuring_a_page_of_content': '親和度：架構出具備內容的網頁',
-      'Multimedia_and_embedding': '多媒體與嵌入',
-        'Multimedia_and_embedding_overview': '多媒體與嵌入的概述',
+      'Multimedia_and_Embedding': '多媒體與嵌入',
+        'Multimedia_and_Embedding_overview': '多媒體與嵌入的概述',
         'Images_in_HTML': 'HTML 中的圖片',
         'Video_and_audio_content': '視訊與音訊內容',
         'Other_embedding_technologies': '從物件到 iframe — 其他嵌入技巧',
@@ -1301,7 +1316,7 @@ var text = mdn.localStringMap({
       'HTML_tables' : 'HTML 表格',
         'HTML_tables_overview' : 'HTML 表格概述',
         'HTML_table_basics' : 'HTML表格基礎',
-        'HTML_table_advanced' : 'HTML Table advanced features and accessibility',
+        'HTML_table_advanced' : 'HTML table advanced features and accessibility',
         'Assessment_Structuring_planet_data' : 'Assessment: Structuring planet data',
     'CSS_styling_the_Web': 'CSS — 設計 Web 的風格',
       'CSS_first_steps': '初探 CSS',
@@ -1310,7 +1325,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'CSS 入門',
         'How_CSS_is_structured': 'How CSS is structured',
         'How_CSS_works': 'CSS 怎麼運作',
-        'Using_your_new_knowledge': 'Using your new knowledge',
+        'Styling_a_biography_page': 'Assessment: Styling a biography page',
       'CSS_building_blocks': 'CSS 組件',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -1319,12 +1334,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Handling different text directions',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Values and units',
+        'CSS_values_and_units': 'CSS values and units',
         'Sizing_items_in_CSS': 'Sizing items in CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Styling tables',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organizing your CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': '樣式化文字',
         'Styling_text_overview': '樣式化文字概述',
         'Fundamental_text_and_font_styling': '基礎的文字與字型樣式化',
@@ -1339,12 +1357,12 @@ var text = mdn.localStringMap({
         'Grids' : '格線',
         'Floats': '浮動',
         'Positioning': '定位',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension': 'Assessment: Fundamental layout comprehension',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — 動態的用戶端指令',
       'JavaScript_first_steps': 'JavaScript 第一步',
         'JavaScript_first_steps_overview': 'JavaScript 第一步概述',
@@ -1573,8 +1591,8 @@ var text = mdn.localStringMap({
         'Debugging_HTML': 'Debugging HTML',
         'Assessment_marking_up_a_letter': 'Assessment: Marking up a letter',
         'Assessment_structuring_a_page_of_content': 'Assessment: Structuring a page of content',
-      'Multimedia_and_embedding': 'Multimedia and embedding',
-        'Multimedia_and_embedding_overview': 'Multimedia and embedding overview',
+      'Multimedia_and_Embedding': 'Multimedia and Embedding',
+        'Multimedia_and_Embedding_overview': 'Multimedia and Embedding overview',
         'Images_in_HTML': 'Images in HTML',
         'Video_and_audio_content': 'Video and audio content',
         'Other_embedding_technologies': 'From object to iframe — other embedding technologies',
@@ -1584,7 +1602,7 @@ var text = mdn.localStringMap({
       'HTML_tables' : 'HTML tables',
         'HTML_tables_overview' : 'HTML tables overview',
         'HTML_table_basics' : 'HTML table basics',
-        'HTML_table_advanced' : 'HTML Table advanced features and accessibility',
+        'HTML_table_advanced' : 'HTML table advanced features and accessibility',
         'Assessment_Structuring_planet_data' : 'Assessment: Structuring planet data',
     'CSS_styling_the_Web': 'CSS — Styling the Web',
       'CSS_first_steps': 'CSS first steps',
@@ -1593,7 +1611,7 @@ var text = mdn.localStringMap({
         'Getting_started_with_CSS': 'Getting started with CSS',
         'How_CSS_is_structured': 'How CSS is structured',
         'How_CSS_works': 'How CSS works',
-        'Using_your_new_knowledge': 'Using your new knowledge',
+        'Styling_a_biography_page': 'Assessment: Styling a biography page',
       'CSS_building_blocks': 'CSS building blocks',
         'CSS_building_blocks_overview': 'CSS building blocks overview',
         'Cascade_and_inheritance': 'Cascade and inheritance',
@@ -1602,12 +1620,15 @@ var text = mdn.localStringMap({
         'Backgrounds_and_borders': 'Backgrounds and borders',
         'Handling_different_text_directions': 'Handling different text directions',
         'Overflowing_content': 'Overflowing content',
-        'Values_and_units': 'Values and units',
+        'CSS_values_and_units': 'CSS values and units',
         'Sizing_items_in_CSS': 'Sizing items in CSS',
         'Images_media_and_form_elements': 'Images, media, and form elements',
         'Styling_tables': 'Styling tables',
         'Debugging_CSS': 'Debugging CSS',
         'Organizing_your_CSS': 'Organizing your CSS',
+        'Fundamental_CSS_comprehension': 'Assessment: Fundamental CSS comprehension',
+        'Creating_fancy_letterheaded_paper': 'Assessment: Creating fancy letterheaded paper',
+        'A_cool_looking_box': 'Assessment: A cool looking box',
       'Styling_text': 'Styling text',
         'Styling_text_overview': 'Styling text overview',
         'Fundamental_text_and_font_styling': 'Fundamental text and font styling',
@@ -1623,12 +1644,12 @@ var text = mdn.localStringMap({
         'Grids' : 'Grids',
         'Floats': 'Floats',
         'Positioning': 'Positioning',
-        'Multiple-column_Layout': 'Multiple-column Layout',
+        'Multiple-column_layout': 'Multiple-column layout',
         'Responsive_design': 'Responsive design',
         'Media_queries': 'Beginner\'s guide to media queries',
-        'Legacy_Layout_Methods': 'Legacy Layout Methods',
-        'Supporting_Older_Browsers': 'Supporting Older Browsers',
-        'Fundamental_Layout_Comprehension': 'Fundamental Layout Comprehension',
+        'Legacy_layout_methods': 'Legacy layout methods',
+        'Supporting_older_browsers': 'Supporting older browsers',
+        'Fundamental_layout_comprehension': 'Assessment: Fundamental layout comprehension',
     'JavaScript_dynamic_client-side_scripting': 'JavaScript — 動的クライアントサイドスクリプト',
       'JavaScript_first_steps': 'JavaScript の第一歩',
         'JavaScript_first_steps_overview': 'JavaScript の第一歩',
@@ -1851,16 +1872,16 @@ var text = mdn.localStringMap({
       </details>
   </li>
   <li class="toggle">
-      <details <%=currentPageIsUnder('HTML/Multimedia_and_embedding')%>>
-          <summary><%=text['Multimedia_and_embedding']%></summary>
+      <details <%=currentPageIsUnder('HTML/Multimedia_and_Embedding')%>>
+          <summary><%=text['Multimedia_and_Embedding']%></summary>
           <ol>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding"><%=text['Multimedia_and_embedding_overview']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Images_in_HTML"><%=text['Images_in_HTML']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Video_and_audio_content"><%=text['Video_and_audio_content']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Other_embedding_technologies"><%=text['Other_embedding_technologies']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web"><%=text['Adding_vector_graphics_to_the_Web']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Responsive_images"><%=text['Responsive_images']%></a></li>
-            <li><a href="<%=baseURL%>HTML/Multimedia_and_embedding/Mozilla_splash_page"><%=text['Assessment_Mozilla_splash_page']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding"><%=text['Multimedia_and_Embedding_overview']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Images_in_HTML"><%=text['Images_in_HTML']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Video_and_audio_content"><%=text['Video_and_audio_content']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Other_embedding_technologies"><%=text['Other_embedding_technologies']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Adding_vector_graphics_to_the_Web"><%=text['Adding_vector_graphics_to_the_Web']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Responsive_images"><%=text['Responsive_images']%></a></li>
+            <li><a href="<%=baseURL%>HTML/Multimedia_and_Embedding/Mozilla_splash_page"><%=text['Assessment_Mozilla_splash_page']%></a></li>
           </ol>
       </details>
   </li>
@@ -1885,7 +1906,7 @@ var text = mdn.localStringMap({
             <li><a href="<%=baseURL%>CSS/First_steps/Getting_started"><%=text['Getting_started_with_CSS']%></a></li>
             <li><a href="<%=baseURL%>CSS/First_steps/How_CSS_is_structured"><%=text['How_CSS_is_structured']%></a></li>
             <li><a href="<%=baseURL%>CSS/First_steps/How_CSS_works"><%=text['How_CSS_works']%></a></li>
-            <li><a href="<%=baseURL%>CSS/First_steps/Using_your_new_knowledge"><%=text['Using_your_new_knowledge']%></a></li>
+            <li><a href="<%=baseURL%>CSS/First_steps/Styling_a_biography_page"><%=text['Styling_a_biography_page']%></a></li>
           </ol>
       </details>
   </li>
@@ -1900,12 +1921,15 @@ var text = mdn.localStringMap({
             <li><a href="<%=baseURL%>CSS/Building_blocks/Backgrounds_and_borders"><%=text['Backgrounds_and_borders']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Handling_different_text_directions"><%=text['Handling_different_text_directions']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Overflowing_content"><%=text['Overflowing_content']%></a></li>
-            <li><a href="<%=baseURL%>CSS/Building_blocks/Values_and_units"><%=text['Values_and_units']%></a></li>
+            <li><a href="<%=baseURL%>CSS/Building_blocks/CSS_values_and_units"><%=text['CSS_values_and_units']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Sizing_items_in_CSS"><%=text['Sizing_items_in_CSS']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Images_media_form_elements"><%=text['Images_media_and_form_elements']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Styling_tables"><%=text['Styling_tables']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Debugging_CSS"><%=text['Debugging_CSS']%></a></li>
             <li><a href="<%=baseURL%>CSS/Building_blocks/Organizing"><%=text['Organizing_your_CSS']%></a></li>
+            <li><a href="<%=baseURL%>CSS/Building_blocks/Fundamental_CSS_comprehension"><%=text['Fundamental_CSS_comprehension']%></a></li>
+            <li><a href="<%=baseURL%>CSS/Building_blocks/Creating_fancy_letterheaded_paper"><%=text['Creating_fancy_letterheaded_paper']%></a></li>
+            <li><a href="<%=baseURL%>CSS/Building_blocks/A_cool_looking_box"><%=text['A_cool_looking_box']%></a></li>
       </details>
   </li>
   <li class="toggle">
@@ -1932,12 +1956,12 @@ var text = mdn.localStringMap({
             <li><a href="<%=baseURL%>CSS/CSS_layout/Grids"><%=text['Grids']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Floats"><%=text['Floats']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Positioning"><%=text['Positioning']%></a></li>
-            <li><a href="<%=baseURL%>CSS/CSS_layout/Multiple-column_Layout"><%=text['Multiple-column_Layout']%></a></li>
+            <li><a href="<%=baseURL%>CSS/CSS_layout/Multiple-column_layout"><%=text['Multiple-column_layout']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Responsive_Design"><%=text['Responsive_design']%></a></li>
             <li><a href="<%=baseURL%>CSS/CSS_layout/Media_queries"><%=text['Media_queries']%></a></li>
-            <li><a href="<%=baseURL%>CSS/CSS_layout/Legacy_Layout_Methods"><%=text['Legacy_Layout_Methods']%></a></li>
-            <li><a href="<%=baseURL%>CSS/CSS_layout/Supporting_Older_Browsers"><%=text['Supporting_Older_Browsers']%></a></li>
-            <li><a href="<%=baseURL%>CSS/CSS_layout/Fundamental_Layout_Comprehension"><%=text['Fundamental_Layout_Comprehension']%></a></li>
+            <li><a href="<%=baseURL%>CSS/CSS_layout/Legacy_layout_methods"><%=text['Legacy_layout_methods']%></a></li>
+            <li><a href="<%=baseURL%>CSS/CSS_layout/Supporting_older_browsers"><%=text['Supporting_older_browsers']%></a></li>
+            <li><a href="<%=baseURL%>CSS/CSS_layout/Fundamental_layout_comprehension"><%=text['Fundamental_layout_comprehension']%></a></li>
           </ol>
       </details>
   </li>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes Issue #5164 and adjusts some minor "typos" (mainly upper and lower case letters)

### Problem

- For the [CSS building blocks module](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks) the assessments are missing in the sidebar.
  - When I was learning, I assumed this module had no assessments because I always paid attention to the sidebar - so I almost overlooked them
- In the [CSS layout module](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout) "Assessment: " is missing before the assessment title in the sidebar.
  - I think that you can easily distinguish the asssessments from "normal" articles - for the other modules it is also like that
- In the [CSS first steps module](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps) the assessment got a new title (see this [pr in mdn/content](https://github.com/mdn/content/pull/13781))
- Sometimes the capitalization was different from the article titles themselves
  - to keep it consistent

### Solution

- Updated the HTML template by adding the missing assessments
  - in the `text` dictionary I've also added the matching string identifiers
  - because I didn't know exactly how you deal with translations, I left them all on the English translation.
- Added "Assessment: " before the assessment title
  - where a translation was present, I also adapted it by comparing and copying previous translations of the particular language for "Assessment"
- Adaptet the string identifier and translation for the new assessment title
- Adaptet the capitalization to fit the article titles
  - for these translations I used Deepl Translate and compared it with the current translation
  - for Latin languages it was just the one letter of course which was lower or uppercase
  - for Chinese (traditional) for example, 1 character was different - I assume that this character has the same meaning but is only capitalized for example - but as I say, I do not know how you handle the translations

---

## How did you test this change?

Because I'm relatively new to all of this, I didn't know exactly how to test this. Maybe someone can explain this to me please.
Of course I will then test the whole thing!
