### PR TITLE
fix(app): fix 404 page yields another 404

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -83,11 +83,17 @@ function PageOrPageNotFound({ pageNotFound, children }) {
   const [notFound, setNotFound] = React.useState<boolean>(!!pageNotFound);
   const { pathname } = useLocation();
   const initialPathname = React.useRef(pathname);
+  const isServer = useIsServer();
+
   React.useEffect(() => {
+    if (!isServer) {
+      setNotFound(false);
+    }
+
     if (initialPathname.current && initialPathname.current !== pathname) {
       setNotFound(false);
     }
-  }, [pathname]);
+  }, [isServer, pathname]);
 
   return notFound ? (
     <StandardLayout>

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -78,22 +78,16 @@ function DocumentLayout({ children }) {
  * originally not found. Perhaps, this new location that the client is
  * requesting is going to work.
  */
-function PageOrPageNotFound({ pageNotFound, children }) {
+function PageOrPageNotFound({ pageNotFound, initialPathname, children }) {
   // It's true by default if the SSR rendering says so.
   const [notFound, setNotFound] = React.useState<boolean>(!!pageNotFound);
   const { pathname } = useLocation();
-  const initialPathname = React.useRef(pathname);
-  const isServer = useIsServer();
 
   React.useEffect(() => {
-    if (!isServer) {
-      setNotFound(false);
-    }
-
     if (initialPathname.current && initialPathname.current !== pathname) {
       setNotFound(false);
     }
-  }, [isServer, pathname]);
+  }, [initialPathname, pathname]);
 
   return notFound ? (
     <StandardLayout>
@@ -118,6 +112,8 @@ function LoadingFallback({ message }: { message?: string }) {
 
 export function App(appProps) {
   const localeMatch = useMatch("/:locale/*");
+  const { pathname } = useLocation();
+  const initialPathname = React.useRef(pathname);
 
   useEffect(() => {
     const locale = localeMatch?.params.locale || appProps.locale;
@@ -136,7 +132,10 @@ export function App(appProps) {
         <WritersHomepage />
       </Layout>
     ) : (
-      <PageOrPageNotFound pageNotFound={appProps.pageNotFound}>
+      <PageOrPageNotFound
+        pageNotFound={appProps.pageNotFound}
+        initialPathname={initialPathname}
+      >
         <Layout pageType="standard-page">
           <Homepage {...appProps} />
         </Layout>
@@ -249,7 +248,10 @@ export function App(appProps) {
             <Route
               path="/docs/*"
               element={
-                <PageOrPageNotFound pageNotFound={appProps.pageNotFound}>
+                <PageOrPageNotFound
+                  pageNotFound={appProps.pageNotFound}
+                  initialPathname={initialPathname}
+                >
                   <DocumentLayout>
                     <Document {...appProps} />
                   </DocumentLayout>


### PR DESCRIPTION
## Summary

Fixes #4615

### Problem

Clicking search suggestion on 404 page yields another 404 because of `useEffect` condition. Currently, `PageOrPageNotFound` component looking for `initialPathname.current && initialPathname.current !== pathname` to be true before `setNotFound(false)` but `initialPathName` and `pathname` always the same. It isn't triggering because of that.

### Solution

- Trigger setNotFound() after client renders the page.

## How did you test this change?

On my local environment. Steps:
1. Go somewhere which throws 404 like: `http://localhost:5042/en-US/Games/Tutorials/2D_Breakout_game_pure_JavaScript`
2. Search something from search bar and click one of the results.
2.1. Old behaviour was yields you to another 404.
2.1. New behaviour is showing correct page.