### PR TITLE
Deprecate {{mediawiki.external}}

### DIFF
--- a/kumascript/macros/mediawiki.external.ejs
+++ b/kumascript/macros/mediawiki.external.ejs
@@ -1,4 +1,9 @@
 <%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 123 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 / * assume we do not have a link (most common use) */
 var str = '[' + $0 + ']';
 


### PR DESCRIPTION
We are trying to remove this one since… August 2008, when MDN migrated away from Mediawiki (to Dekiwiki)

For the first time we are at 0 in mdn/content (see the last PR: mdn/content#15983).

Let's mark it as deprecated and wait until it goes away in mdn/translated-content.