### PR TITLE
chore(deployer): deploy Lambda updates to CloudFront

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -173,6 +173,7 @@ jobs:
 
           DEPLOYER_BUCKET_NAME: mdn-content-dev
           DEPLOYER_BUCKET_PREFIX: ${{ github.event.inputs.deployment_prefix }}
+          DEPLOYER_DISTRIBUTION_ID: E9813D0RN1QZI
           DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD: ${{ github.event.inputs.log_each_successful_upload }}
 
           AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -222,7 +222,8 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
 
           DEPLOYER_BUCKET_NAME: mdn-content-prod
-          DEPLOYER_DISTRIBUTION_ID: E2ZY2DGUN70EMI
+          # Uncomment when we're confident that automatic Lambda deployment is flawless.
+          #DEPLOYER_DISTRIBUTION_ID: E2ZY2DGUN70EMI
 
           AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -222,6 +222,7 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
 
           DEPLOYER_BUCKET_NAME: mdn-content-prod
+          DEPLOYER_DISTRIBUTION_ID: E2ZY2DGUN70EMI
 
           AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_PROD_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_PROD_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -223,6 +223,7 @@ jobs:
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
 
           DEPLOYER_BUCKET_NAME: mdn-content-stage
+          DEPLOYER_DISTRIBUTION_ID: E2MLRMA1VTVDHX
 
           AWS_ACCESS_KEY_ID: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DEPLOYER_STAGE_AND_DEV_AWS_SECRET_ACCESS_KEY }}

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -307,6 +307,7 @@ poetry install
 That should have installed the CLI:
 
 ```sh
+cd deployer
 poetry run deployer --help
 ```
 
@@ -316,11 +317,13 @@ If you want to make a PR, make sure it's formatted with `black` and passes
 You can check that all files are `flake8` fine by running:
 
 ```sh
-flake8 deployer
+cd deployer
+poetry run flake8 .
 ```
 
-And to check that all files are formatted according to `black` run:
+And to format all files with `black` run:
 
 ```sh
-black --check deployer
+cd deployer
+poetry run black deployer
 ```

--- a/deployer/src/deployer/constants.py
+++ b/deployer/src/deployer/constants.py
@@ -13,6 +13,7 @@ CONTENT_TRANSLATED_ROOT = config("CONTENT_TRANSLATED_ROOT", default=None)
 
 DEFAULT_BUCKET_NAME = config("DEPLOYER_BUCKET_NAME", default="mdn-content-dev")
 DEFAULT_BUCKET_PREFIX = config("DEPLOYER_BUCKET_PREFIX", default="main")
+DEFAULT_DISTRIBUTION_ID = config("DEFAULT_DISTRIBUTION_ID", default=None)
 
 # When uploading a bunch of files, the work is done in a thread pool.
 # If you use too many "workers" it might saturate your network, meaning it's

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -10,6 +10,7 @@ from .constants import (
     DEFAULT_BUCKET_NAME,
     DEFAULT_BUCKET_PREFIX,
     DEFAULT_CACHE_CONTROL,
+    DEFAULT_DISTRIBUTION_ID,
     DEFAULT_NO_PROGRESSBAR,
     DEFAULT_REPO,
     DEFAULT_GITHUB_TOKEN,
@@ -17,7 +18,10 @@ from .constants import (
     SPEEDCURVE_DEPLOY_SITE_ID,
     ELASTICSEARCH_URL,
 )
-from .update_lambda_functions import update_all
+from .update_lambda_functions import (
+    update_all as update_lambdas,
+    deploy as deploy_lambdas,
+)
 from .upload import upload_content
 from .utils import log
 from .whatsdeployed import dump as dump_whatsdeployed
@@ -81,6 +85,12 @@ def cli(ctx, **kwargs):
 
 
 @cli.command()
+@click.option(
+    "--distribution",
+    help="Id of the CloudFront distribution",
+    default=DEFAULT_DISTRIBUTION_ID,
+    show_default=True,
+)
 @click.argument(
     "directory",
     type=click.Path(),
@@ -88,9 +98,12 @@ def cli(ctx, **kwargs):
     default="aws-lambda",
 )
 @click.pass_context
-def update_lambda_functions(ctx, directory):
+def update_lambda_functions(ctx, directory, distribution):
     log.info(f"Deployer ({__version__})", bold=True)
-    update_all(directory, dry_run=ctx.obj["dry_run"])
+    dry_run = ctx.obj["dry_run"]
+
+    updated_functions = update_lambdas(directory, dry_run=dry_run)
+    deploy_lambdas(updated_functions, distribution, dry_run=dry_run)
 
 
 @cli.command(

--- a/deployer/src/deployer/main.py
+++ b/deployer/src/deployer/main.py
@@ -91,6 +91,13 @@ def cli(ctx, **kwargs):
     default=DEFAULT_DISTRIBUTION_ID,
     show_default=True,
 )
+@click.option(
+    "--force",
+    default=False,
+    help="Overwrite Lambda function, even if the hash hasn't changed.",
+    show_default=True,
+    is_flag=True,
+)
 @click.argument(
     "directory",
     type=click.Path(),
@@ -98,11 +105,11 @@ def cli(ctx, **kwargs):
     default="aws-lambda",
 )
 @click.pass_context
-def update_lambda_functions(ctx, directory, distribution):
+def update_lambda_functions(ctx, directory, distribution, force):
     log.info(f"Deployer ({__version__})", bold=True)
     dry_run = ctx.obj["dry_run"]
 
-    updated_functions = update_lambdas(directory, dry_run=dry_run)
+    updated_functions = update_lambdas(directory, dry_run=dry_run, force=force)
     deploy_lambdas(updated_functions, distribution, dry_run=dry_run)
 
 

--- a/deployer/src/deployer/update_lambda_functions.py
+++ b/deployer/src/deployer/update_lambda_functions.py
@@ -82,14 +82,17 @@ def update(lambda_function_dir, dry_run=False):
     return None
 
 
-def update_all(directory: Path, dry_run=False):
+def update_all(directory: Path, dry_run=False, force=False):
     log.info(f"Updating all lambda functions within: {directory}")
+
+    updated_functions = []
 
     for lambda_function_dir in get_lambda_function_dirs(directory):
         log.info(f"Found {lambda_function_dir.stem}: ", nl=False)
 
-        info = update(lambda_function_dir, dry_run=dry_run)
+        info = update(lambda_function_dir, dry_run=dry_run, force=force)
         if info:
+            updated_functions.append(info)
             if dry_run:
                 log.info(
                     f"would have published a new version of {info['FunctionName']}"
@@ -99,5 +102,114 @@ def update_all(directory: Path, dry_run=False):
                     f"published version {info['Version']} of {info['FunctionName']} "
                     f"as {info['FunctionArn']}",
                 )
+
         else:
             log.info(" no change (matches the latest version in AWS)")
+
+    return updated_functions
+
+
+def deploy(updated_functions: list, distribution_id, dry_run=False):
+    if len(updated_functions) == 0:
+        log.success(
+            "Skipping Lambda deployment to CloudFront, because no Lambdas were updated."
+        )
+        return
+
+    if not distribution_id:
+        log.warning(
+            "Skipping Lambda deployment to CloudFront, because no --distribution was specified."
+        )
+        return
+
+    # Pre-process updated functions.
+    function_arn_by_prefix = {}
+
+    for update in updated_functions:
+        arn = update["FunctionArn"]
+        version = update["Version"]
+
+        if arn.endswith(version):
+            # update_function_code() returns FunctionArn with version.
+            prefix = arn.replace(version, "")
+        else:
+            # get_function() returns FunctionArn without version.
+            prefix = arn + ":"
+            arn = prefix + version
+
+        function_arn_by_prefix[prefix] = arn
+
+    client = boto3.client("cloudfront")
+
+    # Get config.
+    response = client.get_distribution_config(Id=distribution_id)
+    etag = response["ETag"]
+    distribution_config = response["DistributionConfig"]
+    distribution_description = distribution_config["Comment"]
+
+    log.success(
+        f"Deploying lambda updates to CloudFront distribution {distribution_id} ({distribution_description})..."
+    )
+
+    behavior_items = [
+        distribution_config["DefaultCacheBehavior"]
+    ] + distribution_config["CacheBehaviors"]["Items"]
+
+    # Modify config.
+    changes = False
+    for behavior_item in behavior_items:
+        if "PathPattern" in behavior_item:
+            path_pattern = behavior_item["PathPattern"]
+        else:
+            path_pattern = "Default (*)"
+
+        if (
+            "LambdaFunctionAssociations" not in behavior_item
+            or "Items" not in behavior_item["LambdaFunctionAssociations"]
+        ):
+            continue
+
+        lambda_items = behavior_item["LambdaFunctionAssociations"]["Items"]
+
+        for lambda_item in lambda_items:
+            current_arn = lambda_item["LambdaFunctionARN"]
+
+            for prefix, arn in function_arn_by_prefix.items():
+                if not current_arn.startswith(prefix) or arn == current_arn:
+                    continue
+
+                if dry_run:
+                    log.info(
+                        f"Would update '{path_pattern}' ({lambda_item['EventType']}) from {current_arn} to {arn}"
+                    )
+                else:
+                    log.info(
+                        f"Updating '{path_pattern}' ({lambda_item['EventType']}) from {current_arn} to {arn}"
+                    )
+                    lambda_item["LambdaFunctionARN"] = arn
+
+                changes = True
+                break
+
+    if not changes:
+        log.info(
+            "CloudFront distribution was not changed, because it does not use any of the updated lambdas."
+        )
+        return
+
+    if dry_run:
+        # If this is a dry run, just return the config.
+        log.success(
+            f"Would have deployed lambda updates to CloudFront distribution {distribution_id} ({distribution_description})!"
+        )
+        return distribution_config
+
+    # Update config.
+    response = client.update_distribution(
+        Id=distribution_id, IfMatch=etag, DistributionConfig=distribution_config
+    )
+    log.success(
+        f"Deployed lambda updates to CloudFront distribution {distribution_id} ({distribution_description})!"
+    )
+
+    return response["Distribution"]["DistributionConfig"]

--- a/deployer/src/deployer/update_lambda_functions.py
+++ b/deployer/src/deployer/update_lambda_functions.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -42,6 +43,12 @@ def make_package(lambda_function_dir):
     # Remove any existing zip package(s).
     for zip_filename in lambda_function_dir.glob("*.zip"):
         zip_filename.unlink()
+
+    # Reset timestamp of files for reproducible zips.
+    times = (0, 0)
+    for file in lambda_function_dir.glob("**/*"):
+        os.utime(file, times)
+
     # Create a new zip package.
     subprocess_result = subprocess.run(
         "yarn run make-package",

--- a/deployer/src/deployer/update_lambda_functions.py
+++ b/deployer/src/deployer/update_lambda_functions.py
@@ -62,7 +62,7 @@ def make_package(lambda_function_dir):
         )
 
 
-def update(lambda_function_dir, dry_run=False):
+def update(lambda_function_dir, dry_run=False, force=False):
     zip_filename = make_package(lambda_function_dir)
     function_name, region_name = get_aws_info(lambda_function_dir)
     client = boto3.client("lambda", region_name=region_name)
@@ -71,7 +71,7 @@ def update(lambda_function_dir, dry_run=False):
     function_hash = function_info["Configuration"]["CodeSha256"]
     zip_file_bytes = zip_filename.read_bytes()
     # If nothing has changed, don't do anything.
-    if get_sha256_hash(zip_file_bytes) != function_hash:
+    if force or get_sha256_hash(zip_file_bytes) != function_hash:
         if dry_run:
             # If this is a dry run, just return the existing function info.
             return function_info["Configuration"]


### PR DESCRIPTION
## Summary

Automatize Lambda deployment to CloudFront distributions.

### Problem

Currently, we have to manually update CloudFront distribution behaviors whenever we change the corresponding lambdas (`deployer/aws-lambda/*`).

### Solution

1. Collect the Lambda updates.
2. Find CloudFront behaviors that use the updated Lambda, and update them accordingly.
3. (Related) Reset Lambda file timestamp for reproducible ZIP files.

---

## Screenshots

_Not relevant._

---

## How did you test this change?

1. Ran `poetry run deployer --dry-run update-lambda-functions --distribution E2MLRMA1VTVDHX`
1. Ran `poetry run deployer --dry-run update-lambda-functions --distribution E2MLRMA1VTVDHX --force`
1. Ran `poetry run deployer update-lambda-functions --distribution E2MLRMA1VTVDHX --force`
