### PR TITLE
fix(client/pwa): remove unnecessary globals comment

### DIFF
--- a/client/pwa/src/caches.ts
+++ b/client/pwa/src/caches.ts
@@ -1,5 +1,5 @@
-/* globals __COMMIT_HASH__ */
 declare var __COMMIT_HASH__: string;
+
 export const cacheName = `mdn-app-${__COMMIT_HASH__}`;
 export const contentCache = "mdn-content-v1";
 


### PR DESCRIPTION
## Summary

Fixes the following warning:

<img width="486" alt="image" src="https://user-images.githubusercontent.com/495429/169595577-f2f18328-0152-4599-9629-07ccdfa5a3a8.png">


### Problem

461665bf8dfe3f1b0a9a8488d4ee26e36d5f7655 introduced a `globals` comment, which ESLint complains about.

### Solution

Remove the comment, which seems superfluous given the `declare` statement.

---

## How did you test this change?

This PR does not have this warning. 🎉 
