### PR TITLE
fix(plus-menu): make overview public

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -18,16 +18,16 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
     label: "MDN Plus",
     id: "mdn-plus",
     items: [
+      {
+        description: "More MDN. Your MDN.",
+        hasIcon: true,
+        extraClasses: "mobile-only",
+        iconClasses: "submenu-icon",
+        label: "Overview",
+        url: `/${locale}/plus`,
+      },
       ...(isAuthenticated
         ? [
-            {
-              description: "More MDN. Your MDN.",
-              hasIcon: true,
-              extraClasses: "mobile-only",
-              iconClasses: "submenu-icon",
-              label: "Overview",
-              url: `/${locale}/plus`,
-            },
             {
               description: "Your saved articles from across MDN",
               hasIcon: true,


### PR DESCRIPTION
# Summary

Extracted from partially reverted #5823.

### Problem

The "Overview" item in the Plus menu, which is only visible on mobile, was only shown to subscribers.

### Solution

Moved the item out of the `isAuthenticated` section.

---

## Screenshots

### Before

<img width="412" alt="image" src="https://user-images.githubusercontent.com/495429/160639956-085b35bd-b398-406b-b558-27aa23728f7d.png">

### After

<img width="412" alt="image" src="https://user-images.githubusercontent.com/495429/160639890-d8788a40-0a9a-4520-bbb5-4705d3e04272.png">


---

## How did you test this change?

1. Opened MDN locally and logged out.
2. Used Responsive Design Mode to verify how it looks.