### PR TITLE
Update deprecation comment for {{spec}} macro

### DIFF
--- a/kumascript/macros/spec.ejs
+++ b/kumascript/macros/spec.ejs
@@ -15,8 +15,8 @@ parameters:
 */
 
 // Throw a MacroDeprecatedError flaw
-// Condition for removal: no more use in any content (May 2022: 324 occurrences)
-// 5 occurrences left in en-US
+// Condition for removal: no more use in any content (May 2022: 319 occurrences)
+// 0 occurrences left in en-US
 mdn.deprecated();
 
 var lang = env.locale;


### PR DESCRIPTION
Quick follow-up to the deprecation of the `{{spec}}` macro.  The final instances in en-US were removed, but I forgot to update the comment to reflect this.  :P
