### PR TITLE
build(deps): remove unused cssesc

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "compression": "1.7.4",
     "cookie": "0.5.0",
     "cookie-parser": "1.4.6",
-    "cssesc": "^3.0.0",
     "dayjs": "1.11.1",
     "dotenv": "14.3.0",
     "ejs": "3.1.7",


### PR DESCRIPTION
## Summary

The `cssesc` dependency is unnecessary. 

### Problem

It is never using after https://github.com/mdn/yari/pull/4481

### Solution

Delete `cssesc` dependency from the `package.json`

---

## Screenshots

N/A

---

## How did you test this change?

I confirmed run tests and build.

```
$ yarn run test
$ yarn run build
```

## Others

Other dependencies depend on `cssesc: 3.0.0`. So `yarn.lock` is nothing change.

---

Thank you :)
