### PR TITLE
fix(toc): migrate to IntersectionObserver

### DIFF
--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -2,74 +2,40 @@ import React, { useState } from "react";
 
 import "./index.scss";
 import { Toc } from "../../types";
+import { useFirstVisibleElement } from "../../hooks";
 
 export function TOC({ toc }: { toc: Toc[] }) {
   const [currentViewedTocItem, setCurrentViewedTocItem] = useState("");
 
-  React.useEffect(() => {
-    // Observe headings and siblings.
-    const main = document.querySelector("main") ?? document;
-    const targets = main.querySelectorAll("h1, h1 ~ *, h2, h2 ~ *, h3, h3 ~ *");
-
-    // Tracks if observed elements are visible (intersection with viewport).
-    const intersectionMap = new Map<Element, boolean>();
-
-    // All ids referenced by the TOC.
-    const tocIds = toc.map(({ id }) => id);
-
-    // Maps every observed element to an id referenced by the TOC.
-    const idMap = new Map<Element, string>();
-
-    /**
-     * Updates the visibility of observed elements.
-     */
-    function manageIntersectionMap(entries: IntersectionObserverEntry[]) {
-      for (const entry of entries) {
-        intersectionMap.set(entry.target, entry.isIntersecting);
-      }
-    }
-
-    /**
-     * Sets the first visible item as the currently viewed TOC item.
-     */
-    function updateViewedTocItem() {
-      const visibleIds = Array.from(intersectionMap.entries())
-        .filter(([, value]) => value)
-        .map(([key]) => key)
-        .map((target) => idMap.get(target) ?? "");
-
-      if (visibleIds.length === 0) {
-        return;
-      }
-
-      setCurrentViewedTocItem(visibleIds[0]);
-    }
-
-    const intersectionObserver = new IntersectionObserver(
-      (entries: IntersectionObserverEntry[]) => {
-        manageIntersectionMap(entries);
-        updateViewedTocItem();
-      },
-      {
-        threshold: [0.0, 1.0],
-      }
+  const observedElements = React.useCallback(() => {
+    const mainElement = document.querySelector("main") ?? document;
+    const elements = mainElement.querySelectorAll(
+      "h1, h1 ~ *, h2, h2 ~ *, h3, h3 ~ *"
     );
+    return Array.from(elements);
+  }, []);
 
-    Array.from(targets).reduce((currentId, target) => {
-      const targetId = target.id.toLowerCase();
-      if (targetId && tocIds.includes(targetId)) {
-        currentId = targetId;
+  const referencedIds = toc.map(({ id }) => id);
+  const idByObservedElement = React.useRef(new Map<Element, string>());
+
+  React.useEffect(() => {
+    observedElements().reduce((currentId, observedElement) => {
+      const observedId = observedElement.id.toLowerCase();
+      if (observedId && referencedIds.includes(observedId)) {
+        currentId = observedId;
       }
-      idMap.set(target, currentId);
-
-      intersectionMap.set(target, false);
-      intersectionObserver.observe(target);
+      idByObservedElement.current.set(observedElement, currentId);
 
       return currentId;
     }, "");
+  }, [observedElements, referencedIds]);
 
-    return () => intersectionObserver.disconnect();
-  }, [toc]);
+  useFirstVisibleElement(observedElements, (element: Element | null) => {
+    const id = element ? idByObservedElement.current.get(element) ?? "" : "";
+    if (id !== currentViewedTocItem) {
+      setCurrentViewedTocItem(id);
+    }
+  });
 
   return (
     <aside className="document-toc-container">


### PR DESCRIPTION


## Summary

This makes the "In this article" table of contents (TOC) more reliable.

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/63.

### Problem

Previously, we determined the currently viewed section
"In this article" by listening to the scroll event.

### Solution

Now, we use an [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) to get notified when relevant sections move in/out of the viewport.

---

## Screenshots

### Before

https://user-images.githubusercontent.com/495429/160675734-fb89d918-d392-4c5c-9664-d76aeb401ad2.mov

### After

https://user-images.githubusercontent.com/495429/161737619-3e99bc58-12a5-40b0-a592-30aad4062e01.mov

---

## How did you test this change?

Tested scrolling locally on these pages:

- http://localhost:3000/en-US/plus/docs/faq
- http://localhost:3000/en-US/docs/Web/API/IntersectionObserver
