### PR TITLE
Make whole div area part of search result link

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useCombobox } from "downshift";
 import useSWR from "swr";
 
@@ -358,11 +358,23 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
               index: 0,
             })}
           >
-            No document titles found.
-            <br />
-            <Link to={searchPath}>
+            <a
+              href={searchPath}
+              onClick={(event: React.MouseEvent) => {
+                if (event.ctrlKey || event.metaKey) {
+                  // Open in new tab, don't navigate current tab.
+                  event.stopPropagation();
+                } else {
+                  // Open in same tab, navigate via combobox.
+                  event.preventDefault();
+                }
+              }}
+              tabIndex={-1}
+            >
+              No document titles found.
+              <br />
               Site search for <code>{inputValue}</code>
-            </Link>
+            </a>
           </div>
         ) : (
           [
@@ -404,11 +416,23 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
                 index: resultItems.length,
               })}
             >
-              Not seeing what you're searching for?
-              <br />
-              <Link to={searchPath}>
+              <a
+                href={searchPath}
+                onClick={(event: React.MouseEvent) => {
+                  if (event.ctrlKey || event.metaKey) {
+                    // Open in new tab, don't navigate current tab.
+                    event.stopPropagation();
+                  } else {
+                    // Open in same tab, navigate via combobox.
+                    event.preventDefault();
+                  }
+                }}
+                tabIndex={-1}
+              >
+                Not seeing what you're searching for?
+                <br />
                 Site search for <code>{inputValue}</code>
-              </Link>
+              </a>
             </div>,
           ]
         )}

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -139,7 +139,6 @@
 
     .result-item {
       border-bottom: 1px solid var(--border-secondary);
-      padding: 0.5rem;
       word-break: break-word;
       background: var(--background-secondary);
       font-size: var(--type-smaller-font-size);
@@ -155,6 +154,10 @@
         code {
           font-size: 0.8125rem;
         }
+      }
+      a {
+        display: block;
+        padding: 0.5rem;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes my issue in #6107, though I'm unsure if that's the reported issue. I can't find any other cause for that issue, but I'm mainly unsure since this affects right click and middle click as well, but the OP for that issue said those were not affected.

### Problem

Ctrl+click was not working when clicking the non-text part of search results

### Solution

Change the links in the search results to take up the whole div (using `display: block;`, moving the padding from the div to the link, moving the lines of text for site search inside the links, and switching the site search links to anchor elements with similar code to the search results).

---

## How did you test this change?

Locally by ctrl-clicking the edge of search results, including site search results.
