### PR TITLE
fix(bcd): show table with md style at 426px

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
@@ -1,6 +1,6 @@
 // Style for mobile.
 
-@media screen and (max-width: $screen-sm) {
+@media screen and (max-width: $screen-sm - 1px) {
   thead {
     display: none;
   }


### PR DESCRIPTION
## Summary

### Problem

BCD table is broken on 426px browser width.

### Solution

Reduce the max-width by 1px so the browser doesn't apply `sm` and `md` style at
the same time.

### Before

![image](https://user-images.githubusercontent.com/38681822/169196890-a04bed6f-d098-4920-9fea-8e49047ad0d7.png)

### After

![image](https://user-images.githubusercontent.com/38681822/169196960-3bd0d289-27cf-428b-af38-4c6c2a7fd583.png)