### PR TITLE
Make Plus links refer to "Choose a plan" section when on product page

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -5,6 +5,7 @@ import { useGA } from "../ga-context";
 import { useUserData } from "../user-context";
 import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
 import { isPlusAvailable } from "../utils";
+import { usePlusUrl } from "../plus/utils";
 
 // The <Banner> component displays a simple call-to-action banner at
 // the bottom of the window. The following props allow it to be customized.
@@ -78,10 +79,12 @@ function PlusLaunchAnnouncementBanner({
 }: {
   onDismissed: () => void;
 }) {
+  const plusUrl = usePlusUrl();
+
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
-        <a href="/en-US/plus/" className="mdn-plus">
+        <a href={plusUrl} className="mdn-plus">
           MDN Plus
         </a>{" "}
         is here! Support MDN <em>and</em> make it your own.{" "}

--- a/client/src/plus/utils.ts
+++ b/client/src/plus/utils.ts
@@ -1,0 +1,23 @@
+import { useLocation } from "react-router-dom";
+import { useLocale } from "../hooks";
+
+/**
+ * Returns the URL of the Plus product page, or, if we're
+ * already there, the hash of the "Choose a plan" section.
+ */
+export function usePlusUrl(): string {
+  const { pathname } = useLocation();
+  const locale = useLocale();
+
+  function normalizedUrl(url: string): string {
+    return url.replace(/\/$/, "").toLowerCase();
+  }
+
+  let target = `/${locale}/plus/`;
+
+  if (normalizedUrl(target) === normalizedUrl(pathname)) {
+    target = "#subscribe";
+  }
+
+  return target;
+}

--- a/client/src/plus/utils.ts
+++ b/client/src/plus/utils.ts
@@ -13,7 +13,7 @@ export function usePlusUrl(): string {
     return url.replace(/\/$/, "").toLowerCase();
   }
 
-  let target = `/${locale}/plus/`;
+  let target = `/${locale}/plus`;
 
   if (normalizedUrl(target) === normalizedUrl(pathname)) {
     target = "#subscribe";

--- a/client/src/ui/atoms/button/index.tsx
+++ b/client/src/ui/atoms/button/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 import { Icon } from "../icon";
+import InternalLink from "../internal-link";
 
 import "./index.scss";
 
@@ -85,7 +85,7 @@ export const Button = ({
 
   if (href) {
     return (
-      <Link
+      <InternalLink
         to={href}
         rel={rel}
         className={buttonClasses}
@@ -96,7 +96,7 @@ export const Button = ({
         title={title}
       >
         <span className="button-wrap">{renderContent()}</span>
-      </Link>
+      </InternalLink>
     );
   }
   return (

--- a/client/src/ui/atoms/internal-link/index.tsx
+++ b/client/src/ui/atoms/internal-link/index.tsx
@@ -1,0 +1,18 @@
+import { Link, LinkProps } from "react-router-dom";
+
+/**
+ * Returns a Link, or an anchor, if it targets a hash.
+ */
+export default function InternalLink(props: LinkProps) {
+  const href = props.to;
+
+  if (typeof href === "string" && href.includes("#")) {
+    return (
+      <a href={href} {...props}>
+        {props.children}
+      </a>
+    );
+  }
+
+  return <Link {...props}>{props.children}</Link>;
+}

--- a/client/src/ui/atoms/subscribe-link/index.tsx
+++ b/client/src/ui/atoms/subscribe-link/index.tsx
@@ -1,7 +1,6 @@
-import { useLocale } from "../../../hooks";
-
 import "./index.scss";
 import { Button } from "../button";
+import { usePlusUrl } from "../../../plus/utils";
 
 /**
  *
@@ -9,11 +8,10 @@ import { Button } from "../button";
  * @returns {JSX.Element} - The anchor link with the appropriate URL
  */
 export const SubscribeLink = () => {
-  const locale = useLocale();
-  const endPoint = `/${locale}/plus`;
+  const href = usePlusUrl();
 
   return (
-    <Button href={endPoint} extraClasses="mdn-plus-subscribe-link">
+    <Button href={href} extraClasses="mdn-plus-subscribe-link">
       Get MDN Plus
     </Button>
   );

--- a/client/src/ui/molecules/guides-menu/index.tsx
+++ b/client/src/ui/molecules/guides-menu/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 
 import { useLocale } from "../../../hooks";
+import InternalLink from "../../atoms/internal-link";
 import { Submenu } from "../submenu";
 
 import "./index.scss";
@@ -79,14 +79,14 @@ export const GuidesMenu = ({ visibleSubMenuId, toggleMenu }) => {
         {menu.label}
       </button>
 
-      <Link
+      <InternalLink
         to={`/${locale}/docs/Learn`}
         className="top-level-entry"
         // @ts-ignore
         onClick={() => document?.activeElement?.blur()}
       >
         Guides
-      </Link>
+      </InternalLink>
 
       <Submenu menuEntry={menu} defaultHidden={!isOpen} />
     </li>

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -7,10 +7,13 @@ import { Link } from "react-router-dom";
 import { Submenu } from "../submenu";
 
 import "./index.scss";
+import { usePlusUrl } from "../../../plus/utils";
 
 export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
   const locale = useLocale();
   const userData = useUserData();
+
+  const plusUrl = usePlusUrl();
 
   const isAuthenticated = userData && userData.isAuthenticated;
 
@@ -24,7 +27,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         extraClasses: "mobile-only",
         iconClasses: "submenu-icon",
         label: "Overview",
-        url: `/${locale}/plus`,
+        url: plusUrl,
       },
       ...(isAuthenticated
         ? [
@@ -69,7 +72,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         {plusMenu.label}
       </button>
 
-      <Link to={`/${locale}/plus/`} className="top-level-entry">
+      <Link to={plusUrl} className="top-level-entry">
         {plusMenu.label}
       </Link>
 

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -3,11 +3,11 @@ import * as React from "react";
 import { useUserData } from "../../../user-context";
 import { useLocale } from "../../../hooks";
 
-import { Link } from "react-router-dom";
 import { Submenu } from "../submenu";
 
 import "./index.scss";
 import { usePlusUrl } from "../../../plus/utils";
+import InternalLink from "../../atoms/internal-link";
 
 export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
   const locale = useLocale();
@@ -72,9 +72,9 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         {plusMenu.label}
       </button>
 
-      <Link to={plusUrl} className="top-level-entry">
+      <InternalLink to={plusUrl} className="top-level-entry">
         {plusMenu.label}
-      </Link>
+      </InternalLink>
 
       <Submenu menuEntry={plusMenu} defaultHidden={!isOpen} />
     </li>

--- a/client/src/ui/molecules/reference-menu/index.tsx
+++ b/client/src/ui/molecules/reference-menu/index.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { Link } from "react-router-dom";
 
 import { useLocale } from "../../../hooks";
+import InternalLink from "../../atoms/internal-link";
 import { Submenu } from "../submenu";
 
 import "./index.scss";
@@ -88,14 +88,14 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
         {menu.label}
       </button>
 
-      <Link
+      <InternalLink
         to={`/${locale}/docs/Web`}
         className="top-level-entry"
         // @ts-ignore
         onClick={() => document?.activeElement?.blur()}
       >
         {menu.label}
-      </Link>
+      </InternalLink>
 
       <Submenu menuEntry={menu} defaultHidden={!isOpen} />
     </li>


### PR DESCRIPTION
## Summary

Fixes #5820.

This PR is based on #5823, which I reverted on Friday, because it didn't resolve the issue on staging, even though it worked locally.

### Problem

1. "MDN Plus" in the banner looks like a link, but doesn't actually link to the MDN Plus product page.
2. "Get MDN Plus" doesn't have any effect on the MDN Plus product page.
3. "MDN Plus" in the Plus menu doesn't have any effect on the MDN Plus product page.
4. The `Link` component cannot be used to refer to a specific section of a page using a hash.

### Solution

- (1.) Convert "MDN Plus" in the banner into a link.
- (2./3.) Make "Get MDN Plus" (and "MDN Plus") link to the Plans section, if we're on the product page.
- (4.) Add an `InternalLink` component that returns a `Link` or an `a`nchor, depending on whether the link target contains a hash or not, and use that component in the `Button` component (used for the "Get MDN Plus" button) and in the menus.

---

## How did you test this change?

1. Open http://localhost:3000/en-US/ locally.
2. Make sure that both "MDN Plus" (in the banner) and "Get MDN Plus" (in the toolbar) link to the (top of the) MDN Plus product page.
5. Follow one of the links.
6. Make sure that both link to the plans section (`#subscribe`) now.