### PR TITLE
Mark LearnBox macro as deprecated

### DIFF
--- a/kumascript/macros/LearnBox.ejs
+++ b/kumascript/macros/LearnBox.ejs
@@ -11,6 +11,11 @@
 //            If a tag is prefixed with "!" it indicate that the article must NOT match that tag
 //            Default is [] which means no specific tags required
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 19 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 // L10N
 // ----------------------------------------------------------------------------
 var l10n = {


### PR DESCRIPTION
In mdn/content#15738, @wbamberg removed the last 2 occurrences of the `{{LearnBox}}` macro on MDN.

This PR marks the macro as deprecated so that the flaw dashboard will notify us if somebody uses them again.

There are still 19 occurrences in mdn-translation, but I've opened a [discussion](https://github.com/mdn/mdn-community/discussions/65) on mdn/community to get them removed there too. 