### PR TITLE
Fix findChildren() to not include self in list of children

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -509,6 +509,13 @@ function findChildren(url, recursive = false) {
         filePath.endsWith(HTML_FILENAME) || filePath.endsWith(MARKDOWN_FILENAME)
       );
     })
+    .filter((filePath) => {
+      return !(
+        recursive &&
+        (filePath == path.join(root, folder, HTML_FILENAME) ||
+          filePath == path.join(root, folder, MARKDOWN_FILENAME))
+      );
+    })
     .withMaxDepth(recursive ? Infinity : 1)
     .crawl(path.join(root, folder));
   const childPaths = [...api.sync()];


### PR DESCRIPTION
This PR fixes #6226 and is a follow-up to #6146 that restores the original behavior of `findChildren()` when `recursive` is `true`.

Note: I feel this solution is on the hack-y side, and I'm not fully in love with it.  I'm open to suggestions on how to improve this.
