### PR TITLE
Deprecated h3_gecko_minversion

### DIFF
--- a/kumascript/macros/h3_gecko_minversion.ejs
+++ b/kumascript/macros/h3_gecko_minversion.ejs
@@ -5,6 +5,11 @@
     $2 = [String / Optional] name/id attribute
 */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (currently 60 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var idAttr = $2 ? ' name="' + $2 + '" id="' + $2 + '"' : "";
 
 var str = mdn.localString({


### PR DESCRIPTION
In mdn/content#15086, I removed the last occurrence of this macro in en-US. Time to mark it deprecated so that it doesn't reappear. [Still [60 occurrences in translated-content](https://github.com/mdn/translated-content/search?q=h3_gecko_minversion)]

cc/ @schalkneethling  : what's the process to get a macro removal on the radar of l10n for purging it out of translated-content, so that it actually can be removed from Yari's KumaScript?