### PR TITLE
Removed in messaging only appears when no newer browser has support

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -336,12 +336,14 @@ function getNotes(
   support: bcd.SupportStatement
 ) {
   if (support) {
+    const firstItem = getFirst(support);
     return asList(support)
       .slice()
       .reverse()
       .flatMap((item, i) => {
         const supportNotes = [
-          item.version_removed
+          item.version_removed &&
+          item.version_added === firstItem!.version_added
             ? {
                 iconName: "disabled",
                 label: (


### PR DESCRIPTION
## Summary

Fixes #5922

### Problem

"Removed in" is not appropriate if what was removed was the information, not the support.

### Solution

Only show removed in messaging when no newer browser has support.

---

## Screenshots

### Before

![Screenshot from 2022-04-06 13-52-08](https://user-images.githubusercontent.com/29206584/162038510-d882c8da-1652-4b0b-b211-2569e4ac123e.png)

### After

![Screenshot from 2022-04-06 13-53-01](https://user-images.githubusercontent.com/29206584/162038546-1ba73b89-234d-4307-96b2-22dc4523f56b.png)

### Both

![Screenshot from 2022-04-06 13-56-48](https://user-images.githubusercontent.com/29206584/162038586-db19f5f3-581c-4605-9c3b-4f3c0dc73dae.png)
