### PR TITLE
fix(theme): set color-scheme

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -98,11 +98,11 @@
     <!-- If we modify this script we must update the CSP headers! -->
     <script>
       const c = { light: "#ffffff", dark: "#1b1b1b" };
-      if (window && document.body) {
+      if (window && document.documentElement) {
         const o = window.localStorage.getItem("theme");
         o &&
-          ((document.body.className = o),
-          (document.body.style.backgroundColor = c[o]));
+          ((document.documentElement.className = o),
+          (document.documentElement.style.backgroundColor = c[o]));
       }
     </script>
     <div id="root"></div>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -95,8 +95,18 @@
   </head>
 
   <body>
-    <!-- If we modify this script we must update the CSP headers! -->
     <script>
+      /**
+       * If we modify this script, we must update the CSP hash as follows:
+       * 1. Run `yarn build:client`
+       * 2. Open `client/build/index.html` and locate this (minified) <script> tag.
+       * 3. Copy the inner content of the <script> tag (excluding the script tags).
+       * 4. Open https://csplite.com/csp/sha/ and paste the content.
+       * 5. Copy the `sha256-...` hash.
+       * 6. Open `libs/constants/index.js` and find the current hash in scriptSrcValues.
+       * 7. Remove the old "previous" hash and replace it with the old "current" hash.
+       * 8. Replace the old "current" hash with the new hash (from step 5).
+       */
       const c = { light: "#ffffff", dark: "#1b1b1b" };
       if (window && document.documentElement) {
         const o = window.localStorage.getItem("theme");

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -3,6 +3,8 @@
 @use "../color-palette" as *;
 
 @mixin light-theme {
+  color-scheme: light;
+
   --text-primary: #{$mdn-theme-light-text-primary};
   --text-secondary: #{$mdn-theme-light-text-secondary};
   --text-inactive: #{$mdn-theme-light-text-inactive};
@@ -181,6 +183,8 @@
 }
 
 @mixin dark-theme {
+  color-scheme: dark;
+
   --text-primary: #{$mdn-theme-dark-text-primary};
   --text-secondary: #{$mdn-theme-dark-text-secondary};
   --text-inactive: #{$mdn-theme-dark-text-inactive};

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -324,7 +324,6 @@ body,
   --color-announcement-banner-accent: #{$mdn-color-light-theme-pink-40};
 }
 
-:root,
 .light {
   @include light-theme;
 }
@@ -333,14 +332,13 @@ body,
   @include dark-theme;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
+// OS Default.
+:root:not(.light, .dark) {
+  @media (prefers-color-scheme: light) {
     @include light-theme;
   }
-}
 
-@media (prefers-color-scheme: dark) {
-  :root {
+  @media (prefers-color-scheme: dark) {
     @include dark-theme;
   }
 }

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -187,6 +187,26 @@
       $mdn-color-dark-theme-yellow-30,
       $alpha: -0.6
     )};
+  --background-mark-green: #{color.adjust(
+      $mdn-color-light-theme-green-30,
+      $alpha: -0.6
+    )};
+  --background-information: #{color.adjust(
+      $mdn-theme-light-icon-information,
+      $alpha: -0.9
+    )};
+  --background-warning: #{color.adjust(
+      $mdn-theme-light-icon-warning,
+      $alpha: -0.9
+    )};
+  --background-critical: #{color.adjust(
+      $mdn-theme-light-icon-critical,
+      $alpha: -0.9
+    )};
+  --background-success: #{color.adjust(
+      $mdn-theme-light-icon-success,
+      $alpha: -0.9
+    )};
 
   --border-primary: #{$mdn-theme-dark-border-primary};
   --border-secondary: #{$mdn-theme-dark-border-secondary};
@@ -214,6 +234,10 @@
       $alpha: -0.9
     )};
   --accent-secondary: #{$mdn-theme-dark-accent-secondary};
+  --accent-tertiary: #{color.adjust(
+      $mdn-color-light-theme-blue-50,
+      $alpha: -0.9
+    )};
 
   --shadow-01: #{$mdn-theme-dark-shadow-01};
   --shadow-02: #{$mdn-theme-dark-shadow-02};
@@ -232,6 +256,7 @@
 
   --notecard-link-color: #{$mdn-color-neutral-10};
 
+  --scrollbar-bg: transparent;
   --scrollbar-color: rgba(255, 255, 255, 0.25);
 
   --category-color: #{$mdn-color-dark-theme-blue-30};

--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -161,18 +161,6 @@
       $alpha: -0.3
     )};
 
-  --homepage-hero-bg: radial-gradient(
-    114.42% 123.24% at 6.69% 13.67%,
-    rgba(51, 178, 252, 0.2) 22.84%,
-    rgba(152, 82, 250, 0.2) 47.63%,
-    rgba(255, 230, 0, 0.2) 82.74%
-  );
-  --homepage-secondary-bg: linear-gradient(
-    90deg,
-    #8524ff -43.99%,
-    #4d7fff 159.52%
-  );
-
   --modal-backdrop-color: #{rgba($mdn-theme-dark-background-primary, 0.1)};
   --blend-color: #{$mdn-color-white}80;
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -59,11 +59,11 @@ export function postToIEx(theme: string) {
 }
 
 export function switchTheme(theme: string, set: (theme: string) => void) {
-  const body = document.querySelector("body");
+  const html = document.documentElement;
 
-  if (window && body) {
-    body.className = theme;
-    body.style.backgroundColor = "";
+  if (window && html) {
+    html.className = theme;
+    html.style.backgroundColor = "";
     window.localStorage.setItem("theme", theme);
     set(theme);
     postToIEx(theme);

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -83,7 +83,14 @@ const scriptSrcValues = [
   "assets.codepen.io",
   "production-assets.codepen.io",
 
-  "'sha256-x6Tv+AdV5e6dcolO0TEo+3BG4H2nG2ACjyG8mz6QCes='", // inline no flicker
+  /**
+   * If we modify the inline script in `client/public/index.html`,
+   * we must always update the CSP hash (see instructions there).
+   */
+  // - Previous hash (to avoid cache invalidation issues):
+  "'sha256-x6Tv+AdV5e6dcolO0TEo+3BG4H2nG2ACjyG8mz6QCes='",
+  // - Current hash:
+  "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
 ];
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],


### PR DESCRIPTION
## Summary

Fixes #6101, based on #6054.

### Problem

Chrome was always showing light scrollbars, because it apparently relies on the [`color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme) property being set.

### Solution

1. Set the `color-scheme` property on the `:root` element (i.e. `document.documentElement` or the HTML element).
2. Set the `.dark` and `.light` classes on the `:root` element, not the `body` element.
3. Apply dark/light theme based on [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) only if `:root` element has no `dark`/`light` class.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="931" alt="image" src="https://user-images.githubusercontent.com/495429/165654176-b43a136f-a57d-4410-9f2e-b0a5a1b5b11d.png">

### After

<img width="931" alt="image" src="https://user-images.githubusercontent.com/495429/165654202-44310c03-82cc-44ae-9667-51f41d4e1963.png">

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/CSS/@media/prefers-color-scheme locally in Chrome.
2. Switched theme between "OS Default" (and then used OS settings to switch), "Light" and "Dark".