### PR TITLE
Ensure browsers in BCD tables are always rendered in the correct order

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -47,19 +47,28 @@ function gatherPlatformsAndBrowsers(
     platforms.push("server");
   }
 
-  const browsers = new Set(
-    Object.keys(browserData).filter(
-      (browser) =>
-        platforms.includes(browserData[browser].type) &&
-        (category !== "webextensions" ||
-          browserData[browser].accepts_webextensions)
-    ) as bcd.BrowserNames[]
-  );
+  let browsers: bcd.BrowserNames[] = [];
+
+  // Add browsers in platform order to align table cells
+  for (const platform of platforms) {
+    browsers.push(
+      ...(Object.keys(browserData).filter(
+        (browser) => browserData[browser].type === platform
+      ) as bcd.BrowserNames[])
+    );
+  }
+
+  //
+  if (category === "webextensions") {
+    browsers = browsers.filter(
+      (browser) => browserData[browser].accepts_webextensions
+    );
+  }
 
   // If there is no Node.js data for a category outside of "javascript", don't
   // show it. It ended up in the browser list because there is data for Deno.
   if (category !== "javascript" && !hasNodeJSData) {
-    browsers.delete("nodejs");
+    browsers = browsers.filter((browser) => browser !== "nodejs");
   }
 
   return [platforms, [...browsers]];

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -58,7 +58,7 @@ function gatherPlatformsAndBrowsers(
     );
   }
 
-  //
+  // Filter WebExtension browsers in corresponding tables.
   if (category === "webextensions") {
     browsers = browsers.filter(
       (browser) => browserData[browser].accepts_webextensions


### PR DESCRIPTION
This PR fixes #6314 by enforcing a specific order for the browsers to render in.  In #6308, the code was adjusted to filter for browsers matching the platforms specified; however, this did not enforce any specific order.  Additionally, the original code used a `Set` to generate the list of browsers, which does not actually guarantee an order of values; with both that plus the fact that it's destructured into an array anyways, this PR creates an array instead to ensure a specific order.
