### PR TITLE
fix: hydration errors in SVGs in header and footer

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -19,7 +19,7 @@ export function Footer() {
       <div className="page-footer-grid">
         <div className="page-footer-logo-col">
           <a href="/" className="mdn-footer-logo" aria-label="MDN homepage">
-            <MDNLogo />
+            <MDNLogo aria-labelledby="mdn-footer-logo-svg" />
           </a>
           <p>Your blueprint for a better internet.</p>
           <ul className="social-icons">

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -46,8 +46,10 @@ module.exports = {
           {
             loader: "@svgr/webpack",
             options: {
-              svgo: true,
-              titleProp: true,
+              expandProps: "end",
+              // these properties cause hydration errors when enabled
+              svgo: false,
+              titleProp: false,
             },
           },
         ],


### PR DESCRIPTION
## Summary

Root cause of hydration errors in SVG is use of `svgo` in SVGR.

### Problem

The `svgo` optimizes SVGs simply by stripping extra contents like title, comments, unwanted attributes. So entire SVG DOM tree changes. And `svgo` doesn't work in browsers at client side it's only server side optimization solution.
So it is a big no no for SSR.

### Solution

By simply disabling the optimization most of the hydration errors in top logo, footer mozilla and MDN logos SVGs go away. 


## How did you test this change?

In local dev environment.