### PR TITLE
Deprecate {{property_prefix}} macro

### DIFF
--- a/kumascript/macros/property_prefix.ejs
+++ b/kumascript/macros/property_prefix.ejs
@@ -1,4 +1,9 @@
 <%
+    // Throw a MacroDeprecatedError flaw
+    // Condition for removal: no more use in translated-content (May 2022: 483 occurrences)
+    // 0 occurrences left in en-US
+    mdn.deprecated();
+
     var locale = env.locale;
     
     var tooltip_text = mdn.localString({


### PR DESCRIPTION
This PR marks the `{{property_prefix}}` macro as deprecated, as the last calls were removed in https://github.com/mdn/content/pull/16023.
