### PR TITLE
chore(reference-menu): add Web Extensions item

### DIFF
--- a/client/src/ui/molecules/reference-menu/index.tsx
+++ b/client/src/ui/molecules/reference-menu/index.tsx
@@ -60,6 +60,14 @@ export const ReferenceMenu = ({ visibleSubMenuId, toggleMenu }) => {
         url: `/${locale}/docs/Web/API`,
       },
       {
+        description: "Developing extensions for web browsers",
+        extraClasses: "apis-link-container",
+        hasIcon: true,
+        iconClasses: "submenu-icon",
+        label: "Web Extensions",
+        url: `/${locale}/docs/Mozilla/Add-ons/WebExtensions`,
+      },
+      {
         description: "Web technology reference for developers",
         extraClasses: "apis-link-container desktop-only",
         hasIcon: true,


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5876.

### Problem

The old MDN design had a "Browser extensions" item in the "Technologies" menu (see [here](https://web.archive.org/web/20210401045240mp_/https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions)), but the menus of the new MDN design do not have this menu item anymore.

### Solution

Add a "Browser extensions" item to the "References" menu.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="481" alt="image" src="https://user-images.githubusercontent.com/495429/161132186-3e6ccee6-d1d9-4404-9c8a-532549988582.png">


### After

<img width="481" alt="image" src="https://user-images.githubusercontent.com/495429/161132273-4f95595c-248d-4b08-9b82-f2b57d757092.png">


---

## How did you test this change?

- Open http://localhost:3000/en-US/plus locally.
