### PR TITLE
chore(pwa): manage ContentStatus in IndexedDB, but be backward-compatible (Phase 1 of 3)

### DIFF
--- a/client/pwa/src/db.ts
+++ b/client/pwa/src/db.ts
@@ -40,10 +40,39 @@ interface Whoami {
   is_subscriber: boolean;
 }
 
+export enum ContentStatusPhase {
+  INITIAL = "initial",
+  IDLE = "idle",
+  DOWNLOAD = "download",
+  UNPACK = "unpack",
+  CLEAR = "clear",
+}
+
+export interface LocalContentStatus {
+  version: string;
+  date: string;
+}
+
+export interface RemoteContentStatus {
+  date: string;
+  latest: string;
+  updates: [string];
+}
+
+export interface ContentStatus {
+  id?: number;
+  phase: ContentStatusPhase;
+  local: LocalContentStatus | null;
+  remote: RemoteContentStatus | null;
+  progress: number | null;
+  timestamp: Date;
+}
+
 export class MDNOfflineDB extends Dexie {
   // Declare implicit table properties.
   // (just to inform Typescript. Instanciated by Dexie in stores() method)
   whoami!: Dexie.Table<Whoami, number>; // number = type of the primkey
+  contentStatusHistory!: Dexie.Table<ContentStatus, number>;
   collections!: Dexie.Table<Collections, string>;
   watched!: Dexie.Table<Watched, String>;
   notifications!: Dexie.Table<Notifications, number>;
@@ -57,9 +86,55 @@ export class MDNOfflineDB extends Dexie {
       watched: "url, title, path",
       notifications: "id, title, text, url, created, read, starred",
     });
+    this.version(2).stores({
+      contentStatusHistory: "++id",
+    });
   }
 }
 
 const offlineDb = new MDNOfflineDB();
 
-export { offlineDb };
+async function getContentStatus(): Promise<ContentStatus> {
+  const current = await offlineDb.contentStatusHistory.toCollection().last();
+
+  return (
+    current || {
+      phase: ContentStatusPhase.INITIAL,
+      local: null,
+      remote: null,
+      progress: null,
+      timestamp: new Date(),
+    }
+  );
+}
+
+async function patchContentStatus(
+  changes: Omit<Partial<ContentStatus>, "id" | "timestamp">
+) {
+  const db = offlineDb;
+  const table = db.contentStatusHistory;
+
+  await db.transaction("rw", table, async () => {
+    const oldStatus = await getContentStatus();
+    const newStatus = {
+      ...oldStatus,
+      ...changes,
+      id: undefined,
+      timestamp: new Date(),
+    };
+
+    if (oldStatus.phase === ContentStatusPhase.INITIAL && !changes.phase) {
+      newStatus.phase = ContentStatusPhase.IDLE;
+    }
+
+    if (oldStatus.id && oldStatus.phase === newStatus.phase) {
+      await table.update(oldStatus.id, newStatus);
+    } else {
+      await table.add(newStatus);
+      // Keep latest entries for debugging.
+      await table.reverse().offset(100).delete();
+    }
+  });
+}
+
+export { offlineDb, getContentStatus, patchContentStatus };

--- a/client/pwa/src/unpack-cache.ts
+++ b/client/pwa/src/unpack-cache.ts
@@ -42,6 +42,7 @@ export async function unpackAndCache(data, progress = async (number) => {}) {
 
     await cache.put(location, response);
   }
+  await progress(1);
   await reader.close();
   if (removed) {
     await Promise.all(


### PR DESCRIPTION
Phase 1 of 3, extracted from https://github.com/mdn/yari/pull/5955.

## Summary

The ServiceWorker starts to use IndexedDB, but still accepts the
local version from the client as a fallback on the update message,
and still emits messages to inform clients about the status.

For the ServiceWorker, however, the IndexedDB is the truth.

## How did you test this change?

Edge:

1. Deleted MDNOfflineDB database.
2. Stopped and unregistered ServiceWorker.
3. Went to MDN Offline page.
4. Enabled  offline storage.
5. Downloaded content.
6. Verified that IndexedDB and LocalStorage had the same local version.
7. Cleared content.