### PR TITLE
chore(ui): add td.bg-{green,yellow,red} helper classes

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -4,6 +4,7 @@
 @use "./ui/base/reset";
 @use "./ui/base/themes";
 @use "./ui/base/prism";
+@use "./ui/base/utils";
 
 // These classes are used across several components.
 @use "./ui/molecules/notecards";

--- a/client/src/ui/base/_utils.scss
+++ b/client/src/ui/base/_utils.scss
@@ -1,0 +1,14 @@
+// Background colors for usage in mdn/content.
+td {
+  &.bg-green {
+    background-color: var(--background-mark-green);
+  }
+
+  &.bg-yellow {
+    background-color: var(--background-mark-yellow);
+  }
+
+  &.bg-red {
+    background-color: var(--background-critical);
+  }
+}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes #6347.

### Problem

There is no way to highlight table cells in mdn/content with red/yellow/green background color in a way that is compatible with our themes.

### Solution

Provide helper classes `.bg-green`, `.bg-yellow` and `.bg-red` to be used for table cells in content.

---

## Screenshots

<img width="790" alt="image" src="https://user-images.githubusercontent.com/495429/170117326-7e078121-8f5b-4eb7-a7cb-d516b5803533.png">

<img width="790" alt="image" src="https://user-images.githubusercontent.com/495429/170117436-1313b0f3-2b7c-4c28-8be2-4931ce4eb327.png">

---

## How did you test this change?

1. Make changes to `files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md` in mdn/content.