### PR TITLE
fix(api): use trailing slash where expected

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -70,7 +70,7 @@ export const IEX_DOMAIN =
   "https://interactive-examples.mdn.mozilla.net";
 
 export const HEADER_NOTIFICATIONS_MENU_API_URL =
-  "/api/v1/plus/notifications?limit=1&unread=true";
+  "/api/v1/plus/notifications/?limit=1&unread=true";
 
 export const UPDATES_BASE_URL =
   process.env.REACT_APP_UPDATES_BASE_URL ||

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -29,7 +29,7 @@ export function useLocale() {
 export function useCSRFMiddlewareToken(): string {
   const userData = useUserData();
   const userSettingsAPIURL = React.useMemo(() => {
-    return userData && userData.isAuthenticated ? "/api/v1/settings" : null;
+    return userData && userData.isAuthenticated ? "/api/v1/settings/" : null;
   }, [userData]);
   const { data, error } = useSWR<UserSettings>(
     userSettingsAPIURL,

--- a/server/static.js
+++ b/server/static.js
@@ -109,7 +109,7 @@ app.get("/api/v1/whoami", async (req, res) => {
 
 const mockSettingsDatabase = new Map();
 
-app.get("/api/v1/settings", async (req, res) => {
+app.get("/api/v1/settings/", async (req, res) => {
   const defaultContext = { locale: "en-US", csrfmiddlewaretoken: "xyz123" };
   if (!req.cookies.sessionid) {
     res.status(403).send("oh no you don't");
@@ -128,7 +128,7 @@ app.get("/api/v1/settings", async (req, res) => {
   }
 });
 
-app.post("/api/v1/settings", async (req, res) => {
+app.post("/api/v1/settings/", async (req, res) => {
   if (!req.cookies.sessionid) {
     res.status(403).send("oh no you don't");
   } else {

--- a/testing/content/files/en-us/web/unsafe_html/index.html
+++ b/testing/content/files/en-us/web/unsafe_html/index.html
@@ -36,5 +36,5 @@ attribute:<br>
 <script>alert(1)</script>
 
 <style>
-  * { background-image: url(/api/v1/settings);}
+  * { background-image: url(/api/v1/settings/);}
 </style>


### PR DESCRIPTION
## Summary

Fixes #5989.

### Problem

Some kuma API routes expect a trailing slash, but we omitted it in two locations, causing a delay due to an unnecessary HTTP 301.

### Solution

Update those routes to match what kuma expects.

*Note*: The `/whoami` endpoint does neither expect nor support a trailing slash (because it's a single route, not a router with a `/` route).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="640" alt="image" src="https://user-images.githubusercontent.com/495429/163650343-70f29edb-3096-4280-9ed0-9b5a883fe14a.png">

### After

<img width="640" alt="image" src="https://user-images.githubusercontent.com/495429/163650395-b58de504-dd15-4e3b-b022-5d02cdc5ec68.png">

---

## How did you test this change?

1. Login to MDN Plus.
2. Disable MDN Offline (to avoid side-effects).
3. Open http://localhost:3000/en-US/plus or any other page.
4. Open the "Network" tab of the DevTools, and filter for "XHR" requests.
5. Open the MDN Plus user menu.