### PR TITLE
Deprecate {{exception}} macro

### DIFF
--- a/kumascript/macros/Exception.ejs
+++ b/kumascript/macros/Exception.ejs
@@ -1,4 +1,9 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 22 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var id = "exception-" + $0;
 %>
 <a href="/<%-env.locale%>/docs/Web/API/DOMException#<%-id%>"><code><%- $0 %></code></a>


### PR DESCRIPTION
In mdn/content#15677, I removed the last occurrences of the `{{exception}}` macro.

In order to be sure this macro doesn't sneak back in `mdn/content` while it gets removed from `mdn/translated-content`, we want a `MacroDeprecationError` flaw to be raised if a page is committed again with this macro.

This flaw can be noticed by the committer, the reviewer, and, via the flaw dashboard, all `mdn/content` owners. (Given we normally have 0 such flaws, it will be very noticeable)