### PR TITLE
refactor: separate `require("dotenv")` calls

### DIFF
--- a/build/build-options.js
+++ b/build/build-options.js
@@ -1,4 +1,5 @@
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
 
 const {
   FLAW_LEVELS,

--- a/build/constants.js
+++ b/build/constants.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
-require("dotenv").config({
+const dotenv = require("dotenv");
+dotenv.config({
   path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
 });
 

--- a/content/constants.js
+++ b/content/constants.js
@@ -6,7 +6,8 @@ const {
   DEFAULT_LOCALE,
 } = require("../libs/constants");
 
-require("dotenv").config({
+const dotenv = require("dotenv");
+dotenv.config({
   path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
 });
 

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -4,8 +4,9 @@ const { VALID_LOCALES } = require("@yari-internal/constants");
 const fs = require("fs");
 const path = require("path");
 
+const dotenv = require("dotenv");
 const root = path.join(__dirname, "..", "..", "..");
-require("dotenv").config({
+dotenv.config({
   path: path.join(root, process.env.ENV_FILE || ".env"),
 });
 

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,5 +1,4 @@
 const path = require("path");
-require("dotenv");
 
 const STATIC_ROOT =
   process.env.SERVER_STATIC_ROOT || path.join(__dirname, "../client/build");

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -8,7 +8,8 @@ import render from "./render";
 
 // This is necessary because the ssr.js is in dist/ssr.js
 // and we need to reach the .env this way.
-require("dotenv").config({
+const dotenv = require("dotenv");
+dotenv.config({
   path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
 });
 


### PR DESCRIPTION
## Summary

Separates the `require("dotenv")` calls from their usage.

### Problem

We ran `require("dotenv").config()` in several places, which is fine in CommonJS, but causes trouble when migrating to ESM, because ESM doesn't support directly consuming imported symbols.

This prevents tools like `cjs-to-esm` from automatically migrating this statement.

### Solution

Separate the calls as follows:

```patch
-require("dotenv").config();
+const dotenv = require("dotenv");
+dotenv.config();
```

**Note**: In doing so, I noticed that `server/constants.js` requires dotenv, but doesn't use it, so I removed that call.

---

## Screenshots

_No change._

---

## How did you test this change?

- Ran `yarn start` locally.