### PR TITLE
fix: Dark mode weird white spot with both scrollbars visible

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -187,6 +187,10 @@ u {
   background: var(--scrollbar-color);
 }
 
+*::-webkit-scrollbar-corner {
+  background-color: var(--scrollbar-bg, auto);
+}
+
 .plus .dark,
 .plus {
   --text-link: var(--plus-accent-color);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes #5666 

### Problem

In dark mode there is a white spot when both scrollbars are visible.

### Solution

Add following CSS rule to set the scrollbar corner background color to current theme color:
```CSS
*::-webkit-scrollbar-corner {
  background-color: var(--scrollbar-bg, auto);
}
```

## Screenshots

### Before

![before](https://camo.githubusercontent.com/56a0f7869aea77006a681edd7015cd66803ac9145621e9ce9c9886b3fd7a3ae2/68747470733a2f2f692e696d6775722e636f6d2f6b3743676f715a2e706e67)

### After

Dark mode:
![afterdark](https://i.imgur.com/G50W8jg.png)

Light mode:
![afterlight](https://i.imgur.com/PvdMfjg.png)


## How did you test this change?

In Chrome Version 99.0.4844.82 (Official Build) (64-bit) on Windows 10