### PR TITLE
Use new "type" and "accepts_webextensions" variables from BCD

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -1,20 +1,5 @@
-import type bcd from "@mdn/browser-compat-data/types";
+import { browsers as browserData } from "@mdn/browser-compat-data";
 import { BrowserName } from "./browser-info";
-
-export const PLATFORM_BROWSERS: { [key: string]: bcd.BrowserNames[] } = {
-  desktop: ["chrome", "edge", "firefox", "ie", "opera", "safari"],
-  mobile: [
-    "webview_android",
-    "chrome_android",
-    "firefox_android",
-    "opera_android",
-    "safari_ios",
-    "samsunginternet_android",
-  ],
-  server: ["deno", "nodejs"],
-  "webextensions-desktop": ["chrome", "edge", "firefox", "opera", "safari"],
-  "webextensions-mobile": ["firefox_android", "safari_ios"],
-};
 
 function PlatformHeaders({ platforms, browsers }) {
   return (
@@ -23,19 +8,18 @@ function PlatformHeaders({ platforms, browsers }) {
       {platforms.map((platform) => {
         // Get the intersection of browsers in the `browsers` array and the
         // `PLATFORM_BROWSERS[platform]`.
-        const browsersInPlatform = PLATFORM_BROWSERS[platform].filter(
-          (browser) => browsers.includes(browser)
+        const browsersInPlatform = browsers.filter(
+          (browser) => browserData[browser].type === platform
         );
-        const browserCount = Object.keys(browsersInPlatform).length;
-        const platformId = platform.replace("webextensions-", "");
+        const browserCount = browsersInPlatform.length;
         return (
           <th
             key={platform}
-            className={`bc-platform bc-platform-${platformId}`}
+            className={`bc-platform bc-platform-${platform}`}
             colSpan={browserCount}
             title={platform}
           >
-            <span className={`icon icon-${platformId}`}></span>
+            <span className={`icon icon-${platform}`}></span>
             <span className="visually-hidden">{platform}</span>
           </th>
         );

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -1,10 +1,11 @@
 import React, { useReducer } from "react";
 import { useLocation } from "react-router-dom";
+import { browsers as browserData } from "@mdn/browser-compat-data";
 import type bcd from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import { BrowserCompatibilityErrorBoundary } from "./error-boundary";
 import { FeatureRow } from "./feature-row";
-import { Headers, PLATFORM_BROWSERS } from "./headers";
+import { Headers } from "./headers";
 import { Legend } from "./legend";
 import { listFeatures } from "./utils";
 
@@ -44,12 +45,15 @@ function gatherPlatformsAndBrowsers(
   let platforms = ["desktop", "mobile"];
   if (category === "javascript" || hasNodeJSData || hasDenoData) {
     platforms.push("server");
-  } else if (category === "webextensions") {
-    platforms = ["webextensions-desktop", "webextensions-mobile"];
   }
 
   const browsers = new Set(
-    platforms.map((platform) => PLATFORM_BROWSERS[platform] || []).flat()
+    Object.keys(browserData).filter(
+      (browser) =>
+        platforms.includes(browserData[browser].type) &&
+        (category !== "webextensions" ||
+          browserData[browser].accepts_webextensions)
+    ) as bcd.BrowserNames[]
   );
 
   // If there is no Node.js data for a category outside of "javascript", don't

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/helper-builder-react-jsx": "^7.16.7",
     "@caporal/core": "^2.0.2",
     "@fast-csv/parse": "^4.3.6",
-    "@mdn/browser-compat-data": "^4.2.0",
+    "@mdn/browser-compat-data": "^4.2.1",
     "@use-it/interval": "^1.0.0",
     "accept-language-parser": "^1.5.0",
     "browser-specs": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2133,10 +2133,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@mdn/browser-compat-data@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.2.0.tgz#69a1bfa08a297c1fcc2b7621c09355be67435bc5"
-  integrity sha512-gsXiRMdYubxmsojDo+xnFrL//aTL2PHy1p4hxDbaKfxcvb9a6wBLttRMgzLPDdEZob9T7BgODHY/HdoMZ8gdXQ==
+"@mdn/browser-compat-data@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz#1fead437f3957ceebe2e8c3f46beccdb9bc575b8"
+  integrity sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==
 
 "@mdn/dinocons@^0.5.5":
   version "0.5.5"
@@ -3806,14 +3806,6 @@ batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
   integrity sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=
-
-benchmark@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
-  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
-  dependencies:
-    lodash "^4.17.4"
-    platform "^1.3.3"
 
 bfj@^7.0.2:
   version "7.0.2"
@@ -9324,7 +9316,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@>=4.17.15, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4.17.15, lodash@>=4.17.15, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10750,11 +10742,6 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-platform@^1.3.3:
-  version "1.3.6"
-  resolved "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz"
-  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 playwright-core@1.22.1:
   version "1.22.1"


### PR DESCRIPTION
This PR updates Yari to utilize the new "type" and "accepts_webextensions" variables that have been introduced in BCD to simplify some of the code and simplify the addition of new browsers.  This also bumps BCD to v4.2.1 to fix a TypeScript definitions issue.
