### PR TITLE
chore(eslint): delete `expect-puppeteer` settings from `.eslintrc.js`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,6 @@ module.exports = {
   },
   settings: {
     node: {
-      allowModules: ["expect-puppeteer"],
       resolvePaths: [__dirname],
       tryExtensions: [".js", ".json", ".node", ".tsx", ".ts"],
     },


### PR DESCRIPTION
## Summary

Follow-up #6176. 
The puppeteer has been deleted in  #6176

### Problem

N/A

### Solution

delete `allowModules: ["expect-puppeteer"],` from  `.eslintrc.js`

---

## Screenshots

N/A

---

## How did you test this change?

run `yarn run eslint` and confirmed nothing changes.

Thank you :)
