### PR TITLE
Inline notecard: reduced its size

### DIFF
--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -44,6 +44,20 @@
     content: "";
   }
 
+  &.inline {
+    padding: 0.125rem 0.375rem 0.125rem 1.5rem;
+    margin: 0.5rem;
+    font: var(--type-body-s);
+  }
+
+  &.inline::before {
+    top: 3px;
+    left: 0.2rem;
+    display: block;
+    width: 0.8rem;
+    height: 0.8rem;
+  }
+
   &.warning {
     --note-background: var(--background-warning);
     --note-theme: var(--icon-warning);

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -51,7 +51,7 @@
   }
 
   &.inline::before {
-    top: 3px;
+    top: 0.1875rem;
     left: 0.2rem;
     display: block;
     width: 0.8rem;


### PR DESCRIPTION
## Summary

Inline notecard is very big in size. 

### Problem

Inline notecard needs to be of same size as other badges.

### Solution

Utilize unused class `.notecard.inline` to reduce the size:
```css
  &.inline {
    padding: 0.125rem 0.375rem 0.125rem 1.5rem;
    margin: 0.5rem;
    font: var(--type-body-s);
  }

  &.inline::before {
    top: 0.1875rem;
    left: 0.2rem;
    display: block;
    width: 0.8rem;
    height: 0.8rem;
  }
```

## Screenshots

### Before

![before](https://i.imgur.com/pIZXAHw.png)

### After

![after](https://i.imgur.com/xRBPh0V.png)

![afterwhite](https://i.imgur.com/gq2gCvT.png)


## How did you test this change?

In Chrome on Windows 10.