### PR TITLE
Related to #5868 - Adds localization for ELS new heading [es]

### DIFF
--- a/kumascript/macros/EmbedInteractiveExample.ejs
+++ b/kumascript/macros/EmbedInteractiveExample.ejs
@@ -32,6 +32,9 @@ const text = mdn.localStringMap({
   },
   "fr": {
     "title": "Exemple interactif",
+  },
+  "es": {
+    "title": "Pruébalo",
   }
 });
 


### PR DESCRIPTION
Related to #5874 and #5868

Adds `es` localization for ELS new heading in EmbedInteractiveExample "Try it"

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Related to #5874 and #5868

### Problem

Missing `es` string which was not localizable, thus mixing localized content with English

### Solution

added a `es` string which was not localizable, thus mixing localized content with English

---

## Screenshots

### Before

![Screenshot 2022-03-31 at 16-55-54 MDN Web Docs](https://user-images.githubusercontent.com/13079269/161162689-9276f64b-30fc-4e9c-a26c-4ba7b88a9fb2.png)

### After

![Screenshot 2022-03-31 at 16-56-01 MDN Web Docs](https://user-images.githubusercontent.com/13079269/161162704-b27f0378-6609-45f0-a15d-193b35439092.png)

---

## How did you test this change?

I tested it on a local environment and checked it worked correctly on an English (displaying the original "Try it") and on a Spanish page (with the "Pruébalo" string that I provided)
