### PR TITLE
fix(top-navigation): allow dynamic header height

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -69,8 +69,7 @@
   /* Grid and Layout */
   --max-width: 1440px;
   --gutter: 1rem; /* Space between content and browser window */
-  --top-navigation-height: 4rem;
-  --top-navigation-offset: -4rem;
+  --sticky-header-height: 0px;
 
   --z-index-back: -1;
   --z-index-top: 9999;
@@ -86,7 +85,6 @@
   --form-elem-height: 2rem;
 
   /* Major Components */
-  --sticky-header-height: 0;
   --top-nav-height: 4rem;
   --main-document-header-height: 6rem;
   --icon-size: 1rem;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -8,12 +8,6 @@
   --sticky-header-height: var(--main-document-header-height);
 }
 
-.main-document-header-container {
-  position: sticky;
-  top: 0;
-  z-index: var(--z-index-top);
-}
-
 .main-page-content {
   padding: 3rem 1rem 1rem;
   overflow-wrap: break-word;

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -38,6 +38,7 @@ import "./index.scss";
 // code could come with its own styling rather than it having to be part of the
 // main bundle all the time.
 import "./interactive-examples.scss";
+import { MainHeader } from "../ui/organisms/main-header";
 // import { useUIStatus } from "../ui-context";
 
 // Lazy sub-components
@@ -173,10 +174,10 @@ export function Document(props /* TODO: define a TS interface for this */) {
 
   return (
     <>
-      <div className="main-document-header-container">
+      <MainHeader>
         <TopNavigation />
         <ArticleActionsContainer doc={doc} />
-      </div>
+      </MainHeader>
       {/* only include this if we are not server-side rendering */}
       {!isServer && <OfflineStatusBar />}
       {doc.isTranslated ? (

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -74,7 +74,7 @@
     display: flex;
     overflow: auto;
     position: sticky;
-    top: var(--top-navigation-height);
+    top: var(--sticky-header-height);
     max-height: 100vh;
   }
 

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -66,7 +66,7 @@
       grid-area: toc;
       max-height: 100vh;
       position: sticky;
-      top: var(--top-navigation-height);
+      top: var(--sticky-header-height);
     }
 
     .in-nav-toc {

--- a/client/src/ui/organisms/main-header/index.scss
+++ b/client/src/ui/organisms/main-header/index.scss
@@ -1,0 +1,5 @@
+.main-header {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-index-top);
+}

--- a/client/src/ui/organisms/main-header/index.tsx
+++ b/client/src/ui/organisms/main-header/index.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+
+import "./index.scss";
+
+export const MainHeader = ({ className = "", children }) => {
+  const ref = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (typeof ResizeObserver === "undefined") {
+      // SSR.
+      return;
+    }
+
+    const header = ref.current;
+    if (header instanceof HTMLElement) {
+      const style = document.documentElement.style;
+
+      const observer = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+        for (const entry of entries) {
+          style.setProperty(
+            "--sticky-header-height",
+            `${entry.contentRect.height}px`
+          );
+          break;
+        }
+      });
+
+      observer.observe(header);
+
+      return () => observer.disconnect();
+    }
+  }, []);
+
+  return (
+    <header ref={ref} className={`main-header ${className}`}>
+      {children}
+    </header>
+  );
+};

--- a/client/src/ui/organisms/top-navigation/index.scss
+++ b/client/src/ui/organisms/top-navigation/index.scss
@@ -1,7 +1,6 @@
 @use "../../vars" as *;
 
 .top-navigation {
-  height: var(--top-navigation-height);
   position: relative;
   width: 100%;
   background-color: var(--background-primary);

--- a/client/src/ui/organisms/top-navigation/index.tsx
+++ b/client/src/ui/organisms/top-navigation/index.tsx
@@ -29,10 +29,8 @@ export function TopNavigation() {
   const transparent = TRANSPARENT_NAV_ROUTES.some((r) => route.match(r));
 
   return (
-    <header
-      className={`main-document-header-container top-navigation ${
-        showMainMenu ? "show-nav" : ""
-      }
+    <div
+      className={`top-navigation ${showMainMenu ? "show-nav" : ""}
       ${dark ? " dark" : ""}
       ${transparent ? " is-transparent" : ""}`}
     >
@@ -55,6 +53,6 @@ export function TopNavigation() {
 
         <TopNavigationMain isOpenOnMobile={showMainMenu} />
       </Container>
-    </header>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #6069.

### Problem

The top navigation was assigned a fixed height, which caused its content to overflow with some screen/window widths.

### Solution

Remove the fixed height, allowing the top navigation to take more space if needed.

Follow-up changes:
- Merge `--top-navigation-height` into `--sticky-header-height`, and manage this variable using a `ResizeObserver` to account for the dynamic header height.
- Extract `MainHeader` component from `TopNavigation`, and observe that wrapper's height instead, to account for other header elements.

---

## Screenshots

### Before

<img width="787" alt="image" src="https://user-images.githubusercontent.com/495429/165303960-b3f02b4a-de33-4486-8aa9-68182ef1f2c8.png">


### After

<img width="787" alt="image" src="https://user-images.githubusercontent.com/495429/165304000-a7a47f3f-cf45-47ce-ac2a-5ff87c69df30.png">

---

## How did you test this change?

1. Open http://localhost:3000/en-us/_homepage locally.
2. Change window width.
