### PR TITLE
fix: typo / GitHub case in a11y label

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -40,7 +40,7 @@ export function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <span className="visually-hidden">MDN on Github</span>
+                <span className="visually-hidden">MDN on GitHub</span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Issue TBD
When I ran Grammalecte to review localization, I stumbled upon this one.

### Problem

The label doesn't follow GitHub's case

### Solution

Just fixed the case

## How did you test this change?

Ran Grammalecte on a locally served page to ensure the fix worked.
