### PR TITLE
fix: #6278 for when HTML file are removed/redirected

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -509,9 +509,8 @@ function findChildren(url, recursive = false) {
     .withErrors()
     .filter((filePath) => {
       return (
-        filePath.endsWith(HTML_FILENAME) ||
-        (filePath.endsWith(MARKDOWN_FILENAME) &&
-          !(filePath === baseHTML || filePath === baseMarkdown))
+        (filePath.endsWith(HTML_FILENAME) && !(filePath === baseHTML)) ||
+        (filePath.endsWith(MARKDOWN_FILENAME) && !(filePath === baseMarkdown))
       );
     })
     .withMaxDepth(recursive ? Infinity : 1)


### PR DESCRIPTION
## Summary

#6278 

### Problem

This solves a Boolean logic issue for when an HTML file is concerned by a removal / redirect operation using `yarn tool`

### Solution

Rearrange the boolean expression to be correct (and maybe clearer)


## How did you test this change?

Ran STR from #6278 (namely `yarn tool delete conflicting/Web/API/WebRTC_API_d8621144cbc61520339c3b10c61731f0 fr --redirect Web/API/WebRTC_API`)