### PR TITLE
fix(document): add copy-to-clipboard when location changes

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { Doc, FrequentlyViewedEntry } from "./types";
 
 export function useDocumentURL() {
@@ -12,6 +12,8 @@ export function useDocumentURL() {
 }
 
 export function useCopyExamplesToClipboard(doc: Doc | undefined) {
+  const location = useLocation();
+
   useEffect(() => {
     if (!doc) {
       return;
@@ -78,7 +80,7 @@ export function useCopyExamplesToClipboard(doc: Doc | undefined) {
         };
       }
     );
-  }, [doc]);
+  }, [doc, location]);
 }
 
 function showCopiedMessage(wrapper: HTMLElement, msg: string) {


### PR DESCRIPTION
## Summary

Fixes #6077.

### Problem

The hook that adds the "copy to clipboard" icon was only rendered when the Document changes. However, a re-render also happens when the location changes.

### Solution

Add the location to the hook's dependency.

---

## Screenshots

_None._

---

## How did you test this change?

1. Open http://localhost:3000/en-US/docs/Learn/HTML/Tables/Basics#allowing_cells_to_span_multiple_rows_and_columns locally
2. Click on the different TOC entries