### PR TITLE
build(ts): bump target to ES2020

### DIFF
--- a/markdown/tsconfig.json
+++ b/markdown/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "esModuleInterop": false,
-    "target": "es2019",
+    "target": "ES2020",
     "lib": ["esnext"]
   },
   "include": ["h2m/**/*"],

--- a/ssr/tsconfig.json
+++ b/ssr/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../tsconfig.json",
-  "module": "esnext",
-  "target": "esnext",
   "compilerOptions": {
     "sourceMap": true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strictBindCallApply": true,
-    "target": "ES2018",
+    "target": "ES2020",
     "preserveWatchOutput": true
   },
   "files": []


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Bumps the [target](https://www.typescriptlang.org/tsconfig#target) of our TypeScript configs to ES2020.

### Problem

Previously, we were using ES2018 and ES2019, and it's probably time to move on.

> If you are wondering about the difference between ES2015 (aka ES6) and ES2020, ES2020 adds support for dynamic imports, and import.meta. (Source: https://www.typescriptlang.org/tsconfig#module)

### Solution

Bump to ES2020, which is more defensive than going to ES2021 or even ES2022.

---

## Screenshots

_No change._

---

## How did you test this change?

1. Ran `yarn dev` locally.