### PR TITLE
Remove animateColor from SVGRef

### DIFF
--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -64,7 +64,6 @@ if (s_svg_href) {  %>
      <li class="deprecatedElement"><%-await wrapSVGElement("altGlyphDef")%></li>
      <li class="deprecatedElement"><%-await wrapSVGElement("altGlyphItem")%></li>
      <li><%-await wrapSVGElement("animate")%></li>
-     <li><%-await wrapSVGElement("animateColor")%></li>
      <li><%-await wrapSVGElement("animateMotion")%></li>
      <li><%-await wrapSVGElement("animateTransform")%></li>
    </ol>


### PR DESCRIPTION
`animateColor` was never implemented and is long gone from the docs (it redirects to `animate`.

Time to remove it from the sidebar.