### PR TITLE
fix(cssref-macros): sort css properties content before render

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -329,8 +329,8 @@ const rtlLocales = ['ar', 'he', 'fa'];
 const pageList = await page.subpagesExpand('/en-US/docs/Web/CSS');
 const standardPages = pageList.filter(page => !hasTag(page, "Non-standard"));
 
-const groups = standardPages.filter(page => hasTag(page, "Overview"));
-const properties = standardPages.filter(page => hasTag(page, "CSS Property"));
+const groups = standardPages.filter(page => hasTag(page, "Overview"));const properties = standardPages.filter(page => hasTag(page, "CSS Property")).sort((a, b) =>
+a.title.localeCompare(b.title));
 const selectors = standardPages.filter(page => (hasTag(page, "Selector") && !hasTag(page, "Pseudo-element") && !hasTag(page, "Pseudo-class")));
 const pseudoClasses = standardPages.filter(page => hasTag(page, "Pseudo-class"));
 const pseudoElements = standardPages.filter(page => hasTag(page, "Pseudo-element"));

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -329,8 +329,8 @@ const rtlLocales = ['ar', 'he', 'fa'];
 const pageList = await page.subpagesExpand('/en-US/docs/Web/CSS');
 const standardPages = pageList.filter(page => !hasTag(page, "Non-standard"));
 
-const groups = standardPages.filter(page => hasTag(page, "Overview"));const properties = standardPages.filter(page => hasTag(page, "CSS Property")).sort((a, b) =>
-a.title.localeCompare(b.title));
+const groups = standardPages.filter(page => hasTag(page, "Overview"));
+const properties = standardPages.filter(page => hasTag(page, "CSS Property")).sort((a, b) => a.title.localeCompare(b.title));
 const selectors = standardPages.filter(page => (hasTag(page, "Selector") && !hasTag(page, "Pseudo-element") && !hasTag(page, "Pseudo-class")));
 const pseudoClasses = standardPages.filter(page => hasTag(page, "Pseudo-class"));
 const pseudoElements = standardPages.filter(page => hasTag(page, "Pseudo-element"));


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Fixes #5764 

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

CSSRef macro to build the sidebar links based on folder sorting so property such as `border`, `background`, etc is placed on the bottom after their `border-*`, `background-*`, etc content.


### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

After get the whole properties content, we sort it first using [localeCompare](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare) to make sure the `border`, `background`, etc comes first.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="239" alt="before" src="https://user-images.githubusercontent.com/3371809/162218409-02dd5fc2-09f6-4eff-a500-38e06e763546.png">


### After

<img width="404" alt="after" src="https://user-images.githubusercontent.com/3371809/162218474-df035275-0bc5-4fbc-9150-c2db9c861866.png">


