### PR TITLE
fix: made mandala characters non selectable

### DIFF
--- a/client/src/ui/molecules/mandala/index.scss
+++ b/client/src/ui/molecules/mandala/index.scss
@@ -26,6 +26,7 @@
   svg {
     font-size: 1.5rem;
     font-weight: 300;
+    user-select: none;
   }
 
   svg > text {


### PR DESCRIPTION
## Summary

Mandala decoration characters are selectable. 

### Problem

Buy double clicking or dragging mouse on home page user can accidentally select mandala characters. It doesn't look good.

### Solution

Use `user-select: none` property in the CSS rule.

---

## Screenshots

The video shows both before and after cases:

https://user-images.githubusercontent.com/87750369/161205188-8c57e51c-452d-4598-b971-5b1531e5d066.mov


## How did you test this change?

In Google Chrome on Windows 10.