### PR TITLE
refactor: use `delete` instead of `del` in the `LRU` package

### DIFF
--- a/content/utils.js
+++ b/content/utils.js
@@ -49,7 +49,7 @@ function memoize(fn) {
 
     if (cache.has(key)) {
       if (invalidate) {
-        cache.del(key);
+        cache.delete(key);
       } else {
         return cache.get(key);
       }

--- a/kumascript/index.js
+++ b/kumascript/index.js
@@ -29,7 +29,7 @@ const renderFromURL = async (
   const urlLC = url.toLowerCase();
   if (renderCache.has(urlLC)) {
     if (invalidateCache) {
-      renderCache.del(urlLC);
+      renderCache.delete(urlLC);
     } else {
       return renderCache.get(urlLC);
     }


### PR DESCRIPTION
## Summary

As is the title.

### Problem

The `lru-cache@del` method is deprecated since `7.0`.

> https://github.com/isaacs/node-lru-cache/blob/ff322ad364c727a419a77ad962915a625aaf1b52/index.js#L730

### Solution

Use `delete` instead of `del`.

---

## Screenshots

N/A

---

## How did you test this change?

I just run `yarn run test`. 

And I checked the current [lru-cache@del](https://github.com/isaacs/node-lru-cache/blob/ff322ad364c727a419a77ad962915a625aaf1b52/index.js#L730) method. It's just returns delete method. So, nothing affects the result.


Thank you :)