### PR TITLE
fix(ssr): use same @svgr options as client

### DIFF
--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -46,8 +46,13 @@ module.exports = {
           {
             loader: "@svgr/webpack",
             options: {
-              svgo: true,
+              prettier: false,
+              svgo: false,
+              svgoConfig: {
+                plugins: [{ removeViewBox: false }],
+              },
               titleProp: true,
+              ref: true,
             },
           },
         ],


### PR DESCRIPTION
## Summary

Aligns the `ssr` webpack config with the `client` webpack config regarding `@svgr/webpack`.

### Problem

`ssr` and `client` transform SVGs differently, and this has caused some hydration errors, see: https://github.com/mdn/yari/pull/6403

### Solution

Since most users are effectively seeing the `client` version, use that webpack config for `ssr` as well.

---

## Screenshots

_Should not cause any visual change, except for SSR SVGs no longer being optimized with svgo._

---

## How did you test this change?

Ran `yarn build:ssr`, but will also run a dev build to verify.
