### PR TITLE
Fix SVG sidebar (displays in main content)

### DIFF
--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -48,7 +48,7 @@ function wrapSVGElement(name) {
 }
 
 if (s_svg_href) {  %>
-  <section class="Quick_links" id="Quick_Links">
+  <section class="Quick_links" id="Quick_links">
   <ol>
    <% if (foundTag) {
         for (aTitle of resultSVG) { // SVG entities matching


### PR DESCRIPTION
SVG sidebars don't work anymore. They appear in the main content:
![Capture d’écran 2022-04-14 à 10 07 04](https://user-images.githubusercontent.com/1466293/163342034-25f09361-43bd-4d92-96f4-14397ec6e763.png)


This is caused by the incorrect capitalization of the `id`. This fixes it.

![Capture d’écran 2022-04-14 à 10 11 43](https://user-images.githubusercontent.com/1466293/163342833-0de639ee-8ae6-4e19-8e0a-42f1fd13e6f7.png)

(There should be more work on these sidebars, but that's the minimal set to fix the current problem.)