### PR TITLE
chore(ui): wrap search page result with `display: block`

### DIFF
--- a/client/src/site-search/index.scss
+++ b/client/src/site-search/index.scss
@@ -3,3 +3,7 @@
 .query-string {
   font-style: italic;
 }
+
+.site-search {
+  display: block;
+}

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -49,7 +49,7 @@ export function SiteSearch() {
   }, [query, page, ga]);
 
   return (
-    <div className="main-wrapper site-search main-page-content">
+    <div className="main-wrapper site-search">
       <PageContentContainer>
         <article className="main-page-content">
           {query ? (


### PR DESCRIPTION
## Summary

As is the title.

### Problem

The current seach page cut off on mobile.

### Solution

- Warp `display: block;`
- Delete `main-page-content`
  -  The current search results are wrapped in `main-page-content` twice.

---

## Screenshots

### Before

![mdn-before](https://user-images.githubusercontent.com/11273093/167281688-e7ba53cb-4857-4388-a882-47f45254703b.jpg)

### After

![mdn-after](https://user-images.githubusercontent.com/11273093/167281693-86c704c7-e1da-4925-a695-bf061db851ef.jpg)

---

## How did you test this change?

run locally and check result manually.

Thank you :)