### PR TITLE
fix: Hydration errors in Logo component

### DIFF
--- a/client/src/ui/atoms/logo/index.tsx
+++ b/client/src/ui/atoms/logo/index.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 import { useLocale } from "../../../hooks";
@@ -13,12 +14,20 @@ export function Logo() {
   const locale = useLocale();
   const location = useLocation();
 
-  const plus = isPlus(location.pathname);
-  const docs = isDocs(location.pathname);
+  const [mdnLogo, setMdnLogo] = useState<any>(null);
+  useEffect(() => {
+    if (isPlus(location.pathname)) {
+      setMdnLogo(<MDNPlusLogo />);
+    } else if (isDocs(location.pathname)) {
+      setMdnLogo(<MDNDocsLogo />);
+    } else {
+      setMdnLogo(<MDNLogo />);
+    }
+  }, [location]);
 
   return (
     <a href={`/${locale}/`} className="logo" aria-label="MDN homepage">
-      {(plus && <MDNPlusLogo />) || (docs && <MDNDocsLogo />) || <MDNLogo />}
+      {mdnLogo}
     </a>
   );
 }

--- a/client/src/ui/atoms/logo/index.tsx
+++ b/client/src/ui/atoms/logo/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { useLocation } from "react-router-dom";
 
 import { useLocale } from "../../../hooks";
@@ -14,8 +14,8 @@ export function Logo() {
   const locale = useLocale();
   const location = useLocation();
 
-  const [mdnLogo, setMdnLogo] = useState<any>(null);
-  useEffect(() => {
+  const [mdnLogo, setMdnLogo] = React.useState<React.ReactNode>(<MDNLogo />);
+  React.useEffect(() => {
     if (isPlus(location.pathname)) {
       setMdnLogo(<MDNPlusLogo />);
     } else if (isDocs(location.pathname)) {


### PR DESCRIPTION
## Summary

This is one of the components causing hydration issues.
The issue happens because logo SVG is different based on the URL location or subscription status.

### Problem
Following code causes server and client to to have different logo SVG:
```html
<a href={`/${locale}/`} className="logo" aria-label="MDN homepage">
      {(plus && <MDNPlusLogo />) || (docs && <MDNDocsLogo />) || <MDNLogo />}
</a>
```

### Solution
Put the code in a useEffect hook so that SSR doesn't send the default SVG. And let clients decide which SVG to use.
```js
const [mdnLogo, setMdnLogo] = useState<any>(null);
  useEffect(() => {
    if (isPlus(location.pathname)) {
      setMdnLogo(<MDNPlusLogo />);
    } else if (isDocs(location.pathname)) {
      setMdnLogo(<MDNDocsLogo />);
    } else {
      setMdnLogo(<MDNLogo />);
    }
  }, [location]);

  return (
    <a href={`/${locale}/`} className="logo" aria-label="MDN homepage">
      {mdnLogo}
    </a>
  );
```

## How did you test this change?

I've tested this in Firefox and Chrome on Windows.