### PR TITLE
Fix Downshift related issues

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -463,7 +463,11 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         },
       })}
     >
-      <label htmlFor={`${id}-input`} className="visually-hidden">
+      <label
+        id={`${id}-label`}
+        htmlFor={`${id}-input`}
+        className="visually-hidden"
+      >
         Search MDN
       </label>
 

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -477,7 +477,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           className: isOpen
             ? "has-search-results search-input-field"
             : "search-input-field",
-          name: `input`,
+          name: `q`,
           onMouseOver: initializeSearchIndex,
           onFocus: () => {
             onChangeIsFocused(true);

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -167,7 +167,6 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     defaultSelection,
   } = props;
 
-  const inputId = `${id}-q`;
   const formId = `${id}-form`;
   const navigate = useNavigate();
   const locale = useLocale();
@@ -261,6 +260,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     reset,
     toggleMenu,
   } = useCombobox({
+    id: id,
     items:
       resultItems.length === 0
         ? [nothingFoundItem]
@@ -463,7 +463,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         },
       })}
     >
-      <label htmlFor={inputId} className="visually-hidden">
+      <label htmlFor={`${id}-input`} className="visually-hidden">
         Search MDN
       </label>
 
@@ -473,8 +473,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           className: isOpen
             ? "has-search-results search-input-field"
             : "search-input-field",
-          id: inputId,
-          name: "q",
+          name: `input`,
           onMouseOver: initializeSearchIndex,
           onFocus: () => {
             onChangeIsFocused(true);

--- a/client/src/ui/molecules/a11y-nav/index.tsx
+++ b/client/src/ui/molecules/a11y-nav/index.tsx
@@ -42,7 +42,7 @@ export function A11yNav() {
       <li>
         <a
           id="skip-search"
-          href="#top-nav-search-q"
+          href="#top-nav-search-input"
           onClick={sendAccessMenuItemClick}
           onContextMenu={sendAccessMenuItemClick}
         >


### PR DESCRIPTION
Possible fix for #6294 (hydration errors).

## Summary

The SearchNavigateWidget (downshift useCombobox) has developed some issues over time.
Consider the following response<sup>*</sup> from the server on 27 May 2022 for URL:  
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
```html
<form id="top-nav-search-form" aria-owns="downshift-22010-menu">
  <label for="top-nav-search-q">Search MDN</label>
  <input id="top-nav-search-q" aria-controls="downshift-22010-menu" aria-labelledby="downshift-22010-label">
  <button></button>
  <div id="downshift-22010-menu" role="listbox" aria-labelledby="downshift-22010-label"></div>
</form>
```
* the response has been striped to only relevant part and attributes.

### Issues :
1. Notice the id `downshift-22010-menu` the listbox gets on the server. For URL https://developer.mozilla.org/en-US/ it is `downshift-176-menu`. But on client side the React expects `downshift-1-menu`,
2. The input tag and the listbox gets wrong ARIA attribute `aria-labelledby="downshift-22010-label"`.

## Explanation

**Issue 1**
Both the issues are happening because we let Downshift [auto generate ids](https://github.com/downshift-js/downshift/blob/26c93a539dad09e41adba69ddc3a7d7ecccfc8bb/src/hooks/utils.js#L105). The main culprit is their `idCounter`. It is sort of [a global variable](https://github.com/downshift-js/downshift/blob/26c93a539dad09e41adba69ddc3a7d7ecccfc8bb/src/utils.js#L4). Every time the server serves a request the counter increments; that is why we see such a high(22010) number. The id remains constant for a page may be because the server is caching the results for the page after the first render.

On the other hand, every client starts with a fresh counter, but the counter on the server never resets! 
While hydrating the React sees different ids and complains.

**Issue 2**
We manually set the id `top-nav-search-q` on input part of the combobox widget. But rest of the ids used for ARIA labels are derived from the autogenerated id. That is why the ARIA labels mismatch.

## Solution

Do not rely on their id generation mechanism. It is suitable for client only Apps not for SSR.

It's better to provide the desired id prefix as a parameter to `useCombobox( {id: 'top-nav-search'} )` instead of setting ids on each component of the widget. E.g. existing `getInputProps( {id: inputId} )`.

Following is the rendered html:
```html
<form id="top-nav-search-form" aria-owns="top-nav-search-menu">
  <label id="top-nav-search-label" for="top-nav-search-input">Search MDN</label>
  <input id="top-nav-search-input" aria-controls="top-nav-search-menu" aria-labelledby="top-nav-search-label">
  <button</button>
  <div id="top-nav-search-menu" role="listbox" aria-labelledby="top-nav-search-label"></div>
</form>
```

## How did you test this change?

This needs to be deployed on `content.dev.mdn.mozit.cloud` using `Dev Builds` to test the SSR side.
There are no bugs in Dev environment.

***
## Note

As per the [React 18 upgrade guide](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#other-breaking-changes), now  the hydration errors are more strict:
> **Stricter hydration errors:* Hydration mismatches due to missing or extra text content are now treated like errors instead of warnings.

Considering this, after the [build(deps-dev): bump react from 17.0.2 to 18.1.0](https://github.com/mdn/yari/pull/6235) merge, on 11th May, multiple hydration issues might have surfaced. So, it is possible that even after this PR, we may continue seeing hydration errors.
