### PR TITLE
fix: obey React rules of hooks in active banner

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -81,7 +81,7 @@ function PlusLaunchAnnouncementBanner({
 }: {
   onDismissed: () => void;
 }) {
-  const sendCTAEventToGA = useSendCTAEventToGA()
+  const sendCTAEventToGA = useSendCTAEventToGA();
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -63,14 +63,17 @@ function Banner(props: BannerProps) {
   );
 }
 
-function SendCTAEventToGA(eventCategory: string) {
+function useSendCTAEventToGA() {
   const ga = useGA();
-  ga("send", {
-    hitType: "event",
-    eventCategory: eventCategory,
-    eventAction: "CTA clicked",
-    eventLabel: "banner",
-  });
+
+  return (eventCategory: string) => {
+    ga("send", {
+      hitType: "event",
+      eventCategory: eventCategory,
+      eventAction: "CTA clicked",
+      eventLabel: "banner",
+    });
+  };
 }
 
 function PlusLaunchAnnouncementBanner({
@@ -78,6 +81,7 @@ function PlusLaunchAnnouncementBanner({
 }: {
   onDismissed: () => void;
 }) {
+  const sendCTAEventToGA = useSendCTAEventToGA()
   return (
     <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
       <p className="mdn-cta-copy">
@@ -89,7 +93,7 @@ function PlusLaunchAnnouncementBanner({
           href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => SendCTAEventToGA(PLUS_LAUNCH_ANNOUNCEMENT)}
+          onClick={() => sendCTAEventToGA(PLUS_LAUNCH_ANNOUNCEMENT)}
         >
           Learn more
         </a>{" "}


### PR DESCRIPTION
## Summary

Fixes #5866.

### Problem

Hooks must be called only within components or other hooks.

### Solution

Turns `SendCTAEventToGA` into a `useSendCTAEventToGA` hook.

## How did you test this change?

See repro steps in the issue. I <kbd>Ctrl</kbd>+clicked the _Learn more_ link and the MDN tab did not have a console complaint from React.

Sending this as a quick fix for #5866 even though the issue isn't marked as accepted. No worries if you don't want it; I just thought it'd be fun to get started on the repo & make it a quicker fix if you do accept the issue!