### PR TITLE
chore(homepage): add LatestNews with Hacks articles

### DIFF
--- a/client/src/homepage/index.tsx
+++ b/client/src/homepage/index.tsx
@@ -1,6 +1,7 @@
 import "./index.scss";
 import { HomepageHero } from "./homepage-hero";
 import { FeaturedArticles } from "./featured-articles";
+import { LatestNews } from "./latest-news";
 import RecentContributions from "./recent-contributions";
 import { ContributorSpotlight } from "./contributor-spotlight";
 
@@ -10,6 +11,7 @@ export function Homepage(props) {
       <div className="homepage mdn-ui-body-m">
         <HomepageHero />
         <FeaturedArticles />
+        <LatestNews {...props} />
         <RecentContributions {...props} />
         <ContributorSpotlight {...props} />
       </div>

--- a/client/src/homepage/latest-news/index.scss
+++ b/client/src/homepage/latest-news/index.scss
@@ -1,0 +1,68 @@
+@use "../../ui/vars" as *;
+
+.latest-news {
+  display: flex;
+  flex-direction: column;
+  max-width: 52rem;
+  width: 100%;
+  gap: 1rem;
+  padding: 0 1rem;
+
+  @media screen and (min-width: $screen-lg) {
+    padding: 0;
+  }
+
+  h2 {
+    font: var(--type-heading-h4);
+    margin-top: 1rem;
+  }
+
+  h5 {
+    margin: 0;
+  }
+
+  .news-item {
+    padding: 0.7rem;
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+
+    @media screen and (min-width: $screen-md) {
+      flex-direction: revert;
+    }
+
+    &:nth-child(odd) {
+      border-radius: var(--elem-radius);
+      background: var(--background-secondary);
+    }
+
+    .news-date {
+      font-size: 12px;
+      line-height: 175%;
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .news-title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    line-height: var(--base-line-height);
+    margin: 0;
+
+    a {
+      color: var(--text-primary);
+
+      &:hover {
+        text-decoration: underline;
+        color: var(--text-primary);
+      }
+    }
+
+    .news-source {
+      font-size: var(--type-tiny-font-size);
+      color: var(--text-secondary);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6020.

### Problem

Previously, we had to link manually to Hacks posts.

### Solution

Now, we show a list of Hacks posts directly on the homepage.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="854" alt="image" src="https://user-images.githubusercontent.com/495429/164550917-b2f6cb58-539a-4dfa-a0d8-4316a8d16ad5.png">

### After

<img width="854" alt="image" src="https://user-images.githubusercontent.com/495429/164550870-30e6de8c-a178-44c6-9d8b-b2ff19540d3d.png">

---

## How did you test this change?

1. Run `yarn dev` (which runs `yarn tool spas`).
1. Open http://localhost:3000/en-US/_homepage locally.