### PR TITLE
fix(document): target section content with className

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -185,7 +185,7 @@
   // specific styles to override base styles. The Markdown compiler
   // adds extra divs, so this is a way for these styles to not
   // stomp out component styles.
-  > div:not([class]) > {
+  .section-content {
     p {
       font: var(--type-article-p);
 

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -4,7 +4,10 @@ export function Prose({ section }: { section: any }) {
   const { id } = section;
 
   const Content = () => (
-    <div dangerouslySetInnerHTML={{ __html: section.content }} />
+    <div
+      className="section-content"
+      dangerouslySetInnerHTML={{ __html: section.content }}
+    />
   );
 
   if (!id) {


### PR DESCRIPTION
## Summary

Fixes #6042.

### Problem

#5908 changed the document structure by wrapping section content in `<section>` elements, but one CSS rule targeted the section content using `> div:not([class])`, which no longer matched section content in a `<section>`.

### Solution

- Mark section content with a CSS class (`.section-content`).
- Use that CSS class to set style specific to section content.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="802" alt="image" src="https://user-images.githubusercontent.com/495429/165145881-dcba0959-98b5-486a-a232-a6fade3acbfe.png">

### After

<img width="802" alt="image" src="https://user-images.githubusercontent.com/495429/165145831-72deb33b-2bf4-43f4-8f82-1cc9e91a4d77.png">


---

## How did you test this change?

1. See http://localhost:3000/en-US/docs/Learn/CSS/Building_blocks/Selectors#summary locally.