### PR TITLE
Delete HTML elements that are not part of the platform (in {{HTMLRef}})

### DIFF
--- a/kumascript/macros/HTMLRef.ejs
+++ b/kumascript/macros/HTMLRef.ejs
@@ -176,7 +176,6 @@ var resultAPI = [];
   <li><%-await wrapHTMLElement("img")%></li>
   <li><%-await wrapHTMLElement("input")%></li>
   <li><%-await wrapHTMLElement("ins")%></li>
-  <li><s class="obsoleteElement deprecatedElement"><%-await wrapHTMLElement("isindex")%></s></li>
  </ol>
  </li><li class="no-bullet"><span class="no-link">J K</span>
  <ol>
@@ -189,7 +188,6 @@ var resultAPI = [];
   <li><%-await wrapHTMLElement("legend")%></li>
   <li><%-await wrapHTMLElement("li")%></li>
   <li><%-await wrapHTMLElement("link")%></li>
-  <li><s class="obsoleteElement deprecatedElement"><%-await wrapHTMLElement("listing")%></s></li>
  </ol>
  </li><li class="no-bullet"><span class="no-link">M</span>
  <ol>


### PR DESCRIPTION
`<listing>` and `<isindex>` are the two old HTML elements that have actually been removed from browsers. Docs are gone too.