### PR TITLE
fix(localized-content-note): link to page/section of locale

### DIFF
--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -11,20 +11,17 @@ export function LocalizedContentNote({
     "en-US": {
       linkText:
         "This page was translated from English by the community. Learn more and join the MDN Web Docs community.",
-      url:
-        "/en-US/docs/MDN/Contribute/Localize#active_locales",
+      url: "/en-US/docs/MDN/Contribute/Localize#active_locales",
     },
     fr: {
       linkText:
         "Cette page a été traduite à partir de l'anglais par la communauté. Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
-      url:
-        "/fr/docs/MDN/Contribute/Localize#langues_actives",
+      url: "/fr/docs/MDN/Contribute/Localize#langues_actives",
     },
     ja: {
       linkText:
         "このページはコミュニティーの尽力で英語から翻訳されました。MDN Web Docs コミュニティーについてもっと知り、仲間になるにはこちらから。",
-      url:
-        "/ja/docs/MDN/Contribute/Localize#active_locales",
+      url: "/ja/docs/MDN/Contribute/Localize#active_locales",
     },
     ko: {
       linkText:
@@ -37,8 +34,7 @@ export function LocalizedContentNote({
     "zh-CN": {
       linkText:
         "此页面由社区从英文翻译而来。了解更多并加入 MDN Web Docs 社区。",
-      url:
-        "/zh-CN/docs/MDN/Contribute/Localize#活跃语言",
+      url: "/zh-CN/docs/MDN/Contribute/Localize#活跃语言",
     },
   };
   const inactiveLocaleNoteContent = {

--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -11,14 +11,20 @@ export function LocalizedContentNote({
     "en-US": {
       linkText:
         "This page was translated from English by the community. Learn more and join the MDN Web Docs community.",
+      url:
+        "/en-US/docs/MDN/Contribute/Localize#active_locales",
     },
     fr: {
       linkText:
         "Cette page a été traduite à partir de l'anglais par la communauté. Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
+      url:
+        "/fr/docs/MDN/Contribute/Localize#langues_actives",
     },
     ja: {
       linkText:
         "このページはコミュニティーの尽力で英語から翻訳されました。MDN Web Docs コミュニティーについてもっと知り、仲間になるにはこちらから。",
+      url:
+        "/ja/docs/MDN/Contribute/Localize#active_locales",
     },
     ko: {
       linkText:
@@ -31,6 +37,8 @@ export function LocalizedContentNote({
     "zh-CN": {
       linkText:
         "此页面由社区从英文翻译而来。了解更多并加入 MDN Web Docs 社区。",
+      url:
+        "/zh-CN/docs/MDN/Contribute/Localize#活跃语言",
     },
   };
   const inactiveLocaleNoteContent = {
@@ -56,7 +64,9 @@ export function LocalizedContentNote({
         inactiveLocaleNoteContent[locale].linkText) ||
       inactiveLocaleNoteContent["en-US"].linkText;
   const url = isActive
-    ? "/en-US/docs/MDN/Contribute/Localize#active_locales"
+    ? (activeLocaleNoteContent[locale] &&
+        activeLocaleNoteContent[locale].url) ||
+      activeLocaleNoteContent["en-US"].url
     : "https://github.com/mdn/translated-content/blob/main/PEERS_GUIDELINES.md#activating-a-locale";
 
   const type = isActive ? "neutral" : "warning";


### PR DESCRIPTION
## Summary

Points the URL for localized content notes to the MDN/Contribute/Localize page and section of the corresponding locale with an en-US fallback URL.

### Problem

The localized content notes on translated pages currently all lead to `/en-US/docs/MDN/Contribute/Localize#active_locales` even when the `MDN/Contribute/Localize` page exists in the locale (e.g. these notes on French pages could/should point to `/fr/docs/MDN/Contribute/Localize#langues_actives`).

### Solution

This PR adds the locale Contribute page URL (with the section anchor, e.g. `#langues_actives`) to the JSON if one exists sets the note's `url` to either the locale URL or the en-US fallback URL.

---

## Screenshots

### Before

![fr-localized-note-link-before](https://user-images.githubusercontent.com/87150472/164944471-5692653a-5d39-4be6-aa32-3c4992da3a8f.png)

### After

For French:

![fr-localized-note-correct-link](https://user-images.githubusercontent.com/87150472/164943981-f245b345-8a72-464f-bbd0-a2cea0964de2.png)

For Korean (no corresponding page/URL, points to en-US fallback):

![ko-localized-note-fallback-link](https://user-images.githubusercontent.com/87150472/164943998-ad86f885-9850-4e30-9a06-43ec03a4fada.png)

---

## How did you test this change?

I tested with yari on my local machine by opening several translated pages and checking the URL of the localized note.
