### PR TITLE
sideshowbarker/support multiple bcd queries caugner rebased

### DIFF
--- a/build/bcd-urls.js
+++ b/build/bcd-urls.js
@@ -66,6 +66,9 @@ function normalizeBCDURLs(doc, options) {
       // so mdn_url is accessible at the root. If the block has a key for
       // `__compat` it is not the first block, and the information is nested
       // under `__compat`.
+      if (!data) {
+        continue;
+      }
       const block = data.__compat ? data.__compat : data;
       if (!block.mdn_url) {
         continue;

--- a/build/bcd-urls.js
+++ b/build/bcd-urls.js
@@ -28,7 +28,7 @@ function normalizeBCDURLs(doc, options) {
 
   function getPathFromAbsoluteURL(absURL) {
     // Because the compat data is mutated out of @mdn/browser-compat-data,
-    // through our `packageBCD` function, it's very possible that
+    // through our `queryBCD` function, it's very possible that
     // the `doc[i].type === 'browser_compatibility` has already been
     // processed.
     if (!absURL.includes("://")) {

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -392,11 +392,44 @@ function _addSingleSpecialSection($) {
    * @returns {object}
    */
   function _getBCD(queryString) {
-    const data = queryBCD(queryString);
+    const data = _getBCDData(queryString);
 
     _processBCDData(data);
 
     return data;
+  }
+
+  /**
+   * @param {string} queryString
+   * @returns {object}
+   */
+  function _getBCDData(queryString) {
+    const queries = queryString.split(",");
+
+    const data = queries.reduce((data, query) => {
+      const dataForQuery = queryBCD(query);
+
+      const breadcrumbs = query.split(".");
+      const name = breadcrumbs[breadcrumbs.length - 1];
+
+      return {
+        ...data,
+        [name]: dataForQuery,
+      };
+    }, {});
+
+    const keys = Object.keys(data);
+
+    switch (keys.length) {
+      case 0:
+        return null;
+
+      case 1:
+        return data[keys[0]];
+
+      default:
+        return data;
+    }
   }
 
   /**

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -394,8 +394,19 @@ function _addSingleSpecialSection($) {
   function _getBCD(queryString) {
     const data = queryBCD(queryString);
 
-    if (data === undefined) {
-      return null;
+    _processBCDData(data);
+
+    return data;
+  }
+
+  /**
+   *
+   * @param {object|undefined} data
+   * @returns {object|undefined}
+   */
+  function _processBCDData(data) {
+    if (!data) {
+      return data;
     }
 
     for (const [key, compat] of Object.entries(data)) {
@@ -434,8 +445,6 @@ function _addSingleSpecialSection($) {
         }
       }
     }
-
-    return data;
   }
 }
 

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -442,12 +442,21 @@ function _addSingleSpecialSection($) {
       return data;
     }
 
-    for (const [key, compat] of Object.entries(data)) {
+    for (const [key, value] of Object.entries(data)) {
       let block;
       if (key === "__compat") {
-        block = compat;
-      } else if (compat && compat.__compat) {
-        block = compat.__compat;
+        block = value;
+      } else if (value && value.__compat) {
+        block = value.__compat;
+      } else {
+        // Some features — e.g., css.properties.justify-content — have no
+        // compat data themselves but have subfeatures with compat data.
+        // So we keep recursing through the nested property values until we
+        // either do or don’t find any subfeatures with compat data.
+        // Otherwise, if we’re processing multiple top-level features (that
+        // is, from a browser-compat value which is an array), we’d end up
+        // entirely missing the data for this feature.
+        _processBCDData(value);
       }
       if (block) {
         for (let [browser, info] of Object.entries(block.support)) {

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -346,26 +346,22 @@ function _addSingleSpecialSection($) {
     return proseSections;
   }
   const query = dataQuery.replace(/^bcd:/, "");
-  const { browsers, data } = packageBCD(query);
+  const { browsers, data } = _getBCD(query);
 
   if (specialSectionType === "browser_compatibility") {
-    if (data === undefined) {
-      return [
-        {
-          type: specialSectionType,
-          value: {
-            title,
-            id,
-            isH3,
-            data: null,
-            query,
-            browsers: null,
-          },
+    return [
+      {
+        type: "browser_compatibility",
+        value: {
+          title,
+          id,
+          isH3,
+          data,
+          query,
+          browsers,
         },
-      ];
-    }
-
-    return _buildSpecialBCDSection();
+      },
+    ];
   } else if (specialSectionType === "specifications") {
     const specifications = _getSpecifications(specURLsString, data);
 
@@ -385,7 +381,17 @@ function _addSingleSpecialSection($) {
 
   throw new Error(`Unrecognized special section type '${specialSectionType}'`);
 
-  function _buildSpecialBCDSection() {
+  /**
+   * @param {string} queryString
+   * @returns {object}
+   */
+  function _getBCD(queryString) {
+    const { browsers, data } = packageBCD(queryString);
+
+    if (data === undefined) {
+      return { browsers: null, data: null };
+    }
+
     // First extract a map of all release data, keyed by (normalized) browser
     // name and the versions.
     // You'll have a map that looks like this:
@@ -443,19 +449,7 @@ function _addSingleSpecialSection($) {
       }
     }
 
-    return [
-      {
-        type: "browser_compatibility",
-        value: {
-          title,
-          id,
-          isH3,
-          data,
-          query,
-          browsers,
-        },
-      },
-    ];
+    return { browsers, data };
   }
 
   /**

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -1,5 +1,9 @@
 const cheerio = require("cheerio");
-const { packageBCD, BCD_BROWSER_RELEASES } = require("./resolve-bcd");
+const {
+  queryBCD,
+  BCD_BROWSER_RELEASES,
+  BCD_BROWSERS,
+} = require("./resolve-bcd");
 const specs = require("browser-specs");
 const web = require("../kumascript/src/api/web.js");
 
@@ -346,9 +350,11 @@ function _addSingleSpecialSection($) {
     return proseSections;
   }
   const query = dataQuery.replace(/^bcd:/, "");
-  const { browsers, data } = _getBCD(query);
+  const data = _getBCD(query);
 
   if (specialSectionType === "browser_compatibility") {
+    const browsers = BCD_BROWSERS;
+
     return [
       {
         type: "browser_compatibility",
@@ -386,10 +392,10 @@ function _addSingleSpecialSection($) {
    * @returns {object}
    */
   function _getBCD(queryString) {
-    const { browsers, data } = packageBCD(queryString);
+    const data = queryBCD(queryString);
 
     if (data === undefined) {
-      return { browsers: null, data: null };
+      return null;
     }
 
     for (const [key, compat] of Object.entries(data)) {
@@ -429,7 +435,7 @@ function _addSingleSpecialSection($) {
       }
     }
 
-    return { browsers, data };
+    return data;
   }
 }
 

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -408,13 +408,20 @@ function _addSingleSpecialSection($) {
 
     const data = queries.reduce((data, query) => {
       const dataForQuery = queryBCD(query);
-
-      const breadcrumbs = query.split(".");
-      const name = breadcrumbs[breadcrumbs.length - 1];
-
       return {
         ...data,
-        [name]: dataForQuery,
+        // When processing multiple BCD queries, queryString can be, e.g.,
+        // html.elements.link.rel,html.elements.a.rel,html.elements.area.rel
+        // So as the key here, to ensure the key is unique, we use the full
+        // 'query' value rather than some portion of it. Otherwise, if we
+        // use, e.g., just the part after the last dot, then for the
+        // example above, that ends up being just 'rel' for all three
+        // 'query' values from that full 'queryString' value. And because
+        // 'rel' is not unique, if we used it as the key here, then in each
+        // iteration of the reduce through the 'queryString', we’d end up
+        // setting a new value ('dataForQuery') for the 'rel' key — and
+        // clobbering whatever value was set in the previous iteration.
+        [query]: dataForQuery,
       };
     }, {});
 

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -496,14 +496,39 @@ function _getSpecifications(specURLsString, data) {
   let specURLs = [];
 
   if (data) {
-    // If 'data' is non-null, that means we have data for a BCD feature
-    // that we can extract spec URLs from.
-    for (const [key, compat] of Object.entries(data)) {
-      if (key === "__compat" && compat.spec_url) {
+    // If 'data' is non-null, that means we have data for one or more BCD
+    // features that we can extract spec URLs from.
+    //
+    // If we’re processing data for just one feature, then the 'data'
+    // variable will have a __compat key. So we get the one spec_url value
+    // from that, and move on.
+    //
+    // (The value may contain data for subfeatures too — each subfeature
+    // with its own __compat key that may contain a spec_url — but in that
+    // case, for the purposes of the Specifications section, we don’t want
+    // to recurse through all the subfeatures to get those spec_url values;
+    // instead we only want the spec_url from the top-level __compat key.
+    if (data.__compat) {
+      const compat = data.__compat;
+      if (compat.spec_url) {
         if (Array.isArray(compat.spec_url)) {
           specURLs = compat.spec_url;
         } else {
           specURLs.push(compat.spec_url);
+        }
+      }
+    } else {
+      for (const block of Object.values(data)) {
+        // If we reach here, we’re processing data for two or more features
+        // and the 'data' variable will contain multiple blocks (objects) —
+        // one for each feature — each with its own __compat key
+        const compat = block.__compat;
+        if (compat.spec_url) {
+          if (Array.isArray(compat.spec_url)) {
+            specURLs = compat.spec_url;
+          } else {
+            specURLs.push(compat.spec_url);
+          }
         }
       }
     }

--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -446,7 +446,7 @@ function _addSingleSpecialSection($) {
       let block;
       if (key === "__compat") {
         block = compat;
-      } else if (compat.__compat) {
+      } else if (compat && compat.__compat) {
         block = compat.__compat;
       }
       if (block) {
@@ -522,8 +522,11 @@ function _getSpecifications(specURLsString, data) {
         // If we reach here, we’re processing data for two or more features
         // and the 'data' variable will contain multiple blocks (objects) —
         // one for each feature — each with its own __compat key
+        if (!block) {
+          continue;
+        }
         const compat = block.__compat;
-        if (compat.spec_url) {
+        if (compat && compat.spec_url) {
           if (Array.isArray(compat.spec_url)) {
             specURLs = compat.spec_url;
           } else {

--- a/build/flaws/bad-bcd-queries.js
+++ b/build/flaws/bad-bcd-queries.js
@@ -15,8 +15,15 @@ function getBadBCDQueriesFlaws(doc, $) {
       if (!dataQuery) {
         return "BCD table without 'data-query' or 'id' attribute";
       }
-      const query = dataQuery.replace(/^bcd:/, "");
-      return !queryBCD(query) && `No BCD data for query: ${query}`;
+      const queryArray = dataQuery
+        .replace(/^bcd:/, "")
+        .split(",")
+        .map((query) => query.trim());
+      for (const query of queryArray) {
+        if (!queryBCD(query)) {
+          return `No BCD data for query: ${query}`;
+        }
+      }
     })
     .get()
     .filter((explanation) => !!explanation)

--- a/build/flaws/bad-bcd-queries.js
+++ b/build/flaws/bad-bcd-queries.js
@@ -1,4 +1,4 @@
-const { packageBCD } = require("../resolve-bcd");
+const { queryBCD } = require("../resolve-bcd");
 
 // Bad BCD queries are when the `<div class="bc-data">` tags have an
 // ID (or even lack the `id` attribute) that don't match anything in the
@@ -16,7 +16,7 @@ function getBadBCDQueriesFlaws(doc, $) {
         return "BCD table without 'data-query' or 'id' attribute";
       }
       const query = dataQuery.replace(/^bcd:/, "");
-      return !packageBCD(query).data && `No BCD data for query: ${query}`;
+      return !queryBCD(query) && `No BCD data for query: ${query}`;
     })
     .get()
     .filter((explanation) => !!explanation)

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -2,7 +2,7 @@
 
 const bcd = require("@mdn/browser-compat-data");
 
-function packageBCD(query) {
+function queryBCD(query) {
   return query.split(".").reduce((prev, curr) => {
     return prev && Object.prototype.hasOwnProperty.call(prev, curr)
       ? prev[curr]
@@ -36,7 +36,7 @@ const BCD_BROWSER_RELEASES = (function () {
 })();
 
 module.exports = {
-  BCD_BROWSERS,
   BCD_BROWSER_RELEASES,
-  packageBCD,
+  BCD_BROWSERS,
+  queryBCD,
 };

--- a/build/resolve-bcd.js
+++ b/build/resolve-bcd.js
@@ -3,14 +3,40 @@
 const bcd = require("@mdn/browser-compat-data");
 
 function packageBCD(query) {
-  const data = query.split(".").reduce((prev, curr) => {
+  return query.split(".").reduce((prev, curr) => {
     return prev && Object.prototype.hasOwnProperty.call(prev, curr)
       ? prev[curr]
       : undefined;
   }, bcd);
-  return { browsers: bcd.browsers, data };
 }
 
+const BCD_BROWSERS = bcd.browsers;
+
+// Map of all release data, keyed by (normalized) browser
+// name and the versions:
+//
+//   'chrome_android': {
+//      '28': {
+//        release_date: '2012-06-01',
+//        release_notes: '...',
+//        ...
+//
+const BCD_BROWSER_RELEASES = (function () {
+  const map = new Map();
+  for (const [name, browser] of Object.entries(BCD_BROWSERS)) {
+    const releaseData = new Map();
+    for (const [version, data] of Object.entries(browser.releases || [])) {
+      if (data) {
+        releaseData.set(version, data);
+      }
+    }
+    map.set(name, releaseData);
+  }
+  return map;
+})();
+
 module.exports = {
+  BCD_BROWSERS,
+  BCD_BROWSER_RELEASES,
   packageBCD,
 };

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -506,7 +506,7 @@ export const FeatureRow = React.memo(
   }: {
     index: number;
     feature: {
-      name: string;
+      query: string;
       compat: CompatStatementExtended;
       depth: number;
     };
@@ -521,7 +521,19 @@ export const FeatureRow = React.memo(
       throw new Error("Missing browser info");
     }
 
-    const { name, compat, depth } = feature;
+    const { query, compat, depth } = feature;
+    const breadcrumbs = query.split(".");
+    let name = breadcrumbs[breadcrumbs.length - 1];
+    if (query.startsWith("html.elements") && breadcrumbs.length > 3) {
+      // When we’re processing multiple BCD queries/features, they can end
+      // up with the same 'name' unless we further qualify them; e.g.,
+      // the query string "html.elements.label.for,html.elements.output.for"
+      // would result in a rendered BCD table that has just 'for' as the
+      // feature name in each row. So in this case, we take the last _two_
+      // parts of the query/feature name — that is, e.g., 'label.for' and
+      // 'output.for' — and output those in the rendered table.
+      name = breadcrumbs.slice(-2).join(".");
+    }
     let title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -522,11 +522,39 @@ export const FeatureRow = React.memo(
     }
 
     const { name, compat, depth } = feature;
-    const title = compat.description ? (
+    let title = compat.description ? (
       <span dangerouslySetInnerHTML={{ __html: compat.description }} />
     ) : (
       <code>{name}</code>
     );
+    // When we’re showing a row for a subfeature, the subfeature name or
+    // description on its own may not provide enough context — especially
+    // in the case where we have a BCD table with multiple top-level
+    // features (that is, from a browser-compat value which is an array) —
+    // so in this case, we prefix the subfeature name/description with the
+    // (parent) feature name, acquired from the current mdn_url value.
+    let featureName = "";
+    if (compat.mdn_url) {
+      const nameFromMdnURL = compat.mdn_url.split("/").pop();
+      if (nameFromMdnURL) {
+        featureName = nameFromMdnURL.toLowerCase();
+      }
+    }
+    if (
+      featureName &&
+      !featureName.includes("_") && // only subfeatures have "_" in BCD
+      !name.toLowerCase().includes(featureName) &&
+      !(
+        compat.description &&
+        compat.description.toLowerCase().includes(featureName)
+      )
+    ) {
+      title = (
+        <span>
+          <code>{featureName}</code> ({title})
+        </span>
+      );
+    }
     const activeBrowser = activeCell !== null ? browsers[activeCell] : null;
 
     let titleNode: string | React.ReactNode;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -599,7 +599,11 @@ export const FeatureRow = React.memo(
     return (
       <>
         <tr>
-          <th className={`bc-feature bc-feature-depth-${depth}`} scope="row">
+          <th
+            className={`bc-feature bc-feature-depth-${depth}`}
+            scope="row"
+            title={query}
+          >
             {titleNode}
           </th>
           {browsers.map((browser, i) => (

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -54,6 +54,25 @@ export function listFeatures(
         depth: depth + 1,
       });
       features.push(...listFeatures(subIdentifier, subName, "", depth + 1));
+    } else {
+      // Some features — e.g., css.properties.justify-content — have no
+      // compat data themselves but have subfeatures with compat data. So
+      // we go down one level to check for subfeatures with compat data.
+      // Otherwise, in the case where we’re processing multiple top-level
+      // features (that is, from a browser-compat value which is an array),
+      // we’d end up entirely missing the data for this feature.
+      for (const [subName, subSubIdentifier] of Object.entries(subIdentifier)) {
+        if (subName !== "__compat" && subSubIdentifier.__compat) {
+          features.push({
+            name: parentName ? `${parentName}.${subName}` : subName,
+            compat: subSubIdentifier.__compat,
+            depth: depth + 1,
+          });
+          features.push(
+            ...listFeatures(subSubIdentifier, subName, "", depth + 1)
+          );
+        }
+      }
     }
   }
   return features;

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -46,7 +46,9 @@ export function listFeatures(
     });
   }
 
-  for (const [subName, subIdentifier] of Object.entries(identifier)) {
+  let subName: string;
+  let subIdentifier: BCD.Identifier;
+  for ([subName, subIdentifier] of Object.entries(identifier)) {
     if (subName !== "__compat" && subIdentifier.__compat) {
       features.push({
         query: parentName ? `${parentName}.${subName}` : subName,
@@ -61,8 +63,10 @@ export function listFeatures(
       // Otherwise, in the case where we’re processing multiple top-level
       // features (that is, from a browser-compat value which is an array),
       // we’d end up entirely missing the data for this feature.
-      for (const [subName, subSubIdentifier] of Object.entries(subIdentifier)) {
-        if (subName !== "__compat" && subSubIdentifier.__compat) {
+      let subSubName: string;
+      let subSubIdentifier: BCD.Identifier;
+      for ([subSubName, subSubIdentifier] of Object.entries(subIdentifier)) {
+        if (subSubName !== "__compat" && subSubIdentifier.__compat) {
           features.push({
             query: parentName ? `${parentName}.${subName}` : subName,
             compat: subSubIdentifier.__compat,

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -26,7 +26,7 @@ export function isTruthy<T>(t: T | false | undefined | null): t is T {
 }
 
 interface Feature {
-  name: string;
+  query: string;
   compat: BCD.CompatStatement;
   depth: number;
 }
@@ -40,7 +40,7 @@ export function listFeatures(
   const features: Feature[] = [];
   if (rootName && identifier.__compat) {
     features.push({
-      name: rootName,
+      query: rootName,
       compat: identifier.__compat,
       depth,
     });
@@ -49,7 +49,7 @@ export function listFeatures(
   for (const [subName, subIdentifier] of Object.entries(identifier)) {
     if (subName !== "__compat" && subIdentifier.__compat) {
       features.push({
-        name: parentName ? `${parentName}.${subName}` : subName,
+        query: parentName ? `${parentName}.${subName}` : subName,
         compat: subIdentifier.__compat,
         depth: depth + 1,
       });
@@ -64,7 +64,7 @@ export function listFeatures(
       for (const [subName, subSubIdentifier] of Object.entries(subIdentifier)) {
         if (subName !== "__compat" && subSubIdentifier.__compat) {
           features.push({
-            name: parentName ? `${parentName}.${subName}` : subName,
+            query: parentName ? `${parentName}.${subName}` : subName,
             compat: subSubIdentifier.__compat,
             depth: depth + 1,
           });


### PR DESCRIPTION
## Summary

This extends https://github.com/mdn/yari/pull/6004 to add handling for more cases discovered during testing.

### Problem description (from #6004)

Previously, pages could only reference a single BCD query.

### Solution (from #6004)

1. Refactored `document-extractor.js` to use pure functions for BCD and Specifications.
2. Extracted `BCD_BROWSERS` and `BCD_BROWSER_RELEASES` constants.
3. Combine multiple BCD queries into a common hierarchy (96aa5e27b).

### Additional changes in this PR branch

- Update Specifications section population to handle multiple BCD queries
- Make the flaw checker understand multiple BCD queries
- Handle browser-compat arrays that contain bad BCD feature IDs
- Further update BCD table features population to handle multiple BCD queries
- Prefix parent feature name to subfeatures in multiple-BCD-queries output
