### PR TITLE
perf(build): use fdir instead of glob

### DIFF
--- a/build/sync-translated-content.js
+++ b/build/sync-translated-content.js
@@ -2,10 +2,10 @@ const fs = require("fs");
 const crypto = require("crypto");
 const path = require("path");
 
-const glob = require("glob");
 const chalk = require("chalk");
 const fm = require("front-matter");
 const log = require("loglevel");
+const { fdir } = require("fdir");
 
 const {
   buildURL,
@@ -15,6 +15,8 @@ const {
   Redirect,
   CONTENT_ROOT,
   CONTENT_TRANSLATED_ROOT,
+  HTML_FILENAME,
+  MARKDOWN_FILENAME,
   VALID_LOCALES,
 } = require("../content");
 
@@ -28,9 +30,16 @@ function syncAllTranslatedContent(locale) {
     );
   }
   const redirects = new Map();
-  const files = glob.sync(
-    path.join(CONTENT_TRANSLATED_ROOT, locale, "**", "index.{html,md}")
-  );
+  const api = new fdir()
+    .withFullPaths()
+    .withErrors()
+    .filter((filePath) => {
+      return (
+        filePath.endsWith(HTML_FILENAME) || filePath.endsWith(MARKDOWN_FILENAME)
+      );
+    })
+    .crawl(path.join(CONTENT_TRANSLATED_ROOT, locale));
+  const files = [...api.sync()];
   const stats = {
     movedDocs: 0,
     conflictingDocs: 0,

--- a/content/constants.js
+++ b/content/constants.js
@@ -39,6 +39,9 @@ if (CONTENT_TRANSLATED_ROOT) {
   REPOSITORY_URLS[CONTENT_TRANSLATED_ROOT] = "mdn/translated-content";
 }
 
+const HTML_FILENAME = "index.html";
+const MARKDOWN_FILENAME = "index.md";
+
 function correctContentPathFromEnv(envVarName) {
   let pathName = process.env[envVarName];
   if (!pathName) {
@@ -69,4 +72,6 @@ module.exports = {
   VALID_LOCALES,
   ACTIVE_LOCALES,
   DEFAULT_LOCALE,
+  HTML_FILENAME,
+  MARKDOWN_FILENAME,
 };

--- a/content/document.js
+++ b/content/document.js
@@ -3,7 +3,6 @@ const path = require("path");
 const util = require("util");
 
 const fm = require("front-matter");
-const glob = require("glob");
 const yaml = require("js-yaml");
 const { fdir } = require("fdir");
 
@@ -13,6 +12,8 @@ const {
   ACTIVE_LOCALES,
   VALID_LOCALES,
   ROOTS,
+  HTML_FILENAME,
+  MARKDOWN_FILENAME,
 } = require("./constants");
 const { getPopularities } = require("./popularities");
 const { getWikiHistories } = require("./wikihistories");
@@ -33,9 +34,7 @@ function buildPath(localeFolder, slug) {
   return path.join(localeFolder, slugToFolder(slug));
 }
 
-const HTML_FILENAME = "index.html";
 const getHTMLPath = (folder) => path.join(folder, HTML_FILENAME);
-const MARKDOWN_FILENAME = "index.md";
 const getMarkdownPath = (folder) => path.join(folder, MARKDOWN_FILENAME);
 
 function updateWikiHistory(localeContentRoot, oldSlug, newSlug = null) {
@@ -501,15 +500,18 @@ function findChildren(url, recursive = false) {
   const locale = url.split("/")[1];
   const root = getRoot(locale);
   const folder = urlToFolderPath(url);
-  const globber = recursive ? ["*", "**"] : ["*"];
-  const childPaths = glob.sync(
-    path.join(
-      root,
-      folder,
-      ...globber,
-      `+(${HTML_FILENAME}|${MARKDOWN_FILENAME})`
-    )
-  );
+
+  const api = new fdir()
+    .withFullPaths()
+    .withErrors()
+    .filter((filePath) => {
+      return (
+        filePath.endsWith(HTML_FILENAME) || filePath.endsWith(MARKDOWN_FILENAME)
+      );
+    })
+    .withMaxDepth(recursive ? Infinity : 1)
+    .crawl(path.join(root, folder));
+  const childPaths = [...api.sync()];
   return childPaths
     .map((childFilePath) => path.relative(root, path.dirname(childFilePath)))
     .map((folder) => read(folder));

--- a/content/index.js
+++ b/content/index.js
@@ -5,6 +5,8 @@ const {
   REPOSITORY_URLS,
   ROOTS,
   VALID_LOCALES,
+  HTML_FILENAME,
+  MARKDOWN_FILENAME,
 } = require("./constants");
 const Document = require("./document");
 const Translation = require("./translation");
@@ -28,6 +30,8 @@ module.exports = {
   REPOSITORY_URLS,
   ROOTS,
   VALID_LOCALES,
+  HTML_FILENAME,
+  MARKDOWN_FILENAME,
 
   getPopularities,
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "file-type": "16.5.3",
     "front-matter": "^4.0.2",
     "fs-extra": "10.1.0",
-    "glob": "^7.2.0",
     "got": "11.8.3",
     "hast-util-is-element": "^1.1.0",
     "hast-util-to-html": "^7.1.3",

--- a/server/flaws.js
+++ b/server/flaws.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 
-const glob = require("glob");
+const { fdir } = require("fdir");
 
 const { getPopularities } = require("../content");
 const { FLAW_LEVELS, options: buildOptions } = require("../build");
@@ -211,9 +211,14 @@ module.exports = (req, res) => {
     }
   }
 
-  for (const filePath of glob.sync(
-    path.join(BUILD_OUT_ROOT, locale, "**", "index.json")
-  )) {
+  const api = new fdir()
+    .withFullPaths()
+    .withErrors()
+    .filter((filePath) => {
+      return filePath.endsWith("index.json");
+    })
+    .crawl(path.join(BUILD_OUT_ROOT, locale));
+  for (const filePath of api.sync()) {
     const { doc } = JSON.parse(fs.readFileSync(filePath));
 
     // The home page, for example, also uses a `index.json` but it doesn't have


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

We started to switch for performance, so let's finish it.

### Problem

glob() is slow.

### Solution

Use fdir() everywhere.