### PR TITLE
fix(bcd): gracefully handle disabled JavaScript

### DIFF
--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -80,7 +80,15 @@ function LazyBrowserCompatibilityTableInner({ dataURL }: { dataURL: string }) {
   }, [dataURL]);
 
   if (isServer) {
-    return <p>BCD tables only load in the browser</p>;
+    return (
+      <p>
+        BCD tables only load in the browser
+        <noscript>
+          {" "}
+          with JavaScript enabled. Enable JavaScript to view data.
+        </noscript>
+      </p>
+    );
   }
   if (!data && !error) {
     return <Loading />;


### PR DESCRIPTION
## Summary

Fixes #4581

### Problem

If you disable JavaScript, the "browser compatibility" section does not load and displays "BCD tables only load in the browser". This error message is not clear enough.

### Solution

Use a noscript tag to add to the pre-existing error message.

---

## Screenshots

### Before

![Screenshot from 2022-05-10 10-41-22](https://user-images.githubusercontent.com/29206584/167655632-57a966a0-a93c-4c57-a342-a4b201cbfc56.png)

### After

![Screenshot from 2022-05-10 10-41-38](https://user-images.githubusercontent.com/29206584/167655659-939c6380-a488-42b0-b9fd-7e43c97c5795.png)

---

## How did you test this change?

Used inspect element while JavaScript was disabled on the live site, since JavaScript being disabled on the dev site caused the page not to load at all.
