### PR TITLE
fix(plus/manage-upgrade-dialog): manage via "Watch list"

### DIFF
--- a/client/src/ui/molecules/manage-upgrade-dialog/index.tsx
+++ b/client/src/ui/molecules/manage-upgrade-dialog/index.tsx
@@ -28,7 +28,10 @@ export function ManageOrUpgradeDialogNotifications({ setShow }) {
         unlimited subscriptions
       </p>
       <div className="watch-submenu-item is-button-row">
-        <Button type="secondary" href={`/${locale}/plus/notifications`}>
+        <Button
+          type="secondary"
+          href={`/${locale}/plus/notifications/watching`}
+        >
           Manage
         </Button>
         <Button href={`/${locale}/plus`}>Upgrade</Button>


### PR DESCRIPTION
## Summary

Previously, the "Manage" link for the "Watch" action linked to
the "All notifications" page, which doesn't allow removing pages.

Now, it links to the "Watch list", which allows the user to
unwatch other pages, in order to watch a different page instead.

### Problem

_See above._

### Solution

_See above._

---

## Screenshots

Context:

<img width="524" alt="image" src="https://user-images.githubusercontent.com/495429/167465659-40ad4511-74ff-493f-9aa0-4752b0efc9de.png">

<img width="455" alt="image" src="https://user-images.githubusercontent.com/495429/167465981-6476e4e4-904d-46ae-beb4-1b7aa80debfd.png">

---

## How did you test this change?

1. Logged in with a Free account.
2. Watched 5 pages.
3. Opened [another page](http://localhost:3000/en-US/docs/Web/Accessibility) and clicked on "Watch".
4. Then clicked on "Manage".
5. Verified that I got referred to the "Watch list", not the "All notifications" tab.