### PR TITLE
Trigger content notifications from our builds

### DIFF
--- a/content/notify.ts
+++ b/content/notify.ts
@@ -12,7 +12,7 @@ require("dotenv").config();
 
 const { CONTENT_ROOT } = process.env;
 
-const DATE_RANGE_REGEXP = /^(\d{4}-\d{2}-\d{2})+\.\.(\d{4}-\d{2}-\d{2}|\*)$/;
+const DATE_RANGE_REGEXP = /^(\d{4}-\d{2}-\d{2})(\.\.(\d{4}-\d{2}-\d{2}|\*))?$/;
 const FORCE_NOTIFICATION_LABEL = "force-notifications";
 
 function main() {
@@ -20,7 +20,7 @@ function main() {
 
   if (!DATE_RANGE_REGEXP.test(merged)) {
     console.error(
-      "Please specify merged date as a range: YYYY-MM-DD..YYYY-MM-DD | YYYY-MM-DD..*"
+      "Please specify merged date in this format: YYYY-MM-DD | YYYY-MM-DD..YYYY-MM-DD | YYYY-MM-DD..*"
     );
     process.exit(1);
   }

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -15,13 +15,23 @@ function main() {
   processPR(id);
 }
 
+interface PullRequest {
+  files: ChangedFile[];
+}
+
+interface ChangedFile {
+  path: string;
+  additions: number;
+  deletions: number;
+}
+
 function processPR(id: number) {
   const ghJSON = JSON.parse(
     child_process.execSync(`gh pr view ${id} --json files`, {
       cwd: CONTENT_ROOT,
       encoding: "utf-8",
     })
-  );
+  ) as PullRequest;
 
   for (const file of ghJSON.files) {
     let notify = false;
@@ -40,11 +50,11 @@ function processPR(id: number) {
   }
 }
 
-function netDiffSize(file) {
+function netDiffSize(file: ChangedFile) {
   return file.additions - file.deletions;
 }
 
-function getSlug(path) {
+function getSlug(path: string) {
   const cmd = `yq --front-matter=extract '.slug' ${path}`;
   return child_process.execSync(cmd, {
     cwd: CONTENT_ROOT,

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -77,7 +77,7 @@ function processPR(pr: PullRequest) {
     file.path.endsWith("index.md")
   );
 
-  if (!force && markdownFiles.length > 5) {
+  if (!force && markdownFiles.length >= 6) {
     // If a merged PR modifies six or more Markdown files,
     // then no notifications should be issued for that PR
     // (to avoid issuing notifications for bulk edits).

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -4,11 +4,12 @@
 // Requires `yq` CLI
 // Known issues: it doesn't ignore completely new slugs
 
-const child_process = require("child_process");
-const frontmatter = require("front-matter");
-const fs = require("fs");
+import * as child_process from "child_process";
+import frontmatter from "front-matter";
+import * as fs from "fs";
+import { config as dotenvConfig } from "dotenv";
 
-require("dotenv").config();
+dotenvConfig();
 
 const { CONTENT_ROOT } = process.env;
 
@@ -48,6 +49,9 @@ interface ChangedFile {
   path: string;
   additions: number;
   deletions: number;
+}
+interface PageFrontmatter {
+  slug: string;
 }
 
 function processMergedPRs(merged: string) {
@@ -107,7 +111,7 @@ function getSlug(path: string) {
 
   const markdown = fs.readFileSync(`${CONTENT_ROOT}/${path}`, "utf8");
 
-  const frontMatter = frontmatter(markdown);
+  const frontMatter = frontmatter<PageFrontmatter>(markdown);
 
   return frontMatter.attributes.slug;
 }

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -11,9 +11,13 @@ require("dotenv").config();
 const { CONTENT_ROOT } = process.env;
 
 function main() {
-  const arg = process.argv[2];
+  const id = Number(process.argv[2]);
+  processPR(id);
+}
+
+function processPR(id: number) {
   const ghJSON = JSON.parse(
-    child_process.execSync(`gh pr view ${arg} --json files`, {
+    child_process.execSync(`gh pr view ${id} --json files`, {
       cwd: CONTENT_ROOT,
       encoding: "utf-8",
     })
@@ -29,7 +33,7 @@ function main() {
 
       if (notify === true) {
         const slug = getSlug(file.path);
-        console.log(`${arg}\t${slug}`);
+        console.log(`${id}\t${slug}`);
         // TODO: post to notifications API endpoint
       }
     }

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -1,0 +1,45 @@
+// Runs from the root of the mdn/content checkout
+// Requires `gh` CLI
+// Requires `jq` CLI
+// Requires `yq` CLI
+// Known issues: it doesn't ignore completely new slugs
+
+const child_process = require("child_process");
+
+function main() {
+  const arg = process.argv[2];
+  const ghJSON = JSON.parse(
+    child_process.execSync(`gh pr view ${arg} --json files`, {
+      encoding: "utf-8",
+    })
+  );
+
+  for (const file of ghJSON.files) {
+    let notify = false;
+    if (file.path.endsWith("index.md")) {
+      const net = netDiffSize(file);
+      if (!(net < 5)) {
+        notify = true;
+      }
+
+      if (notify === true) {
+        const slug = getSlug(file.path);
+        console.log(`${arg}\t${slug}`);
+        // TODO: post to notifications API endpoint
+      }
+    }
+  }
+}
+
+function netDiffSize(file) {
+  return file.additions - file.deletions;
+}
+
+function getSlug(path) {
+  const cmd = `yq --front-matter=extract '.slug' ${path}`;
+  return child_process.execSync(cmd, {
+    encoding: "utf-8",
+  });
+}
+
+main();

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -13,6 +13,7 @@ require("dotenv").config();
 const { CONTENT_ROOT } = process.env;
 
 const DATE_RANGE_REGEXP = /^(\d{4}-\d{2}-\d{2})+\.\.(\d{4}-\d{2}-\d{2}|\*)$/;
+const FORCE_NOTIFICATION_LABEL = "force-notifications";
 
 function main() {
   const merged = process.argv[2];
@@ -33,6 +34,14 @@ interface PullRequest {
   title: string;
   url: string;
   files: ChangedFile[];
+  labels: Label[];
+}
+
+interface Label {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
 }
 
 interface ChangedFile {
@@ -44,7 +53,7 @@ interface ChangedFile {
 function processMergedPRs(merged: string) {
   const search = ["is:merged", `merged:${merged}`];
 
-  const fields = ["id", "number", "url", "title", "files"];
+  const fields = ["id", "number", "url", "labels", "title", "files"];
 
   const prs = JSON.parse(
     child_process.execSync(
@@ -60,21 +69,32 @@ function processMergedPRs(merged: string) {
 }
 
 function processPR(pr: PullRequest) {
-  for (const file of pr.files) {
-    let notify = false;
-    if (file.path.endsWith("index.md")) {
-      const net = netDiffSize(file);
+  // A PR labeled force-notifications must trigger a notification
+  // issued for every slug modified by the PR.
+  const force = pr.labels.some(({ name }) => name === FORCE_NOTIFICATION_LABEL);
 
-      if (!(net < 5)) {
-        notify = true;
-      }
+  const markdownFiles = pr.files.filter((file) =>
+    file.path.endsWith("index.md")
+  );
 
-      if (notify === true) {
-        const slug = getSlug(file.path);
-        console.log(`${pr.number}\t${slug}`);
-        // TODO: post to notifications API endpoint
-      }
+  if (!force && markdownFiles.length > 5) {
+    // If a merged PR modifies six or more Markdown files,
+    // then no notifications should be issued for that PR
+    // (to avoid issuing notifications for bulk edits).
+    return;
+  }
+
+  for (const file of markdownFiles) {
+    if (!force && netDiffSize(file) < 5) {
+      // If the net diff size for a Markdown file is less than 5,
+      // then no notifications should be issued for the affected
+      // slug (to avoid issuing notifications for minor edits).
+      continue;
     }
+
+    const slug = getSlug(file.path);
+    console.log(`${pr.number}\t${slug}`);
+    // TODO: post to notifications API endpoint
   }
 }
 

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -6,10 +6,15 @@
 
 const child_process = require("child_process");
 
+require("dotenv").config();
+
+const { CONTENT_ROOT } = process.env;
+
 function main() {
   const arg = process.argv[2];
   const ghJSON = JSON.parse(
     child_process.execSync(`gh pr view ${arg} --json files`, {
+      cwd: CONTENT_ROOT,
       encoding: "utf-8",
     })
   );
@@ -38,6 +43,7 @@ function netDiffSize(file) {
 function getSlug(path) {
   const cmd = `yq --front-matter=extract '.slug' ${path}`;
   return child_process.execSync(cmd, {
+    cwd: CONTENT_ROOT,
     encoding: "utf-8",
   });
 }

--- a/content/notify.ts
+++ b/content/notify.ts
@@ -5,17 +5,33 @@
 // Known issues: it doesn't ignore completely new slugs
 
 const child_process = require("child_process");
+const frontmatter = require("front-matter");
+const fs = require("fs");
 
 require("dotenv").config();
 
 const { CONTENT_ROOT } = process.env;
 
+const DATE_RANGE_REGEXP = /^(\d{4}-\d{2}-\d{2})+\.\.(\d{4}-\d{2}-\d{2}|\*)$/;
+
 function main() {
-  const id = Number(process.argv[2]);
-  processPR(id);
+  const merged = process.argv[2];
+
+  if (!DATE_RANGE_REGEXP.test(merged)) {
+    console.error(
+      "Please specify merged date as a range: YYYY-MM-DD..YYYY-MM-DD | YYYY-MM-DD..*"
+    );
+    process.exit(1);
+  }
+
+  processMergedPRs(merged);
 }
 
 interface PullRequest {
+  id: string;
+  number: number;
+  title: string;
+  url: string;
   files: ChangedFile[];
 }
 
@@ -25,25 +41,37 @@ interface ChangedFile {
   deletions: number;
 }
 
-function processPR(id: number) {
-  const ghJSON = JSON.parse(
-    child_process.execSync(`gh pr view ${id} --json files`, {
-      cwd: CONTENT_ROOT,
-      encoding: "utf-8",
-    })
-  ) as PullRequest;
+function processMergedPRs(merged: string) {
+  const search = ["is:merged", `merged:${merged}`];
 
-  for (const file of ghJSON.files) {
+  const fields = ["id", "number", "url", "title", "files"];
+
+  const prs = JSON.parse(
+    child_process.execSync(
+      `gh pr list --search '${search.join(" ")}' --json ${fields.join(",")}`,
+      {
+        cwd: CONTENT_ROOT,
+        encoding: "utf-8",
+      }
+    )
+  ) as PullRequest[];
+
+  prs.forEach((pr) => processPR(pr));
+}
+
+function processPR(pr: PullRequest) {
+  for (const file of pr.files) {
     let notify = false;
     if (file.path.endsWith("index.md")) {
       const net = netDiffSize(file);
+
       if (!(net < 5)) {
         notify = true;
       }
 
       if (notify === true) {
         const slug = getSlug(file.path);
-        console.log(`${id}\t${slug}`);
+        console.log(`${pr.number}\t${slug}`);
         // TODO: post to notifications API endpoint
       }
     }
@@ -55,11 +83,13 @@ function netDiffSize(file: ChangedFile) {
 }
 
 function getSlug(path: string) {
-  const cmd = `yq --front-matter=extract '.slug' ${path}`;
-  return child_process.execSync(cmd, {
-    cwd: CONTENT_ROOT,
-    encoding: "utf-8",
-  });
+  path = path.substring("files/".length);
+
+  const markdown = fs.readFileSync(`${CONTENT_ROOT}/${path}`, "utf8");
+
+  const frontMatter = frontmatter(markdown);
+
+  return frontMatter.attributes.slug;
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build:ssr": "cd ssr && webpack --mode=production",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
+    "content-notify": "ts-node content/notify.ts",
     "dev": "yarn prepare-build && nf -j Procfile.dev start",
     "eslint": "eslint .",
     "filecheck": "cd filecheck && node cli.js",


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari-private/issues/981.

### Problems

1. Content update notifications are currently triggered manually.
2. Content updates don't appear directly after a build, but only after the cache expires (1h) or is invalidated manually.

### Solutions

- [x] Add a tool to determine content PRs and pages that require notifications
- [x] Have the tool ~~post the notifications to kuma~~ create a `changes.json` file for kuma
- [ ] Run the tool as part of the build process (stage-build, prod-build)
- [ ] Make sure relevant changes always trigger a notification, but only once (remember last date AND/OR defer notifications for 1h AND/OR have kuma accept a unique key alongside incoming notifications to prevent duplicates)

---

## Screenshots

_No changes._

---

## How did you test this change?

- Ran `yarn content-notify '2022-03-29..*'` locally