### PR TITLE
fix(metadata): Switch heading for Github reporting links to be in sequentially-descending order

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -3,7 +3,7 @@ import { Doc } from "./types";
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
-      <h4>Found a problem with this page?</h4>
+      <h3>Found a problem with this page?</h3>
       <ul>
         <li>
           <EditOnGitHubLink doc={doc} />

--- a/client/src/document/organisms/metadata/index.scss
+++ b/client/src/document/organisms/metadata/index.scss
@@ -8,9 +8,10 @@
   box-shadow: var(--shadow-01);
   border-radius: var(--elem-radius);
 
-  h4 {
+  h3 {
     padding: 0;
     margin-top: 0.5rem;
+    font: var(--type-heading-h4);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6000. Very similar to #4107 (which regressed during the redesign).

### Problem

Lighthouse flags it when heading elements are not in a sequentially-descending order.

### Solution

Switch h4 to h3 with styling making it look like an h4.

---

User interface not changed (CSS rules were were put in place to ensure that).

## How did you test this change?

Ensured the user interface was unchanged and ran a Lighthouse report in Chrome after making the changes. That report did not flag this.