### PR TITLE
feat: open with a new tab when click `View on MDN`

### DIFF
--- a/client/src/document/toolbar/edit-actions.tsx
+++ b/client/src/document/toolbar/edit-actions.tsx
@@ -84,6 +84,8 @@ export function EditActions({
         <a
           href={`https://developer.mozilla.org/${locale}/docs/${slug}`}
           className="button"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           View on MDN
         </a>


### PR DESCRIPTION
## Summary

I'm trying to translate the MDN content and confirm it with yari which runs locally.
IMHO, It is better if open with a new tab when click `View on MDN`.

### Problem

N/A

### Solution

Add `target="_blank"` and `rel="noopener noreferrer"` to `<a>` tag.

---

## Screenshots

### Before

N/A

### After

![2022-04-23 224316](https://user-images.githubusercontent.com/11273093/164901877-c8b820ee-5c04-45ed-879c-4c0dfed184c2.jpg)
---

## How did you test this change?

1. `yarn run test:client`
2. Manually
    a. `yarn dev`
    b. open a content
    c. click `view on MDN`

---

Thank you :)