### PR TITLE
chore(macros): mark interface.ejs as deprecated

### DIFF
--- a/kumascript/macros/interface.ejs
+++ b/kumascript/macros/interface.ejs
@@ -6,9 +6,8 @@
 //
 //  $0 - Interface name
 
-// Throw a MacroDeprecatedError flaw
-// No more use in en-US
-// Still 288 uses in translated-content (then we can delete it)
+// Deprecated in April 2022, as no longer used in en-US.
+// Delete once no longer used in translated-content.
 mdn.deprecated();
 
 let lang = env.locale;

--- a/kumascript/macros/interface.ejs
+++ b/kumascript/macros/interface.ejs
@@ -6,6 +6,11 @@
 //
 //  $0 - Interface name
 
+// Throw a MacroDeprecatedError flaw
+// No more use in en-US
+// Still 288 uses in translated-content (then we can delete it)
+mdn.deprecated();
+
 let lang = env.locale;
 let basePath = "/" + lang + "/docs/Mozilla/Tech/XPCOM/Reference/Interface/";
 


### PR DESCRIPTION
We have removed the `interface` macro from mdn/content:

 ```
rg "\{ *interface" | wc -l
       0
```

Still 288 in mdn/translated-content. 

Meanwhile, we want to be sure they don't reappear in mdn/content, so marking it as deprecated will warn us in the flaw system if a new one is added. (As we have 0 deprecated macros left in mdn/content, we will notice it.)

For translators: this was used to mark internal Firefox interfaces, so this should be used only for links to outdated/removed parts of mdn (E.g. `{{interface("nsIDOMWindowUtils")}}`) Replacing them by the argument in codeface should do it: (E.g. `nsIDOMWindowUtils`).
