### PR TITLE
chore(css): insert breakpoint between screen-md + screen-lg

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -503,7 +503,7 @@ pre {
     }
   }
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: $screen-xl) {
     columns: 3;
     margin-bottom: 0.5rem;
   }

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
@@ -1,4 +1,4 @@
-@media screen and (min-width: $screen-lg) {
+@media screen and (min-width: $screen-xl) {
   .table-scroll {
     width: 100%;
     margin: 0;

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -340,7 +340,7 @@ dl.bc-notes-list {
 @import "./index-mobile";
 @import "./index-desktop";
 @import "./index-desktop-md";
-@import "./index-desktop-lg";
+@import "./index-desktop-xl";
 
 .bcd-cell-text-wrapper {
   display: flex;

--- a/client/src/homepage/latest-news/index.scss
+++ b/client/src/homepage/latest-news/index.scss
@@ -8,7 +8,7 @@
   gap: 1rem;
   padding: 0 1rem;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: $screen-xl) {
     padding: 0;
   }
 

--- a/client/src/homepage/recent-contributions/index.scss
+++ b/client/src/homepage/recent-contributions/index.scss
@@ -8,7 +8,7 @@
   gap: 1rem;
   padding: 0 1rem;
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: $screen-xl) {
     padding: 0;
   }
 

--- a/client/src/plus/offer-overview/offer-overview-feature/index.scss
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.scss
@@ -18,7 +18,7 @@
     justify-content: space-between;
     margin: 0 auto;
 
-    @media screen and (min-width: $screen-lg) {
+    @media screen and (min-width: $screen-xl) {
       flex-direction: row;
     }
 
@@ -35,7 +35,7 @@
       border-radius: 1rem;
       max-width: 25rem;
       height: 100%;
-      @media screen and (min-width: $screen-lg) {
+      @media screen and (min-width: $screen-xl) {
         max-width: min(50%, 20rem);
       }
     }
@@ -63,7 +63,7 @@
       align-items: center;
       max-width: 40rem;
 
-      @media screen and (min-width: $screen-lg) {
+      @media screen and (min-width: $screen-xl) {
         text-align: initial;
         align-items: initial;
         height: 100%;
@@ -76,7 +76,7 @@
 .offer-overview-feature:nth-child(even) {
   .wrapper {
     flex-direction: column;
-    @media screen and (min-width: $screen-lg) {
+    @media screen and (min-width: $screen-xl) {
       flex-direction: row;
     }
   }
@@ -85,7 +85,7 @@
   background: var(--background-secondary);
   .wrapper {
     flex-direction: column;
-    @media screen and (min-width: $screen-lg) {
+    @media screen and (min-width: $screen-xl) {
       flex-direction: row-reverse;
     }
   }

--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -240,7 +240,7 @@ $mdn-theme-dark-code-background-block: $mdn-color-neutral-80;
 
 $screen-sm: 426px;
 $screen-md: 769px;
-$screen-lg: 1200px;
+$screen-xl: 1200px;
 $screen-xxl: 1441px;
 
 /*

--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -241,7 +241,7 @@ $mdn-theme-dark-code-background-block: $mdn-color-neutral-80;
 $screen-sm: 426px;
 $screen-md: 769px;
 $screen-lg: 1200px;
-$screen-xl: 1441px;
+$screen-xxl: 1441px;
 
 /*
  * z-index scale

--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -240,6 +240,7 @@ $mdn-theme-dark-code-background-block: $mdn-color-neutral-80;
 
 $screen-sm: 426px;
 $screen-md: 769px;
+$screen-lg: 992px;
 $screen-xl: 1200px;
 $screen-xxl: 1441px;
 

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -63,7 +63,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: $screen-xl) {
     li {
       display: inline-flex;
     }

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -53,7 +53,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-lg) {
+  @media screen and (min-width: $screen-xl) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(0, 2.5fr) minmax(0, 15rem);
     gap: 3rem;

--- a/client/src/ui/organisms/article-actions-container/index.scss
+++ b/client/src/ui/organisms/article-actions-container/index.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-xl) {
+  @media screen and (min-width: $screen-xxl) {
     .container {
       padding-right: 1rem;
       padding-left: 1rem;

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -216,7 +216,7 @@
   }
 }
 
-@media screen and (min-width: $screen-xl) {
+@media screen and (min-width: $screen-xxl) {
   .page-footer {
     &-grid {
       gap: 2.5rem;


### PR DESCRIPTION
## Summary

Required for #6074.

### Problem

We only have four responsive breakpoints at 426 / 769 / 1200 / 1441 px, with a big gap between 760 and 1200 px. This does not give us enough flexibility for elements that are slightly larger than ~769px.

### Solution

This PR inserts a new `screen-lg` breakpoint at 992px (adopted [from Bootstrap](https://getbootstrap.com/docs/5.0/layout/breakpoints/#available-breakpoints)), renaming the existing `screen-{lg,xl}` breakpoints to `screen-{xl,xxl}`.

---

## Screenshots

_No visual changes._

---

## How did you test this change?

_Not tested._