### PR TITLE
fix(hooks): fallback rootMargin to '0px'

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -296,7 +296,7 @@ export function useFirstVisibleElement(
     visibleElementCallback(firstVisibleElement);
   }, [visibleElementCallback, firstVisibleElement]);
 
-  const [rootMargin, setRootMargin] = useState<string>("");
+  const [rootMargin, setRootMargin] = useState<string>("0px");
   const stickyHeaderHeight = useStickyHeaderHeight();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6029.

### Problem

RootMargin of the IntersectionObserver was defaulting to an empty string, which caused problems in Firefox 98 and earlier.

### Solution

Fallback to 0px.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
