### PR TITLE
Localization: Update French strings for `WebAssemblySidebar` KS macro

### DIFF
--- a/kumascript/macros/WebAssemblySidebar.ejs
+++ b/kumascript/macros/WebAssemblySidebar.ejs
@@ -17,6 +17,20 @@ var text = mdn.localStringMap({
       'Exported_functions' : 'Exported WebAssembly functions',
     'Object_reference' : 'Object reference'
   },
+  'fr': {
+    'WebAssembly_home_page' : "Page d'accueil WebAssembly",
+    'Tutorials' : "Tutoriels",
+      'WebAssembly_concepts' : "Concepts WebAssembly",
+      'Compiling_to_wasm' : "Compiler du C/C++ en WebAssembly",
+      'Compiling_rust_to_wasm' : "Compiler du Rust en WebAssembly",
+      'JavaScript_API' : "Utiliser l'API JavaScript WebAssembly",
+      'Text_format' : "Comprendre le format texte WebAssembly",
+      'Text_format_to_wasm' : "Convertir du format texte WebAssembly en wasm",
+      'Loading_and_running' : "Chargement et exécution de code WebAssembly",
+      'Caching_modules' : "Mise en cache des modules WebAssembly compilés",
+      'Exported_functions' : "Fonctions WebAssembly exportées",
+    'Object_reference' : "Référence objet"
+  },
   'ru': {
     'WebAssembly_home_page' : 'WebAssembly',
     'Tutorials' : 'Уроки',


### PR DESCRIPTION
## Summary
https://github.com/mdn/translated-content/issues/5135

### Problem

This sidebar was not localized in `fr`

### Solution

Added fr strings

## How did you test this change?

Spun up a local server