### PR TITLE
chore(offline-settings): use ContentStatus from IndexedDB (Phase 2 of 3)

### DIFF
--- a/client/pwa/src/db.ts
+++ b/client/pwa/src/db.ts
@@ -1,3 +1,8 @@
+// WARNING - This file is duplicated at two locations:
+// - client/pwa/src/db.ts
+// - client/src/offline-settings/db.ts
+// Until we find a solution, keep both files in sync.
+
 import Dexie from "dexie";
 
 interface Watched {

--- a/client/pwa/src/service-worker.ts
+++ b/client/pwa/src/service-worker.ts
@@ -116,16 +116,6 @@ async function initOncePerRun(self: ServiceWorkerGlobalScope) {
     phase: ContentStatusPhase.IDLE,
     progress: null,
   });
-
-  // Deprecated.
-  const contentStatus = await getContentStatus();
-  await messageAllClients(self, {
-    type: "updateStatus",
-    progress: 0,
-    state: "init",
-    currentVersion: contentStatus.local?.version,
-    currentDate: contentStatus.local?.date,
-  });
 }
 
 self.addEventListener("activate", (e: ExtendableEvent) => {
@@ -232,13 +222,6 @@ export async function updateContent(
       phase: ContentStatusPhase.DOWNLOAD,
     });
 
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: 0,
-      state: "downloading",
-    });
-
     const useDiff = local && remote.updates.includes(local.version);
 
     const url = new URL(
@@ -263,24 +246,10 @@ export async function updateContent(
       progress: 0,
     });
 
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: 0,
-      state: "unpacking",
-    });
-
     await unpackAndCache(buf, async (progress) => {
       await patchContentStatus({
         phase: ContentStatusPhase.UNPACK,
         progress: progress,
-      });
-
-      // Deprecated.
-      await messageAllClients(self, {
-        type: "updateStatus",
-        progress,
-        state: "unpacking",
       });
     });
 
@@ -293,15 +262,6 @@ export async function updateContent(
       progress: null,
     });
 
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: 0,
-      state: "init",
-      currentVersion: remote.latest,
-      currentDate: remote.date,
-    });
-
     console.log(`[update] synchronizing`);
     await synchronizeDb();
 
@@ -312,15 +272,6 @@ export async function updateContent(
     await patchContentStatus({
       phase: ContentStatusPhase.IDLE,
       progress: null,
-    });
-
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: 0,
-      state: "init",
-      currentVersion: remote.latest,
-      currentDate: remote.date,
     });
   } finally {
     updating = false;
@@ -339,13 +290,6 @@ async function clearContent(self: ServiceWorkerGlobalScope) {
       phase: ContentStatusPhase.CLEAR,
     });
 
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: 0,
-      state: "clearing",
-    });
-
     console.log(`[clear] deleting`);
     const success = await deleteContentCache();
     console.log(`[clear] done: ${success}`);
@@ -354,15 +298,6 @@ async function clearContent(self: ServiceWorkerGlobalScope) {
   } finally {
     await patchContentStatus({
       phase: ContentStatusPhase.IDLE,
-    });
-
-    // Deprecated.
-    await messageAllClients(self, {
-      type: "updateStatus",
-      progress: -1,
-      state: "init",
-      currentVersion: null,
-      currentDate: null,
     });
   }
 }

--- a/client/src/offline-settings/clear.tsx
+++ b/client/src/offline-settings/clear.tsx
@@ -1,26 +1,22 @@
-import { STATE, UpdateStatus } from "./mdn-worker";
+import { ContentStatus, ContentStatusPhase } from "./db";
 
 export default function ClearButton({
   updateStatus,
   clear,
   disabled = false,
 }: {
-  updateStatus: UpdateStatus | null;
+  updateStatus: ContentStatus | null;
   clear: () => void;
   disabled?: boolean;
 }) {
   let button;
-  if (
-    (updateStatus?.state === STATE.nothing ||
-      updateStatus?.state === STATE.updateAvailable) &&
-    updateStatus?.currentVersion !== null
-  ) {
+  if (updateStatus?.phase === ContentStatusPhase.IDLE && updateStatus?.local) {
     button = (
       <button className="button" onClick={clear} disabled={disabled}>
         Clear data
       </button>
     );
-  } else if (updateStatus?.state === STATE.clearing) {
+  } else if (updateStatus?.phase === ContentStatusPhase.CLEAR) {
     button = <button disabled>Clearing…</button>;
   } else {
     button = (

--- a/client/src/offline-settings/db.ts
+++ b/client/src/offline-settings/db.ts
@@ -1,3 +1,8 @@
+// WARNING - This file is duplicated at two locations:
+// - client/pwa/src/db.ts
+// - client/src/offline-settings/db.ts
+// Until we find a solution, keep both files in sync.
+
 import Dexie from "dexie";
 
 interface Watched {

--- a/client/src/offline-settings/db.ts
+++ b/client/src/offline-settings/db.ts
@@ -1,0 +1,140 @@
+import Dexie from "dexie";
+
+interface Watched {
+  url: string;
+  title: string;
+  path: string;
+  status: string;
+}
+
+interface Notifications {
+  id: number;
+  title: string;
+  text: string;
+  url: string;
+  created: Date;
+  read: boolean;
+  starred: boolean;
+}
+
+interface Parent {
+  uri: string;
+  title: string;
+}
+
+interface Collections {
+  id?: number;
+  url: string;
+  title: string;
+  parents?: Array<Parent>[];
+  notes?: string;
+  created: Date;
+}
+
+interface Whoami {
+  id?: number;
+  username: string;
+  is_authenticated: boolean;
+  email: string;
+  avatar_url: string;
+  is_subscriber: boolean;
+}
+
+export enum ContentStatusPhase {
+  INITIAL = "initial",
+  IDLE = "idle",
+  DOWNLOAD = "download",
+  UNPACK = "unpack",
+  CLEAR = "clear",
+}
+
+export interface LocalContentStatus {
+  version: string;
+  date: string;
+}
+
+export interface RemoteContentStatus {
+  date: string;
+  latest: string;
+  updates: [string];
+}
+
+export interface ContentStatus {
+  id?: number;
+  phase: ContentStatusPhase;
+  local: LocalContentStatus | null;
+  remote: RemoteContentStatus | null;
+  progress: number | null;
+  timestamp: Date;
+}
+
+export class MDNOfflineDB extends Dexie {
+  // Declare implicit table properties.
+  // (just to inform Typescript. Instanciated by Dexie in stores() method)
+  whoami!: Dexie.Table<Whoami, number>; // number = type of the primkey
+  contentStatusHistory!: Dexie.Table<ContentStatus, number>;
+  collections!: Dexie.Table<Collections, string>;
+  watched!: Dexie.Table<Watched, String>;
+  notifications!: Dexie.Table<Notifications, number>;
+
+  constructor() {
+    super("MDNOfflineDB");
+    this.version(1).stores({
+      whoami:
+        "++, username, is_authenticated, email, avatar_url, is_subscriber",
+      collections: "url, title, created",
+      watched: "url, title, path",
+      notifications: "id, title, text, url, created, read, starred",
+    });
+    this.version(2).stores({
+      contentStatusHistory: "++id",
+    });
+  }
+}
+
+const offlineDb = new MDNOfflineDB();
+
+async function getContentStatus(): Promise<ContentStatus> {
+  const current = await offlineDb.contentStatusHistory.toCollection().last();
+
+  return (
+    current || {
+      phase: ContentStatusPhase.INITIAL,
+      local: null,
+      remote: null,
+      progress: null,
+      timestamp: new Date(),
+    }
+  );
+}
+
+async function patchContentStatus(
+  changes: Omit<Partial<ContentStatus>, "id" | "timestamp">
+) {
+  const db = offlineDb;
+  const table = db.contentStatusHistory;
+
+  await db.transaction("rw", table, async () => {
+    const oldStatus = await getContentStatus();
+    const newStatus = {
+      ...oldStatus,
+      ...changes,
+      id: undefined,
+      timestamp: new Date(),
+    };
+
+    if (oldStatus.phase === ContentStatusPhase.INITIAL && !changes.phase) {
+      newStatus.phase = ContentStatusPhase.IDLE;
+    }
+
+    if (oldStatus.id && oldStatus.phase === newStatus.phase) {
+      await table.update(oldStatus.id, newStatus);
+    } else {
+      await table.add(newStatus);
+      // Keep latest entries for debugging.
+      await table.reverse().offset(100).delete();
+    }
+  });
+}
+
+export { offlineDb, getContentStatus, patchContentStatus };

--- a/client/src/offline-settings/mdn-worker.tsx
+++ b/client/src/offline-settings/mdn-worker.tsx
@@ -1,32 +1,13 @@
-import { UPDATES_BASE_URL } from "../constants";
-
-export enum STATE {
-  init = "init",
-  nothing = "nothing",
-  clearing = "clearing",
-  updateAvailable = "updateAvailable",
-  downloading = "downloading",
-  unpacking = "unpacking",
-  cleaning = "cleaning",
-}
-
-export class UpdateData {
-  date: Date;
-  latest: string;
-  updates: [string];
-
-  constructor({ date, latest, updates }) {
-    this.date = new Date(date);
-    this.latest = latest;
-    this.updates = updates;
-  }
-}
+import { getContentStatus } from "./db";
 
 export class SettingsData {
   offline?: boolean;
   preferOnline?: boolean;
   autoUpdates?: boolean;
+
+  /** @deprecated Now managed by PWA in IndexedDB. */
   currentVersion?: string | null;
+  /** @deprecated Now managed by PWA in IndexedDB. */
   currentDate?: string | null;
 
   constructor() {
@@ -38,28 +19,8 @@ export class SettingsData {
   }
 }
 
-export class UpdateStatus {
-  progress?: number;
-  state: STATE;
-  currentVersion?: string | null;
-  currentDate?: string | null;
-  updateVersion?: string | null;
-  updateDate?: string | null;
-
-  constructor() {
-    this.progress = -1;
-    this.state = STATE.init;
-    this.currentVersion = null;
-    this.currentDate = null;
-    this.updateVersion = null;
-    this.updateDate = null;
-  }
-}
-
 export class MDNWorker {
-  updateStatus: UpdateStatus;
   settings: SettingsData;
-  latestUpdate: UpdateData | null;
   updating: boolean;
   registered: boolean;
   timeout?: ReturnType<typeof setTimeout> | null;
@@ -67,12 +28,7 @@ export class MDNWorker {
 
   constructor() {
     this.settings = this.offlineSettings();
-    this.updateStatus = new UpdateStatus();
-    //this.settings.currentVersion = "87fe3ab8a3";
-    this.updateStatus.currentDate = this.settings.currentDate || null;
-    this.updateStatus.currentVersion = this.settings.currentVersion || null;
     this.updating = false;
-    this.latestUpdate = null;
     this.registered = false;
     this.timeout = null;
     this.keepAlive = null;
@@ -82,22 +38,18 @@ export class MDNWorker {
     }
   }
 
-  async autoUpdate() {
+  autoUpdate() {
     console.log("running auto update");
     if (this.timeout) {
       clearTimeout(this.timeout);
       this.timeout = null;
     }
-    await this.getUpdate();
     this.update();
     this.timeout = setTimeout(() => this.autoUpdate(), 60 * 60 * 1000);
   }
 
   async messageHandler(event) {
     switch (event.data.type) {
-      case "updateStatus":
-        await window.mdnWorker.setStatus(event.data);
-        break;
       case "pong":
         console.log("pong");
         break;
@@ -110,59 +62,12 @@ export class MDNWorker {
     return navigator.serviceWorker.controller;
   }
 
-  update() {
-    if (
-      this.updating ||
-      this.updateStatus.currentVersion === this.latestUpdate?.latest
-    ) {
-      return;
-    }
-    this.updating = true;
-    const payload = {};
-    if (
-      this.latestUpdate &&
-      this.updateStatus.currentVersion &&
-      this.latestUpdate.updates.includes(this.updateStatus.currentVersion)
-    ) {
-      payload["current"] = this.updateStatus.currentVersion;
-    }
-    if (this.latestUpdate) {
-      payload["latest"] = this.latestUpdate.latest;
-      payload["date"] = this.latestUpdate.date;
-    }
-    this.updateStatus.state = STATE.downloading;
-    this.controller()?.postMessage({ type: "update", ...payload });
+  checkForUpdate(): void {
+    this.controller()?.postMessage({ type: "checkForUpdate" });
   }
 
-  async getUpdate(): Promise<UpdateData | null> {
-    if (
-      this.updating ||
-      !(
-        this.updateStatus.state === STATE.nothing ||
-        this.updateStatus.state === STATE.init
-      )
-    ) {
-      return this.latestUpdate;
-    }
-    let update;
-    if (
-      this.latestUpdate &&
-      new Date(this.latestUpdate.date) > new Date(Date.now() - 86400000)
-    ) {
-      update = this.latestUpdate;
-    } else {
-      let res = await fetch(`${UPDATES_BASE_URL}/update.json`);
-      update = await res.json();
-    }
-    this.updateStatus.updateVersion = update?.latest;
-    this.updateStatus.updateDate = update?.date;
-    if (this.settings.currentVersion !== update?.latest) {
-      this.updateStatus.state = STATE.updateAvailable;
-    } else {
-      this.updateStatus.state = STATE.nothing;
-    }
-    this.latestUpdate = update;
-    return update;
+  update() {
+    this.controller()?.postMessage({ type: "update" });
   }
 
   swName(onlineFirst: boolean | null | undefined = null) {
@@ -188,12 +93,8 @@ export class MDNWorker {
     }
   }
 
-  async updateAvailable() {
-    await this.getUpdate();
-    return this.status();
-  }
-  status() {
-    return this.updateStatus;
+  async status() {
+    return await getContentStatus();
   }
 
   offlineSettings(): SettingsData {
@@ -226,7 +127,7 @@ export class MDNWorker {
       settingsData.autoUpdates === true &&
       current.autoUpdates === false
     ) {
-      await this.autoUpdate();
+      this.autoUpdate();
     }
 
     const settings = { ...current, ...settingsData };
@@ -234,62 +135,8 @@ export class MDNWorker {
     this.settings = settings;
     return settings;
   }
-  clear() {
-    this.updateStatus.state = STATE.clearing;
+  async clear() {
     this.controller()?.postMessage({ type: "clear" });
-  }
-
-  async setStatus(updateStatus: UpdateStatus) {
-    if (typeof updateStatus.progress !== "undefined") {
-      this.updateStatus.progress = updateStatus.progress;
-    }
-    if (typeof updateStatus.currentDate !== "undefined") {
-      this.updateStatus.currentDate = updateStatus.currentDate;
-    }
-    if (typeof updateStatus.currentVersion !== "undefined") {
-      this.updateStatus.currentVersion = updateStatus.currentVersion;
-    }
-    await this.setOfflineSettings({
-      currentDate: this.updateStatus.currentDate,
-      currentVersion: this.updateStatus.currentVersion || null,
-    });
-    if (updateStatus.state) {
-      if (
-        updateStatus.state === STATE.init &&
-        this.updateStatus.state !== STATE.init
-      ) {
-        this.updating = false;
-        this.updateStatus.updateVersion = null;
-        this.updateStatus.updateDate = null;
-        this.updateStatus.state = updateStatus.state;
-        await this.getUpdate();
-      } else {
-        if (
-          [STATE.clearing, STATE.downloading, STATE.unpacking].includes(
-            updateStatus.state
-          )
-        ) {
-          this.updating = true;
-        } else {
-          this.updating = false;
-        }
-
-        if (this.updating && !this.keepAlive) {
-          this.keepAlive = setInterval(() => {
-            this.controller()?.postMessage({ type: "keepalive" });
-            if (!this.updating && this.keepAlive) {
-              clearInterval(this.keepAlive);
-              this.keepAlive = null;
-            }
-          }, 10000);
-        }
-        if (!this.updating && this.keepAlive) {
-          clearInterval(this.keepAlive);
-          this.keepAlive = null;
-        }
-        this.updateStatus.state = updateStatus.state;
-      }
-    }
   }
 }
 
@@ -299,17 +146,19 @@ declare global {
   }
 }
 
-if (!window.mdnWorker) {
-  window.mdnWorker = new MDNWorker();
+export function getMDNWorker(): MDNWorker {
+  if (!window.mdnWorker) {
+    window.mdnWorker = new MDNWorker();
+  }
+  return window.mdnWorker;
 }
+
+const mdnWorker = getMDNWorker();
 
 function registerMessageHandler() {
-  navigator.serviceWorker.addEventListener(
-    "message",
-    window.mdnWorker.messageHandler
-  );
+  navigator.serviceWorker.addEventListener("message", mdnWorker.messageHandler);
 }
 
-if (window.mdnWorker.settings.offline) {
-  window.mdnWorker.enableServiceWorker(window.mdnWorker.settings.preferOnline);
+if (mdnWorker.settings.offline) {
+  mdnWorker.enableServiceWorker(mdnWorker.settings.preferOnline);
 }

--- a/client/src/offline-settings/mdn-worker.tsx
+++ b/client/src/offline-settings/mdn-worker.tsx
@@ -91,6 +91,20 @@ export class MDNWorker {
     }
   }
 
+  toggleKeepAlive(keepAlive: boolean) {
+    if (this.keepAlive && !keepAlive) {
+      console.log("[worker] keepalive -> enabling");
+      clearInterval(this.keepAlive);
+      this.keepAlive = null;
+    } else if (keepAlive && !this.keepAlive) {
+      console.log("[worker] keepalive -> disabling");
+      this.keepAlive = setInterval(
+        () => this.controller()?.postMessage({ type: "keepalive" }),
+        10000
+      );
+    }
+  }
+
   async status() {
     return await getContentStatus();
   }

--- a/client/src/offline-settings/mdn-worker.tsx
+++ b/client/src/offline-settings/mdn-worker.tsx
@@ -21,14 +21,12 @@ export class SettingsData {
 
 export class MDNWorker {
   settings: SettingsData;
-  updating: boolean;
   registered: boolean;
   timeout?: ReturnType<typeof setTimeout> | null;
   keepAlive: ReturnType<typeof setInterval> | null;
 
   constructor() {
     this.settings = this.offlineSettings();
-    this.updating = false;
     this.registered = false;
     this.timeout = null;
     this.keepAlive = null;

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -1,5 +1,5 @@
 import { Switch } from "../ui/atoms/switch";
-import { SettingsData, STATE, UpdateStatus } from "./mdn-worker";
+import { SettingsData, getMDNWorker } from "./mdn-worker";
 import useInterval from "@use-it/interval";
 
 import { useEffect, useRef, useState } from "react";
@@ -7,6 +7,7 @@ import UpdateButton from "./update";
 import ClearButton from "./clear";
 import { Spinner } from "../ui/atoms/spinner";
 import { MDN_PLUS_TITLE } from "../constants";
+import { ContentStatus } from "./db";
 
 function displayEstimate({ usage = 0, quota = Infinity }: StorageEstimate) {
   const usageInMib = Math.round(usage / (1024 * 1024));
@@ -37,7 +38,7 @@ export default function SettingsApp({ ...appProps }) {
 
 function Settings() {
   document.title = `MDN Offline | ${MDN_PLUS_TITLE}`;
-  const [status, setStatus] = useState<UpdateStatus>();
+  const [status, setStatus] = useState<ContentStatus>();
   const [saving, setSaving] = useState<boolean>(true);
 
   const [estimate, setEstimate] = useState<StorageEstimate | null>(null);
@@ -47,9 +48,10 @@ function Settings() {
 
   useEffect(() => {
     const init = async () => {
-      setSettings(await window.mdnWorker.offlineSettings());
-      setStatus(await window.mdnWorker.updateAvailable());
+      const mdnWorker = getMDNWorker();
+      setSettings(await mdnWorker.offlineSettings());
       setEstimate(await navigator?.storage?.estimate?.());
+      mdnWorker.checkForUpdate();
     };
     init().then(() => {});
   }, []);
@@ -62,23 +64,20 @@ function Settings() {
 
   const updateSettings = async (change: SettingsData) => {
     setSaving(true);
-    let newSettings = await window.mdnWorker.setOfflineSettings(change);
+    const mdnWorker = getMDNWorker();
+    let newSettings = await mdnWorker.setOfflineSettings(change);
     setSettings(newSettings);
   };
 
-  useInterval(() => {
-    const next = window.mdnWorker.status();
-    if (next.state === STATE.nothing) {
-      if (next.state !== status?.state) {
-        setStatus({ ...next });
-      }
-    } else {
-      setStatus({ ...next });
-    }
+  useInterval(async () => {
+    const mdnWorker = getMDNWorker();
+    const next = await mdnWorker.status();
+    setStatus({ ...next });
   }, 500);
 
   const update = () => {
-    window.mdnWorker.update();
+    const mdnWorker = getMDNWorker();
+    mdnWorker.update();
     setStatus(status);
   };
 
@@ -86,14 +85,15 @@ function Settings() {
     if (
       window.confirm("All downloaded content will be removed from your device")
     ) {
-      window.mdnWorker.clear();
+      const mdnWorker = getMDNWorker();
+      mdnWorker.clear();
       setStatus(status);
     }
   };
 
   if (
     settings?.autoUpdates &&
-    status?.state === STATE.updateAvailable &&
+    status?.remote?.latest !== status?.local?.version &&
     !updateTriggered.current
   ) {
     update();

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -7,7 +7,7 @@ import UpdateButton from "./update";
 import ClearButton from "./clear";
 import { Spinner } from "../ui/atoms/spinner";
 import { MDN_PLUS_TITLE } from "../constants";
-import { ContentStatus } from "./db";
+import { ContentStatus, ContentStatusPhase } from "./db";
 
 function displayEstimate({ usage = 0, quota = Infinity }: StorageEstimate) {
   const usageInMib = Math.round(usage / (1024 * 1024));
@@ -61,6 +61,14 @@ function Settings() {
     };
     init();
   }, [settings]);
+
+  useEffect(() => {
+    const mdnWorker = getMDNWorker();
+    const keepAlive = status?.phase
+      ? status?.phase !== ContentStatusPhase.IDLE
+      : false;
+    mdnWorker.toggleKeepAlive(keepAlive);
+  }, [status?.phase]);
 
   const updateSettings = async (change: SettingsData) => {
     setSaving(true);

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -64,10 +64,21 @@ function Settings() {
 
   useEffect(() => {
     const mdnWorker = getMDNWorker();
-    const keepAlive = status?.phase
+    const isWorkerBusy = status?.phase
       ? status?.phase !== ContentStatusPhase.IDLE
       : false;
-    mdnWorker.toggleKeepAlive(keepAlive);
+    mdnWorker.toggleKeepAlive(isWorkerBusy);
+
+    if (isWorkerBusy) {
+      // Warn when leaving page.
+      const listener = (e) => {
+        e.preventDefault();
+        e.returnValue = "";
+      };
+      window.addEventListener("beforeunload", listener);
+
+      return () => window.removeEventListener("beforeunload", listener);
+    }
   }, [status?.phase]);
 
   const updateSettings = async (change: SettingsData) => {

--- a/client/src/offline-settings/settings.tsx
+++ b/client/src/offline-settings/settings.tsx
@@ -165,7 +165,9 @@ function Settings() {
           {window?.location.hash === "#debug" && (
             <li>
               <h4>Debug</h4>
-              <span>{JSON.stringify(status, null, 2)}</span>
+              <span style={{ fontFamily: "monospace", whiteSpace: "pre" }}>
+                {JSON.stringify(status, null, 2)}
+              </span>
             </li>
           )}
           {usage && (

--- a/client/src/offline-settings/update.tsx
+++ b/client/src/offline-settings/update.tsx
@@ -1,83 +1,83 @@
-import { STATE, UpdateStatus } from "./mdn-worker";
+import { ContentStatus, ContentStatusPhase } from "./db";
 
 export default function UpdateButton({
   updateStatus,
   update,
   disabled = false,
 }: {
-  updateStatus: UpdateStatus | null;
+  updateStatus: ContentStatus | null;
   update: () => void;
   disabled?: boolean;
 }) {
   const current =
-    updateStatus?.currentDate &&
+    updateStatus?.local?.date &&
     `Last updated: ${Intl.DateTimeFormat([], { dateStyle: "medium" }).format(
-      Date.parse(updateStatus.currentDate)
+      Date.parse(updateStatus?.local?.date)
     )}`;
   let button: JSX.Element | null = null;
   let info: string | undefined;
-  let progress = (updateStatus?.progress || 0) * 100;
-  if (!updateStatus || updateStatus?.state === STATE.init) {
-    info = "Checking for updates";
-  }
-  if (updateStatus?.state === STATE.nothing) {
-    info = "Your content is up to date";
-    button = <button disabled>Up to date</button>;
-  }
-  if (updateStatus?.state === STATE.updateAvailable) {
-    if (updateStatus?.currentDate) {
-      info = "Update available";
+
+  switch (updateStatus?.phase) {
+    case ContentStatusPhase.INITIAL:
+      info = "Checking for updates";
+      break;
+
+    case ContentStatusPhase.IDLE:
+      if (updateStatus?.local?.version === updateStatus?.remote?.latest) {
+        info = "Your content is up to date";
+        button = <button disabled>Up to date</button>;
+      } else {
+        if (updateStatus?.local) {
+          info = "Update available";
+          button = (
+            <button className="button" onClick={update} disabled={disabled}>
+              {" "}
+              Update now
+            </button>
+          );
+        } else {
+          info =
+            "Start using MDN Offline by downloading the latest version of MDN Web Docs";
+          button = (
+            <button className="button" onClick={update} disabled={disabled}>
+              {" "}
+              Download
+            </button>
+          );
+        }
+      }
+      break;
+
+    case ContentStatusPhase.DOWNLOAD:
+      if (updateStatus?.local) {
+        info = "Update in progress…";
+      } else {
+        info = "Download in progress…";
+      }
+      button = <button disabled={disabled}>Downloading…</button>;
+      break;
+
+    case ContentStatusPhase.UNPACK:
+      if (updateStatus?.local) {
+        info = "Update in progress…";
+      } else {
+        info = "Download in progress…";
+      }
+      const progress = (updateStatus?.progress || 0) * 100;
       button = (
-        <button className="button" onClick={update} disabled={disabled}>
-          {" "}
-          Update now
+        <button disabled={disabled}>
+          Unpacking…{" "}
+          {progress?.toLocaleString(undefined, {
+            maximumFractionDigits: 0,
+          })}
+          %
         </button>
       );
-    } else {
-      info =
-        "Start using MDN Offline by downloading the latest version of MDN Web Docs";
-      button = (
-        <button className="button" onClick={update} disabled={disabled}>
-          {" "}
-          Download
-        </button>
-      );
-    }
-  }
-  if (updateStatus?.state === STATE.downloading) {
-    if (updateStatus?.currentDate) {
-      info = "Update in progress…";
-    } else {
-      info = "Download in progress…";
-    }
-    button = <button disabled={disabled}>Downloading…</button>;
-  }
-  if (updateStatus?.state === STATE.unpacking) {
-    if (updateStatus?.currentDate) {
-      info = "Update in progress…";
-    } else {
-      info = "Download in progress…";
-    }
-    button = (
-      <button disabled={disabled}>
-        Unpacking…{" "}
-        {progress?.toLocaleString(undefined, {
-          maximumFractionDigits: 0,
-        })}
-        %
-      </button>
-    );
-  }
-  if (updateStatus?.state === STATE.cleaning) {
-    if (updateStatus?.currentDate) {
-      info = "Update in progress…";
-    } else {
-      info = "Download in progress…";
-    }
-    button = <button disabled>Cleaning…</button>;
-  }
-  if (updateStatus?.state === STATE.clearing) {
-    info = "Clearing…";
+      break;
+
+    case ContentStatusPhase.CLEAR:
+      info = "Clearing…";
+      break;
   }
 
   return (

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cookie-parser": "1.4.6",
     "cssesc": "^3.0.0",
     "dayjs": "1.11.1",
+    "dexie": "3.2.1",
     "dotenv": "14.3.0",
     "ejs": "3.1.7",
     "express": "4.17.3",

--- a/testing/tests/offline-db.test.js
+++ b/testing/tests/offline-db.test.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+test("db.ts should be identical (PWA vs. Client)", () => {
+  function sha256sum(path) {
+    const content = fs.readFileSync(path);
+    return crypto.createHash("sha256").update(content).digest("hex");
+  }
+
+  const pwaDb = path.join("client", "pwa", "src", "db.ts");
+  const clientDb = path.join("client", "src", "offline-settings", "db.ts");
+
+  const [clientDbHash, pwaDbHash] = [clientDb, pwaDb].map(sha256sum);
+
+  expect(clientDbHash).toEqual(pwaDbHash);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5684,6 +5684,11 @@ detect-port-alt@1.1.6:
     address "^1.0.1"
     debug "^2.6.0"
 
+dexie@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/dexie/-/dexie-3.2.1.tgz#ef21456d725e700c1ab7ac4307896e4fdabaf753"
+  integrity sha512-Y8oz3t2XC9hvjkP35B5I8rUkKKwM36GGRjWQCMjzIYScg7W+GHKDXobSYswkisW7CxL1/tKQtggMDsiWqDUc1g==
+
 diagnostics@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz"


### PR DESCRIPTION
Phases:
1. https://github.com/mdn/yari/pull/5980
2. https://github.com/mdn/yari/pull/5955
3. TODO

## Summary

Fixes https://github.com/mdn/yari/issues/5920.

### Problem

Previously, we managed state regarding the Offline Content (e.g. what version do we have locally, what is the latest version remotely, what are we currently doing) in the Client, by handling messages from the Service Worker.

However, not every message was necessarily handled, because clients cannot handle messages while performing a classic page navigation. This caused an inconsistent state, i.e. client and Service Worker were not on the same "page".

### Solution

Now, we manage the ContentStatus exclusively in the ServiceWorker, persisting it in the IndexedDB, and access it in the Client.

Details:
- Added a `contentStatusHistory` table to the `MDNOfflineDB` (IndexedDB).
- Introduced `getContentStatus()` (Client + SW) and `patchContentStatus()` (SW) helpers.

Other changes:
- Renamed `state` to `phase`, and reworked phases (initial / idle / download / unpack / clear).
- Unpacking now updates progress to `1` when unpacking finished.

### Limitations

1. The db is not lazy-loaded in the `client`, i.e. it is initialized as soon as the MDN Offline page is visited (which cannot really be avoided, because the ContentStatus in the db decides what to show on the MDN Offline page).
2. The db is duplicated in `client/pwa/src/db.ts` and `client/src/offline-settings/db.ts`.

---

## Screenshots

_No change._

---

## How did you test this change?

1. Opened MDN Offline page and disabled "Enable offline storage".
2. Deleted MDNOfflineDB from IndexedDB.
3. Reloaded MDN Offline settings and enabled "Enable offline storage".
4. Clicked "Download" button.
5. Reloaded page during Download and Unpack phases.
6. Waited for Unpack phase to finish.
7. Clicked "Clear" button.