### PR TITLE
BCD tables: replace `isRoot` with `depth`

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -513,7 +513,7 @@ export const FeatureRow = React.memo(
     feature: {
       name: string;
       compat: CompatStatementExtended;
-      depth: number;
+      isRoot: boolean;
     };
     browsers: bcd.BrowserNames[];
     activeCell: number | null;
@@ -526,20 +526,15 @@ export const FeatureRow = React.memo(
       throw new Error("Missing browser info");
     }
 
-    const { name, compat, depth } = feature;
-    let titleMargin: string = depth * 0.75 + "em";
-
+    const { name, compat, isRoot } = feature;
     const title = compat.description ? (
-      <span
-        dangerouslySetInnerHTML={{ __html: compat.description }}
-        style={{ marginLeft: titleMargin }}
-      />
+      <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
-      <code style={{ marginLeft: titleMargin }}>{name}</code>
+      <code>{name}</code>
     );
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
-    let titleNode: React.ReactNode;
+    let titleNode: string | React.ReactNode;
 
     if (compat.bad_url && compat.mdn_url) {
       titleNode = (
@@ -550,7 +545,7 @@ export const FeatureRow = React.memo(
           {compat.status && <StatusIcons status={compat.status} />}
         </div>
       );
-    } else if (compat.mdn_url && depth > 0) {
+    } else if (compat.mdn_url && !isRoot) {
       titleNode = (
         <a href={compat.mdn_url} className="bc-table-row-header">
           {title}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -513,7 +513,7 @@ export const FeatureRow = React.memo(
     feature: {
       name: string;
       compat: CompatStatementExtended;
-      isRoot: boolean;
+      depth: number;
     };
     browsers: bcd.BrowserNames[];
     activeCell: number | null;
@@ -526,7 +526,7 @@ export const FeatureRow = React.memo(
       throw new Error("Missing browser info");
     }
 
-    const { name, compat, isRoot } = feature;
+    const { name, compat, depth } = feature;
     const title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
@@ -538,23 +538,33 @@ export const FeatureRow = React.memo(
 
     if (compat.bad_url && compat.mdn_url) {
       titleNode = (
-        <div className="bc-table-row-header">
+        <div
+          className="bc-table-row-header"
+          style={{ marginLeft: depth + "em" }}
+        >
           <abbr className="new" title={`${compat.mdn_url} does not exist`}>
             {title}
           </abbr>
           {compat.status && <StatusIcons status={compat.status} />}
         </div>
       );
-    } else if (compat.mdn_url && !isRoot) {
+    } else if (compat.mdn_url && depth > 0) {
       titleNode = (
-        <a href={compat.mdn_url} className="bc-table-row-header">
+        <a
+          href={compat.mdn_url}
+          className="bc-table-row-header"
+          style={{ marginLeft: depth + "em" }}
+        >
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
         </a>
       );
     } else {
       titleNode = (
-        <div className="bc-table-row-header">
+        <div
+          className="bc-table-row-header"
+          style={{ marginLeft: depth + "em" }}
+        >
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
         </div>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -513,7 +513,7 @@ export const FeatureRow = React.memo(
     feature: {
       name: string;
       compat: CompatStatementExtended;
-      isRoot: boolean;
+      depth: number;
     };
     browsers: bcd.BrowserNames[];
     activeCell: number | null;
@@ -526,7 +526,7 @@ export const FeatureRow = React.memo(
       throw new Error("Missing browser info");
     }
 
-    const { name, compat, isRoot } = feature;
+    const { name, compat, depth } = feature;
     const title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
@@ -545,7 +545,7 @@ export const FeatureRow = React.memo(
           {compat.status && <StatusIcons status={compat.status} />}
         </div>
       );
-    } else if (compat.mdn_url && !isRoot) {
+    } else if (compat.mdn_url && depth > 0) {
       titleNode = (
         <a href={compat.mdn_url} className="bc-table-row-header">
           {title}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -535,12 +535,13 @@ export const FeatureRow = React.memo(
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
     let titleNode: string | React.ReactNode;
+    let titleMargin: string = depth * 0.75 + "em";
 
     if (compat.bad_url && compat.mdn_url) {
       titleNode = (
         <div
           className="bc-table-row-header"
-          style={{ marginLeft: depth + "em" }}
+          style={{ marginLeft: titleMargin }}
         >
           <abbr className="new" title={`${compat.mdn_url} does not exist`}>
             {title}
@@ -553,7 +554,7 @@ export const FeatureRow = React.memo(
         <a
           href={compat.mdn_url}
           className="bc-table-row-header"
-          style={{ marginLeft: depth + "em" }}
+          style={{ marginLeft: titleMargin }}
         >
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
@@ -563,7 +564,7 @@ export const FeatureRow = React.memo(
       titleNode = (
         <div
           className="bc-table-row-header"
-          style={{ marginLeft: depth + "em" }}
+          style={{ marginLeft: titleMargin }}
         >
           {title}
           {compat.status && <StatusIcons status={compat.status} />}

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -527,22 +527,23 @@ export const FeatureRow = React.memo(
     }
 
     const { name, compat, depth } = feature;
+    let titleMargin: string = depth * 0.75 + "em";
+
     const title = compat.description ? (
-      <span dangerouslySetInnerHTML={{ __html: compat.description }} />
+      <span
+        dangerouslySetInnerHTML={{ __html: compat.description }}
+        style={{ marginLeft: titleMargin }}
+      />
     ) : (
-      <code>{name}</code>
+      <code style={{ marginLeft: titleMargin }}>{name}</code>
     );
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
-    let titleNode: string | React.ReactNode;
-    let titleMargin: string = depth * 0.75 + "em";
+    let titleNode: React.ReactNode;
 
     if (compat.bad_url && compat.mdn_url) {
       titleNode = (
-        <div
-          className="bc-table-row-header"
-          style={{ marginLeft: titleMargin }}
-        >
+        <div className="bc-table-row-header">
           <abbr className="new" title={`${compat.mdn_url} does not exist`}>
             {title}
           </abbr>
@@ -551,21 +552,14 @@ export const FeatureRow = React.memo(
       );
     } else if (compat.mdn_url && depth > 0) {
       titleNode = (
-        <a
-          href={compat.mdn_url}
-          className="bc-table-row-header"
-          style={{ marginLeft: titleMargin }}
-        >
+        <a href={compat.mdn_url} className="bc-table-row-header">
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
         </a>
       );
     } else {
       titleNode = (
-        <div
-          className="bc-table-row-header"
-          style={{ marginLeft: titleMargin }}
-        >
+        <div className="bc-table-row-header">
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
         </div>

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -16,21 +16,20 @@ export function isTruthy<T>(t: T | false | undefined | null): t is T {
 interface Feature {
   name: string;
   compat: bcd.CompatStatement;
-  depth: number;
+  isRoot: boolean;
 }
 
 export function listFeatures(
   identifier: bcd.Identifier,
   parentName: string = "",
-  rootName: string = "",
-  depth: number = 0
+  rootName: string = ""
 ): Feature[] {
   const features: Feature[] = [];
   if (rootName && identifier.__compat) {
     features.push({
       name: rootName,
       compat: identifier.__compat,
-      depth,
+      isRoot: true,
     });
   }
 
@@ -39,9 +38,9 @@ export function listFeatures(
       features.push({
         name: parentName ? `${parentName}.${subName}` : subName,
         compat: subIdentifier.__compat,
-        depth: depth + 1,
+        isRoot: parentName !== "",
       });
-      features.push(...listFeatures(subIdentifier, subName, "", depth + 1));
+      features.push(...listFeatures(subIdentifier, subName));
     }
   }
   return features;

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -16,20 +16,21 @@ export function isTruthy<T>(t: T | false | undefined | null): t is T {
 interface Feature {
   name: string;
   compat: bcd.CompatStatement;
-  isRoot: boolean;
+  depth: number;
 }
 
 export function listFeatures(
   identifier: bcd.Identifier,
   parentName: string = "",
-  rootName: string = ""
+  rootName: string = "",
+  depth: number = 0
 ): Feature[] {
   const features: Feature[] = [];
   if (rootName && identifier.__compat) {
     features.push({
       name: rootName,
       compat: identifier.__compat,
-      isRoot: true,
+      depth,
     });
   }
 
@@ -38,9 +39,9 @@ export function listFeatures(
       features.push({
         name: parentName ? `${parentName}.${subName}` : subName,
         compat: subIdentifier.__compat,
-        isRoot: parentName !== "",
+        depth: depth + 1,
       });
-      features.push(...listFeatures(subIdentifier, subName));
+      features.push(...listFeatures(subIdentifier, subName, "", depth + 1));
     }
   }
   return features;


### PR DESCRIPTION
This PR replaces the `isRoot` property of BCD features with a `depth` property instead, which should provide a better base for #5851.  The `isRoot` property is also non-functional; properties on the third depth are marked as `isRoot` when they shouldn't be.

Before, this PR attempted to perform a similar change as in #5851 as described below.  It has now been stripped of style changes in favor of the other PR.

<hr />

~~This PR adds a small left margin to the names of child features within BCD tables to better represent parent-child relationships between features.  This should help reduce confusions such as https://github.com/mdn/browser-compat-data/issues/15608.~~

~~Before:~~
<img width="775" alt="Screen Shot 2022-04-01 at 05 33 42" src="https://user-images.githubusercontent.com/5179191/161265876-8663f051-e261-446e-8244-eda680333b76.png">

~~After:~~
<img width="773" alt="Screen Shot 2022-04-01 at 05 36 15" src="https://user-images.githubusercontent.com/5179191/161265926-9da9be2e-32cf-4cf9-8b27-b1e3f20d5b39.png">

~~To check to make sure the table is still functioning as intended, I checked the following two pages:~~
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#browser_compatibility
http://localhost:3000/en-US/docs/Web/CSS/gap#browser_compatibility
