### PR TITLE
Localization: typofix in `GamesSidebar` macro in French

### DIFF
--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -270,7 +270,7 @@ const text = mdn.localStringMap({
       "WebVR_guide": "WebVR (réalité virtuelle)",
       "3D_collision_detection": "Détection de collision en 3D",
       "Bounding_volume_collision_detection_with_THREE.js": "Détection de collision de volumes avec THREE.js",
-    "Implementing_game_control_mechanisms": "Mise en place des contrôle du jeu",
+    "Implementing_game_control_mechanisms": "Mise en place des contrôles du jeu",
       "Control_mechanisms": "Aperçu des mécanismes de contrôle du jeu",
       "Mobile_touch": "Commandes tactiles mobiles",
       "Desktop_with_mouse_and_keyboard": "Commandes à la souris et au clavier",


### PR DESCRIPTION
## Summary
https://github.com/mdn/translated-content/issues/5135 from which I did check the current macro and only found a typo

### Problem

Plural typo in one French string for this macro.

### Solution

Fixing the typo according to plural/number rules of French.

## How did you test this change?
I did not.