### PR TITLE
Localization: Update French strings for `ServiceWorkerSidebar` KS macro

### DIFF
--- a/kumascript/macros/ServiceWorkerSidebar.ejs
+++ b/kumascript/macros/ServiceWorkerSidebar.ejs
@@ -31,7 +31,7 @@ var text = mdn.localStringMap({
     'Overview': 'Aperçu des interfaces Service Worker',
     'Service_Worker_guides': 'Guides Service Worker',
     'Interfaces': 'Interfaces',
-    'Documentation': 'Documentation&nbsp;:',
+    'Documentation': 'Documentation\xa0:',
     'Useful_lists': 'Listes utiles',
     'Contribute': 'Contribuer',
     'The_MDN_project': 'Le projet MDN',

--- a/kumascript/macros/ServiceWorkerSidebar.ejs
+++ b/kumascript/macros/ServiceWorkerSidebar.ejs
@@ -26,6 +26,22 @@ var text = mdn.localStringMap({
     'Channel_Messaging_API': 'Channel Messaging API',
     'Web_Workers_API': 'Web Workers API'
   },
+  'fr': {
+    'Service_Worker_API': 'API Service Worker',
+    'Overview': 'Aperçu des interfaces Service Worker',
+    'Service_Worker_guides': 'Guides Service Worker',
+    'Interfaces': 'Interfaces',
+    'Documentation': 'Documentation&nbsp;:',
+    'Useful_lists': 'Listes utiles',
+    'Contribute': 'Contribuer',
+    'The_MDN_project': 'Le projet MDN',
+    'Using_Service_Workers': 'Utiliser les service workers',
+    'Related_APIs': 'API associées',
+    'Push_API': 'API Push',
+    'Notifications_API': 'API Notifications',
+    'Channel_Messaging_API': 'API Channel Messaging',
+    'Web_Workers_API': 'API Web Workers'
+  },
   'ja': {
     'Service_Worker_API': 'サービスワーカー API',
     'Overview': 'サービスワーカーインターフェイスの概要',


### PR DESCRIPTION
## Summary
https://github.com/mdn/translated-content/issues/5135

### Problem

This sidebar was not localized in `fr`

### Solution

Added fr strings

## How did you test this change?

Spun up a local server