### PR TITLE
Support multiple BCD queries

### DIFF
--- a/build/bcd-urls.js
+++ b/build/bcd-urls.js
@@ -28,7 +28,7 @@ function normalizeBCDURLs(doc, options) {
 
   function getPathFromAbsoluteURL(absURL) {
     // Because the compat data is mutated out of @mdn/browser-compat-data,
-    // through our `packageBCD` function, it's very possible that
+    // through our `queryBCD` function, it's very possible that
     // the `doc[i].type === 'browser_compatibility` has already been
     // processed.
     if (!absURL.includes("://")) {

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -344,26 +344,22 @@ function _addSingleSpecialSection($) {
     return proseSections;
   }
   const query = dataQuery.replace(/^bcd:/, "");
-  const { browsers, data } = packageBCD(query);
+  const { browsers, data } = _getBCD(query);
 
   if (specialSectionType === "browser_compatibility") {
-    if (data === undefined) {
-      return [
-        {
-          type: specialSectionType,
-          value: {
-            title,
-            id,
-            isH3,
-            data: null,
-            query,
-            browsers: null,
-          },
+    return [
+      {
+        type: "browser_compatibility",
+        value: {
+          title,
+          id,
+          isH3,
+          data,
+          query,
+          browsers,
         },
-      ];
-    }
-
-    return _buildSpecialBCDSection();
+      },
+    ];
   } else if (specialSectionType === "specifications") {
     const specifications = _getSpecifications(specURLsString, data);
 
@@ -383,7 +379,17 @@ function _addSingleSpecialSection($) {
 
   throw new Error(`Unrecognized special section type '${specialSectionType}'`);
 
-  function _buildSpecialBCDSection() {
+  /**
+   * @param {string} queryString
+   * @returns {object}
+   */
+  function _getBCD(queryString) {
+    const { browsers, data } = packageBCD(queryString);
+
+    if (data === undefined) {
+      return { browsers: null, data: null };
+    }
+
     // First extract a map of all release data, keyed by (normalized) browser
     // name and the versions.
     // You'll have a map that looks like this:
@@ -449,19 +455,7 @@ function _addSingleSpecialSection($) {
       }
     }
 
-    return [
-      {
-        type: "browser_compatibility",
-        value: {
-          title,
-          id,
-          isH3,
-          data,
-          query,
-          browsers,
-        },
-      },
-    ];
+    return { browsers, data };
   }
 
   /**

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -390,11 +390,44 @@ function _addSingleSpecialSection($) {
    * @returns {object}
    */
   function _getBCD(queryString) {
-    const data = queryBCD(queryString);
+    const data = _getBCDData(queryString);
 
     _processBCDData(data);
 
     return data;
+  }
+
+  /**
+   * @param {string} queryString
+   * @returns {object}
+   */
+  function _getBCDData(queryString) {
+    const queries = queryString.split(",");
+
+    const data = queries.reduce((data, query) => {
+      const dataForQuery = queryBCD(query);
+
+      const breadcrumbs = query.split(".");
+      const name = breadcrumbs[breadcrumbs.length - 1];
+
+      return {
+        ...data,
+        [name]: dataForQuery,
+      };
+    }, {});
+
+    const keys = Object.keys(data);
+
+    switch (keys.length) {
+      case 0:
+        return null;
+
+      case 1:
+        return data[keys[0]];
+
+      default:
+        return data;
+    }
   }
 
   /**

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -392,8 +392,19 @@ function _addSingleSpecialSection($) {
   function _getBCD(queryString) {
     const data = queryBCD(queryString);
 
-    if (data === undefined) {
-      return null;
+    _processBCDData(data);
+
+    return data;
+  }
+
+  /**
+   *
+   * @param {object|undefined} data
+   * @returns {object|undefined}
+   */
+  function _processBCDData(data) {
+    if (!data) {
+      return data;
     }
 
     for (const [key, compat] of Object.entries(data)) {
@@ -435,8 +446,6 @@ function _addSingleSpecialSection($) {
         }
       }
     }
-
-    return data;
   }
 
   /**

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -1,5 +1,5 @@
 const cheerio = require("cheerio");
-const { packageBCD } = require("./resolve-bcd");
+const { packageBCD, BCD_BROWSER_RELEASES } = require("./resolve-bcd");
 const specs = require("browser-specs");
 const web = require("../kumascript/src/api/web.js");
 
@@ -390,30 +390,6 @@ function _addSingleSpecialSection($) {
       return { browsers: null, data: null };
     }
 
-    // First extract a map of all release data, keyed by (normalized) browser
-    // name and the versions.
-    // You'll have a map that looks like this:
-    //
-    //   'chrome_android': {
-    //      '28': {
-    //        release_date: '2012-06-01',
-    //        release_notes: '...',
-    //        ...
-    //
-    // The reason we extract this to a locally scoped map, is so we can
-    // use it to augment the `__compat` blocks for the latest version
-    // when (if known) it was added.
-    const browserReleaseData = new Map();
-    for (const [name, browser] of Object.entries(browsers)) {
-      const releaseData = new Map();
-      for (const [version, data] of Object.entries(browser.releases || [])) {
-        if (data) {
-          releaseData.set(version, data);
-        }
-      }
-      browserReleaseData.set(name, releaseData);
-    }
-
     for (const [key, compat] of Object.entries(data)) {
       let block;
       if (key === "__compat") {
@@ -440,11 +416,10 @@ function _addSingleSpecialSection($) {
               infoEntry.version_added.startsWith("≤")
                 ? infoEntry.version_added.slice(1)
                 : infoEntry.version_added;
-            if (browserReleaseData.has(browser)) {
-              if (browserReleaseData.get(browser).has(added)) {
-                infoEntry.release_date = browserReleaseData
-                  .get(browser)
-                  .get(added).release_date;
+            if (BCD_BROWSER_RELEASES.has(browser)) {
+              if (BCD_BROWSER_RELEASES.get(browser).has(added)) {
+                infoEntry.release_date =
+                  BCD_BROWSER_RELEASES.get(browser).get(added).release_date;
               }
             }
           }

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -1,5 +1,9 @@
 const cheerio = require("cheerio");
-const { packageBCD, BCD_BROWSER_RELEASES } = require("./resolve-bcd");
+const {
+  queryBCD,
+  BCD_BROWSER_RELEASES,
+  BCD_BROWSERS,
+} = require("./resolve-bcd");
 const specs = require("browser-specs");
 const web = require("../kumascript/src/api/web.js");
 
@@ -344,9 +348,11 @@ function _addSingleSpecialSection($) {
     return proseSections;
   }
   const query = dataQuery.replace(/^bcd:/, "");
-  const { browsers, data } = _getBCD(query);
+  const data = _getBCD(query);
 
   if (specialSectionType === "browser_compatibility") {
+    const browsers = BCD_BROWSERS;
+
     return [
       {
         type: "browser_compatibility",
@@ -384,10 +390,10 @@ function _addSingleSpecialSection($) {
    * @returns {object}
    */
   function _getBCD(queryString) {
-    const { browsers, data } = packageBCD(queryString);
+    const data = queryBCD(queryString);
 
     if (data === undefined) {
-      return { browsers: null, data: null };
+      return null;
     }
 
     for (const [key, compat] of Object.entries(data)) {
@@ -430,7 +436,7 @@ function _addSingleSpecialSection($) {
       }
     }
 
-    return { browsers, data };
+    return data;
   }
 
   /**

--- a/build/flaws/bad-bcd-queries.js
+++ b/build/flaws/bad-bcd-queries.js
@@ -1,4 +1,4 @@
-const { packageBCD } = require("../resolve-bcd");
+const { queryBCD } = require("../resolve-bcd");
 
 // Bad BCD queries are when the `<div class="bc-data">` tags have an
 // ID (or even lack the `id` attribute) that don't match anything in the
@@ -14,7 +14,7 @@ function getBadBCDQueriesFlaws(doc, $) {
         return "BCD table without an ID";
       }
       const query = dataQuery.replace(/^bcd:/, "");
-      return !packageBCD(query).data && `No BCD data for query: ${query}`;
+      return !queryBCD(query) && `No BCD data for query: ${query}`;
     })
     .get()
     .filter((explanation) => !!explanation)

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -2,7 +2,7 @@
 
 const bcd = require("@mdn/browser-compat-data");
 
-function packageBCD(query) {
+function queryBCD(query) {
   return query.split(".").reduce((prev, curr) => {
     return prev && Object.prototype.hasOwnProperty.call(prev, curr)
       ? prev[curr]
@@ -36,7 +36,7 @@ const BCD_BROWSER_RELEASES = (function () {
 })();
 
 module.exports = {
-  BCD_BROWSERS,
   BCD_BROWSER_RELEASES,
-  packageBCD,
+  BCD_BROWSERS,
+  queryBCD,
 };

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -3,14 +3,40 @@
 const bcd = require("@mdn/browser-compat-data");
 
 function packageBCD(query) {
-  const data = query.split(".").reduce((prev, curr) => {
+  return query.split(".").reduce((prev, curr) => {
     return prev && Object.prototype.hasOwnProperty.call(prev, curr)
       ? prev[curr]
       : undefined;
   }, bcd);
-  return { browsers: bcd.browsers, data };
 }
 
+const BCD_BROWSERS = bcd.browsers;
+
+// Map of all release data, keyed by (normalized) browser
+// name and the versions:
+//
+//   'chrome_android': {
+//      '28': {
+//        release_date: '2012-06-01',
+//        release_notes: '...',
+//        ...
+//
+const BCD_BROWSER_RELEASES = (function () {
+  const map = new Map();
+  for (const [name, browser] of Object.entries(BCD_BROWSERS)) {
+    const releaseData = new Map();
+    for (const [version, data] of Object.entries(browser.releases || [])) {
+      if (data) {
+        releaseData.set(version, data);
+      }
+    }
+    map.set(name, releaseData);
+  }
+  return map;
+})();
+
 module.exports = {
+  BCD_BROWSERS,
+  BCD_BROWSER_RELEASES,
   packageBCD,
 };


### PR DESCRIPTION
## Summary

Alternative implementation of #5972 to allow frontmatter to reference multiple BCD queries.

### Problem

Previously, pages could only reference a single BCD query.

### Solution

1. Refactored `document-extractor.js` to use pure functions for BCD and Specifications.
2. Extracted `BCD_BROWSERS` and `BCD_BROWSER_RELEASES` constants.
3. Combine multiple BCD queries into a common hierarchy (96aa5e27b).

---

## Screenshots

Example combining `html.elements.article` and `html.elements.dialog`:

<img width="785" alt="image" src="https://user-images.githubusercontent.com/495429/164016557-0bef55fb-3882-4932-8fee-2be5b78ab159.png">

---

## How did you test this change?

1. Updated `mdn/content/files/en-US/web/html/element/article/index.md` as follows:

```patch
-browser-compat: html.elements.article
+browser-compat:
+  - html.elements.article
+  - html.elements.dialog
```