### PR TITLE
fix: hydration errors in RecentContributions component

### DIFF
--- a/client/src/homepage/recent-contributions/index.tsx
+++ b/client/src/homepage/recent-contributions/index.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import useSWR from "swr";
@@ -28,6 +29,13 @@ function RecentContributions(props: HydrationData<any>) {
     }
   );
 
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    if (!mounted) {
+      setMounted(true);
+    }
+  }, [mounted]);
+
   return hyData?.recentContributions ? (
     <section className="recent-contributions">
       <h2>Recent contributions</h2>
@@ -47,7 +55,7 @@ function RecentContributions(props: HydrationData<any>) {
                 </span>
               </p>
               <span className="request-date">
-                {dayjs(updated_at).fromNow()}
+                {mounted && dayjs(updated_at).fromNow()}
               </span>
             </li>
           )


### PR DESCRIPTION
## Summary

Here is one way to solve hydration errors related to timestamps.

### Problem

Timestamps on server and client do not match. Sot it throws hydration error.

### Solution

If we display timestamps only after the component is mounted.

