### PR TITLE
test(developing): move env variables from workflow to script

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -66,11 +66,6 @@ jobs:
           curl --retry-connrefused --retry 5 --silent http://localhost:3000 > /dev/null
 
       - name: Test viewing the dev server
-        env:
-          # This will make sure the tests in `testing/tests/*.test.js` only run
-          # if the development server is up and ready to be tested.
-          TESTING_DEVELOPING: true
-          CONTENT_ROOT: mdn/content/files
         run: |
           yarn test:developing
 

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -83,15 +83,11 @@ jobs:
 
       - name: Test viewing the dev server
         env:
-          # This will make sure the tests in `testing/tests/*.test.js` only run
-          # if the development server is up and ready to be tested.
-          TESTING_DEVELOPING: true
           # When running Yari from within mdn/content it only starts 1 server;
           # the one on localhost:5042. No React dev server; the one
           # on localhost:3000.
           # Testing that dev server is not relevant or important in this context.
           DEVELOPING_SKIP_DEV_URL: true
-          CONTENT_ROOT: mdn/content/files
         run: |
           yarn test:developing
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test": "yarn prettier-check && yarn test:client && yarn test:kumascript && yarn test:content && yarn test:testing",
     "test:client": "cd client && tsc --noEmit && react-scripts test --env=jsdom",
     "test:content": "jest content",
-    "test:developing": "playwright test developing",
+    "test:developing": "cross-env CONTENT_ROOT=mdn/content/files TESTING_DEVELOPING=true playwright test developing",
     "test:headless": "playwright test headless",
     "test:kumascript": "jest kumascript --env=node",
     "test:prepare": "yarn build:prepare && yarn build && yarn start:static-server",

--- a/testing/README.md
+++ b/testing/README.md
@@ -106,7 +106,6 @@ yarn dev
 And in another terminal, run:
 
 ```sh
-export TESTING_DEVELOPING=true
 yarn test:developing
 ```
 
@@ -128,9 +127,7 @@ Now, to run the tests in another terminal:
 
 ```sh
 cd /back/to/mdn/yari
-export TESTING_DEVELOPING=true
-export DEVELOPING_SKIP_DEV_URL=true
-yarn test:developing
+DEVELOPING_SKIP_DEV_URL=true yarn test:developing
 ```
 
 **Note!** It's admittedly many permutations of testing and it's hard to remember


### PR DESCRIPTION
## Summary

This allows running `yarn test:developing` without setting any ENV var.

### Problem

Previously, we would set 2-3 environment variables as part of the GitHub workflows, and `yarn test:developing` would only succeed if those environment variables were set manually beforehand.

### Solution

Now we always set those variables as part of the `test:developing` run using `cross-env`.

---

## Screenshots

_No visual changes._

---

## How did you test this change?

- Ran `yarn test:developing` locally.
