### PR TITLE
Indicate subfeatures in compatibility table through indenting

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -531,8 +531,6 @@ export const FeatureRow = React.memo(
     ) : (
       <code>{name}</code>
     );
-    const path = name.split(".");
-    const depth = path.length;
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
     let titleNode: string | React.ReactNode;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -531,6 +531,7 @@ export const FeatureRow = React.memo(
     ) : (
       <code>{name}</code>
     );
+    const borderleftwidth = `calc(8 * ${(name.match(/\./g) || []).length}px)`;
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
     let titleNode: string | React.ReactNode;
@@ -563,7 +564,11 @@ export const FeatureRow = React.memo(
     return (
       <>
         <tr>
-          <th className="bc-feature" scope="row">
+          <th
+            className="bc-feature"
+            style={{ borderLeftWidth: borderleftwidth }}
+            scope="row"
+          >
             {titleNode}
           </th>
           {browsers.map((browser, i) => (

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -531,7 +531,8 @@ export const FeatureRow = React.memo(
     ) : (
       <code>{name}</code>
     );
-    const borderleftwidth = `calc(8 * ${(name.match(/\./g) || []).length}px)`;
+    const path = name.split(".");
+    const depth = path.length;
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
     let titleNode: string | React.ReactNode;
@@ -564,11 +565,7 @@ export const FeatureRow = React.memo(
     return (
       <>
         <tr>
-          <th
-            className="bc-feature"
-            style={{ borderLeftWidth: borderleftwidth }}
-            scope="row"
-          >
+          <th className={`bc-feature bc-feature-depth-${depth}`} scope="row">
             {titleNode}
           </th>
           {browsers.map((browser, i) => (

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -91,6 +91,13 @@
       display: block;
     }
   }
+  .bc-feature-depth-2 {
+    border-left-width: 8px;
+  }
+
+  .bc-feature-depth-3 {
+    border-left-width: 16px;
+  }
 }
 
 .bc-head-txt-label {

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -94,10 +94,6 @@
   .bc-feature-depth-2 {
     border-left-width: 8px;
   }
-
-  .bc-feature-depth-3 {
-    border-left-width: 16px;
-  }
 }
 
 .bc-head-txt-label {


### PR DESCRIPTION
## Summary

Fixes #5843 and fixes #3321

### Problem

There is no indication of sub-features in the browser compatibility table

### Solution

Indents sub-features in the browser compatibility table using border-left-width

---

## Screenshots

### Before

![Image before](https://user-images.githubusercontent.com/4053256/160475091-10b59aa6-6fe7-4fc7-8e87-bcbba29df87c.png)

### After

![Screenshot from 2022-03-29 12-34-25](https://user-images.githubusercontent.com/29206584/160661610-eaf40eea-6c5a-4d8b-bbfd-ece8e0b75e18.png)