### PR TITLE
fix(search): hide results unless focused

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -319,7 +319,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
   }, [resultItems, inputValue]);
 
   const searchResults = (() => {
-    if (!isOpen || !inputValue.trim()) {
+    if (!inputValue.trim()) {
       return null;
     }
 

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -443,6 +443,8 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     );
   })();
 
+  const blurTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   return (
     <form
       action={formAction}
@@ -477,10 +479,19 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           name: "q",
           onMouseOver: initializeSearchIndex,
           onFocus: () => {
+            if (blurTimeout.current) {
+              // For example: click on search item.
+              clearTimeout(blurTimeout.current);
+            }
             onChangeIsFocused(true);
           },
           onBlur: () => {
-            onChangeIsFocused(false);
+            if (blurTimeout.current) {
+              clearTimeout(blurTimeout.current);
+            }
+            blurTimeout.current = setTimeout(() => {
+              onChangeIsFocused(false);
+            }, 0);
           },
           onKeyDown(event) {
             if (event.key === "Escape" && inputRef.current) {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -266,7 +266,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         ? [nothingFoundItem]
         : [...resultItems, onlineSearch],
     inputValue,
-    isOpen: inputValue !== "",
+    isOpen: isFocused,
     defaultIsOpen: isFocused,
     defaultHighlightedIndex: 0,
     onSelectedItemChange: ({ type, selectedItem }) => {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useCombobox } from "downshift";
 import useSWR from "swr";
 
@@ -163,13 +163,11 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     onChangeInputValue,
     isFocused,
     onChangeIsFocused,
-    onResultPicked,
     defaultSelection,
   } = props;
 
   const inputId = `${id}-q`;
   const formId = `${id}-form`;
-  const navigate = useNavigate();
   const locale = useLocale();
 
   const [searchIndex, searchIndexError, initializeSearchIndex] =
@@ -270,20 +268,12 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     defaultIsOpen: isFocused,
     defaultHighlightedIndex: 0,
     onSelectedItemChange: ({ type, selectedItem }) => {
-      if (type !== useCombobox.stateChangeTypes.InputBlur && selectedItem) {
-        navigate(selectedItem.url);
-        onChangeInputValue("");
-        reset();
-        toggleMenu();
-        inputRef.current?.blur();
-        if (onResultPicked) {
-          onResultPicked();
-        }
-        window.scroll({
-          top: 0,
-          left: 0,
-          behavior: "smooth",
-        });
+      if (type === useCombobox.stateChangeTypes.InputBlur) {
+        // Ignore: Happens when focusing the hp search.
+        return;
+      }
+      if (selectedItem) {
+        window.location.href = selectedItem.url;
       }
     },
   });

--- a/testing/tests/headless.search.spec.js
+++ b/testing/tests/headless.search.spec.js
@@ -31,7 +31,7 @@ test.describe("Autocomplete search", () => {
     await page.waitForLoadState("networkidle");
     expect(await page.innerText("h1")).toBe("<foo>: A test tag");
     // Should have been redirected too...
-    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo/"));
   });
 
   test("find nothing by title search", async ({ page }) => {
@@ -69,7 +69,7 @@ test.describe("Autocomplete search", () => {
     await page.waitForLoadState("networkidle");
     expect(await page.innerText("h1")).toBe("<foo>: A test tag");
     // Should have been redirected too...
-    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo/"));
   });
 
   test("find nothing by fuzzy-search", async ({ page }) => {


### PR DESCRIPTION
## Summary

### Problem

Search results from the top navigation search are permanently visible if the search input is not empty. To hide the search results, the user has to manually reset the search input.

This also means that those search results were visible on the dedicated search page, because the search input is prefilled with the search query parameter.

### Solution

Show the search results only while the search input has focus, i.e. hide them as soon as the search input no longer has focus.

---

## Screenshots

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

https://user-images.githubusercontent.com/495429/163634798-fd4768ac-068c-4501-be70-71151185e31e.mov

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
