### PR TITLE
minor fixes

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -161,7 +161,7 @@ function postLocalFileLinks($, doc) {
     // links, so it's presumed to be worth it.
     if (
       !href ||
-      /^(\/|\.\.|http|#|mailto:|about:|ftp:|news:|irc:|ftp:)/i.test(href)
+      /^(\/|\.\.|http|#|mailto:|about:|ftp:|news:|irc:)/i.test(href)
     ) {
       return;
     }

--- a/content/image.js
+++ b/content/image.js
@@ -49,7 +49,7 @@ function findByURLWithFallback(url) {
   let filePath = findByURL(url);
   const urlParts = url.split("/");
   const locale = urlParts[1].toLowerCase();
-  if (!filePath && locale !== DEFAULT_LOCALE) {
+  if (!filePath && locale !== DEFAULT_LOCALE.toLowerCase()) {
     urlParts[1] = DEFAULT_LOCALE;
     const defaultLocaleURL = urlParts.join("/");
     filePath = findByURL(defaultLocaleURL);


### PR DESCRIPTION
## Summary

- remove duplicate `ftp:` in regexp
- fix: compare with locale in lowercase

### Problem

- `build/index.js`: duplicate `ftp:` in regexp
- `content/image.js`: DEFAULT_LOCALE ( `en-US` ) will not equal to `en-us`
