### PR TITLE
fix(ssr): restore watch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "test:prepare": "yarn prepare-build && yarn build && yarn start:static-server",
     "test:testing": "jest --rootDir testing",
     "tool": "node tool/cli.js",
-    "traits:build": "cd traits && node cli.js"
+    "traits:build": "cd traits && node cli.js",
+    "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "jest": {
     "globals": {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6006.

### Problem

The`watch:ssr` script is used in Procfile.dev, but was accidentally removed.

### Solution

Restore the script.

---

## Screenshots

(n/a)

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
