### PR TITLE
fix(document): use <section>s with aria-labelledby

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "./hooks";
 import { Doc } from "./types";
 // Ingredients
-import { Prose, ProseWithHeading } from "./ingredients/prose";
+import { Prose } from "./ingredients/prose";
 import { LazyBrowserCompatibilityTable } from "./lazy-bcd-table";
 import { SpecificationSection } from "./ingredients/spec-section";
 
@@ -226,24 +226,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
 function RenderDocumentBody({ doc }) {
   return doc.body.map((section, i) => {
     if (section.type === "prose") {
-      // Only exceptional few should use the <Prose/> component,
-      // as opposed to <ProseWithHeading/>.
-      if (!section.value.id) {
-        return (
-          <Prose
-            key={section.value.id || `prose${i}`}
-            section={section.value}
-          />
-        );
-      } else {
-        return (
-          <ProseWithHeading
-            key={section.value.id}
-            id={section.value.id}
-            section={section.value}
-          />
-        );
-      }
+      return <Prose key={section.value.id} section={section.value} />;
     } else if (section.type === "browser_compatibility") {
       return (
         <LazyBrowserCompatibilityTable

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -1,37 +1,26 @@
 import { DisplayH2, DisplayH3 } from "./utils";
 
-export function Prose({ id, section }: { id?: string; section: any }) {
-  return (
-    <section
-      aria-labelledby={id}
-      dangerouslySetInnerHTML={{ __html: section.content }}
-    />
-  );
-}
+export function Prose({ section }: { section: any }) {
+  const { id } = section;
 
-export function ProseWithHeading({
-  id,
-  section,
-}: {
-  id: string;
-  section: any;
-}) {
+  const Content = () => (
+    <div dangerouslySetInnerHTML={{ __html: section.content }} />
+  );
+
+  if (!id) {
+    return <Content />;
+  }
+
+  const DisplayHx = section.isH3 ? DisplayH3 : DisplayH2;
+
   return (
-    <>
-      {section.isH3 ? (
-        <DisplayH3
-          id={id}
-          title={section.title}
-          titleAsText={section.titleAsText}
-        />
-      ) : (
-        <DisplayH2
-          id={id}
-          title={section.title}
-          titleAsText={section.titleAsText}
-        />
-      )}
-      <Prose id={id} section={section} />
-    </>
+    <section aria-labelledby={id}>
+      <DisplayHx
+        id={id}
+        title={section.title}
+        titleAsText={section.titleAsText}
+      />
+      <Content />
+    </section>
   );
 }

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -3,7 +3,7 @@ import { DisplayH2, DisplayH3 } from "./utils";
 export function Prose({ id, section }: { id?: string; section: any }) {
   return (
     <section
-      aria-describedby={id}
+      aria-labelledby={id}
       dangerouslySetInnerHTML={{ __html: section.content }}
     />
   );

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -1,10 +1,21 @@
 import { DisplayH2, DisplayH3 } from "./utils";
 
-export function Prose({ section }) {
-  return <div dangerouslySetInnerHTML={{ __html: section.content }} />;
+export function Prose({ id, section }: { id?: string; section: any }) {
+  return (
+    <section
+      aria-describedby={id}
+      dangerouslySetInnerHTML={{ __html: section.content }}
+    />
+  );
 }
 
-export function ProseWithHeading({ id, section }) {
+export function ProseWithHeading({
+  id,
+  section,
+}: {
+  id: string;
+  section: any;
+}) {
   return (
     <>
       {section.isH3 ? (
@@ -20,7 +31,7 @@ export function ProseWithHeading({ id, section }) {
           titleAsText={section.titleAsText}
         />
       )}
-      <Prose section={section} />
+      <Prose id={id} section={section} />
     </>
   );
 }

--- a/testing/content/files/en-us/web/externallinks/index.html
+++ b/testing/content/files/en-us/web/externallinks/index.html
@@ -3,6 +3,8 @@ title: Lots of external links
 slug: Web/ExternalLinks
 ---
 
+<h2 id="external_links">External links</h2>
+
 <ul>
   <li><a href="https://www.peterbe.com">Peterbe.com</a></li>
   <li><a class="something already" href="https://www.mozilla.org">Mozilla.org</a></li>

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1502,8 +1502,8 @@ test("external links always get the right attributes", () => {
   // 4 links on that page and we'll do 2 assertions for each one, plus
   // 1 for the extra sanity check.
   expect.assertions(4 * 2 + 1);
-  expect($("article > section a").length).toBe(4); // sanity check
-  $("article > section a").each((i, element) => {
+  expect($("article > section div a").length).toBe(4); // sanity check
+  $("article > section div a").each((i, element) => {
     const $a = $(element);
     expect($a.hasClass("external")).toBe(true);
     expect(

--- a/testing/tests/index.test.js
+++ b/testing/tests/index.test.js
@@ -1502,8 +1502,8 @@ test("external links always get the right attributes", () => {
   // 4 links on that page and we'll do 2 assertions for each one, plus
   // 1 for the extra sanity check.
   expect.assertions(4 * 2 + 1);
-  expect($("article > div a").length).toBe(4); // sanity check
-  $("article > div a").each((i, element) => {
+  expect($("article > section a").length).toBe(4); // sanity check
+  $("article > section a").each((i, element) => {
     const $a = $(element);
     expect($a.hasClass("external")).toBe(true);
     expect(


### PR DESCRIPTION
## Summary

Makes sure we use `<section>` elements with ~~`aria-describedby`~~ `aria-labelledby` in MDN articles.

### Problem

Previously, we were just using `<div>`s to wrap MDN article sections, which is not ideal.

### Solution

I replaced the `<div>`s with `<section>`s and added ~~`aria-describedby`~~ `aria-labelledby` where possible.

---

## Screenshots

_No visual changes._

---

## How did you test this change?

I did not see any differences, **but** I did not check for potential CSS rules targeting those `div`s.