### PR TITLE
fix(bcd): extract browser release date for nested features at any depth

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -407,44 +407,36 @@ function _addSingleSpecialSection($) {
       browserReleaseData.set(name, releaseData);
     }
 
-    for (const [key, compat] of Object.entries(data)) {
-      let block;
-      if (key === "__compat") {
-        block = compat;
-      } else if (compat.__compat) {
-        block = compat.__compat;
-      }
-      if (block) {
-        for (let [browser, info] of Object.entries(block.support)) {
-          // `info` here will be one of the following:
-          //  - a single simple_support_statement:
-          //    { version_added: 42 }
-          //  - an array of simple_support_statements:
-          //    [ { version_added: 42 }, { prefix: '-moz', version_added: 35 } ]
-          //
-          // Standardize the first version to an array of one, so we don't have
-          // to deal with two different forms below
-          if (!Array.isArray(info)) {
-            info = [info];
-          }
-          for (const infoEntry of info) {
-            const added =
-              typeof infoEntry.version_added === "string" &&
-              infoEntry.version_added.startsWith("≤")
-                ? infoEntry.version_added.slice(1)
-                : infoEntry.version_added;
-            if (browserReleaseData.has(browser)) {
-              if (browserReleaseData.get(browser).has(added)) {
-                infoEntry.release_date = browserReleaseData
-                  .get(browser)
-                  .get(added).release_date;
-              }
+    for (const block of _extractCompatBlocks(data)) {
+      for (let [browser, info] of Object.entries(block.support)) {
+        // `info` here will be one of the following:
+        //  - a single simple_support_statement:
+        //    { version_added: 42 }
+        //  - an array of simple_support_statements:
+        //    [ { version_added: 42 }, { prefix: '-moz', version_added: 35 } ]
+        //
+        // Standardize the first version to an array of one, so we don't have
+        // to deal with two different forms below
+        if (!Array.isArray(info)) {
+          info = [info];
+        }
+        for (const infoEntry of info) {
+          const added =
+            typeof infoEntry.version_added === "string" &&
+            infoEntry.version_added.startsWith("≤")
+              ? infoEntry.version_added.slice(1)
+              : infoEntry.version_added;
+          if (browserReleaseData.has(browser)) {
+            if (browserReleaseData.get(browser).has(added)) {
+              infoEntry.release_date = browserReleaseData
+                .get(browser)
+                .get(added).release_date;
             }
           }
-          info.sort((a, b) =>
-            _compareVersions(_getFirstVersion(b), _getFirstVersion(a))
-          );
         }
+        info.sort((a, b) =>
+          _compareVersions(_getFirstVersion(b), _getFirstVersion(a))
+        );
       }
     }
 
@@ -515,6 +507,25 @@ function _addSingleSpecialSection($) {
     }
 
     return version.split(".").map(Number);
+  }
+
+  /**
+   * Recursively extracts `__compat` objects from the `feature` and from all
+   * nested features at any depth.
+   *
+   * @param {Object} feature The feature.
+   * @returns {Object[]} The array of `__compat` objects.
+   */
+  function _extractCompatBlocks(feature) {
+    const blocks = [];
+    for (const [key, value] of Object.entries(feature)) {
+      if (key === "__compat") {
+        blocks.push(value);
+      } else if (typeof value === "object") {
+        blocks.push(..._extractCompatBlocks(value));
+      }
+    }
+    return blocks;
   }
 
   function _buildSpecialSpecSection() {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Fixes #5829.

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

When hovering over a browser version of a feature whose nesting level is 2 or more, the tooltip says "Toggle history" instead of the browser release date.

This was because when traversing the features, only 1 level of nesting was checked.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

The problem is solved by extracting `__compat` objects of the feature recursively using the `_extractCompatBlocks()` function.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="638" alt="before" src="https://user-images.githubusercontent.com/23465488/160254530-3e8f8731-51b2-4234-b1ac-bff045e2e595.png">

### After

<img width="638" alt="after" src="https://user-images.githubusercontent.com/23465488/160254534-459836bb-65e4-44de-85a9-545bbb375b47.png">

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

1. Opened http://localhost:3000/en-US/docs/Web/API/HTMLCanvasElement/getContext#browser_compatibility locally.
2. Hovered over Chrome browser version of the "`options.alpha` parameter" feature.
