### PR TITLE
Deprecate the {{Draft}} macro

### DIFF
--- a/kumascript/macros/Draft.ejs
+++ b/kumascript/macros/Draft.ejs
@@ -13,6 +13,11 @@
 // If you use a profile link, make sure your profile includes a way to
 // contact you.
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 349 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var s_draft = 'Draft';
 var s_not_complete = 'This page is not complete.';
 


### PR DESCRIPTION
We just merged the removal of the two last occurrences of this macro on mdn/content. Let's make sure it doesn't sneak back in.

This is one of the two preconditions to merge #4943. The other is to have 0 occurrences left in `mdn/translated-content`.