### PR TITLE
fix(themes): copy missing vars from light to dark

### DIFF
--- a/client/src/ui/base/_themes.scss
+++ b/client/src/ui/base/_themes.scss
@@ -220,6 +220,9 @@
   --button-secondary-hover: #{$mdn-theme-dark-button-secondary-hover};
   --button-secondary-active: #{$mdn-theme-dark-button-secondary-active};
   --button-secondary-inactive: #{$mdn-theme-dark-button-secondary-inactive};
+  --button-secondary-border-focus: #{$mdn-theme-light-button-secondary-border-focus};
+  --button-secondary-border-red: #{$mdn-theme-light-button-secondary-border-red};
+  --button-secondary-border-red-focus: #{$mdn-theme-light-button-secondary-border-red-focus};
 
   --icon-primary: #{$mdn-theme-dark-icon-primary};
   --icon-secondary: #{$mdn-theme-dark-icon-secondary};
@@ -287,6 +290,14 @@
   --http-mark-color: #{$mdn-color-dark-theme-green-70};
   --apis-mark-color: #{$mdn-color-dark-theme-violet-70};
   --learn-mark-color: #{$mdn-color-dark-theme-pink-70};
+
+  --plus-accent-background-color: #{$mdn-color-light-theme-red-50}30;
+  --html-accent-background-color: #{$mdn-color-light-theme-red-50}30;
+  --css-accent-background-color: #{$mdn-color-light-theme-blue-50}30;
+  --js-accent-background-color: #{$mdn-color-light-theme-yellow-50}30;
+  --http-accent-background-color: #{$mdn-color-light-theme-green-50}30;
+  --apis-accent-background-color: #{$mdn-color-light-theme-violet-50}30;
+  --learn-accent-background-color: #{$mdn-color-light-theme-pink-50}30;
 
   --plus-accent-engage: #{color.adjust(
       $mdn-color-dark-theme-red-40,


### PR DESCRIPTION
## Summary

Fixes a design regression on the MDN Plus product page.

### Problem

In #6102, I decoupled the dark theme from the light theme, but I didn't copy all missing variables that were only present in the light theme. Accordingly, some things didn't look like they should in the dark theme.

### Solution

Copy over those missing variables.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="781" alt="image" src="https://user-images.githubusercontent.com/495429/166301208-58cd6531-0d2a-4c05-bfa3-dd73282b111c.png">

### After

<img width="781" alt="image" src="https://user-images.githubusercontent.com/495429/166301113-58192b1a-1082-4bf4-942a-a61ad36a7563.png">

---

## How did you test this change?

- Opened http://localhost:3000/en-US/plus locally.
- Verified that the page looks like before.