### PR TITLE
Deprecate {{ifmethod}} and {{ifattribute}}

### DIFF
--- a/kumascript/macros/ifattribute.ejs
+++ b/kumascript/macros/ifattribute.ejs
@@ -2,6 +2,11 @@
 /* creates a link to an attribute in an interface */
 /* parameters: interface_name, attribute_name */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (currently 8 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var lang = env.locale;
 
 var destNewType = "/" + lang + '/docs/XPCOM_Interface_Reference/' + $0;

--- a/kumascript/macros/ifmethod.ejs
+++ b/kumascript/macros/ifmethod.ejs
@@ -6,8 +6,8 @@
 // Throw a MacroDeprecatedError flaw
 // Condition for removal: no more use in translated-content (currently 26 files)
 // 0 occurrences left in en-US
-
 mdn.deprecated();
+
 var lang = env.locale;
 var destNewType = lang + '/docs/XPCOM_Interface_Reference/' + $0;
 var apiString = $0 + '.' + $1 + '()';

--- a/kumascript/macros/ifmethod.ejs
+++ b/kumascript/macros/ifmethod.ejs
@@ -2,6 +2,12 @@
 /* creates a link to a method in an interface */
 /* parameters: interface name then method name */
 /* get a page's language (Don't use page.language!) */
+
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (currently 26 files)
+// 0 occurrences left in en-US
+
+mdn.deprecated();
 var lang = env.locale;
 var destNewType = lang + '/docs/XPCOM_Interface_Reference/' + $0;
 var apiString = $0 + '.' + $1 + '()';


### PR DESCRIPTION
`{{ifmethod}}` and `{{ifattribute}}` create only red links as the linked content has been deleted.

This is similar to what we did for `{{interface}}` in mdn/yari#6011.

After mdn/content#15848 will land, this is what we have in mdn/content:
![Capture d’écran 2022-05-10 à 08 53 15](https://user-images.githubusercontent.com/1466293/167566331-91b9aa01-d28b-41a1-86dd-831a09544d15.png)

As soon as it does, I'll open a request in mdn/mdn-community to get it removed from mdn/translated-content. 