### PR TITLE
Update the link to activating a locale

### DIFF
--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -57,7 +57,7 @@ export function LocalizedContentNote({
       inactiveLocaleNoteContent["en-US"].linkText;
   const url = isActive
     ? "/en-US/docs/MDN/Contribute/Localize#active_locales"
-    : "https://github.com/mdn/translated-content#promoting-an-inactive-locale-to-tier-1";
+    : "https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#activating-a-locale";
 
   const type = isActive ? "neutral" : "warning";
   return <NoteBanner linkText={linkText} url={url} type={type} />;


### PR DESCRIPTION
## Summary

Updating the link to activate a locale

### Problem

Current link in the banner follows to wrong target. You can find this link in German or Polish translations, for example [here](https://developer.mozilla.org/pl/docs/Web/HTML). This pr updates the link

![image](https://user-images.githubusercontent.com/2382567/162235427-8323a683-e4e4-4447-ab47-b8ff6a6b3fb9.png)