### PR TITLE
build(deps-dev): add @types/node 16.11.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@types/hast": "^2.3.4",
     "@types/jest": "^27.5.1",
     "@types/mdast": "^3.0.10",
+    "@types/node": "^16.11.38",
     "@types/react": "^18.0.10",
     "@types/react-dom": "^18.0.3",
     "@types/react-modal": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2138,6 +2138,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
   integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
 
+"@types/node@^16.11.38":
+  version "16.11.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.38.tgz#be0edd097b23eace6c471c525a74b3f98803017f"
+  integrity sha512-hjO/0K140An3GWDw2HJfq7gko3wWeznbjXgg+rzPdVzhe198hp4x2i1dgveAOEiFKd8sOilAxzoSJiVv5P/CUg==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"


### PR DESCRIPTION
## Summary

Adds `@types/node` to resolve the following warning:

> ts-node@10.8.0" has unmet peer dependency "@types/node@*".

---

## How did you test this change?

Ran `yarn` and the warning no longer appeared.
