### PR TITLE
fix(molecules/mandala): remove `<Mandala />` from the accessibility tree

### DIFF
--- a/client/src/ui/molecules/mandala/index.tsx
+++ b/client/src/ui/molecules/mandala/index.tsx
@@ -16,6 +16,7 @@ function Mandala({
       className={`mandala-container ${animateColors ? "animate-colors" : ""} ${
         extraClasses || ""
       }`}
+      aria-hidden="true"
     >
       <div
         className={`mandala-translate ${


### PR DESCRIPTION
Rationale: because the component is built around an inline SVG made of textual content using lose characters like forward slashes, curly braces, and the likes it was exposed in the accessibility tree, making it passive to be read out loud by a screen reader (i.e VoiceOver on macOS).

A demonstration of the issue is [recorded and shared as an unlisted video on YouTube](https://youtu.be/ILD7FyeseRU)

## Summary

Fixes #6332 

### Problem

The characters composing the Mandala component were read out loud by VoiceOver, which could cause confusion to users of assistive technologies, given the contents of the component are purely decorative.

Check the screen capture with VoiceOver video: https://youtu.be/ILD7FyeseRU

### Solution

Add `aria-hidden="true"` to the Mandala container so that is is not exposed in the Accessibility tree anymore.


## Screenshots


### Before

<img width="499" alt="Screenshot 2022-05-21 at 12 24 39" src="https://user-images.githubusercontent.com/607262/169649332-b1f779fe-5f2f-4252-8f5c-8a28703d3f8d.png">


### After

<img width="498" alt="Screenshot 2022-05-21 at 12 50 05" src="https://user-images.githubusercontent.com/607262/169649346-f35949a1-9370-42a6-a808-ddce4a7b3efb.png">

---

## How did you test this change?

Running the project locally and checking the `/_homepage` route and checking both the accessibility tree _and_ how VoiceOver reads the page out loud.
