### PR TITLE
Deprecate {{Tag}}

### DIFF
--- a/kumascript/macros/Tag.ejs
+++ b/kumascript/macros/Tag.ejs
@@ -7,6 +7,12 @@
  * @param [optional]
  *  The locale to link to (by default it's the same locale as the current page)
  */
+ 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content (May 2022: 593 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
+
  var lang = $1 || env.locale
  var url = '/' + lang + '/docs/tag/' + encodeURI($0);
 


### PR DESCRIPTION
I'm removing the last occurrence of `{{Tag}}` in mdn/content#16006.

Let's mark it as deprecated.