### PR TITLE
fix(bcd): remove double border from bc-history

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
@@ -5,8 +5,9 @@
     display: none;
   }
 
-  .bc-support {
+  td.bc-support {
     display: block;
+    border-left-width: 0;
   }
 
   .bc-feature,

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -75,6 +75,12 @@
         color: var(--text-primary-green);
       }
     }
+
+    .bc-history {
+      td {
+        border-left-width: 0;
+      }
+    }
   }
 
   th {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Bc-history cell in bc table has extra left border.

### Solution

Remove excess border at left.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://user-images.githubusercontent.com/4408379/165466585-16eda432-2b28-4c83-a002-7a2b512f46e8.png)


### After

![image](https://user-images.githubusercontent.com/4408379/165466682-1310b438-0032-4c18-a11c-55e49f0b415a.png)

---

## How did you test this change?

1. Visit https://developer.mozilla.org/ru/docs/Web/CSS/:where for the test