### PR TITLE
fix(search): add missing key to nothing-found element

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -399,6 +399,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
                 className:
                   "nothing-found result-item " +
                   (highlightedIndex === resultItems.length ? "highlight" : ""),
+                key: "nothing-found",
                 item: onlineSearch,
                 index: resultItems.length,
               })}


### PR DESCRIPTION
## Summary

Fixes a React warning when focusing the Search locally and the Search index was not yet initialized.

### Problem

An element in the `InnerSearchNavigateWidget` component did not have a key. This caused a React warning:

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `InnerSearchNavigateWidget`. See https://reactjs.org/link/warning-keys for more information.
div
InnerSearchNavigateWidget@http://localhost:3000/static/js/main.chunk.js:17227:7
SearchErrorBoundary@http://localhost:3000/static/js/main.chunk.js:17653:5
SearchNavigateWidget
div
Search@http://localhost:3000/static/js/main.chunk.js:28486:7
div
TopNavigationMain@http://localhost:3000/static/js/main.chunk.js:31288:7
div
Container@http://localhost:3000/static/js/main.chunk.js:18909:7
header
TopNavigation@http://localhost:3000/static/js/main.chunk.js:31548:88
div
Layout@http://localhost:3000/static/js/main.chunk.js:2433:7
DocumentLayout@http://localhost:3000/static/js/main.chunk.js:2499:7
PageOrPageNotFound@http://localhost:3000/static/js/main.chunk.js:2527:7
Route@http://localhost:3000/static/js/vendors~main.chunk.js:43990:23
Routes@http://localhost:3000/static/js/vendors~main.chunk.js:44035:24
Route@http://localhost:3000/static/js/vendors~main.chunk.js:43990:23
Routes@http://localhost:3000/static/js/vendors~main.chunk.js:44035:24
Suspense
App@http://localhost:3000/static/js/main.chunk.js:2588:88
Router@http://localhost:3000/static/js/vendors~main.chunk.js:44006:24
BrowserRouter@http://localhost:3000/static/js/vendors~main.chunk.js:43514:18
UIProvider@http://localhost:3000/static/js/main.chunk.js:18140:99
UserDataProvider@http://localhost:3000/static/js/main.chunk.js:31804:58
GAProvider@http://localhost:3000/static/js/main.chunk.js:9744:58
```

### Solution

Add a `key` to the element that renders the `nothing-found` message.

---

## Screenshots

_Not applicable_.

---

## How did you test this change?

1. Open http://localhost:3000/en-US/docs/Learn/HTML locally.
2. Press CTRL + K to focus the search input.
3. Type "te" quickly.
4. Look at the browser console.