### PR TITLE
fix: #5868 - Adds localization for ELS new heading

### DIFF
--- a/kumascript/macros/EmbedInteractiveExample.ejs
+++ b/kumascript/macros/EmbedInteractiveExample.ejs
@@ -26,6 +26,15 @@ if ($1) {
   }
 }
 
+const text = mdn.localStringMap({
+  "en-US": {
+    "title": "Try it",
+  },
+  "fr": {
+    "title": "Exemple interactif",
+  }
+});
+
 %>
-<h2>Try it</h2>
+<h2><%=text["title"]%></h2>
 <iframe class="interactive <%= heightClass %>" height="200" src="<%= url %>" title="MDN Web Docs Interactive Example"></iframe>


### PR DESCRIPTION
## Summary

Fixes #5868 

### Problem

#5667 added a string which was not localizable, thus mixing localized content with English 
![image](https://user-images.githubusercontent.com/2413436/161107282-dcd12ddf-9b36-42e7-9d5a-8d5ebf5554a9.png)


### Solution

This adds a `mdn.localStringMap` to leverage a simple and existing mechanism to localize this new string

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/2413436/161107966-86a87268-8c2d-4cb8-bc94-f25c781f0d48.png)

### After

![image](https://user-images.githubusercontent.com/2413436/161107829-e4f2a9de-d099-4ebf-b399-2015d0a96f3d.png)

---

## How did you test this change?

I tested it on a local environment and checked it worked correctly on an English (displaying the original "Try it") and on a French page (with the "Exemple interactif" string that I provided)
