### PR TITLE
fix(top-navigation): expand only at 1200px or more

### DIFF
--- a/client/src/ui/molecules/auth-container/index.scss
+++ b/client/src/ui/molecules/auth-container/index.scss
@@ -12,7 +12,7 @@
   padding: 0;
   text-align: center;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     align-items: center;
     flex-flow: row;
     gap: 1rem;

--- a/client/src/ui/molecules/guides-menu/index.scss
+++ b/client/src/ui/molecules/guides-menu/index.scss
@@ -11,7 +11,7 @@
     display: none;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     .desktop-only {
       display: inherit;
     }

--- a/client/src/ui/molecules/language-menu/index.scss
+++ b/client/src/ui/molecules/language-menu/index.scss
@@ -11,7 +11,7 @@
     padding: 0.5rem;
   }
 
-  @media (min-width: $screen-md) {
+  @media (min-width: $screen-lg) {
     right: 0;
   }
 }

--- a/client/src/ui/molecules/main-menu/index.scss
+++ b/client/src/ui/molecules/main-menu/index.scss
@@ -13,12 +13,12 @@ ul.main-menu {
   &.show {
     display: block;
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-lg) {
       display: flex;
     }
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     align-items: center;
     display: flex;
     justify-content: space-around;
@@ -40,7 +40,7 @@ ul.main-menu {
 }
 
 /* Enable hover interaction if javascript is not available */
-@media screen and (min-width: $screen-md) {
+@media screen and (min-width: $screen-lg) {
   ul.main-menu .submenu {
     display: none;
   }

--- a/client/src/ui/molecules/plus-menu/index.scss
+++ b/client/src/ui/molecules/plus-menu/index.scss
@@ -6,7 +6,7 @@
     background-color: var(--plus-accent-color);
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     .mobile-only {
       display: none;
     }

--- a/client/src/ui/molecules/reference-menu/index.scss
+++ b/client/src/ui/molecules/reference-menu/index.scss
@@ -6,7 +6,7 @@
     display: none;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     .desktop-only {
       display: inherit;
     }

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -40,7 +40,7 @@
       }
     }
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-lg) {
       &:invalid {
         width: 1rem;
       }

--- a/client/src/ui/molecules/submenu/index.scss
+++ b/client/src/ui/molecules/submenu/index.scss
@@ -44,7 +44,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     background-color: var(--background-secondary);
     border-radius: var(--elem-radius);
     border: 1px solid var(--border-primary);
@@ -93,7 +93,7 @@
     background: none;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     border-bottom: 1px solid var(--border-primary);
   }
 }
@@ -110,7 +110,7 @@
 .submenu-item {
   font-size: var(--type-smaller-font-size);
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     // If there is sub-text associated with this heading, make it bold.
     &:not(:only-child) {
       font-weight: var(--font-body-strong-weight);
@@ -121,7 +121,7 @@
 .submenu-item-description {
   display: none;
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     display: block;
     margin: 0.25rem 0 0 0;
     font-size: var(--type-tiny-font-size);

--- a/client/src/ui/molecules/user-menu/index.scss
+++ b/client/src/ui/molecules/user-menu/index.scss
@@ -20,13 +20,13 @@
     }
   }
 
-  @media screen and (max-width: $screen-md) {
+  @media screen and (max-width: $screen-lg) {
     .user-menu-toggle:hover {
       --button-bg: transparent;
     }
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     /*
       The user menu button is shaped like an avatar and thus has some
       very specific focus and hover states.

--- a/client/src/ui/organisms/top-navigation-main/index.scss
+++ b/client/src/ui/organisms/top-navigation-main/index.scss
@@ -39,7 +39,7 @@
     margin-bottom: 1.5rem;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     .theme-toggle {
       align-self: initial;
       margin-bottom: initial;
@@ -84,7 +84,7 @@
       min-height: 53px;
     }
 
-    @media screen and (max-width: $screen-md) {
+    @media screen and (max-width: $screen-lg) {
       &.button {
         --button-color: var(--text-secondary);
         --button-padding: 0;
@@ -105,7 +105,7 @@
       }
     }
 
-    @media screen and (min-width: $screen-md) {
+    @media screen and (min-width: $screen-lg) {
       border-top: none;
       border-radius: var(--elem-radius);
       padding: 0.5rem;
@@ -149,7 +149,7 @@
     display: none;
   }
 
-  @media screen and (min-width: $screen-md) {
+  @media screen and (min-width: $screen-lg) {
     align-items: center;
     display: flex;
     flex: 1;

--- a/client/src/ui/organisms/top-navigation/index.scss
+++ b/client/src/ui/organisms/top-navigation/index.scss
@@ -1,7 +1,6 @@
 @use "../../vars" as *;
 
 .top-navigation {
-  height: var(--top-navigation-height);
   position: relative;
   width: 100%;
   background-color: var(--background-primary);
@@ -43,7 +42,7 @@
   }
 }
 
-@media screen and (min-width: $screen-md) {
+@media screen and (min-width: $screen-lg) {
   .main-menu-toggle {
     display: none;
   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6069.

### Problem

The expanded top navigation was overflowing with some screen sizes (with a width of around 800px).

### Solution

Avoid this overflow by using the additional breakpoint (#6098) to expand the top navigation only on large screens (with a width of 1200px or more). On medium and smaller screens, the hamburger menu button is displayed instead.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="821" alt="image" src="https://user-images.githubusercontent.com/495429/165645460-53ec1470-7941-4c93-ac44-d5cdcc99ca9b.png">

### After

<img width="821" alt="image" src="https://user-images.githubusercontent.com/495429/165645483-88da099b-6dc1-4c6d-af8c-8100d9c5d2b0.png">

<img width="821" alt="image" src="https://user-images.githubusercontent.com/495429/165645589-0b017bd2-9858-4261-86ae-fbe27e76c30e.png">


---

## How did you test this change?

1. Open http://localhost:3000/en-US/docs/Web/API/ResizeObserver locally.
2. Use responsive mode to test larger and smaller screens.