### PR TITLE
fix(toc): ignore <section>s when observing visible elements

### DIFF
--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -10,7 +10,7 @@ export function TOC({ toc }: { toc: Toc[] }) {
   const observedElements = React.useCallback(() => {
     const mainElement = document.querySelector("main") ?? document;
     const elements = mainElement.querySelectorAll(
-      "h1, h1 ~ *, h2, h2 ~ *, h3, h3 ~ *"
+      "h1, h1 ~ *:not(section), h2, h2 ~ *:not(section), h3, h3 ~ *:not(section)"
     );
     return Array.from(elements);
   }, []);


### PR DESCRIPTION
## Summary

Fixes #6041.

### Problem

In #5908, we changed the document structure by wrapping (most) document sections in a `<section>` element. This caused a regression on the TOC highlighting. The TOC wrongly associated the new `<section>` elements with the _previous_ heading, causing the previous TOC entry to be highlighted.

This was because the section's _actual_ heading is a child element of the section itself, and therefore essentially comes _after_ the section element. This goes against the heuristic of the TOC implementation, which assumes that headings precede corresponding content.

### Solution

Don't consider `<section>` as relevant elements for determining the currently visible element.

_Note_: It would be nice to only observe `<section>`s or (even better) `<div class="section-content">` instead, but this doesn't work (yet), because not all sections are wrapped in these yet (especially the content following h1, as well as the Specifications and Browser compatibility sections).

---

## Screenshots

### Before

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/495429/165301564-15b44e80-3bb4-47e0-81e6-8e6b1545c214.png">

### After

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/495429/165301524-c14d3386-bea8-4abd-9797-38942521e4ff.png">


---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/API/IntersectionObserver#properties locally and navigated to different sections by scrolling and clicking on the TOC items.
