### PR TITLE
Highlight missing links without hrefs

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -594,9 +594,10 @@ a.page-not-created {
 
   &:link,
   &:hover,
+  &:not([href]),
   &:focus {
     color: var(--icon-critical);
-    text-decoration-style: wavy;
+    text-decoration: underline wavy;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6033

### Problem

On https://developer.mozilla.org/en-US/docs/Web/API/SVGElement, the properties without associated pages and the sidebar elements without associated pages don't have href's, so are still indistinguishable from normal links until hovered over.

This is what I was referring to with [this comment](https://github.com/mdn/yari/issues/5546#issuecomment-1096865094).

### Solution

Add &:not([href]) to the CSS rule for missing links and use text-decoration itself since sidebar links don't have underlines ever.

---

## Screenshots

### Before

![Screenshot from 2022-04-21 14-52-48](https://user-images.githubusercontent.com/29206584/164532933-bb7b480d-7629-4729-ad96-d1445b87196b.png)

### After

![Screenshot from 2022-04-21 14-54-52](https://user-images.githubusercontent.com/29206584/164533217-51447d04-209f-43f4-951c-75ab62004f3f.png)