### PR TITLE
refactor(esm): extract dirname = __dirname

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 const { readGitignoreFiles } = require("eslint-gitignore");
 const path = require("path");
+
+const dirname = __dirname;
+
 const ignores = readGitignoreFiles({
   cwd: path.join(".git", "info"),
   patterns: ["exclude"],
@@ -27,7 +30,7 @@ module.exports = {
   },
   settings: {
     node: {
-      resolvePaths: [__dirname],
+      resolvePaths: [dirname],
       tryExtensions: [".js", ".json", ".node", ".tsx", ".ts"],
     },
   },

--- a/build/constants.js
+++ b/build/constants.js
@@ -1,12 +1,13 @@
 const path = require("path");
 
 const dotenv = require("dotenv");
+const dirname = __dirname;
 dotenv.config({
-  path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
+  path: path.join(dirname, "..", process.env.ENV_FILE || ".env"),
 });
 
 const BUILD_OUT_ROOT =
-  process.env.BUILD_OUT_ROOT || path.join(__dirname, "..", "client", "build");
+  process.env.BUILD_OUT_ROOT || path.join(dirname, "..", "client", "build");
 
 const FLAW_LEVELS = Object.freeze({
   ERROR: "error",

--- a/build/flaws/broken-links.js
+++ b/build/flaws/broken-links.js
@@ -9,6 +9,8 @@ const { FLAW_LEVELS } = require("../constants");
 const { findMatchesInText } = require("../matches-in-text");
 const { DEFAULT_LOCALE, VALID_LOCALES } = require("../../libs/constants");
 
+const dirname = __dirname;
+
 function findMatchesInMarkdown(rawContent, href) {
   const matches = [];
   visit(fromMarkdown(rawContent), "link", (node) => {
@@ -24,10 +26,7 @@ const _safeToHttpsDomains = new Map();
 function getSafeToHttpDomains() {
   if (!_safeToHttpsDomains.size) {
     const fileParsed = JSON.parse(
-      fs.readFileSync(
-        path.join(__dirname, "safe-to-https-domains.json"),
-        "utf-8"
-      )
+      fs.readFileSync(path.join(dirname, "safe-to-https-domains.json"), "utf-8")
     );
     Object.entries(fileParsed).forEach(([key, value]) =>
       _safeToHttpsDomains.set(key, value)

--- a/build/spas.js
+++ b/build/spas.js
@@ -18,6 +18,8 @@ const { splitSections } = require("./utils");
 const cheerio = require("cheerio");
 const { findByURL } = require("../content/document");
 
+const dirname = __dirname;
+
 const FEATURED_ARTICLES = [
   "Web/CSS/color-scheme",
   "Web/HTML/Element/dialog",
@@ -249,7 +251,7 @@ async function buildSPAs(options) {
     }
   }
   await buildStaticPages(
-    path.join(__dirname, "../copy/plus"),
+    path.join(dirname, "../copy/plus"),
     "plus/docs",
     "MDN Plus"
   );

--- a/client/pwa/webpack.config.js
+++ b/client/pwa/webpack.config.js
@@ -5,14 +5,16 @@ const commitHash = require("child_process")
   .trim();
 const webpack = require("webpack");
 
+const dirname = __dirname;
+
 module.exports = {
   entry: {
-    bundle: path.join(__dirname, "./src/service-worker.ts"),
+    bundle: path.join(dirname, "./src/service-worker.ts"),
   },
 
   output: {
     filename: "service-worker.js",
-    path: path.join(__dirname, "../public/"),
+    path: path.join(dirname, "../public/"),
   },
 
   mode: "development",

--- a/client/pwa/webpack.production.config.js
+++ b/client/pwa/webpack.production.config.js
@@ -5,14 +5,16 @@ const commitHash = require("child_process")
   .trim();
 const webpack = require("webpack");
 
+const dirname = __dirname;
+
 module.exports = {
   entry: {
-    bundle: path.join(__dirname, "./src/service-worker.ts"),
+    bundle: path.join(dirname, "./src/service-worker.ts"),
   },
 
   output: {
     filename: "service-worker.js",
-    path: path.join(__dirname, "../public/"),
+    path: path.join(dirname, "../public/"),
   },
 
   mode: "production",

--- a/content/constants.js
+++ b/content/constants.js
@@ -7,8 +7,9 @@ const {
 } = require("../libs/constants");
 
 const dotenv = require("dotenv");
+const dirname = __dirname;
 dotenv.config({
-  path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
+  path: path.join(dirname, "..", process.env.ENV_FILE || ".env"),
 });
 
 const CONTENT_ROOT = correctContentPathFromEnv("CONTENT_ROOT");

--- a/content/popularities.js
+++ b/content/popularities.js
@@ -1,6 +1,8 @@
 const fs = require("fs");
 const path = require("path");
 
+const dirname = __dirname;
+
 // Module-level cache
 const popularities = new Map();
 
@@ -8,7 +10,7 @@ function getPopularities() {
   if (!popularities.size) {
     // This is the file that's *not* checked into git.
     const filePath = path.resolve(
-      path.join(__dirname, "..", "popularities.json")
+      path.join(dirname, "..", "popularities.json")
     );
     Object.entries(JSON.parse(fs.readFileSync(filePath, "utf-8"))).forEach(
       ([url, value]) => {

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -4,8 +4,10 @@ const { VALID_LOCALES } = require("@yari-internal/constants");
 const fs = require("fs");
 const path = require("path");
 
+const dirname = __dirname;
+
 const dotenv = require("dotenv");
-const root = path.join(__dirname, "..", "..", "..");
+const root = path.join(dirname, "..", "..", "..");
 dotenv.config({
   path: path.join(root, process.env.ENV_FILE || ".env"),
 });

--- a/kumascript/src/templates.js
+++ b/kumascript/src/templates.js
@@ -29,7 +29,9 @@ const fs = require("fs");
 const path = require("path");
 const ejs = require("ejs");
 
-const DEFAULT_MACROS_DIRECTORY = path.normalize(`${__dirname}/../macros/`);
+const dirname = __dirname;
+
+const DEFAULT_MACROS_DIRECTORY = path.normalize(`${dirname}/../macros/`);
 
 class Templates {
   constructor(macroDirectory = DEFAULT_MACROS_DIRECTORY) {

--- a/kumascript/tests/macros.test.js
+++ b/kumascript/tests/macros.test.js
@@ -6,10 +6,11 @@
 const fs = require("fs");
 const ejs = require("ejs");
 const Templates = require("../src/templates.js");
+const dirname = __dirname;
 
 describe("macros/ directory", () => {
   describe("compile all macros", () => {
-    const templates = new Templates(`${__dirname}/../macros`);
+    const templates = new Templates(`${dirname}/../macros`);
     const templateMap = templates.getTemplateMap();
     const macroNames = Array.from(templateMap.keys());
 

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -4,7 +4,8 @@ const fs = require("fs");
 const path = require("path");
 const jsdom = require("jsdom");
 const extend = require("extend");
-const fixture_dir = path.resolve(__dirname, "fixtures/compat");
+const dirname = __dirname;
+const fixture_dir = path.resolve(dirname, "fixtures/compat");
 
 const { JSDOM } = jsdom;
 

--- a/kumascript/tests/macros/DefaultAPISidebar.test.js
+++ b/kumascript/tests/macros/DefaultAPISidebar.test.js
@@ -10,13 +10,15 @@ const {
   lintHTML,
 } = require("./utils");
 
+const dirname = __dirname;
+
 /**
  * Load all the fixtures.
  */
 const fs = require("fs");
 const path = require("path");
 const pagesFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/defaultapisidebar/pages.json"
 );
 const pagesJSON = JSON.parse(fs.readFileSync(pagesFixturePath, "utf8"));
@@ -25,14 +27,14 @@ const subpagesJSON = [
   pagesJSON["/en-US/docs/Web/API/TestInterface_API/MyGuidePage2"],
 ];
 const commonl10nFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/defaultapisidebar/commonl10n.json"
 );
 const commonl10nFixture = JSON.parse(
   fs.readFileSync(commonl10nFixturePath, "utf8")
 );
 const groupDataFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/defaultapisidebar/groupdata.json"
 );
 const groupDataFixture = JSON.parse(

--- a/kumascript/tests/macros/HTTPSidebar.test.js
+++ b/kumascript/tests/macros/HTTPSidebar.test.js
@@ -13,10 +13,12 @@ const {
   lintHTML,
 } = require("./utils");
 
+const dirname = __dirname;
+
 // Load fixture data.
 const fixtureData = JSON.parse(
   fs.readFileSync(
-    path.resolve(__dirname, "fixtures", "documentData2.json"),
+    path.resolve(dirname, "fixtures", "documentData2.json"),
     "utf8"
   )
 );

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -10,13 +10,15 @@ const {
   lintHTML,
 } = require("./utils");
 
+const dirname = __dirname;
+
 /**
  * Load all the fixtures.
  */
 const fs = require("fs");
 const path = require("path");
 const groupDataFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/listgroups/groupdata.json"
 );
 const groupDataFixture = JSON.parse(

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -10,34 +10,36 @@ const {
   lintHTML,
 } = require("./utils");
 
+const dirname = __dirname;
+
 /**
  * Load all the fixtures.
  */
 const fs = require("fs");
 const path = require("path");
 const subpagesFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/apiref/subpages.json"
 );
 const subpagesFixture = JSON.parse(
   fs.readFileSync(subpagesFixturePath, "utf8")
 );
 const commonl10nFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/apiref/commonl10n.json"
 );
 const commonl10nFixture = JSON.parse(
   fs.readFileSync(commonl10nFixturePath, "utf8")
 );
 const groupDataFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/apiref/groupdata.json"
 );
 const groupDataFixture = JSON.parse(
   fs.readFileSync(groupDataFixturePath, "utf8")
 );
 const interfaceDataNoEntriesFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/apiref/interfacedata_no_entries.json"
 );
 const interfaceDataNoEntriesFixture = fs.readFileSync(
@@ -45,7 +47,7 @@ const interfaceDataNoEntriesFixture = fs.readFileSync(
   "utf8"
 );
 const interfaceDataFixturePath = path.resolve(
-  __dirname,
+  dirname,
   "fixtures/apiref/interfacedata.json"
 );
 const interfaceDataFixture = JSON.parse(

--- a/kumascript/tests/macros/page-api.test.js
+++ b/kumascript/tests/macros/page-api.test.js
@@ -11,10 +11,12 @@ const path = require("path");
 const { Document } = require("../../../content");
 const { assert, itMacro, describeMacro, beforeEachMacro } = require("./utils");
 
+const dirname = __dirname;
+
 // Load fixture data.
 const fixtureData = JSON.parse(
   fs.readFileSync(
-    path.resolve(__dirname, "fixtures", "documentData1.json"),
+    path.resolve(dirname, "fixtures", "documentData1.json"),
     "utf8"
   )
 );

--- a/kumascript/tests/macros/utils.js
+++ b/kumascript/tests/macros/utils.js
@@ -7,6 +7,8 @@ const { HtmlValidate } = require("html-validate");
 const Environment = require("../../src/environment.js");
 const Templates = require("../../src/templates.js");
 
+const dirname = __dirname;
+
 // When we were doing mocha testing, we used this.macro to hold this.
 // But Jest doesn't use the this object, so we just store the object here.
 let macro = null;
@@ -57,7 +59,7 @@ assert.sameMembers = (a1, a2) => {
 };
 
 function createMacroTestObject(macroName) {
-  const templates = new Templates(`${__dirname}/../../macros/`);
+  const templates = new Templates(`${dirname}/../../macros/`);
   const pageContext = {
     locale: "en-US",
     url: "",

--- a/kumascript/tests/render.test.js
+++ b/kumascript/tests/render.test.js
@@ -12,11 +12,13 @@ const {
   MacroExecutionError,
 } = require("../src/errors.js");
 
+const dirname = __dirname;
+
 const PAGE_ENV = { slug: "" };
 
 describe("render() function", () => {
   function fixture(name) {
-    return `${__dirname}/fixtures/render/${name}`;
+    return `${dirname}/fixtures/render/${name}`;
   }
   function get(name) {
     return fs.readFileSync(fixture(name), "utf8");

--- a/kumascript/tests/templates.test.js
+++ b/kumascript/tests/templates.test.js
@@ -5,6 +5,8 @@
 const Templates = require("../src/templates.js");
 const path = require("path");
 
+const dirname = __dirname;
+
 describe("Templates class", () => {
   it("has the expected methods", () => {
     expect(typeof Templates).toBe("function");
@@ -13,7 +15,7 @@ describe("Templates class", () => {
   });
 
   function dir(name) {
-    return path.resolve(__dirname, "fixtures", "templates", name);
+    return path.resolve(dirname, "fixtures", "templates", name);
   }
 
   it("throws on non-existent dir", () => {

--- a/markdown/h2m/handlers/cards.ts
+++ b/markdown/h2m/handlers/cards.ts
@@ -7,11 +7,13 @@ import { asArray } from "../utils";
 import { toText } from "./to-text";
 import { QueryAndTransform } from "./utils";
 
+const dirname = __dirname;
+
 const gettextLocalizationMap = (() => {
   const getTextDefaultDomainName = "messages";
   let gtLocalizationMap = new Map();
   let localesOnFS = fs
-    .readdirSync(path.join(__dirname, "../../localizations"))
+    .readdirSync(path.join(dirname, "../../localizations"))
     .map((str) => str.split(".")[0]);
   localesOnFS.forEach((localeStr) => {
     const translations = require("../../localizations/" + localeStr + ".json");

--- a/markdown/m2h/handlers/index.js
+++ b/markdown/m2h/handlers/index.js
@@ -5,18 +5,17 @@ const code = require("./code");
 const { asDefinitionList, isDefinitionList } = require("./dl");
 const { one, all, wrap } = require("./mdast-util-to-hast-utils");
 
+const dirname = __dirname;
+
 /* A utilitary function which parses a JSON gettext file
   to return a Map with each localized string and its matching ID  */
 function getL10nCardMap(locale = DEFAULT_LOCALE) {
   // Test if target localization file exists, if
   // not, fallback on English
-  let localeFilePath = path.join(
-    __dirname,
-    `../../localizations/${locale}.json`
-  );
+  let localeFilePath = path.join(dirname, `../../localizations/${locale}.json`);
   if (!fs.existsSync(localeFilePath)) {
     localeFilePath = path.join(
-      __dirname,
+      dirname,
       `../../localizations/${DEFAULT_LOCALE}.json`
     );
   }

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,7 +1,9 @@
 const path = require("path");
 
+const dirname = __dirname;
+
 const STATIC_ROOT =
-  process.env.SERVER_STATIC_ROOT || path.join(__dirname, "../client/build");
+  process.env.SERVER_STATIC_ROOT || path.join(dirname, "../client/build");
 const PROXY_HOSTNAME =
   process.env.REACT_APP_KUMA_HOST || "developer.mozilla.org";
 const CONTENT_HOSTNAME = process.env.SERVER_CONTENT_HOST;

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -6,11 +6,13 @@ import { StaticRouter } from "react-router-dom/server";
 import { App } from "../client/src/app";
 import render from "./render";
 
+const dirname = __dirname;
+
 // This is necessary because the ssr.js is in dist/ssr.js
 // and we need to reach the .env this way.
 const dotenv = require("dotenv");
 dotenv.config({
-  path: path.join(__dirname, "..", process.env.ENV_FILE || ".env"),
+  path: path.join(dirname, "..", process.env.ENV_FILE || ".env"),
 });
 
 export function renderHTML(url, context) {

--- a/ssr/render.js
+++ b/ssr/render.js
@@ -7,6 +7,8 @@ import { ALWAYS_ALLOW_ROBOTS, BUILD_OUT_ROOT } from "../build/constants";
 
 const { DEFAULT_LOCALE } = require("../libs/constants");
 
+const dirname = __dirname;
+
 // When there are multiple options for a given language, this gives the
 // preferred locale for that language (language => preferred locale).
 const PREFERRED_LOCALE = {
@@ -51,7 +53,7 @@ const lazy = (creator) => {
   };
 };
 
-const clientBuildRoot = path.resolve(__dirname, "../../client/build");
+const clientBuildRoot = path.resolve(dirname, "../../client/build");
 
 const readBuildHTML = lazy(() => {
   const html = fs.readFileSync(
@@ -70,7 +72,7 @@ const getGAScriptPathName = lazy((relPath = "/static/js/ga.js") => {
   // Return the relative path if there exists a `BUILD_ROOT/static/js/ga.js`.
   // If the file doesn't exist, return falsy.
   // Remember, unless explicitly set, the BUILD_OUT_ROOT defaults to a path
-  // based on `__dirname` but that's wrong when compared as a source and as
+  // based on `dirname` but that's wrong when compared as a source and as
   // a webpack built asset. So we need to remove the `/ssr/` portion of the path.
   let root = BUILD_OUT_ROOT;
   if (!fs.existsSync(root)) {

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -3,11 +3,13 @@ const path = require("path");
 const nodeExternals = require("webpack-node-externals");
 const webpack = require("webpack");
 
+const dirname = __dirname;
+
 module.exports = {
-  context: path.resolve(__dirname, "."),
+  context: path.resolve(dirname, "."),
   entry: "./index.js",
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(dirname, "dist"),
     filename: "[name].js",
     sourceMapFilename: "[name].js.map",
     libraryTarget: "commonjs2",

--- a/testing/tests/filecheck.test.js
+++ b/testing/tests/filecheck.test.js
@@ -3,11 +3,9 @@ const path = require("path");
 
 const { checkFile } = require("../../filecheck/checker");
 
-const SAMPLES_DIRECTORY = path.join(
-  __dirname,
-  "filechecker",
-  "samplefiles-html"
-);
+const dirname = __dirname;
+
+const SAMPLES_DIRECTORY = path.join(dirname, "filechecker", "samplefiles-html");
 
 describe("checking files", () => {
   it("should spot SVGs with scripts inside them", async () => {
@@ -36,7 +34,7 @@ describe("checking files", () => {
 
   it("should spot files that are not mentioned in md source", async () => {
     const filePath = path.join(
-      path.join(__dirname, "filechecker", "samplefiles-md"),
+      path.join(dirname, "filechecker", "samplefiles-md"),
       "orphan.png"
     );
     // Sanity check the test itself

--- a/tool/cli.js
+++ b/tool/cli.js
@@ -14,6 +14,8 @@ const {
 const log = require("loglevel");
 const cheerio = require("cheerio");
 
+const dirname = __dirname;
+
 const { DEFAULT_LOCALE, VALID_LOCALES } = require("../libs/constants");
 const {
   CONTENT_ROOT,
@@ -614,7 +616,7 @@ program
     "Convert an AWS Athena log aggregation CSV into a popularities.json file"
   )
   .option("--outfile <path>", "output file", {
-    default: path.resolve(path.join(__dirname, "..", "popularities.json")),
+    default: path.resolve(path.join(dirname, "..", "popularities.json")),
   })
   .option("--max-uris <number>", "limit to top <number> entries", {
     default: MAX_GOOGLE_ANALYTICS_URIS,
@@ -689,10 +691,7 @@ program
       const { outfile, debug, account } = options;
       if (account) {
         const dntHelperCode = fs
-          .readFileSync(
-            path.join(__dirname, "mozilla.dnthelper.min.js"),
-            "utf-8"
-          )
+          .readFileSync(path.join(dirname, "mozilla.dnthelper.min.js"), "utf-8")
           .trim();
 
         const gaScriptURL = `https://www.google-analytics.com/${


### PR DESCRIPTION
## Summary

This prepares us for ESM, which no longer provides __dirname,
by introducing a variable `dirname`, which can be replaced
by `fileURLToPath(new URL('.', import.meta.url))` later.

Used regular expression: `(?<!const dirname = )__dirname`

### Problem

We use `__dirname` in several places, but this will no longer be available when we switch to ESM, and needs to be replaced by something like `fileURLToPath(new URL(., import.meta.url))`.

### Solution

To make this migration smoother, this PR already introduces a `dirname` variable, which is initialized after all `require()` calls.

---

## Screenshots

_No change._

---

## How did you test this change?

_Not tested._