### PR TITLE
refactor: use `clear` instead of `reset` in the `LRU` package

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -307,7 +307,7 @@ async function buildDocument(document, documentOptions = {}) {
   const liveSamples = [];
 
   if (options.clearKumascriptRenderCache) {
-    renderKumascriptCache.reset();
+    renderKumascriptCache.clear();
   }
   try {
     [renderedHtml, flaws] = await kumascript.render(document.url);


### PR DESCRIPTION
## Summary

As is the title.

### Problem

The `lru-cache@reset` method is deprecated since 7.0.

> https://github.com/isaacs/node-lru-cache/blob/ff322ad364c727a419a77ad962915a625aaf1b52/index.js#L812-L815

### Solution

use `clear` instead of `reset`.

---

## Screenshots

N/A

---

## How did you test this change?

run `yarn build`.

Thank you :)