### PR TITLE
fix(fs): call {read,write}FileSync() with 'utf-8', not 'utf8'

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -38,7 +38,7 @@ async function buildContributorSpotlight(options, locale) {
   for (const contributor of fs.readdirSync(contributorSpotlightRoot)) {
     const markdown = fs.readFileSync(
       `${contributorSpotlightRoot}/${contributor}/index.md`,
-      "utf8"
+      "utf-8"
     );
 
     const frontMatter = frontmatter(markdown);
@@ -209,7 +209,7 @@ async function buildSPAs(options) {
       }
 
       const locale = "en-us";
-      const markdown = fs.readFileSync(filepath, "utf8");
+      const markdown = fs.readFileSync(filepath, "utf-8");
 
       const frontMatter = frontmatter(markdown);
       const rawHTML = await m2h(frontMatter.body, locale);

--- a/build/sync-translated-content.js
+++ b/build/sync-translated-content.js
@@ -109,7 +109,7 @@ function syncTranslatedContent(inFilePath, locale) {
     followed: false,
   };
 
-  const rawDoc = fs.readFileSync(inFilePath, "utf8");
+  const rawDoc = fs.readFileSync(inFilePath, "utf-8");
   const fileName = path.basename(inFilePath);
   const extension = path.extname(fileName);
   const bareFileName = path.basename(inFilePath, extension);

--- a/content/document.js
+++ b/content/document.js
@@ -232,7 +232,7 @@ const read = memoize((folderOrFilePath, roots = ROOTS) => {
     CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT)
   );
 
-  const rawContent = fs.readFileSync(filePath, "utf8");
+  const rawContent = fs.readFileSync(filePath, "utf-8");
   if (!rawContent) {
     throw new Error(`${filePath} is an empty file`);
   }

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -35,7 +35,7 @@ function buildRedirectsMap() {
       ].find((path) => fs.existsSync(path));
 
       if (path) {
-        const content = fs.readFileSync(path, "utf8");
+        const content = fs.readFileSync(path, "utf-8");
         const lines = content.split("\n");
         const redirectLines = lines.filter(
           (line) => line.startsWith("/") && line.includes("\t")

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -14,7 +14,7 @@ fs.readdirSync(fixture_dir).forEach(function (fn) {
   fixtureCompatData = extend(
     true,
     fixtureCompatData,
-    JSON.parse(fs.readFileSync(path.resolve(fixture_dir, fn), "utf8"))
+    JSON.parse(fs.readFileSync(path.resolve(fixture_dir, fn), "utf-8"))
   );
 });
 

--- a/kumascript/tests/macros/DefaultAPISidebar.test.js
+++ b/kumascript/tests/macros/DefaultAPISidebar.test.js
@@ -21,7 +21,7 @@ const pagesFixturePath = path.resolve(
   dirname,
   "fixtures/defaultapisidebar/pages.json"
 );
-const pagesJSON = JSON.parse(fs.readFileSync(pagesFixturePath, "utf8"));
+const pagesJSON = JSON.parse(fs.readFileSync(pagesFixturePath, "utf-8"));
 const subpagesJSON = [
   pagesJSON["/en-US/docs/Web/API/TestInterface_API/MyGuidePage1"],
   pagesJSON["/en-US/docs/Web/API/TestInterface_API/MyGuidePage2"],
@@ -31,14 +31,14 @@ const commonl10nFixturePath = path.resolve(
   "fixtures/defaultapisidebar/commonl10n.json"
 );
 const commonl10nFixture = JSON.parse(
-  fs.readFileSync(commonl10nFixturePath, "utf8")
+  fs.readFileSync(commonl10nFixturePath, "utf-8")
 );
 const groupDataFixturePath = path.resolve(
   dirname,
   "fixtures/defaultapisidebar/groupdata.json"
 );
 const groupDataFixture = JSON.parse(
-  fs.readFileSync(groupDataFixturePath, "utf8")
+  fs.readFileSync(groupDataFixturePath, "utf-8")
 );
 
 /**

--- a/kumascript/tests/macros/HTTPSidebar.test.js
+++ b/kumascript/tests/macros/HTTPSidebar.test.js
@@ -19,7 +19,7 @@ const dirname = __dirname;
 const fixtureData = JSON.parse(
   fs.readFileSync(
     path.resolve(dirname, "fixtures", "documentData2.json"),
-    "utf8"
+    "utf-8"
   )
 );
 

--- a/kumascript/tests/macros/ListGroups.test.js
+++ b/kumascript/tests/macros/ListGroups.test.js
@@ -22,7 +22,7 @@ const groupDataFixturePath = path.resolve(
   "fixtures/listgroups/groupdata.json"
 );
 const groupDataFixture = JSON.parse(
-  fs.readFileSync(groupDataFixturePath, "utf8")
+  fs.readFileSync(groupDataFixturePath, "utf-8")
 );
 
 /**

--- a/kumascript/tests/macros/apiref.test.js
+++ b/kumascript/tests/macros/apiref.test.js
@@ -22,21 +22,21 @@ const subpagesFixturePath = path.resolve(
   "fixtures/apiref/subpages.json"
 );
 const subpagesFixture = JSON.parse(
-  fs.readFileSync(subpagesFixturePath, "utf8")
+  fs.readFileSync(subpagesFixturePath, "utf-8")
 );
 const commonl10nFixturePath = path.resolve(
   dirname,
   "fixtures/apiref/commonl10n.json"
 );
 const commonl10nFixture = JSON.parse(
-  fs.readFileSync(commonl10nFixturePath, "utf8")
+  fs.readFileSync(commonl10nFixturePath, "utf-8")
 );
 const groupDataFixturePath = path.resolve(
   dirname,
   "fixtures/apiref/groupdata.json"
 );
 const groupDataFixture = JSON.parse(
-  fs.readFileSync(groupDataFixturePath, "utf8")
+  fs.readFileSync(groupDataFixturePath, "utf-8")
 );
 const interfaceDataNoEntriesFixturePath = path.resolve(
   dirname,
@@ -44,14 +44,14 @@ const interfaceDataNoEntriesFixturePath = path.resolve(
 );
 const interfaceDataNoEntriesFixture = fs.readFileSync(
   interfaceDataNoEntriesFixturePath,
-  "utf8"
+  "utf-8"
 );
 const interfaceDataFixturePath = path.resolve(
   dirname,
   "fixtures/apiref/interfacedata.json"
 );
 const interfaceDataFixture = JSON.parse(
-  fs.readFileSync(interfaceDataFixturePath, "utf8")
+  fs.readFileSync(interfaceDataFixturePath, "utf-8")
 );
 
 /**

--- a/kumascript/tests/macros/page-api.test.js
+++ b/kumascript/tests/macros/page-api.test.js
@@ -17,7 +17,7 @@ const dirname = __dirname;
 const fixtureData = JSON.parse(
   fs.readFileSync(
     path.resolve(dirname, "fixtures", "documentData1.json"),
-    "utf8"
+    "utf-8"
   )
 );
 const fix_url = "/en-US/docs/Web/HTTP/Basics_of_HTTP";

--- a/kumascript/tests/render.test.js
+++ b/kumascript/tests/render.test.js
@@ -21,7 +21,7 @@ describe("render() function", () => {
     return `${dirname}/fixtures/render/${name}`;
   }
   function get(name) {
-    return fs.readFileSync(fixture(name), "utf8");
+    return fs.readFileSync(fixture(name), "utf-8");
   }
   function renderPrerequisiteFromURL(url) {
     throw new Error(`unexpected prerequisite: ${url}`);

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -58,7 +58,7 @@ const clientBuildRoot = path.resolve(dirname, "../../client/build");
 const readBuildHTML = lazy(() => {
   const html = fs.readFileSync(
     path.join(clientBuildRoot, "index.html"),
-    "utf8"
+    "utf-8"
   );
   if (!html.includes('<div id="root"></div>')) {
     throw new Error(
@@ -91,7 +91,7 @@ const getGAScriptPathName = lazy((relPath = "/static/js/ga.js") => {
 const extractWebFontURLs = lazy(() => {
   const urls = [];
   const manifest = JSON.parse(
-    fs.readFileSync(path.join(clientBuildRoot, "asset-manifest.json"), "utf8")
+    fs.readFileSync(path.join(clientBuildRoot, "asset-manifest.json"), "utf-8")
   );
   for (const entrypoint of manifest.entrypoints) {
     if (!entrypoint.endsWith(".css")) continue;

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -947,7 +947,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
       });
 
       const inventory = allPaths.map((entry) => {
-        const fileContents = fs.readFileSync(entry.path, "utf8");
+        const fileContents = fs.readFileSync(entry.path, "utf-8");
         const parsed = frontmatter(fileContents);
 
         return {


### PR DESCRIPTION
## Summary

Extracted from #5017, calls `fs.{read,write}FileSync()` with 'utf-8', not 'utf8'.

### Problem

We call `fs.{read,write}FileSync()` inconsistently with `utf-8` and `utf8`.

**Note**: [Both values are supported](https://github.com/nodejs/node/blob/7ad5b420aebc1bcd07be187481cf48a4180a60c0/lib/buffer.js#L685-L692).

### Solution

Use `utf-8` consistently.

---

## Screenshots

_No visual change._

---

## How did you test this change?

_Not specifically tested, apart from running `yarn dev` successfully._