### PR TITLE
chore(aws-lambda): log parsed redirect files

### DIFF
--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -22,6 +22,7 @@ function buildRedirectsMap() {
     }
 
     const base = process.env[envvar];
+    console.log(`${envvar} = ${base}`);
 
     VALID_LOCALES.forEach((locale) => {
       const path = [
@@ -43,6 +44,7 @@ function buildRedirectsMap() {
           const [source, target] = redirectLine.split("\t", 2);
           redirectMap.set(source.toLowerCase(), target);
         }
+        console.log(`- ${path}: ${redirectLines.length} redirects`);
       }
     });
   });


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Makes it easier to debug what redirects are considered in the `content-origin-request` lambda.

### Problem

For some reason, the `redirects.json` is incomplete (so the lambda doesn't handle mdn/content redirects), and I don't know why.

### Solution

Add `console.log()` calls to the build of the `content-origin-request` lambda.

---

## Screenshots

<img width="669" alt="image" src="https://user-images.githubusercontent.com/495429/171513483-6c8a3130-49b0-4459-a42d-3a718bc988b7.png">

---

## How did you test this change?

- Ran `yarn build` in `deployer/aws-lambda/content-origin-request`.
