### PR TITLE
fix(h2m): override Prettier config to preserve Markdown wrapping

### DIFF
--- a/markdown/h2m/index.ts
+++ b/markdown/h2m/index.ts
@@ -18,7 +18,7 @@ const getTransformProcessor = (options) =>
     .use(gfm)
     .use(remarkPrettier, {
       report: false,
-      options: { embeddedLanguageFormatting: "off" },
+      options: { embeddedLanguageFormatting: "off", proseWrap: "preserve" },
     });
 
 export async function h2m(

--- a/testing/content/files/en-us/markdown/tool/h2m/expected.md
+++ b/testing/content/files/en-us/markdown/tool/h2m/expected.md
@@ -14,8 +14,7 @@ Nothing to say, really.
 
 Basic formatting such as **bold** and _emphasis_.
 
-Here's a section that simply mentions links like <https://www.peterbe.com> for
-example.
+Here's a section that simply mentions links like <https://www.peterbe.com> for example.
 
 ### Heading 3
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes #6075.

### Problem

The Prettier config change is unexpectedly affecting Markdown files from `h2m` command.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

This PR will override Prettier's [prose wrap](https://prettier.io/docs/en/options.html#prose-wrap) config to a default value (`preserve`) for `h2m`'s `remark-prettier`.

## How did you test this change?

I've ran `yarn md h2m web/api/document --mode keep --locale ko` before and after the change. I can confirm that this PR will restore the old behavior which I seek.

Sidenote, I'm willing to ~~change the commit~~ change the title to follow Conventional Commits but not quite sure how to actually write it. `fix(prettier)`, `chore(prettier)`, or `chore(markdown)`?