### PR TITLE
fix(csp): add *.gravatar.com to img-src

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -123,6 +123,7 @@ const CSP_DIRECTIVES = {
     // Avatars
     "*.githubusercontent.com",
     "*.googleusercontent.com",
+    "*.gravatar.com",
     "mozillausercontent.com",
     "firefoxusercontent.com",
     "profile.stage.mozaws.net",


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/foxfooding-mdn-plus/issues/92.

### Problem

Firefox Accounts falls back to Gravatar images, if no Profile picture is selected, but these were not shown properly on the MDN site, because Gravatar was not part of our Content-Security-Policy.

### Solution

Add `*.gravatar.com` to our `CSP_DIRECTIVES` constant.

**Note**: While the [Gravatar docs](https://en.gravatar.com/site/implement/images/) mention the domain `www.gravatar.com`, the issue above mentions `secure.gravatar.com`, and [this page](https://rapidsec.com/csp-packages/gravatar) (not verified) recommends `*.gravatar.com` for `image-src`, so I decided to go with this wildcard, to be on the safe side.

---

## How did you test this change?

_Did not test, as it's a trivial change, similar to https://github.com/mdn/yari/pull/5786._