### PR TITLE
fix:collections ~ add copy to empty state

### DIFF
--- a/client/src/plus/collections/collections-tab.tsx
+++ b/client/src/plus/collections/collections-tab.tsx
@@ -138,15 +138,17 @@ export function CollectionsTab({
       {error && <DataError error={error} />}
       <ul className="notification-list">
         <div className="icon-card-list">
-          {list.map((item) => (
-            <CollectionListItem
-              item={item}
-              onEditSubmit={collectionsSaveHandler}
-              key={item.id}
-              showEditButton={true}
-              handleDelete={deleteCollectionItem}
-            />
-          ))}
+          {list.length
+            ? list.map((item) => (
+                <CollectionListItem
+                  item={item}
+                  onEditSubmit={collectionsSaveHandler}
+                  key={item.id}
+                  showEditButton={true}
+                  handleDelete={deleteCollectionItem}
+                />
+              ))
+            : "You don't have any saved pages in your collection."}
         </div>
       </ul>
       {subscriptionLimitReached && <LimitBanner type="collections" />}

--- a/client/src/plus/collections/frequently-viewed-tab.tsx
+++ b/client/src/plus/collections/frequently-viewed-tab.tsx
@@ -46,15 +46,17 @@ export function FrequentlyViewedTab({ selectedTerms }) {
       <SearchFilter filters={[]} sorts={SORTS} />
       <ul className="notification-list">
         <div className="icon-card-list">
-          {list.map((item) => (
-            <CollectionListItem
-              item={item}
-              onEditSubmit={() => null}
-              key={item.id}
-              showEditButton={false}
-              handleDelete={deleteFrequentlyViewed}
-            />
-          ))}
+          {list.length
+            ? list.map((item) => (
+                <CollectionListItem
+                  item={item}
+                  onEditSubmit={() => null}
+                  key={item.id}
+                  showEditButton={false}
+                  handleDelete={deleteFrequentlyViewed}
+                />
+              ))
+            : "There are no items in your frequently viewed articles collection."}
         </div>
       </ul>
     </>


### PR DESCRIPTION
Adds copy to empty states for both curated collections and frequestly viewed pages.

Fix: https://github.com/mdn/foxfooding-mdn-plus/issues/88
