### PR TITLE
fix(eslint): resolve two issues

### DIFF
--- a/client/pwa/src/db.ts
+++ b/client/pwa/src/db.ts
@@ -5,14 +5,14 @@
 
 import Dexie from "dexie";
 
-interface Watched {
+export interface Watched {
   url: string;
   title: string;
   path: string;
   status: string;
 }
 
-interface Notifications {
+export interface Notifications {
   id: number;
   title: string;
   text: string;
@@ -27,7 +27,7 @@ interface Parent {
   title: string;
 }
 
-interface Collections {
+export interface Collections {
   id?: number;
   url: string;
   title: string;
@@ -36,7 +36,7 @@ interface Collections {
   created: Date;
 }
 
-interface Whoami {
+export interface Whoami {
   id?: number;
   username: string;
   is_authenticated: boolean;

--- a/client/src/homepage/featured-articles/index.scss
+++ b/client/src/homepage/featured-articles/index.scss
@@ -47,7 +47,7 @@
     .tile-title {
       flex-grow: 1;
       display: flex;
-      align-items: end;
+      align-items: flex-end;
       font: var(--type-heading-h5);
       font-weight: 500;
       line-height: var(--intermediate-line-height);

--- a/client/src/offline-settings/db.ts
+++ b/client/src/offline-settings/db.ts
@@ -5,14 +5,14 @@
 
 import Dexie from "dexie";
 
-interface Watched {
+export interface Watched {
   url: string;
   title: string;
   path: string;
   status: string;
 }
 
-interface Notifications {
+export interface Notifications {
   id: number;
   title: string;
   text: string;
@@ -27,7 +27,7 @@ interface Parent {
   title: string;
 }
 
-interface Collections {
+export interface Collections {
   id?: number;
   url: string;
   title: string;
@@ -36,7 +36,7 @@ interface Collections {
   created: Date;
 }
 
-interface Whoami {
+export interface Whoami {
   id?: number;
   username: string;
   is_authenticated: boolean;


### PR DESCRIPTION
## Summary

Extracted from #5970, this resolves two issues reported by ESLint.

### Problem

1. We're using `align-items: end;` and supposedly the value `end` has mixed support.
2. [TypeScript-ESLint](https://github.com/typescript-eslint/typescript-eslint) is complaining about unused interfaces (although they are used).

### Solution

1. Replace `end` by `flex-end`, as suggested by ESLint.
2. Export those "unused" interfaces, to suppress the warning.

---

## Screenshots

_None._

---

## How did you test this change?

_Not tested._