### PR TITLE
correct the `zh-CN` translation

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1079,7 +1079,7 @@ var text = mdn.localStringMap({
         'CSS_first_steps_overview': 'CSS第一步概览',
         'What_is_CSS':  '什么是CSS',
         'Getting_started_with_CSS': '让我们开始CSS之旅',
-        'How_CSS_is_structured': '如何让构建CSS',
+        'How_CSS_is_structured': '如何构建CSS',
         'How_CSS_works': 'CSS如何运行',
         'Using_your_new_knowledge': '运用你的新知识',
       'CSS_building_blocks': 'CSS 构建基础',


### PR DESCRIPTION
## Summary

Fixes mdn/translated-content#1882

### Problem

The translation about `How CSS is structured` is not correct in `zh-CN`. Correct it by keeping the same with the title of this article.

### Solution

Correct the translation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://user-images.githubusercontent.com/15844309/161543320-52c246f6-bf18-4b80-813a-33980d81950f.png)

### After

![image](https://user-images.githubusercontent.com/15844309/161543455-e8dbd3ca-1bc5-441c-86de-3399bf03f6e8.png)
