### PR TITLE
build(workflows/labeler): fix pattern, add more labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,22 @@
+browser-compat:
+  - "client/src/document/ingredients/browser-compatability-table/**/*"
 macros:
-  - "kumascript/*"
+  - "kumascript/**/*"
+dependencies:
+  - "**/poetry.lock"
+  - "**/yarn.lock"
+deployer:
+  - "deployer/**/*"
+flaw-system:
+  - "build/flaws/**/*"
+github-actions:
+  - ".github/workflows/**/*"
+markdown:
+  - "markdown/**/*"
+plus:
+  - "client/src/plus/**/*"
+plus:offline:
+  - "client/pwa/src/**/*"
+  - "client/src/offline-settings/**/*"
+python:
+  - "**/*.py"


### PR DESCRIPTION
## Summary

Updates the [actions/labeler](https://github.com/actions/labeler) config to assign more labels.

### Problem

We're using [actions/labeler](https://github.com/actions/labeler) to mark PRs with labels based on the files they touch, but so far we only had one (incomplete) rule for the `macros` label.

### Solution

Fix the `macros` rule, and add more rules.
