### PR TITLE
Revert "Revert "chore(prettier): automatically wrap markdown files""

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,12 @@
       "options": {
         "plugins": ["prettier-plugin-packagejson"]
       }
+    },
+    {
+      "files": ["**/*.md"],
+      "options": {
+        "proseWrap": "always"
+      }
     }
   ]
 }


### PR DESCRIPTION
This reverts commit a6996698db5f72d5e3b398b8dfaefa7853a8701f.

See: https://github.com/mdn/yari/pull/6032, https://github.com/mdn/yari/pull/6085

Thanks to https://github.com/mdn/yari/pull/6076, it should be safe to re-enable markdown wrapping in our `.prettierrc` without affecting content.
