### PR TITLE
fix(hooks): check for IntersectionObserver support

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -304,6 +304,11 @@ export function useFirstVisibleElement(
   }, [stickyHeaderHeight]);
 
   useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") {
+      // SSR or old browser.
+      return;
+    }
+
     const observedElements = observedElementsProvider();
     const visibilityByElement = new Map<Element, boolean>();
 


### PR DESCRIPTION
## Summary

Fixes #6113.

### Problem

Older browsers that don't support the IntersectionObserver got a blank page on pages with a TOC since  #5852. This was because

### Solution

Be backwards-compatible by checking for IntersectionObserver support before using it.

---

## Screenshots

_Not relevant._

---

## How did you test this change?

1. Open http://localhost:3000/en-US/docs/Web/API/ResizeObserver locally and make sure the TOC highlighting still works.