### PR TITLE
Allow the browser-compat frontmatter value to be an array

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -240,6 +240,37 @@ code {
   font-weight: var(--font-body-strong-weight);
 }
 
+div.specs p {
+  border: 1px solid var(--border-primary);
+  font: var(--type-body-l);
+  font-size: 0.875rem;
+  line-height: 1.75;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+}
+
+div.specs ~ div.specs p,
+div.specs p ~ p {
+  border-top-style: none;
+}
+
+.spec-header {
+  background: var(--background-tertiary);
+  border: 1px solid var(--border-primary);
+  border-bottom-style: none;
+  font: var(--type-body-l);
+  font-size: 0.875rem;
+  font-weight: var(--font-body-strong-weight);
+  line-height: 1.5;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.spec-header ~ .spec-header {
+  display: none;
+}
+
 table {
   font: var(--type-body-l);
   border: 1px solid var(--border-primary);

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -115,11 +115,13 @@ export default function BrowserCompatibilityTable({
   data,
   browsers: browserInfo,
   locale,
+  showTableHeadings,
 }: {
   query: string;
   data: bcd.Identifier;
   browsers: bcd.Browsers;
   locale: string;
+  showTableHeadings: boolean;
 }) {
   const location = useLocation();
 
@@ -147,8 +149,28 @@ export default function BrowserCompatibilityTable({
     return `${url}?${sp.toString()}`;
   }
 
+  // “tableHeading” holds a BCD feature name. If there’s a “description”
+  // key in BCD for the feature, we use that description — after stripping
+  // out any HTML tags from it. Otherwise, if there’s no “description” key,
+  // we just use the BCD feature name. (These can be different; for
+  // example, the BCD feature name may be “for_of”, while its description
+  // is the string “<code>for...of</code>”.
+  let tableHeading;
+  if (data && data.__compat) {
+    tableHeading = data.__compat.description ? (
+      <h3
+        dangerouslySetInnerHTML={{
+          __html: data.__compat.description.replace(/<[^>]+>/g, ""),
+        }}
+      />
+    ) : (
+      <h3>{name}</h3>
+    );
+  }
+
   return (
     <BrowserCompatibilityErrorBoundary>
+      {showTableHeadings ? tableHeading : null}
       <BrowserInfoContext.Provider value={browserInfo}>
         <a
           className="bc-github-link external external-icon"

--- a/client/src/document/ingredients/spec-section.tsx
+++ b/client/src/document/ingredients/spec-section.tsx
@@ -22,30 +22,28 @@ export function SpecificationSection({
       {title && !isH3 && <DisplayH2 id={id} title={title} />}
       {title && isH3 && <DisplayH3 id={id} title={title} />}
 
+      {/*
+        If we were to output HTML table markup here, then in the case where
+        we have multiple BCD features from a browser-compat frontmatter
+        key, we’d end up with multiple tables in the output. So we instead
+        output a simpler HTML structure for each specification, and use CSS
+        to push each piece together to make the collective end result look
+        like a table; client/src/document/index.scss has the CSS styles.
+      */}
+      <div className="spec-header">Specification</div>
       {specifications.length > 0 ? (
-        <table className="standard-table">
-          <thead>
-            <tr>
-              <th scope="col">Specification</th>
-            </tr>
-          </thead>
-          <tbody>
-            {specifications.map((spec) => (
-              <tr key={spec.bcdSpecificationURL}>
-                <td>
-                  <a href={spec.bcdSpecificationURL}>
-                    {spec.title} <br />
-                    {spec.bcdSpecificationURL.includes("#") && (
-                      <small>
-                        # {`${spec.bcdSpecificationURL.split("#")[1]}`}
-                      </small>
-                    )}
-                  </a>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <div className="specs">
+          {specifications.map((spec) => (
+            <p key={spec.bcdSpecificationURL}>
+              <a href={spec.bcdSpecificationURL}>
+                {spec.title} <br />
+                {spec.bcdSpecificationURL.includes("#") && (
+                  <small># {`${spec.bcdSpecificationURL.split("#")[1]}`}</small>
+                )}
+              </a>
+            </p>
+          ))}
+        </div>
       ) : (
         <NoteCard type="warning">
           <h4>No specification found</h4>

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -25,12 +25,14 @@ const isServer = typeof window === "undefined";
 
 export function LazyBrowserCompatibilityTable({
   id,
+  showTableHeadings,
   title,
   isH3,
   query,
   dataURL,
 }: {
   id: string;
+  showTableHeadings: boolean;
   title: string;
   isH3: boolean;
   query: string;
@@ -41,7 +43,10 @@ export function LazyBrowserCompatibilityTable({
       {title && !isH3 && <DisplayH2 id={id} title={title} />}
       {title && isH3 && <DisplayH3 id={id} title={title} />}
       {dataURL ? (
-        <LazyBrowserCompatibilityTableInner dataURL={dataURL} />
+        <LazyBrowserCompatibilityTableInner
+          dataURL={dataURL}
+          showTableHeadings={showTableHeadings}
+        />
       ) : (
         <NoteCard type="warning">
           <p>
@@ -59,7 +64,13 @@ export function LazyBrowserCompatibilityTable({
   );
 }
 
-function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
+function LazyBrowserCompatibilityTableInner({
+  dataURL,
+  showTableHeadings,
+}: {
+  dataURL: string;
+  showTableHeadings: boolean;
+}) {
   const locale = useLocale();
   const [bcdDataURL, setBCDDataURL] = useState("");
 
@@ -92,7 +103,11 @@ function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
   return (
     <ErrorBoundary>
       <Suspense fallback={<Loading message="Loading BCD table" />}>
-        <BrowserCompatibilityTable locale={locale} {...data} />
+        <BrowserCompatibilityTable
+          locale={locale}
+          showTableHeadings={showTableHeadings}
+          {...data}
+        />
       </Suspense>
     </ErrorBoundary>
   );


### PR DESCRIPTION
We currently have some existing documents that use multiple `{{Compat(...)}}` macros within the same document — because without the `browser-compat` frontmatter key being allowed to contain an array, there’s no other way to have multiple BCD tables in the same document except by putting multiple `{{Compat(...)}}` macros in the document.

So, allowing the `browser-compat` value to contain an array eliminates the need for authors to put multiple `{{Compat(...)}}` macros in a document.

And reducing the need for authors to use the `{{Compat(...)}}` macro at all is also in line with our general de-macro-ization plans — in that it takes us a big step closer to completely eliminating the `{{Compat}}` macro altogether.

---
Part of the context for this change is that https://github.com/mdn/yari/discussions/5347#discussioncomment-2280927 has persuaded me that it would be a good idea for us to move wholly over to just using the `browser-compat` and `spec-urls` macros, and never using the `{{Specifications}}` and `{{Compat}}` macros.

The specific parts of https://github.com/mdn/yari/discussions/5347#discussioncomment-2280927 I found persuasive were:

> ### Macros with arguments
>  ...
> …my preferences are toward:
> 
> 1. Providing _fewer_ ways to author things. Either the key is the only way it's done, or there ought be more unified way of richly citing/embedding non-MDN content.
> 2. Not committing to Kumascript-isms in Markdown.
> 
> In general, I'd really like to get away from macros as a way of embedding stuff in Markdown and it didn't feel like it was in scope for this discussion. That said, I'd like us to explore alternatives to Kumascript macro syntax, particularly the bits that are most unlike Markdown (in this case, arguments).