### PR TITLE
chore(breadcrumbs): add top and bottom margin to `<li>` and apply a smaller size font

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -10,6 +10,8 @@
   }
 
   li {
+    margin: 0.2rem 0;
+    font-size: 0.9rem;
     display: none;
     hyphens: auto;
 


### PR DESCRIPTION
## Summary

### Problem

IMHO, the current breadcrumbs need more margin, especially a mobile size screen.

### Solution

* Add top and bottom margin to breadcrumbs
* Apply smaller size font

---

## Screenshots

### Before (mobile)

![before-mobile](https://user-images.githubusercontent.com/11273093/170138409-185ef711-df90-492a-9f6d-6628e352319d.jpg)

### After (mobile)

![after-mobile](https://user-images.githubusercontent.com/11273093/170138427-b9f76a1a-0b43-456c-864f-c5e3e3039247.jpg)

### Before (desktop)

![before-desktop](https://user-images.githubusercontent.com/11273093/170138446-e95bc67d-1ee9-4d81-9d68-5920e350a275.jpg)

### After (desktop)

![after-desktop](https://user-images.githubusercontent.com/11273093/170138461-b20de8f7-37e3-4fe0-a888-5e62b1b46b7e.jpg)

---

## How did you test this change?

run `yarn dev` and check locally.

Thank you :)