### PR TITLE
fix(sidebar): reduce max-height by offset

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -1,6 +1,7 @@
 @use "../../../ui/vars" as *;
 
 .sidebar {
+  --offset: var(--top-navigation-height);
   color: var(--text-secondary);
 
   .backdrop {
@@ -74,7 +75,7 @@
     display: flex;
     overflow: auto;
     position: sticky;
-    top: var(--top-navigation-height);
+    top: var(--offset);
     max-height: 100vh;
   }
 

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -2,7 +2,7 @@
 
 .sidebar {
   --offset: var(--top-navigation-height);
-  --max-height: 100vh;
+  --max-height: calc(100vh - var(--offset));
   color: var(--text-secondary);
 
   .backdrop {

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -2,6 +2,7 @@
 
 .sidebar {
   --offset: var(--top-navigation-height);
+  --max-height: 100vh;
   color: var(--text-secondary);
 
   .backdrop {
@@ -28,8 +29,8 @@
       padding: 1rem;
       width: 80vw;
       max-width: 20rem;
-      height: 100vh;
-      max-height: 100vh;
+      height: var(--max-height);
+      max-height: var(--max-height);
       overflow: auto;
       background: var(--background-primary);
       border-right: 1px solid var(--border-primary);
@@ -76,7 +77,7 @@
     overflow: auto;
     position: sticky;
     top: var(--offset);
-    max-height: 100vh;
+    max-height: var(--max-height);
   }
 
   &-heading {


### PR DESCRIPTION
## Summary

Fixes #6144.

### Problem

When we implemented sticky headers, we encountered the issue that the sidebars scrolled behind the article-actions-container, and added a `top` value as a workaround. However, we did not adjust the sidebar height (`100vw`), causing the bottom of the sidebar to be hidden.

### Solution

- Reduced the sidebar max-height by the sidebar offset.
- Extracted CSS variables `--offset` and `--max-height` for this.

---

## Screenshots

### Before

<img width="511" alt="image" src="https://user-images.githubusercontent.com/495429/166296392-1e56e124-37ae-4f18-bff3-464836fe8332.png">

### After

<img width="511" alt="image" src="https://user-images.githubusercontent.com/495429/166296335-cd48e8db-1684-49d9-9ef5-d61662f49c34.png">


---

## How did you test this change?

1. Opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys locally.
2. Scrolled the sidebar down, without scrolling the main content.
3. Verified that the last sidebar item is visible.