### PR TITLE
Revert "chore(prettier): automatically wrap markdown files"

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,12 +5,6 @@
       "options": {
         "plugins": ["prettier-plugin-packagejson"]
       }
-    },
-    {
-      "files": ["**/*.md"],
-      "options": {
-        "proseWrap": "always"
-      }
     }
   ]
 }

--- a/testing/content/files/en-us/markdown/tool/h2m/expected.md
+++ b/testing/content/files/en-us/markdown/tool/h2m/expected.md
@@ -14,8 +14,7 @@ Nothing to say, really.
 
 Basic formatting such as **bold** and _emphasis_.
 
-Here's a section that simply mentions links like <https://www.peterbe.com> for
-example.
+Here's a section that simply mentions links like <https://www.peterbe.com> for example.
 
 ### Heading 3
 


### PR DESCRIPTION
This reverts commit 5111d71e3330c28f4c22886d77dfdda660d6df4c.

Interim fix for https://github.com/mdn/yari/issues/6075
