### PR TITLE
chore(macros): remove TODO.ejs

### DIFF
--- a/kumascript/macros/TODO.ejs
+++ b/kumascript/macros/TODO.ejs
@@ -1,1 +1,0 @@
-<span class="inlineIndicator todo todoInline"><strong>FIXME:</strong> <em><%=$0%></em></span>


### PR DESCRIPTION
Once mdn/translated-content#5180 is merged, there won't be any occurrence of the macro `{{TODO}}` left. We can then delete it:

In mdn/content:
```
rg "\{ *TODO" | wc -l
       0
```

In mdn/translated-content (before the merge of mdn/translated-content#5180):
```
rg "\{ *TODO"
files/de/web/css/align-items/index.html
68:<p>{{ TODO() }}</p>

files/ko/mdn/guidelines/writing_style_guide/index.html
779:<p><strong>{{TODO("Finish this once we finalize the landing page standards")}}</strong></p>
```