### PR TITLE
test: add scripts to simulate developing/testing workflow

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist/
 libs/
 client/public/service-worker.js
 client/public/
+mdn/content/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 __pycache__/
 .idea/
 
+*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ md-conversion-problems-report*.md
 
 testing/content/files/en-us/_githistory.json
 testing/translated-content/files/**/_githistory.json
+
+testing/content/files/en-us/markdown/tool/h2m/index.md
+testing/content/files/en-us/markdown/tool/m2h/index.html
 # eslintcache
 client/.eslintcache
 popularities.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 
 # testing
 /coverage
+/mdn/content/
 
 # pwa
 /client/public/service-worker.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -23,4 +23,5 @@ _githistory.json
 /testing/content/
 /kumascript/coverage/
 /ssr/mozilla.dnthelper.min.js
+/mdn/content
 popularities.json

--- a/scripts/developing.sh
+++ b/scripts/developing.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env sh
+
+# Script equivalent of .github/workflows/developing.yml
+
+set -e
+
+echo "--------------------"
+echo "Checkout mdn/content"
+echo "--------------------"
+
+if [ -d "mdn/content/.git" ]; then
+  pushd mdn/content
+  git checkout main
+  git fetch
+  git reset --hard origin/main
+  popd
+else
+  rm -rf mdn/content
+  mkdir -p mdn
+  git clone --depth=1 https://github.com/mdn/content.git mdn/content
+fi
+
+echo "-------------------------"
+echo "Install all yarn packages"
+echo "-------------------------"
+
+yarn --frozen-lockfile
+
+echo "--------------------"
+echo "Start the dev server"
+echo "--------------------"
+
+export CONTENT_ROOT="mdn/content/files"
+ls "$CONTENT_ROOT/en-us/mdn/kitchensink"
+echo "" > client/.env
+
+yarn build:prepare
+
+yarn start > developing.log 2>&1 &
+PID=$!
+
+{
+    sleep 3
+
+    curl --retry-connrefused --retry 5 http://localhost:5042 > /dev/null
+    curl --retry-connrefused --retry 5 --silent http://localhost:3000 > /dev/null
+
+    echo "---------------------------"
+    echo "Test viewing the dev server"
+    echo "---------------------------"
+
+    yarn test:developing
+
+    echo "-----------"
+    echo "Stop server"
+    echo "-----------"
+
+    kill $PID
+    rm client/.env
+    rm developing.log
+
+    echo "----------"
+    echo "Result: ✅"
+    echo "----------"
+} || {
+    echo "-----------"
+    echo "Stop server"
+    echo "-----------"
+
+    kill $PID
+    rm client/.env
+
+    cat developing.log
+    rm developing.log
+
+    echo "----------"
+    echo "Result: ❌"
+    echo "----------"
+}
+

--- a/scripts/testing.sh
+++ b/scripts/testing.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+# Script equivalent of .github/workflows/testing.yml
+
+set -e
+
+echo "-------------------------"
+echo "Install all yarn packages"
+echo "-------------------------"
+
+yarn --frozen-lockfile
+
+echo "-------------"
+echo "Lint prettier"
+echo "-------------"
+
+yarn prettier-check
+
+echo "-----------"
+echo "Lint ESLint"
+echo "-----------"
+
+yarn eslint
+
+echo "-------------------"
+echo "Unit testing client"
+echo "-------------------"
+
+yarn test:client
+
+echo "----------------------"
+echo "Build and start server"
+echo "----------------------"
+
+export ENV_FILE="testing/.env"
+cp testing/.env client/
+
+yarn build:prepare
+yarn build
+
+nohup yarn start:static-server > testing.log 2>&1 &
+PID=$!
+
+sleep 1
+
+{
+    curl --fail --retry-connrefused --retry 5 http://localhost:5042 > /dev/null
+
+    echo "------------------"
+    echo "Functional testing"
+    echo "------------------"
+
+    yarn test:testing
+    yarn test:headless
+
+    echo "-----------"
+    echo "Stop server"
+    echo "-----------"
+
+    kill $PID
+    rm client/.env
+    rm testing.log
+
+    echo "----------"
+    echo "Result: ✅"
+    echo "----------"
+} || {
+    kill $PID
+    rm client/.env
+
+    cat testing.log
+    rm testing.log
+
+    echo "----------"
+    echo "Result: ❌"
+    echo "----------"
+}
+
+echo "--------------------------"
+echo "Basic m2h/h2m tool testing"
+echo "--------------------------"
+
+yarn md m2h markdown/tool/m2h --locale en-US
+diff -s testing/content/files/en-us/markdown/tool/m2h/index.html testing/content/files/en-us/markdown/tool/m2h/expected.html
+yarn md h2m markdown/tool/h2m --locale en-US
+diff -s testing/content/files/en-us/markdown/tool/h2m/index.md testing/content/files/en-us/markdown/tool/h2m/expected.md


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Adds scripts to simulate the testing and developing workflows locally.

### Problem

Currently there is no easy way to run the testing/developing workflows locally.

### Solution

Adds scripts that mirrors exactly what those workflows do.

---

## How did you test this change?

1. Ran `scripts/testing.sh` locally.
2. Ran `scripts/developing.sh` locally.