### PR TITLE
fix(static-page): add key to sections

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -94,8 +94,11 @@ function StaticPage({
         <div className="toc">{toc || null}</div>
         <main id="content" className="main-content" role="main">
           <article className={`main-page-content ${extraClasses || ""}`}>
-            {hyData.sections.map((section) => (
-              <section dangerouslySetInnerHTML={{ __html: section }}></section>
+            {hyData.sections.map((section, index) => (
+              <section
+                key={index}
+                dangerouslySetInnerHTML={{ __html: section }}
+              ></section>
             ))}
           </article>
         </main>


### PR DESCRIPTION
## Summary

Resolves the following React warning in the MDN Plus docs:

> Each child in a list should have a unique "key" prop.

---

## Screenshots

_No change._

---

## How did you test this change?

Opened http://localhost:3000/en-US/plus/docs/features/notifications locally, and compared this branch with `main`.