### PR TITLE
fix(plus-docs): replace <Link> by <a>

### DIFF
--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useLocation } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { MDN_PLUS_TITLE } from "../../constants";
 import StaticPage from "../../homepage/static-page";
 import "./index.scss";
@@ -51,16 +51,16 @@ function RelatedTopics({
 
             return (
               <li key={itemPathname} className="document-toc-item">
-                <Link
+                <a
+                  href={itemPathname}
                   className="document-toc-link"
                   aria-current={
                     itemPathname.toLowerCase() ===
                     locationPathname.toLowerCase()
                   }
-                  to={itemPathname}
                 >
                   {title}
-                </Link>
+                </a>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary

Fixes #6253.

### Problem

Navigating in the MDN Plus docs only changed the URL and the highlighted item in the TOC, but not the content.

### Solution

Replaced `<Link>`s with `<a>` to avoid client-side navigation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

https://user-images.githubusercontent.com/495429/168038320-2e31cb70-6325-48ba-ae53-0c67fb1cd8e4.mov

### After

https://user-images.githubusercontent.com/495429/168038398-9594dcbf-7234-47ad-b2d5-579980cb4c0d.mov

---

## How did you test this change?

1. Opened http://localhost:3000/en-US/plus/docs/faq locally.
2. Clicked on "MDN Offline" on the left.