### PR TITLE
Mark macros for old compatibility tables as deprecated

### DIFF
--- a/kumascript/macros/CompatAndroid.ejs
+++ b/kumascript/macros/CompatAndroid.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var AndroidVer = $0;
 %>
 

--- a/kumascript/macros/CompatChrome.ejs
+++ b/kumascript/macros/CompatChrome.ejs
@@ -5,6 +5,13 @@
 // Parameters:
 //  $0  The Chrome version number
 
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var ChromeVer = $0;
 %>
 <%-ChromeVer%>

--- a/kumascript/macros/CompatGeckoDesktop.ejs
+++ b/kumascript/macros/CompatGeckoDesktop.ejs
@@ -1,5 +1,12 @@
 <%
 
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var fxVer = '';
 var geckoVer = $0;
 

--- a/kumascript/macros/CompatGeckoMobile.ejs
+++ b/kumascript/macros/CompatGeckoMobile.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var fxVer = '';
 var gecko = $0.split('.',1);
 if (gecko == '2') {

--- a/kumascript/macros/CompatIE.ejs
+++ b/kumascript/macros/CompatIE.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var IEver = $0;
 %>
 

--- a/kumascript/macros/CompatNo.ejs
+++ b/kumascript/macros/CompatNo.ejs
@@ -1,4 +1,12 @@
 <%
+
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var text = mdn.localString({
     "en-US": "No&nbsp;support",
     "de"   : "Nicht unterstützt",

--- a/kumascript/macros/CompatOpera.ejs
+++ b/kumascript/macros/CompatOpera.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var OperaVer = $0;
 %>
 <%- OperaVer %>

--- a/kumascript/macros/CompatOperaMobile.ejs
+++ b/kumascript/macros/CompatOperaMobile.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var OperaVer = $0;
 %>
 <%-OperaVer%>

--- a/kumascript/macros/CompatSafari.ejs
+++ b/kumascript/macros/CompatSafari.ejs
@@ -1,4 +1,11 @@
 <%
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var SafariVer = $0;
 %>
 <%- SafariVer %>

--- a/kumascript/macros/CompatUnknown.ejs
+++ b/kumascript/macros/CompatUnknown.ejs
@@ -1,4 +1,12 @@
 <%
+
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var style = "color: rgb(255, 153, 0);";
 
 // Localizers: add your language to the switch statement below!

--- a/kumascript/macros/CompatVersionUnknown.ejs
+++ b/kumascript/macros/CompatVersionUnknown.ejs
@@ -1,4 +1,12 @@
 <% 
+
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var str = mdn.localStringMap({
    "en-US": {
        'title': "Please update this with the earliest version of support.",

--- a/kumascript/macros/CompatibilityTable.ejs
+++ b/kumascript/macros/CompatibilityTable.ejs
@@ -1,4 +1,12 @@
 <%
+
+// Compatibility tables have been migrated to {{Compat}} which uses the
+// browser-compat-data project. Remove this file when compat tables in
+// translated-content are converted to {{Compat}}
+
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
+
 var s_header = mdn.localString({
     "en-US": [ "Desktop", "Mobile" ],
     "pt-BR": [ "Desktop", "Dispositivo móvel" ],


### PR DESCRIPTION
This PR marks all of the macros for old compatibility tables as deprecated to imply the intent to remove them in the future.
