### PR TITLE
Related #5096, Adds [es] for FirefoxSidebar.ejs

### DIFF
--- a/kumascript/macros/FirefoxSidebar.ejs
+++ b/kumascript/macros/FirefoxSidebar.ejs
@@ -25,13 +25,13 @@ const text = mdn.localStringMap({
     "Firefox_documentation": "Firefox documentation",
   },
   "es": {
-    "Firefox_releases": "Firefox releases",
-      "Firefox_release_notes_developer": "Firefox release notes for developers",
-      "Experimental_features_firefox": "Experimental features in Firefox",
+    "Firefox_releases": "Lanzamientos de Firefox",
+      "Firefox_release_notes_developer": "Notas de lanzamiento de Firefox, para desarrolladores",
+      "Experimental_features_firefox": "Caracteristicas experimentales en Firefox",
     "Add-ons": "Complementos",
       "Browser_extensions": "Extensiones del navegador",
       "Themes": "Temas",
-    "Firefox_documentation": "Firefox documentation",
+    "Firefox_documentation": "Documentación de Firefox",
   },
   "fr": {
     "Firefox_releases": "Versions de Firefox",


### PR DESCRIPTION
Related to https://github.com/mdn/yari/issues/5096

Add `es` localization for FirefoxSidebar.ejs

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Related to https://github.com/mdn/yari/issues/5096

### Problem

New menu entries that need `es` strings.

### Solution

added `es` strings

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screenshot 2022-04-05 at 11-44-50 Notas de desarrollo de Firefox - Mozilla MDN](https://user-images.githubusercontent.com/13079269/161804799-f3df98e9-c6c9-4295-9f8e-4d985154e9b0.png)

### After

![Screenshot 2022-04-05 at 11-20-58 MDN Web Docs](https://user-images.githubusercontent.com/13079269/161804840-5b5ac61b-b01a-4a8b-a23e-a04589eb84a4.png)

---

## How did you test this change?

I tested it on a local environment and checked it worked correctly
