### PR TITLE
Pass full MDN URL in “Report a problem with this content on GitHub” link

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -124,7 +124,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   } else {
     url.pathname = "/mdn/content/issues/new";
     sp.set("template", "page-report.yml");
-    sp.set("mdn-url", doc.mdn_url);
+    sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
     sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
   }
 


### PR DESCRIPTION
This is a follow-up to https://github.com/mdn/yari/pull/5887. `Doc.mdn_url` is a relative URL (path) — so to pass the full MDN URL in the _“Report a problem with this content on GitHub”_ link, we need to prefix “https://developer.mozilla.org” to `Doc.mdn_url`.