### PR TITLE
fix(contributor-spotlight): link to en-US

### DIFF
--- a/build/spas.js
+++ b/build/spas.js
@@ -34,7 +34,7 @@ let featuredContributor;
 async function buildContributorSpotlight(options) {
   // for now, these will only be available in English
   const locale = "en-US";
-  const prefix = "community/spotlight";
+  const prefix = `/${locale}/community/spotlight`;
   const profileImg = "profile-image.jpg";
 
   for (const contributor of fs.readdirSync(contributorSpotlightRoot)) {


### PR DESCRIPTION
## Summary

Makes sure that the Contributor Spotlight link uses the `en-US` locale.

### Problem

When opening the homepage with a locale other than `en-US`, clicking the Contributor Spotlight link leads to an empty page, because these pages aren't built in other locales.

Example:

- https://developer.mozilla.org/fr/ links to https://developer.mozilla.org/fr/community/spotlight/vinyl-da-i-gyu-kazotetsu

### Solution

Always use `en-US` in the link.

---

## Screenshots

_No visual change._

---

## How did you test this change?

1. Ran `yarn tool spas` and `yarn start`
2. Opened http://localhost:3000/fr/_homepage and clicked on the Contributor Spotlight link.