### PR TITLE
chore(ui): migrate 404 and search to page layout

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -190,7 +190,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
           </div>
         )
       )}
-      <div className="article-wrapper">
+      <div className="main-wrapper">
         <RenderSideBar doc={doc} />
 
         <div className="toc">

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -88,7 +88,7 @@ function StaticPage({
         </div>
       </div>
 
-      <div className="article-wrapper">
+      <div className="main-wrapper">
         <SidebarContainer doc={hyData}>
           {sidebarHeader || null}
         </SidebarContainer>

--- a/client/src/page-not-found/index.scss
+++ b/client/src/page-not-found/index.scss
@@ -1,15 +1,7 @@
 @use "sass:math";
 
 .page-not-found {
-  p {
-    margin-top: 50px;
-  }
-
   .fallback-document {
-    p {
-      margin-top: 0.5rem;
-    }
-
     .fallback-link {
       font-size: 1rem;
     }

--- a/client/src/page-not-found/index.tsx
+++ b/client/src/page-not-found/index.tsx
@@ -28,24 +28,26 @@ export function PageNotFound() {
   return (
     <div className="main-wrapper page-not-found">
       <PageContentContainer>
-        {/* This string should match the `pageTitle` set in ssr/render.js */}
-        <h1>Page not found</h1>
+        <article className="main-page-content">
+          {/* This string should match the `pageTitle` set in ssr/render.js */}
+          <h1>Page not found</h1>
 
-        {url && (
-          <p className="sorry-message">
-            Sorry, the page <code>{url}</code> could not be found.
+          {url && (
+            <p className="sorry-message">
+              Sorry, the page <code>{url}</code> could not be found.
+            </p>
+          )}
+
+          {url && (
+            <React.Suspense fallback={null}>
+              <FallbackLink url={url} />
+            </React.Suspense>
+          )}
+
+          <p>
+            <a href="/">Go back to the home page</a>
           </p>
-        )}
-
-        {url && (
-          <React.Suspense fallback={null}>
-            <FallbackLink url={url} />
-          </React.Suspense>
-        )}
-
-        <p>
-          <a href="/">Go back to the home page</a>
-        </p>
+        </article>
       </PageContentContainer>
     </div>
   );

--- a/client/src/page-not-found/index.tsx
+++ b/client/src/page-not-found/index.tsx
@@ -26,7 +26,7 @@ export function PageNotFound() {
   }, [location]);
 
   return (
-    <div className="page-not-found">
+    <div className="main-wrapper page-not-found">
       <PageContentContainer>
         {/* This string should match the `pageTitle` set in ssr/render.js */}
         <h1>Page not found</h1>

--- a/client/src/site-search/form.tsx
+++ b/client/src/site-search/form.tsx
@@ -16,11 +16,18 @@ export default function SiteSearchForm() {
   const [searchParams] = useSearchParams();
   const queryLocales = searchParams.getAll("locale");
 
+  const showLanguageOptions = locale.toLowerCase() !== "en-us";
+  const showAdvancedOptions = showLanguageOptions;
+
+  if (!showAdvancedOptions) {
+    return null;
+  }
+
   return (
     <div className="advanced-options">
       {/* Language only applies if you're browsing in, say, French
       and want to search in English too. */}
-      {locale.toLowerCase() !== "en-us" && (
+      {showLanguageOptions && (
         <div className="language-options">
           <h2>Language:</h2>
           <ul className="language-option-list">

--- a/client/src/site-search/index.scss
+++ b/client/src/site-search/index.scss
@@ -1,9 +1,5 @@
 @use "../ui/vars" as *;
 
-.site-search {
-  min-height: 500px;
-}
-
 .query-string {
   font-style: italic;
 }

--- a/client/src/site-search/index.scss
+++ b/client/src/site-search/index.scss
@@ -2,11 +2,6 @@
 
 .site-search {
   min-height: 500px;
-  padding-top: 2rem;
-
-  @media screen and (min-width: $screen-md) {
-    padding-top: 3rem;
-  }
 }
 
 .query-string {

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -49,7 +49,7 @@ export function SiteSearch() {
   }, [query, page, ga]);
 
   return (
-    <div className="site-search main-page-content">
+    <div className="main-wrapper site-search main-page-content">
       <PageContentContainer>
         {query ? (
           <h1>

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -51,26 +51,28 @@ export function SiteSearch() {
   return (
     <div className="main-wrapper site-search main-page-content">
       <PageContentContainer>
-        {query ? (
-          <h1>
-            Search results for: <span className="query-string">{query}</span>{" "}
-            {page && page !== "1" && `(page ${page})`}
-          </h1>
-        ) : (
-          <h1>No query, no results.</h1>
-        )}
+        <article className="main-page-content">
+          {query ? (
+            <h1>
+              Search results for: <span className="query-string">{query}</span>{" "}
+              {page && page !== "1" && `(page ${page})`}
+            </h1>
+          ) : (
+            <h1>No query, no results.</h1>
+          )}
 
-        {!isServer && (
-          <React.Suspense fallback={<Loading />}>
-            <SiteSearchForm />
-          </React.Suspense>
-        )}
+          {!isServer && (
+            <React.Suspense fallback={<Loading />}>
+              <SiteSearchForm />
+            </React.Suspense>
+          )}
 
-        {!isServer && query && (
-          <React.Suspense fallback={<Loading />}>
-            <SearchResults />
-          </React.Suspense>
-        )}
+          {!isServer && query && (
+            <React.Suspense fallback={<Loading />}>
+              <SearchResults />
+            </React.Suspense>
+          )}
+        </article>
       </PageContentContainer>
     </div>
   );

--- a/client/src/ui/atoms/page-content/index.tsx
+++ b/client/src/ui/atoms/page-content/index.tsx
@@ -3,7 +3,7 @@ import React from "react";
 // What we use on the document pages
 export function MainContentContainer({
   children,
-  className = "main-content",
+  className = "",
 }: {
   children: React.ReactNode;
   className?: string;
@@ -13,7 +13,7 @@ export function MainContentContainer({
       // This exists for the benefit of a11y navigation which
       // uses anchor links to focus in on the content.
       id="content"
-      className={className}
+      className={`main-content ${className}`}
       role="main"
     >
       {children}

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -19,7 +19,7 @@
   }
 }
 
-.article-wrapper {
+.main-wrapper {
   display: flex;
   max-width: var(--max-width);
   margin: 0 auto;


### PR DESCRIPTION
## Summary

Fixes #5986.

### Problem

Both the PageNotFound page and the Search page did not have the regular MDN layout.

### Solution

Apply the regular page layout to those pages.

---

## Screenshots

### PageNotFound

#### Before

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/495429/163632239-62adc429-c84f-409a-9d38-383bdc8f0b9c.png">

#### After

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/495429/163632191-26264f0a-9e8f-4368-bd33-09d5d45dab70.png">

### Search

#### Before

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/495429/163632530-8adc2583-fa20-4ba8-80bd-b7e04d429542.png">

#### After

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/495429/163632508-9c2ff13a-806e-4b9c-a647-eeeef46994da.png">

*Note*: The top nav search results are currently always visible when there is a search query, which may cause an overlap with the dedicated search results using the common layout. This will be fixed by #5988.


---

## How did you test this change?

1. Opened [non-existent page](http://localhost:3000/en-US/test) locally.
2. Performed [search](http://localhost:3000/en-US/search?q=test) locally.
