### PR TITLE
Add Ctrl/Cmd+K as a Keyboard Shortcut for search

### DIFF
--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -8,17 +8,17 @@ export type SearchProps = {
   onChangeIsFocused: (isFocused: boolean) => void;
 };
 
-export function useFocusOnSlash(
+export function useFocusOnSlashOrCtrlOrCmdK(
   inputRef: React.RefObject<null | HTMLInputElement>
 ) {
   useEffect(() => {
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
       if (
-        event.key === "/" &&
-        !event.ctrlKey &&
-        !event.metaKey &&
-        !["TEXTAREA", "INPUT"].includes(event.target.tagName)
+        (event.key === "/" && !event.ctrlKey && !event.metaKey) ||
+        (event.key.toLowerCase() === "k" &&
+          (event.metaKey || event.ctrlKey) &&
+          !["TEXTAREA", "INPUT"].includes(event.target.tagName))
       ) {
         if (input && document.activeElement !== input) {
           event.preventDefault();

--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -8,18 +8,18 @@ export type SearchProps = {
   onChangeIsFocused: (isFocused: boolean) => void;
 };
 
-export function useFocusOnSlashOrCtrlOrCmdK(
+export function useFocusViaKeyboard(
   inputRef: React.RefObject<null | HTMLInputElement>
 ) {
   useEffect(() => {
     function focusOnSearchMaybe(event) {
       const input = inputRef.current;
-      if (
-        (event.key === "/" && !event.ctrlKey && !event.metaKey) ||
-        (event.key.toLowerCase() === "k" &&
-          (event.metaKey || event.ctrlKey) &&
-          !["TEXTAREA", "INPUT"].includes(event.target.tagName))
-      ) {
+      const keyPressed = event.key;
+      const ctrlOrMetaPressed = event.ctrlKey || event.metaKey;
+      const isSlash = keyPressed === "/" && !ctrlOrMetaPressed;
+      const isCtrlK = keyPressed.toLowerCase() === "k" && ctrlOrMetaPressed;
+      const isTextField = ["TEXTAREA", "INPUT"].includes(event.target.tagName);
+      if ((isSlash || isCtrlK) && !isTextField) {
         if (input && document.activeElement !== input) {
           event.preventDefault();
           input.focus();

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -9,7 +9,7 @@ import { preload, preloadSupported } from "./document/preloading";
 import { Button } from "./ui/atoms/button";
 
 import { useLocale } from "./hooks";
-import { SearchProps, useFocusOnSlash } from "./search-utils";
+import { SearchProps, useFocusOnSlashOrCtrlOrCmdK } from "./search-utils";
 
 const PRELOAD_WAIT_MS = 500;
 const SHOW_INDEXING_AFTER_MS = 500;
@@ -288,7 +288,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     },
   });
 
-  useFocusOnSlash(inputRef);
+  useFocusOnSlashOrCtrlOrCmdK(inputRef);
 
   useEffect(() => {
     if (isFocused) {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -9,7 +9,7 @@ import { preload, preloadSupported } from "./document/preloading";
 import { Button } from "./ui/atoms/button";
 
 import { useLocale } from "./hooks";
-import { SearchProps, useFocusOnSlashOrCtrlOrCmdK } from "./search-utils";
+import { SearchProps, useFocusViaKeyboard } from "./search-utils";
 
 const PRELOAD_WAIT_MS = 500;
 const SHOW_INDEXING_AFTER_MS = 500;
@@ -288,7 +288,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     },
   });
 
-  useFocusOnSlashOrCtrlOrCmdK(inputRef);
+  useFocusViaKeyboard(inputRef);
 
   useEffect(() => {
     if (isFocused) {


### PR DESCRIPTION
## Summary

Fixes #5935

### Problem

Vimium overrides / by default.

### Solution

Add another keyboard shortcut for search

## How did you test this change?

Locally on Firefox, tried Ctrl+k and Ctrl+K (capital and lowercase). Locally on Chrome, tried ⊞ + k (which is the metaKey for Chromium browsers on Windows, like Cmd is for browsers on Mac: see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey)