### PR TITLE
fix(macros/Compat): move query from id to dataset

### DIFF
--- a/build/bcd-urls.js
+++ b/build/bcd-urls.js
@@ -58,7 +58,7 @@ function normalizeBCDURLs(doc, options) {
     if (section.type !== "browser_compatibility") continue;
 
     // This happens if a query is "broken".
-    // E.g. <div class="bc-data" id="bcd:apii.TypoCatching">
+    // E.g. <div class="bc-data" data-query="apii.TypoCatching">
     if (!section.value.data) continue;
 
     for (const [key, data] of Object.entries(section.value.data)) {
@@ -127,7 +127,7 @@ function extractBCDData(doc) {
 
       if (!section.value.data) {
         // This happens if a query is "broken".
-        // E.g. <div class="bc-data" id="bcd:apii.TypoCatching">
+        // E.g. <div class="bc-data" data-query="apii.TypoCatching">
         continue;
       }
       const fileName = ++nextId > 1 ? `bcd-${nextId}.json` : "bcd.json";

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -154,7 +154,7 @@ function extractSections($) {
  * first. For example BCD tables. If the input is this:
  *
  *   <h2 id="browser_compat">Browser Compat</h2>
- *   <div class="bc-data" id="bcd:foo.bar.thing">...</div>
+ *   <div class="bc-data" data-query="foo.bar.thing">...</div>
  *
  * Then, extract the ID, get the structured data and eventually return this:
  *
@@ -327,7 +327,9 @@ function _addSingleSpecialSection($) {
   let specialSectionType = null;
   if ($.find("div.bc-data").length) {
     specialSectionType = "browser_compatibility";
-    dataQuery = $.find("div.bc-data").attr("id");
+    const elem = $.find("div.bc-data");
+    // Macro adds "data-query", but some translated-content still uses "id".
+    dataQuery = elem.attr("data-query") || elem.attr("id");
   } else if ($.find("div.bc-specs").length) {
     specialSectionType = "specifications";
     dataQuery = $.find("div.bc-specs").attr("data-bcd-query");
@@ -335,9 +337,9 @@ function _addSingleSpecialSection($) {
   }
 
   // Some old legacy documents haven't been re-rendered yet, since it
-  // was added, so the `div.bc-data` tag doesn't have a `id="bcd:..."`
-  // attribute. If that's the case, bail and fail back on a regular
-  // prose section :(
+  // was added, so the `div.bc-data` tag doesn't have a a `id="bcd:..."`
+  // or `data-bcd="..."` attribute. If that's the case, bail and fall
+  // back on a regular prose section :(
   if (!dataQuery && specURLsString === "") {
     // I wish there was a good place to log this!
     const [proseSections] = _addSectionProse($);

--- a/build/flaws/bad-bcd-queries.js
+++ b/build/flaws/bad-bcd-queries.js
@@ -9,9 +9,11 @@ const { packageBCD } = require("../resolve-bcd");
 function getBadBCDQueriesFlaws(doc, $) {
   return $("div.bc-data")
     .map((i, element) => {
-      const dataQuery = $(element).attr("id");
+      const $element = $(element);
+      // Macro adds "data-query", but some translated-content still uses "id".
+      const dataQuery = $element.attr("data-query") || $element.attr("id");
       if (!dataQuery) {
-        return "BCD table without an ID";
+        return "BCD table without 'data-query' or 'id' attribute";
       }
       const query = dataQuery.replace(/^bcd:/, "");
       return !packageBCD(query).data && `No BCD data for query: ${query}`;

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -35,7 +35,7 @@ if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");
 }
 var depth = $1 || 1;
-var output = `<div class="bc-data" id="bcd:${query}" data-depth="${depth}">
+var output = `<div class="bc-data" data-query="${query}" data-depth="${depth}">
   If you're able to see this, something went wrong on this page.
 </div>`;
 %>

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -21,7 +21,8 @@ describeMacro("Compat", function () {
   itMacro("Outputs a simple div tag", async (macro) => {
     const result = await macro.call("api.feature");
     const dom = JSDOM.fragment(result);
-    assert.equal(dom.querySelector("div.bc-data").id, "bcd:api.feature");
+    assert.equal(dom.querySelector("div.bc-data").id, "");
+    assert.equal(dom.querySelector("div.bc-data").dataset.query, "api.feature");
     assert.equal(dom.querySelector("div.bc-data").dataset.depth, "1");
     assert.equal(
       dom.querySelector("div.bc-data").textContent.trim(),


### PR DESCRIPTION
## Summary

Extracted from #6165.

Previously, the macro would add `id="bcd:{QUERY}"`, which is an
invalid id, and is being reported by html-validate 6.9.0 and later.

Now, we add `data-query="{QUERY}"` instead of an invalid id.