### PR TITLE
fix:banner - small copy update to launch banner

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -93,8 +93,8 @@ function PlusLaunchAnnouncementBanner({
           <a href={plusUrl} className="mdn-plus">
             MDN Plus
           </a>{" "}
-          now available in <em>your</em> market! Support MDN <em>and</em> make
-          it your own.{" "}
+          now available in <span className="underlined">your</span> country!
+          Support MDN <span className="underlined">and</span> make it your own.{" "}
           <a
             href="https://hacks.mozilla.org/2022/04/mdn-plus-now-available-in-more-markets"
             target="_blank"

--- a/client/src/banners/banner.scss
+++ b/client/src/banners/banner.scss
@@ -45,9 +45,8 @@
     }
   }
 
-  em {
+  .underlined {
     font-style: normal;
-    font-weight: 600;
     text-decoration: underline var(--color-announcement-banner-accent) 0.15rem;
   }
 


### PR DESCRIPTION
Hermina asked to make these small tweaks to the copy and style of the launch banner.

## Changes

* change markets to countries
* Do not bold `and` and `your`

![Screenshot 2022-04-28 at 21 46 15](https://user-images.githubusercontent.com/10350960/165834060-4e41892e-1f99-4b62-913c-94c299467d2b.png)

