### PR TITLE
Upgrade to BCD v5.0.0

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/browser-info.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/browser-info.tsx
@@ -1,11 +1,11 @@
 import React, { useContext } from "react";
-import type bcd from "@mdn/browser-compat-data/types";
+import type BCD from "@mdn/browser-compat-data/types";
 
-export const BrowserInfoContext = React.createContext<bcd.Browsers | null>(
+export const BrowserInfoContext = React.createContext<BCD.Browsers | null>(
   null
 );
 
-export function BrowserName({ id }: { id: bcd.BrowserNames }) {
+export function BrowserName({ id }: { id: BCD.BrowserNames }) {
   const browserInfo = useContext(BrowserInfoContext);
   if (!browserInfo) {
     throw new Error("Missing browser info");

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import type bcd from "@mdn/browser-compat-data/types";
+import type BCD from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
@@ -19,7 +19,7 @@ import { LEGEND_LABELS } from "./legend";
 // Yari builder will attach extra keys from the compat data
 // it gets from @mdn/browser-compat-data. These are "Yari'esque"
 // extras that helps us avoiding to have a separate data structure.
-interface CompatStatementExtended extends bcd.CompatStatement {
+interface CompatStatementExtended extends BCD.CompatStatement {
   // When a compat statement has a .mdn_url but it's actually not a good
   // one, the Yari builder will attach an extra boolean that indicates
   // that it's not a valid link.
@@ -29,7 +29,7 @@ interface CompatStatementExtended extends bcd.CompatStatement {
 
 function getSupportClassName(
   support: SupportStatementExtended | undefined,
-  browser: bcd.BrowserStatement
+  browser: BCD.BrowserStatement
 ): "no" | "yes" | "partial" | "preview" | "removed-partial" | "unknown" {
   if (!support) {
     return "unknown";
@@ -67,7 +67,7 @@ function getSupportBrowserReleaseDate(
   return getCurrentSupport(support)!.release_date;
 }
 
-function StatusIcons({ status }: { status: bcd.StatusBlock }) {
+function StatusIcons({ status }: { status: BCD.StatusBlock }) {
   const icons = [
     status.experimental && {
       title: "Experimental. Expect behavior to change in the future.",
@@ -102,7 +102,7 @@ function StatusIcons({ status }: { status: bcd.StatusBlock }) {
 
 function labelFromString(
   version: string | boolean | null | undefined,
-  browser: bcd.BrowserStatement
+  browser: BCD.BrowserStatement
 ) {
   if (typeof version !== "string") {
     return <>{"?"}</>;
@@ -121,7 +121,7 @@ function labelFromString(
 function versionLabelFromSupport(
   added: string | boolean | null | undefined,
   removed: string | boolean | null | undefined,
-  browser: bcd.BrowserStatement
+  browser: BCD.BrowserStatement
 ) {
   if (typeof removed !== "string") {
     return <>{labelFromString(added, browser)}</>;
@@ -140,8 +140,8 @@ const CellText = React.memo(
     browser,
     timeline = false,
   }: {
-    support: bcd.SupportStatement | undefined;
-    browser: bcd.BrowserStatement;
+    support: BCD.SupportStatement | undefined;
+    browser: BCD.BrowserStatement;
     timeline?: boolean;
   }) => {
     const currentSupport = getCurrentSupport(support);
@@ -261,7 +261,7 @@ function Icon({ name }: { name: string }) {
   );
 }
 
-function CellIcons({ support }: { support: bcd.SupportStatement | undefined }) {
+function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
   const supportItem = getCurrentSupport(support);
   if (!supportItem) {
     return null;
@@ -285,8 +285,8 @@ function FlagsNote({
   supportItem,
   browser,
 }: {
-  supportItem: bcd.SimpleSupportStatement;
-  browser: bcd.BrowserStatement;
+  supportItem: BCD.SimpleSupportStatement;
+  browser: BCD.BrowserStatement;
 }) {
   const hasAddedVersion = typeof supportItem.version_added === "string";
   const hasRemovedVersion = typeof supportItem.version_removed === "string";
@@ -327,8 +327,8 @@ function FlagsNote({
 }
 
 function getNotes(
-  browser: bcd.BrowserStatement,
-  support: bcd.SupportStatement
+  browser: BCD.BrowserStatement,
+  support: BCD.SupportStatement
 ) {
   if (support) {
     return asList(support)
@@ -447,9 +447,9 @@ function CompatCell({
   onToggle,
   locale,
 }: {
-  browserId: bcd.BrowserNames;
-  browserInfo: bcd.BrowserStatement;
-  support: bcd.SupportStatement | undefined;
+  browserId: BCD.BrowserNames;
+  browserInfo: BCD.BrowserStatement;
+  support: BCD.SupportStatement | undefined;
   showNotes: boolean;
   onToggle: () => void;
   locale: string;
@@ -510,7 +510,7 @@ export const FeatureRow = React.memo(
       compat: CompatStatementExtended;
       depth: number;
     };
-    browsers: bcd.BrowserNames[];
+    browsers: BCD.BrowserNames[];
     activeCell: number | null;
     onToggleCell: ([row, column]: [number, number]) => void;
     locale: string;

--- a/client/src/document/ingredients/browser-compatibility-table/headers.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/headers.tsx
@@ -1,4 +1,4 @@
-import { browsers as browserData } from "@mdn/browser-compat-data";
+import bcd from "@mdn/browser-compat-data";
 import { BrowserName } from "./browser-info";
 
 function PlatformHeaders({ platforms, browsers }) {
@@ -9,7 +9,7 @@ function PlatformHeaders({ platforms, browsers }) {
         // Get the intersection of browsers in the `browsers` array and the
         // `PLATFORM_BROWSERS[platform]`.
         const browsersInPlatform = browsers.filter(
-          (browser) => browserData[browser].type === platform
+          (browser) => bcd.browsers[browser].type === platform
         );
         const browserCount = browsersInPlatform.length;
         return (

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -1,7 +1,7 @@
 import React, { useReducer } from "react";
 import { useLocation } from "react-router-dom";
-import { browsers as browserData } from "@mdn/browser-compat-data";
-import type bcd from "@mdn/browser-compat-data/types";
+import bcd from "@mdn/browser-compat-data";
+import type BCD from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import { BrowserCompatibilityErrorBoundary } from "./error-boundary";
 import { FeatureRow } from "./feature-row";
@@ -37,8 +37,8 @@ const ISSUE_METADATA_TEMPLATE = `
  */
 function gatherPlatformsAndBrowsers(
   category: string,
-  data: bcd.Identifier
-): [string[], bcd.BrowserNames[]] {
+  data: BCD.Identifier
+): [string[], BCD.BrowserNames[]] {
   const hasNodeJSData = data.__compat && "nodejs" in data.__compat.support;
   const hasDenoData = data.__compat && "deno" in data.__compat.support;
 
@@ -47,21 +47,21 @@ function gatherPlatformsAndBrowsers(
     platforms.push("server");
   }
 
-  let browsers: bcd.BrowserNames[] = [];
+  let browsers: BCD.BrowserNames[] = [];
 
   // Add browsers in platform order to align table cells
   for (const platform of platforms) {
     browsers.push(
-      ...(Object.keys(browserData).filter(
-        (browser) => browserData[browser].type === platform
-      ) as bcd.BrowserNames[])
+      ...(Object.keys(bcd.browsers).filter(
+        (browser) => bcd.browsers[browser].type === platform
+      ) as BCD.BrowserNames[])
     );
   }
 
   // Filter WebExtension browsers in corresponding tables.
   if (category === "webextensions") {
     browsers = browsers.filter(
-      (browser) => browserData[browser].accepts_webextensions
+      (browser) => bcd.browsers[browser].accepts_webextensions
     );
   }
 
@@ -82,7 +82,7 @@ function FeatureListAccordion({
   locale,
 }: {
   features: ReturnType<typeof listFeatures>;
-  browsers: bcd.BrowserNames[];
+  browsers: BCD.BrowserNames[];
   locale: string;
 }) {
   const [[activeRow, activeColumn], dispatchCellToggle] = useReducer<
@@ -120,8 +120,8 @@ export default function BrowserCompatibilityTable({
   locale,
 }: {
   query: string;
-  data: bcd.Identifier;
-  browsers: bcd.Browsers;
+  data: BCD.Identifier;
+  browsers: BCD.Browsers;
   locale: string;
 }) {
   const location = useLocation();

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import type bcd from "@mdn/browser-compat-data/types";
+import type BCD from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
@@ -27,9 +27,9 @@ export const LEGEND_LABELS = {
 type LEGEND_KEY = keyof typeof LEGEND_LABELS;
 
 function getActiveLegendItems(
-  compat: bcd.Identifier,
+  compat: BCD.Identifier,
   name: string,
-  browserInfo: bcd.Browsers
+  browserInfo: BCD.Browsers
 ) {
   const legendItems = new Set<LEGEND_KEY>();
 
@@ -101,7 +101,7 @@ export function Legend({
   compat,
   name,
 }: {
-  compat: bcd.Identifier;
+  compat: BCD.Identifier;
   name: string;
 }) {
   const browserInfo = useContext(BrowserInfoContext);

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -1,8 +1,8 @@
-import type bcd from "@mdn/browser-compat-data/types";
+import type BCD from "@mdn/browser-compat-data/types";
 
 // Extended for the fields, beyond the bcd types, that are extra-added
 // exclusively in Yari.
-interface SimpleSupportStatementExtended extends bcd.SimpleSupportStatement {
+interface SimpleSupportStatementExtended extends BCD.SimpleSupportStatement {
   // Known for some support statements where the browser *version* is known,
   // as opposed to just "true" and if the version release date is known.
   release_date?: string;
@@ -27,12 +27,12 @@ export function isTruthy<T>(t: T | false | undefined | null): t is T {
 
 interface Feature {
   name: string;
-  compat: bcd.CompatStatement;
+  compat: BCD.CompatStatement;
   depth: number;
 }
 
 export function listFeatures(
-  identifier: bcd.Identifier,
+  identifier: BCD.Identifier,
   parentName: string = "",
   rootName: string = "",
   depth: number = 0
@@ -60,8 +60,8 @@ export function listFeatures(
 }
 
 export function versionIsPreview(
-  version: bcd.VersionValue | string | undefined,
-  browser: bcd.BrowserStatement
+  version: BCD.VersionValue | string | undefined,
+  browser: BCD.BrowserStatement
 ): boolean {
   if (version === "preview") {
     return true;
@@ -76,7 +76,7 @@ export function versionIsPreview(
   return false;
 }
 
-export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
+export function hasNoteworthyNotes(support: BCD.SimpleSupportStatement) {
   return (
     support.notes?.length &&
     !support.version_removed &&
@@ -84,11 +84,11 @@ export function hasNoteworthyNotes(support: bcd.SimpleSupportStatement) {
   );
 }
 
-function hasLimitation(support: bcd.SimpleSupportStatement) {
+function hasLimitation(support: BCD.SimpleSupportStatement) {
   return hasMajorLimitation(support) || support.notes;
 }
 
-function hasMajorLimitation(support: bcd.SimpleSupportStatement) {
+function hasMajorLimitation(support: BCD.SimpleSupportStatement) {
   return (
     support.partial_implementation ||
     support.alternative_name ||
@@ -99,7 +99,7 @@ function hasMajorLimitation(support: bcd.SimpleSupportStatement) {
 }
 
 export function isOnlySupportedWithAltName(
-  support: bcd.SupportStatement | undefined
+  support: BCD.SupportStatement | undefined
 ) {
   return (
     support &&
@@ -109,7 +109,7 @@ export function isOnlySupportedWithAltName(
 }
 
 export function isOnlySupportedWithPrefix(
-  support: bcd.SupportStatement | undefined
+  support: BCD.SupportStatement | undefined
 ) {
   return (
     support &&
@@ -119,7 +119,7 @@ export function isOnlySupportedWithPrefix(
 }
 
 export function isOnlySupportedWithFlags(
-  support: bcd.SupportStatement | undefined
+  support: BCD.SupportStatement | undefined
 ) {
   return (
     support &&
@@ -129,17 +129,17 @@ export function isOnlySupportedWithFlags(
 }
 
 export function isFullySupportedWithoutLimitation(
-  support: bcd.SimpleSupportStatement
+  support: BCD.SimpleSupportStatement
 ) {
   return support.version_added && !hasLimitation(support);
 }
 
-export function isNotSupportedAtAll(support: bcd.SimpleSupportStatement) {
+export function isNotSupportedAtAll(support: BCD.SimpleSupportStatement) {
   return !support.version_added && !hasLimitation(support);
 }
 
 function isFullySupportedWithoutMajorLimitation(
-  support: bcd.SimpleSupportStatement
+  support: BCD.SimpleSupportStatement
 ) {
   return support.version_added && !hasMajorLimitation(support);
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@caporal/core": "^2.0.2",
     "@fast-csv/parse": "^4.3.6",
-    "@mdn/browser-compat-data": "^4.2.1",
+    "@mdn/browser-compat-data": "^5.0.0",
     "@use-it/interval": "^1.0.0",
     "accept-language-parser": "^1.5.0",
     "browser-specs": "^3.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,10 +1542,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@mdn/browser-compat-data@^4.2.1":
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz#1fead437f3957ceebe2e8c3f46beccdb9bc575b8"
-  integrity sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==
+"@mdn/browser-compat-data@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.0.0.tgz#956c13fe360a9bd67f367d0ff7f5ba6256de2393"
+  integrity sha512-/3O7c2B8FWgyvnNVz5J/jKBNGHMJaII+DRdi+CJg21dHNq6WS0AbiwX1+Z/XcAvMmbDTX6XhH5tmUrjfTSDo5g==
 
 "@mdn/dinocons@^0.5.5":
   version "0.5.5"


### PR DESCRIPTION
This PR upgrades BCD to v5.0.0 and updates imports to account for some differences made in v5.0.0.  Typedefs now use a capital namespace to differentiate the data vs. the typedefs.
