### PR TITLE
fix:bcd ~ address a couple of regressions since readability update

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -259,9 +259,17 @@
 dl.bc-notes-list {
   dt.bc-supports {
     margin-top: 1rem;
+
+    &:first-child {
+      margin-top: 0rem;
+    }
   }
   dd.bc-supports-dd {
     margin-bottom: 1rem;
+
+    &:last-child {
+      margin-bottom: 0rem;
+    }
   }
 }
 

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -39,10 +39,12 @@
     tr {
       height: 3rem;
 
-      &:last-child {
-        th,
-        td {
-          border-bottom-width: 0;
+      @media screen and (min-width: $screen-md) {
+        &:last-child {
+          th,
+          td {
+            border-bottom-width: 0;
+          }
         }
       }
 
@@ -228,8 +230,6 @@
 
   .bc-version-label {
     display: inline;
-    font-weight: 650;
-    line-height: 1rem;
   }
 
   abbr {
@@ -336,13 +336,11 @@ dl.bc-notes-list {
 
 .bcd-cell-text-wrapper {
   display: flex;
-  flex-direction: row-reverse;
   gap: 0.5rem;
 
   @media screen and (min-width: $screen-md) {
     align-items: center;
     flex-direction: column;
-    justify-content: space-between;
   }
 }
 
@@ -382,7 +380,6 @@ dl.bc-notes-list {
 .bc-notes-wrapper {
   .bcd-cell-text-wrapper {
     flex-direction: row;
-    justify-content: initial;
   }
 }
 


### PR DESCRIPTION
Address a couple of bugs with the BCD table since the readability update.

![Screenshot of a simple BCD table in dark mode on mobile listing all browser as green](https://user-images.githubusercontent.com/10350960/164238858-6d909106-fdab-4e68-b7eb-25aa91c24f67.png)

![Screenshot of a simple BCD table in dark mode on mobile with one of the browser’s history expanded](https://user-images.githubusercontent.com/10350960/164239012-96196483-9488-4acc-8ab2-9415bacf9241.png)

![Screenshot of BCD table on desktop with one of the history fields expanded](https://user-images.githubusercontent.com/10350960/164239242-c87fd060-ac31-4d32-a7fc-83b24643b9ae.png)

![Screenshot of BCD table on mobile. The history field of Firefox is expanded showing a timeline for the feature](https://user-images.githubusercontent.com/10350960/164239336-96011b99-2a6b-4efe-be93-1c9b8c5fdc50.png)

