### PR TITLE
Auto-label macros pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+macros:
+  - "kumascript/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v2.1.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR fixes #6248 by adding an auto-labeler that will mark pull requests that modify `kumascript` as `macros`.
