### PR TITLE
fix(deployer): handle index error of type str

### DIFF
--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -109,7 +109,14 @@ def index(
             else:
                 count_errors += 1
                 error_data = info["index"]["error"]
-                error_key = f"{error_data['type']}: {error_data['reason']}"
+
+                if isinstance(error_data, dict):
+                    error_key = f"{error_data['type']}: {error_data['reason']}"
+                elif isinstance(error_data, str):
+                    error_key = error_data
+                else:
+                    error_key = str(error_data)
+
                 errors_counter[error_key] += 1
             count_done += 1
             bar.update(1)


### PR DESCRIPTION
Should fix the following deployer error on dev builds:

```
Deleting any possible existing index and creating a new one called 'mdn_docs_20220506172812'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/.cache/pypoetry/virtualenvs/deployer-nuEoiHvI-py3.8/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/runner/work/yari/yari/deployer/src/deployer/main.py", line 311, in search_index
    search.index(
  File "/home/runner/work/yari/yari/deployer/src/deployer/search/__init__.py", line 112, in index
    error_key = f"{error_data['type']}: {error_data['reason']}"
TypeError: string indices must be integers
```

See: https://github.com/mdn/yari/commit/0238584c52bb5857396d99dac85c74d7e6322e10/checks#step:16:99