### PR TITLE
fix(fundamental-redirects): don't treat 'Web' as locale

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -7,7 +7,7 @@ const {
 
 const startRe = /^\^?\/?/;
 const startTemplate = /^\//;
-const LOCALE_PATTERN = "[a-zA-Z]{2}(?:-[a-zA-Z]{2})?";
+const LOCALE_PATTERN = "(?:[a-zA-Z]{2}|eng)(?:-[a-zA-Z]{2})?";
 
 function redirect(pattern, template, options = {}) {
   return (path) => {

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -7,6 +7,7 @@ const {
 
 const startRe = /^\^?\/?/;
 const startTemplate = /^\//;
+const LOCALE_PATTERN = "[a-zA-Z]{2}(?:-[a-zA-Z]{2})?";
 
 function redirect(pattern, template, options = {}) {
   return (path) => {
@@ -36,7 +37,7 @@ function localeRedirect(
 ) {
   const patternStrWithLocale = pattern.source.replace(
     startRe,
-    "^(?<locale>\\w{2,3}(?:-\\w{2})?/)?"
+    "^(?<locale>" + LOCALE_PATTERN + "/)?"
   );
   const patternWithLocale = new RegExp(patternStrWithLocale, pattern.flags);
   let _template = template;

--- a/testing/tests/redirects.test.js
+++ b/testing/tests/redirects.test.js
@@ -254,7 +254,11 @@ const SCL3_REDIRECT_URLS = [].concat(
   ),
   url_test("/MDN/Contribute", "/en-US/docs/MDN/Contribute"),
   url_test("/mdn/contribute", "/en-US/docs/MDN/Contribute"),
-  url_test("/en-US/docs/MDN/Contribute", null, { statusCode: 404 })
+  url_test("/en-US/docs/MDN/Contribute", null, { statusCode: 404 }),
+  url_test(
+    "/Web/JavaScript/Reference/Global_Objects/Array/from",
+    "/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
+  )
 );
 
 const GITHUB_IO_URLS = [].concat(


### PR DESCRIPTION
## Summary

Fixes #4435

### Problem

We have some "fundamental" redirects, that redirect whole sections that were moved.

However, https://developer.allizom.org/Web/JavaScript/ is wrongly redirected to https://developer.allizom.org/Web/docs/JavaScript/ instead of https://developer.allizom.org/docs/Web/JavaScript/, because "Web" is being interpreted as a locale (as mentioned [in this comment](https://github.com/mdn/yari/issues/4435#issuecomment-895581734)).

### Solution

Reduce the locale pattern from `[a-zA-Z0-9]{2,3}(-[a-zA-Z0-9]{2})?` to `[a-zA-Z]{2}(-[a-zA-Z]{2})?`, because all our locales use tags consisting of two characters.

Note that the primary tag consists of only characters anyway (see https://www.rfc-editor.org/rfc/rfc3066#section-2.1).

---

## Screenshots

_Not applicable._

---

## How did you test this change?

Added a testcase.