### PR TITLE
fix:style ~ remove underscore from h1 elements in reference docs

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -53,7 +53,6 @@
   }
 
   h1 {
-    @include mdn.uify();
     &::after {
       text-decoration-color: var(--category-color);
     }


### PR DESCRIPTION
remove the underscore added to `h1` elements on the reference and learn documentation pages.

fix #6044