### PR TITLE
feat: enable dark mode in browser UI

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -97,12 +97,21 @@
   <body>
     <!-- If we modify this script we must update the CSP headers! -->
     <script>
-      const c = { light: "#ffffff", dark: "#1b1b1b" };
-      if (window && document.body) {
-        const o = window.localStorage.getItem("theme");
-        o &&
-          ((document.body.className = o),
-          (document.body.style.backgroundColor = c[o]));
+      const themes = { light: "#ffffff", dark: "#1b1b1b" };
+      if (window && document.documentElement) {
+        const storedTheme = window.localStorage.getItem("theme");
+        const preferDarkMode = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+        const setColor = (themeName) => {
+          document.documentElement.className = themeName;
+          document.documentElement.style.backgroundColor = themes[themeName];
+        };
+        if (storedTheme) {
+          setColor(storedTheme);
+        } else {
+          setColor(preferDarkMode ? "dark" : "light");
+        }
       }
     </script>
     <div id="root"></div>

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -178,6 +178,8 @@
   --text-primary-green: #{$mdn-color-light-theme-green-60};
   --text-primary-blue: #{$mdn-color-light-theme-blue-60};
   --text-primary-yellow: #{$mdn-color-light-theme-yellow-60};
+
+  color-scheme: light;
 }
 
 @mixin dark-theme {
@@ -307,6 +309,8 @@
   --text-primary-green: #{$mdn-color-dark-theme-green-30};
   --text-primary-blue: #{$mdn-color-dark-theme-blue-30};
   --text-primary-yellow: #{$mdn-color-dark-theme-yellow-30};
+
+  color-scheme: dark;
 }
 
 body,
@@ -327,16 +331,4 @@ body,
 
 .dark {
   @include dark-theme;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    @include light-theme;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    @include dark-theme;
-  }
 }

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -59,11 +59,11 @@ export function postToIEx(theme: string) {
 }
 
 export function switchTheme(theme: string, set: (theme: string) => void) {
-  const body = document.querySelector("body");
+  const html = document.documentElement;
 
-  if (window && body) {
-    body.className = theme;
-    body.style.backgroundColor = "";
+  if (window && html) {
+    html.className = theme;
+    html.style.backgroundColor = "";
     window.localStorage.setItem("theme", theme);
     set(theme);
     postToIEx(theme);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

We can change a browser's color scheme in according with used color mode on website. For example, scrollbars will use dark colors, when dark mode is enabled.

Fixes #6101.

### Problem

At the moment with dark mode on, the browser UI stays light, which is quite harmful for your eyes. 

### Solution

Using the `color-scheme` property we can tell the browser which color scheme to use according to the currently selected color scheme on the site.

---

## Screenshots


### Before

![image](https://user-images.githubusercontent.com/4408379/165026670-105eaf66-e7c2-4ed2-9f20-3f56f3516944.png)



### After

![image](https://user-images.githubusercontent.com/4408379/165026551-21725d62-4344-4f11-b18e-cf7c40b64f14.png)




