### PR TITLE
Deprecate macros only used in translated content

### DIFF
--- a/kumascript/macros/CSSTutorialTOC.ejs
+++ b/kumascript/macros/CSSTutorialTOC.ejs
@@ -1,4 +1,9 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 45 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var l = env.locale;
 
 if(l === "ru"){

--- a/kumascript/macros/DOM0.ejs
+++ b/kumascript/macros/DOM0.ejs
@@ -1,4 +1,9 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 285 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var s_str = mdn.localString({
     "en-US": "DOM Level 0. Not part of any standard.",
     "es":    "DOM Nivel 0. No es parte de ninguna norma.",

--- a/kumascript/macros/DiscussionList.ejs
+++ b/kumascript/macros/DiscussionList.ejs
@@ -10,6 +10,11 @@
 //  $4  Twitter ID (null if none)
 //  $5  Stack Overflow tag (null if none)
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 150 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var lang = env.locale; /* get the page language */
 var mailingList;
 var newsgroup;

--- a/kumascript/macros/EditorGuideQuicklinks.ejs
+++ b/kumascript/macros/EditorGuideQuicklinks.ejs
@@ -1,4 +1,9 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 9 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var s_guide = 'Editor guide';
 var s_ckeditor = 'CKEditor documentation site';
 var s_mxr = 'MXR: Mozilla source cross-reference';

--- a/kumascript/macros/GlossaryList.ejs
+++ b/kumascript/macros/GlossaryList.ejs
@@ -11,6 +11,11 @@
 //      * `split` : A string with one of the value `h1`, `h2`, `h3`, `h4`, `h5`, `h6`. If this property is define with a valid value, the list of terms will be split with intermediate title for each letter.
 //      * `css`   : A sring representing some extra CSS class to apply to the list (to the top most UL elements)
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 42 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var URL    = "/en-US/docs/Glossary";
 
 var i;

--- a/kumascript/macros/HTML5ArticleTOC.ejs
+++ b/kumascript/macros/HTML5ArticleTOC.ejs
@@ -1,4 +1,10 @@
 <%
+
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 6 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var LOCALE = env.locale;
 var PATH  = "/" + LOCALE + "/docs/";
 var HTML5Documentation = "HTML5 Documentation";

--- a/kumascript/macros/HTMLVersionInline.ejs
+++ b/kumascript/macros/HTMLVersionInline.ejs
@@ -1,6 +1,11 @@
 <%
 /* one parameter: HTML version */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 585 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var link = "HTML " + $0;
 var envLocale = env.locale;
 

--- a/kumascript/macros/Note.ejs
+++ b/kumascript/macros/Note.ejs
@@ -1,3 +1,8 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 381 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 /* Purpose: Important paragraphs, NOT endnotes or footnotes */
 %><%- await template('NoteStart') %><%-$0%><%- await template('NoteEnd') %>

--- a/kumascript/macros/NoteEnd.ejs
+++ b/kumascript/macros/NoteEnd.ejs
@@ -1,1 +1,8 @@
+<%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 420 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+%>
+
 </div>

--- a/kumascript/macros/NoteStart.ejs
+++ b/kumascript/macros/NoteStart.ejs
@@ -8,6 +8,11 @@
 // Parameters
 //  None.
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 420 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var note = mdn.localString({
     "en-US": "Note:",
     "de": "Hinweis:",

--- a/kumascript/macros/ObsoleteGeneric.ejs
+++ b/kumascript/macros/ObsoleteGeneric.ejs
@@ -7,6 +7,11 @@ $3 : additional information required for the type specified by the first paramet
     method requires the method name
 */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 1347 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var lang = env.locale;
 
 var str = "";

--- a/kumascript/macros/Obsolete_Header.ejs
+++ b/kumascript/macros/Obsolete_Header.ejs
@@ -3,6 +3,11 @@
 /* prepend version with HTML, CSS, JS or Gecko for those techs */
 /* for backwards compatibility unprefixed is Gecko, please avoid this */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 690 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var str = "";
 
 if ($0) {

--- a/kumascript/macros/Obsolete_Inline.ejs
+++ b/kumascript/macros/Obsolete_Inline.ejs
@@ -13,6 +13,11 @@
 // compatibility, unprefixed versions are assumed to refer to Gecko, but
 // you shouldn't rely on this.
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 1824 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var str = "";
 var type = 0;   // assume we want the text badge
 

--- a/kumascript/macros/TemplateLink.ejs
+++ b/kumascript/macros/TemplateLink.ejs
@@ -14,6 +14,11 @@
  * $0 - Name of the template to link to.
  */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 915 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 let dest = "https://github.com/mdn/yari/tree/main/kumascript/macros/" + $0 + ".ejs";
 let text = $0;
 %>

--- a/kumascript/macros/ToolsSidebar.ejs
+++ b/kumascript/macros/ToolsSidebar.ejs
@@ -1,5 +1,10 @@
 <%
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 534 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 const locale = env.locale;
 
 const baseURL = `/${locale}/docs/Tools/`;

--- a/kumascript/macros/gecko_callout_heading.ejs
+++ b/kumascript/macros/gecko_callout_heading.ejs
@@ -5,6 +5,11 @@
 // Parameters:
 //  $0 - Gecko version
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 12 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var lang = env.locale;
 var str = "Gecko " + $0 + " note";
 

--- a/kumascript/macros/jsOverrides.ejs
+++ b/kumascript/macros/jsOverrides.ejs
@@ -15,6 +15,11 @@
  * @param a list of properties or methods overridden by this object
  */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 84 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var prototypes = {
   "Array": {
     methods: [

--- a/kumascript/macros/languages.ejs
+++ b/kumascript/macros/languages.ejs
@@ -1,2 +1,9 @@
 <% /* This is a no-op, for now. Kuma handles this in the navbar 
       on the server-side from database relations */ %>
+
+<%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 2208 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+%>

--- a/kumascript/macros/nextPage.ejs
+++ b/kumascript/macros/nextPage.ejs
@@ -2,6 +2,11 @@
 /* $0 = the URL of the previous page */
 /* $1 = the title of the previous page */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 33 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var s_text = mdn.localString({
   "en-US": "Go to Next Section:",
   "fr": "Retourner à la section suivant :",

--- a/kumascript/macros/previousPage.ejs
+++ b/kumascript/macros/previousPage.ejs
@@ -2,6 +2,11 @@
 /* $0 = the URL of the previous page */
 /* $1 = the title of the previous page */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 39 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var s_text = mdn.localString({
   "en-US": "Go to Previous Section:",
   "fr": "Retourner à la section précédente :",

--- a/kumascript/macros/web.link.ejs
+++ b/kumascript/macros/web.link.ejs
@@ -1,1 +1,7 @@
+<%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 1668 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+%>
 <%-web.link($0, $1, $2, $3)%>

--- a/kumascript/macros/wiki.localize.ejs
+++ b/kumascript/macros/wiki.localize.ejs
@@ -4,6 +4,11 @@
  * For paremeter details see http://developer.mindtouch.com/en/docs/DekiScript/Reference/Wiki_Functions_and_Variables/Wiki.Localize
 */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 39 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 var str = 'Not implemented, update template.';
 
 switch($0) {


### PR DESCRIPTION
This PR deprecates all of the macros that are only used in translated content, aside from the old browser compatibility table macros (taken care of in #6251), and `outdated` (which seems like it's probably useful for translated content).
