### PR TITLE
build(workflows): invalidate CDN after deployment

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -209,6 +209,19 @@ jobs:
 
           poetry run deployer search-index ../client/build
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Invalidate CDN
+        env:
+          DISTRIBUTION: E9813D0RN1QZI
+          PATHS: /*
+        run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -259,6 +259,19 @@ jobs:
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Invalidate CDN
+        env:
+          DISTRIBUTION: E2ZY2DGUN70EMI
+          PATHS: /*
+        run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -260,6 +260,19 @@ jobs:
             --note "${GITHUB_SHA}" \
             --detail "run_id=${GITHUB_RUN_ID} action=${GITHUB_ACTION}"
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Invalidate CDN
+        env:
+          DISTRIBUTION: E2MLRMA1VTVDHX
+          PATHS: /*
+        run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5947.

### Problem

Previously, we had to invalidate the CDN manually, or wait for the TTL.

### Solution

Now, CDN invalidations are created automatically after build deployments.

---

## How did you test this change?

1. Reduced the `stage-build.yml` workflow to the "Configure AWS Credentials" and "Invalidate CDN".
2. Triggered the action manually (see [result](https://github.com/mdn/yari/runs/6099994054?check_suite_focus=true)).
