### PR TITLE
Allow authors to omit the {{Compat}} and {{Specifications}} macros

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -543,7 +543,7 @@ async function buildDocument(document, documentOptions = {}) {
   // section blocks are of type "prose" and their value is a string blob
   // of HTML.
   try {
-    const [sections, sectionFlaws] = extractSections($);
+    const [sections, sectionFlaws] = extractSections($, document.metadata);
     doc.body = sections;
     if (sectionFlaws.length) {
       injectSectionFlaws(doc, sectionFlaws, options);


### PR DESCRIPTION
Fixes #6390.

For the normal case where a `{{Compat}}` or `{{Specifications}}` macro has no arguments, this change allows authors to completely omit the macro.

That is, this change allows authors to just do the following:

```markdown
## Specifications

## Browser compatibility
```

... rather than needing to do this:

```markdown
## Specifications

{{Specifications}}

## Browser compatibility

{{Compat}}
```

This change works by directly passing the frontmatter metadata down to the code that builds the contents of the “Browser compatibility” and “Specifications” sections — rather than needing for it to be indirectly passed by the `{{Compat}}` and `{{Specifications}}` macros.

This change is also in line with our general de-macro-ization plans — in that it takes us a big step closer to completely eliminating the `{{Compat}}` and `{{Specifications}}` macros.

---
Part of the context for this change is that https://github.com/mdn/yari/discussions/5347#discussioncomment-2280927 has persuaded me that it would be a good idea for us to move wholly over to just using the `browser-compat` and `spec-urls` macros, and never using the `{{Specifications}}` and `{{Compat}} macros.

The specific parts of https://github.com/mdn/yari/discussions/5347#discussioncomment-2280927 I found persuasive were:

> ### Macros with arguments
>  ...
> …my preferences are toward:
> 
> 1. Providing _fewer_ ways to author things. Either the key is the only way it's done, or there ought be more unified way of richly citing/embedding non-MDN content.
> 2. Not committing to Kumascript-isms in Markdown.
> 
> In general, I'd really like to get away from macros as a way of embedding stuff in Markdown and it didn't feel like it was in scope for this discussion. That said, I'd like us to explore alternatives to Kumascript macro syntax, particularly the bits that are most unlike Markdown (in this case, arguments).