### PR TITLE
fix(search): apply padding to links on homepage search

### DIFF
--- a/client/src/homepage/homepage-hero/index.scss
+++ b/client/src/homepage/homepage-hero/index.scss
@@ -105,7 +105,9 @@
       z-index: var(--z-index-search-results-home);
 
       .result-item {
-        padding: 0.5rem 1.5rem;
+        a {
+          padding: 0.5rem 1.5rem;
+        }
 
         mark {
           background: none;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Follow up to #6132

### Problem

The home page search padding was incorrect and not part of the link

### Solution

Move the padding

## Screenshots

### Before

<img width="867" alt="image" src="https://user-images.githubusercontent.com/495429/167014855-3feb98e4-926c-4a82-8e15-f9456eeda969.png">

### After

<img width="867" alt="image" src="https://user-images.githubusercontent.com/495429/167014940-34d0ea9f-bad0-40d1-aefd-09980ffb7a7b.png">

---

## How did you test this change?

This stylesheet wasn't being applied locally for some reason, so testing was done purely through DevTools.