### PR TITLE
JSRef macro: Add WebAssembly .Tag and .Exception

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -60,7 +60,8 @@ var groupData = {
                    "Int32Array", "Uint32Array", "Float32Array", "Float64Array", "BigInt64Array", "BigUint64Array"],
     "Proxy": ["Proxy", "handler"],
     "WebAssembly": ["WebAssembly", "WebAssembly.Module", "WebAssembly.Global", "WebAssembly.Instance", "WebAssembly.Memory",
-                    "WebAssembly.Table", "WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError"],
+                    "WebAssembly.Table", "WebAssembly.CompileError", "WebAssembly.LinkError", "WebAssembly.RuntimeError",
+                    "WebAssembly.Tag", "WebAssembly.Exception"],
 };
 
 // Exceptions, we want the main object in the sidebar (e.g. Int8Array -> TypedArray)


### PR DESCRIPTION
## Summary

Add `WebAssembly .Tag` and `WebAssembly .Exception` to the sidebar. These were added to spec recently and are in FF100.
You can see related docs work in https://github.com/mdn/content/issues/14392

### Problem

These were missing from the sidebar.

### Solution

Isn't this how JS sidebar works?

---


## How did you test this change?

I did not. 