### PR TITLE
fix(spas): correct prefix for feature docs

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -132,20 +132,20 @@ async function buildSPAs(options) {
           noIndexing: true,
         },
         {
-          prefix: "plus/docs/collections",
+          prefix: "plus/docs/faq",
+          pageTitle: `FAQ | ${MDN_PLUS_TITLE}`,
+        },
+        {
+          prefix: "plus/docs/features/collections",
           pageTitle: `Collections | ${MDN_PLUS_TITLE}`,
         },
         {
-          prefix: "plus/docs/notifications",
+          prefix: "plus/docs/features/notifications",
           pageTitle: `Notifications | ${MDN_PLUS_TITLE}`,
         },
         {
-          prefix: "plus/docs/offline",
+          prefix: "plus/docs/features/offline",
           pageTitle: `MDN Offline | ${MDN_PLUS_TITLE}`,
-        },
-        {
-          prefix: "plus/docs/faq",
-          pageTitle: `FAQ | ${MDN_PLUS_TITLE}`,
         },
         {
           prefix: "plus/notifications",


### PR DESCRIPTION
## Summary

Fixes the SPA prefixes for the MDN Plus feature docs, as noticed by @fiji-flo while reviewing #5952.

### Problem

The MDN Plus feature docs are located at `/plus/docs/features/*`, but `spas.js` uses just `/plus/docs` as a prefix, omitting the `features` path.

### Solution

Fixed the prefixes accordingly.

---

## Screenshots

_Should not effect the UI._

---

## How did you test this change?

Opened locally:

- http://localhost:3000/en-US/plus/docs/features/notifications
- http://localhost:3000/en-US/plus/docs/features/collections
- http://localhost:3000/en-US/plus/docs/features/offline