### PR TITLE
fix(mandala): make 4th circle spin

### DIFF
--- a/client/src/ui/molecules/mandala/index.tsx
+++ b/client/src/ui/molecules/mandala/index.tsx
@@ -93,7 +93,7 @@ function Mandala({
                   dur="500s"
                   type="rotate"
                   from="360 337.5 337.5"
-                  to="360 337.5 337.5"
+                  to="0 337.5 337.5"
                   repeatCount="indefinite"
                 />
               )}


### PR DESCRIPTION
## Summary

Includes a fix mentioned in #5930 

- MDN Plus product page Mandala's 4th circle spin bug
  - https://github.com/mdn/yari/blob/e9bae54c292016d3f064c14aac6a5e253b6e9af6/client/src/ui/molecules/mandala/index.tsx#L95-L96

### Problem

The 4th circle of MDN Plus product page's Mandala SVG doesn't rotate because `from` and `to` attribute of `animateTransform` are same.

### Solution

```diff
- to="360 337.5 337.5"
+ to="0 337.5 337.5"
```

---

## Screenshots

### Before

#### 4th circle with `../../` doesn't rotate

https://user-images.githubusercontent.com/43103163/162446729-a4f6b1a8-66c8-4a53-a24e-7873e821730d.mp4

### After

#### 4th circle with `../../` rotates

https://user-images.githubusercontent.com/43103163/162446772-2ded8f35-13eb-4397-8c34-668a53998193.mp4

---

## How did you test this change?

- Start the Yari web server `yarn dev`
- open `http://localhost:3000/en-US/plus`