### PR TITLE
chore(writers-homepage): disable via REACT_APP_DISABLE_WRITERS_HOMEPAGE

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -5,7 +5,11 @@ import { Routes, Route, useLocation, useMatch } from "react-router-dom";
 // and applied before any component specific style
 import "./app.scss";
 
-import { CRUD_MODE, PLUS_IS_ENABLED } from "./constants";
+import {
+  CRUD_MODE,
+  PLUS_IS_ENABLED,
+  WRITERS_HOMEPAGE_IS_DISABLED,
+} from "./constants";
 import { Homepage } from "./homepage";
 import { Document } from "./document";
 import { A11yNav } from "./ui/molecules/a11y-nav";
@@ -125,7 +129,7 @@ export function App(appProps) {
   // But if the App is loaded from the code that builds the SPAs, then `isServer`
   // is true. So you have to have `isServer && CRUD_MODE` at the same time.
   const homePage =
-    !isServer && CRUD_MODE ? (
+    !isServer && !WRITERS_HOMEPAGE_IS_DISABLED ? (
       <Layout pageType="standard-page">
         <WritersHomepage />
       </Layout>

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -36,6 +36,12 @@ export const VALID_LOCALES = new Set([
   "zh-TW",
 ]);
 
+export const WRITERS_HOMEPAGE_IS_DISABLED = Boolean(
+  JSON.parse(
+    process.env.REACT_APP_DISABLE_WRITERS_HOMEPAGE ?? String(!CRUD_MODE)
+  )
+);
+
 export const MDN_PLUS_TITLE = "MDN Plus";
 
 export const PLUS_IS_ENABLED = Boolean(

--- a/client/src/writers-homepage/index.tsx
+++ b/client/src/writers-homepage/index.tsx
@@ -107,6 +107,11 @@ export default function WritersHomepage() {
             <Link to={`/${locale}/_traits`}>All Documents Traits</Link>
           </li>
         </ul>
+        <div className="notecard note">
+          Looking for the standard MDN homepage? Add{" "}
+          <code>REACT_APP_DISABLE_WRITERS_HOMEPAGE=true</code> to your{" "}
+          <code>.env</code> file.
+        </div>
       </div>
     </PageContentContainer>
   );

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -246,6 +246,12 @@ host name instead. That means you can log in _from_ Yari with a single click.
 This removes sign-in and `whoami` XHR fetching.
 Useful when using Yari purely for content editing as authentication is then not required.
 
+### `REACT_APP_DISABLE_WRITERS_HOMEPAGE`
+
+**Default: `!CRUD_MODE`**
+
+Disables the "Writer's homepage", which shows instead of the regular MDN homepage.
+
 ### `REACT_APP_CRUD_MODE`
 
 **Default: `NODE_ENV==='development'`**


### PR DESCRIPTION
## Summary

Allows disabling the "Writer's homepage", which is shown by default in development mode instead of the regular MDN homepage.

### Problem

Previously, the "Writer's homepage" was always shown in development mode.

### Solution

Now, the "Writer's homepage" can be disabled by setting an environment variable, and the "Writer's homepage" has a note about this.

---

## Screenshots

<img width="992" alt="image" src="https://user-images.githubusercontent.com/495429/161853907-b5966bb9-916b-4222-9c37-ccb42c7a10cc.png">

---

## How did you test this change?

- Set `REACT_APP_DISABLE_WRITERS_HOMEPAGE=true` in `.env` and verified that "Writer's homepage" no longer shows.
