### PR TITLE
syntax-highlight.js - add batch as a supported language

### DIFF
--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -16,6 +16,7 @@ const loadAllLanguages = lazy(() => {
   loadLanguages([
     "python",
     "bash",
+    "batch",
     "sql",
     "json",
     "glsl",


### PR DESCRIPTION
MDN shows batch files in a number of code blocks. Usually the fenced blocks are marked up with `bat` and then it later gets changed to `bash` to hide the error. Note that the actual key is `batch` according to this doc: https://lucidar.me/en/web-dev/list-of-supported-languages-by-prism/

This comes out of the discussion here: https://github.com/mdn/content/pull/16077#discussion_r873245304

If this fix goes in, we will need to change the [files/en-us/web/security/subresource_integrity/index.md](https://github.com/mdn/content/pull/16077/files/691d0e65ff48d899121067ac46ae239a89df115c#diff-58e33a19ce64773c6540bf790766a75bc7624ac76633c75a0b7ce9dd6fdd36f5) to use `batch` instead of `bash`.