### PR TITLE
build(deps): add @babel/preset-env, remove @babel/helper-builder-react-jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "lodash": ">=4.17.15"
   },
   "dependencies": {
-    "@babel/helper-builder-react-jsx": "^7.16.7",
     "@caporal/core": "^2.0.2",
     "@fast-csv/parse": "^4.3.6",
     "@mdn/browser-compat-data": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.0",
     "@babel/eslint-parser": "^7.17.0",
+    "@babel/preset-env": "^7.18.0",
     "@mdn/dinocons": "^0.5.5",
     "@mdn/minimalist": "^2.0.4",
     "@playwright/test": "^1.22.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,7 +915,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.16.7"
     "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.16.4":
+"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.16.4", "@babel/preset-env@^7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.18.0.tgz#ec7e51f4c6e026816000b230ed7cf74a1530d91d"
   integrity sha512-cP74OMs7ECLPeG1reiCQ/D/ypyOxgfm8uR6HRYV23vTJ7Lu1nbgj9DQDo/vH59gnn7GOAwtTDPPYV4aXzsMKHA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,14 +85,6 @@
     "@babel/helper-explode-assignable-expression" "^7.16.7"
     "@babel/types" "^7.16.7"
 
-"@babel/helper-builder-react-jsx@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.16.7.tgz#6f9da7cea0fde8420e0938d490837feb5bde8dda"
-  integrity sha512-XKorXOl2868Un8/XK2o4GLlXr8Q08KthWI5W3qyCkh6tCGf5Ncg3HR4oN2UO+sqPoAlcMgz9elFW/FZvAHYotA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.7"
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-compilation-targets@^7.13.0", "@babel/helper-compilation-targets@^7.16.7", "@babel/helper-compilation-targets@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz#09c63106d47af93cf31803db6bc49fef354e2ebe"


### PR DESCRIPTION
## Summary

Essentially replaces `@babel/helper-builder-react-jsx` with `@babel/preset-env`.

### Problem

The `babel-loader` README suggests installing `@babel/preset-env` alongside `@babel/core`, but we don't have it. Instead, we have installed `@babel/helper-builder-react-jsx`, which doesn't sound right to me.

### Solution

Add `@babel/preset-env`, remove `@babel/helper-builder-react-jsx`.

---

## Screenshots

_No change._

---

## How did you test this change?

- Ran `yarn dev` locally.
