### PR TITLE
FIX: Stripe plans - Cloudfront custom header value

### DIFF
--- a/deployer/aws-lambda/mdn-stripe-price-ids/index.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/index.js
@@ -7,7 +7,6 @@ const STAGE_ENV = "stage";
 
 exports.handler = async (event) => {
   const request = event.Records[0].cf.request;
-  console.log(request.origin.custom.customHeaders);
   //This should fail if this header is not set.
   const ENV =
     request.origin.custom.customHeaders["x-mdn-env"][0].value || "prod";

--- a/deployer/aws-lambda/mdn-stripe-price-ids/index.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/index.js
@@ -7,8 +7,10 @@ const STAGE_ENV = "stage";
 
 exports.handler = async (event) => {
   const request = event.Records[0].cf.request;
+  console.log(request.origin.custom.customHeaders);
   //This should fail if this header is not set.
-  const ENV = request.origin.custom.customHeaders["x-mdn-env"].value || "prod";
+  const ENV =
+    request.origin.custom.customHeaders["x-mdn-env"][0].value || "prod";
   //Always fall back to prod
   const lookupData = ENV === STAGE_ENV ? stageLookup : prodLookup;
 

--- a/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
@@ -99,7 +99,7 @@ function getEventForAcceptHeaderAndCountry(
             origin: {
               custom: {
                 customHeaders: {
-                  "x-mdn-env": { key: "x-mdn-env", value: env },
+                  "x-mdn-env": [{ key: "x-mdn-env", value: env }],
                 },
               },
             },


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

Stripe plans lambda was not correctly determining environment. 

Header format was 

"x-mdn-env": [{ key: "x-mdn-env", value: env }]

not

"x-mdn-env": { key: "x-mdn-env", value: env }


### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?



<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
