### PR TITLE
Fix dark mode on mobile in BCD

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -239,6 +239,7 @@
 
 .bc-notes-wrapper {
   margin-bottom: 1rem;
+  color: var(--text-primary);
 
   &:last-child {
     margin-bottom: 0;


### PR DESCRIPTION
## Summary

Fixes #5924

### Problem

The browser history on mobile is black even in dark mode

### Solution

Specifically set the color to --text-primary.

---

## Screenshots

### Before

<img src="https://user-images.githubusercontent.com/83923848/162174859-ebd0765a-1462-4bc2-b541-909354bdf8f9.jpg" height="auto" width="356">

### After

![Screenshot from 2022-04-07 11-43-37](https://user-images.githubusercontent.com/29206584/162240762-c62ab41e-802c-47b2-95de-6ecbc9998a48.png)
