### PR TITLE
fix(deployer): use correct env for distirbution

### DIFF
--- a/deployer/src/deployer/constants.py
+++ b/deployer/src/deployer/constants.py
@@ -13,7 +13,7 @@ CONTENT_TRANSLATED_ROOT = config("CONTENT_TRANSLATED_ROOT", default=None)
 
 DEFAULT_BUCKET_NAME = config("DEPLOYER_BUCKET_NAME", default="mdn-content-dev")
 DEFAULT_BUCKET_PREFIX = config("DEPLOYER_BUCKET_PREFIX", default="main")
-DEFAULT_DISTRIBUTION_ID = config("DEFAULT_DISTRIBUTION_ID", default=None)
+DEFAULT_DISTRIBUTION_ID = config("DEPLOYER_DISTRIBUTION_ID", default=None)
 
 # When uploading a bunch of files, the work is done in a thread pool.
 # If you use too many "workers" it might saturate your network, meaning it's


### PR DESCRIPTION
## Summary

Fixes #6171.

### Problem

The deployer was using a different env variable for the CloudFront distribution than was specified in the workflows.

### Solution

Update the deployer to use the env variable defined in the workflows.

---

## How did you test this change?

Ran `deployer update-lambda-functions` locally:

```console
$ DEPLOYER_DISTRIBUTION_ID=E2MLRMA1VTVDHX poetry run deployer --dry-run update-lambda-functions                                                                      130 ↵
Deployer (0.3.0)
Updating all lambda functions within: aws-lambda
Found content-origin-request: would have published a new version of mdn-content-origin-request
Found content-origin-response: would have published a new version of mdn-content-origin-response
Found mdn-stripe-price-ids: would have published a new version of mdn-stripe-price-ids
Deploying lambda updates to CloudFront distribution E2MLRMA1VTVDHX (MDN stage Yari CDN)...
Would update 'Default (*)' (origin-response) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:981 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:$LATEST
Would update 'Default (*)' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:1400 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:$LATEST
Would update '/' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:1400 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:$LATEST
Would update 'api/v1/stripe/plans' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-stripe-price-ids:14 to arn:aws:lambda:us-east-1:***:function:mdn-stripe-price-ids:$LATEST
Would update 'docs/*' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:1400 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:$LATEST
Would update '*/docs/*' (origin-response) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:981 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:$LATEST
Would update '*/docs/*' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:1400 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:$LATEST
Would update '*/plus*' (origin-request) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:1390 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-request:$LATEST
Would update '*/plus*' (origin-response) from arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:981 to arn:aws:lambda:us-east-1:***:function:mdn-content-origin-response:$LATEST
Would have deployed lambda updates to CloudFront distribution E2MLRMA1VTVDHX (MDN stage Yari CDN)!
```