### PR TITLE
refactor(banners): introduce BannerId enum + currentBannerId

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -23,7 +23,7 @@ import { Contribute } from "./community";
 import { ContributorSpotlight } from "./contributor-spotlight";
 import { useIsServer } from "./hooks";
 
-import { Banner, hasActiveBanners } from "./banners";
+import { Banner } from "./banners";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
@@ -45,7 +45,7 @@ function Layout({ pageType, children }) {
   return (
     <>
       <A11yNav />
-      {!isServer && hasActiveBanners && <Banner />}
+      {!isServer && <Banner />}
       <div className={`page-wrapper  ${category || ""} ${pageType}`}>
         {pageType !== "document-page" && <TopNavigation />}
         {children}

--- a/client/src/banners/README.md
+++ b/client/src/banners/README.md
@@ -1,44 +1,31 @@
 # Using banners
 
-Your first step is to define an `id` for the banner or reuse one of the previous
-banners' (if appropriate) `ids` in `client/src/banners/ids.ts`. For example:
+Your first step is to define an `id` for the banner in the `BannerId` enum in
+`client/src/banners/ids.ts`, or use an existing one. For example:
 
 ```js
-export const REDESIGN_ANNOUNCEMENT = "redesign_announcement";
+export enum BannerId {
+  // ...
+  REDESIGN_ANNOUNCEMENT = "redesign_announcement",
+};
 ```
 
-Next go into `client/src/banners/index.tsx` and import your banner id:
+Next go into `client/src/banners/index.tsx` and update `currentBannerId`:
 
 ```js
-import { REDESIGN_ANNOUNCEMENT } from "./ids";
+const currentBannerId: BannerId | null = BannerId.REDESIGN_ANNOUNCEMENT;
 ```
 
-> NOTE: If there are currently no banners running, ensure that you set
-> `hasActiveBanners` to `true`.
-
-In the `Banner` function update the following code as appropriate:
+To adjust the the number of days to embargo the banner, update `daysToEmbargo`:
 
 ```js
-if (CRUD_MODE || !isEmbargoed(REDESIGN_ANNOUNCEMENT)) {
-  return (
-    <React.Suspense fallback={null}>
-      <ActiveBanner
-        id={REDESIGN_ANNOUNCEMENT}
-        onDismissed={() => {
-          setEmbargoed(REDESIGN_ANNOUNCEMENT, 7);
-        }}
-      />
-    </React.Suspense>
-  );
-}
+const daysToEmbargo = 14;
 ```
 
-> NOTE: The seconds parameter to the `setEmbargoed` function is the number of
-> days to embargo the banner. A banner will always show if you have
-> `REACT_APP_CRUD_MODE` set to `true` in `.env` or the banner is not embargoed.
+> NOTE: Banners are not embargoed, if `REACT_APP_CRUD_MODE` is set to `true`.
 
-Now head over to `client/src/banners/active-banner.tsx` and update the following
-function as appropriate:
+Now head over to `client/src/banners/active-banner.tsx` and add or update the
+the component function for the banner as appropriate:
 
 ```js
 function RedesignAnnouncementBanner({
@@ -65,23 +52,27 @@ function RedesignAnnouncementBanner({
 }
 ```
 
-Lastly update the `ActiveBanner` function to list your banner:
+Lastly update the `ActiveBanner` function to include your banner:
 
 ```js
 export default function ActiveBanner({
   id,
   onDismissed,
 }: {
-  id: string,
+  id: BannerId,
   onDismissed: () => void,
 }) {
-  if (id === REDESIGN_ANNOUNCEMENT) {
-    return <RedesignAnnouncementBanner onDismissed={onDismissed} />;
+  switch (id) {
+    // ...
+
+    case BannerId.REDESIGN_ANNOUNCEMENT:
+      return <RedesignAnnouncementBanner onDismissed={onDismissed} />;
+
+    // ...
   }
-  throw new Error(`Unrecognized banner to display (${id})`);
 }
 ```
 
 ## What to do when disabling all banners?
 
-Go to `client/src/banners/index.tsx` and set `hasActiveBanners` to `false`.
+Go to `client/src/banners/index.tsx` and set `currentBannerId` to `null`.

--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
 import { useGA } from "../ga-context";
 import { useUserData } from "../user-context";
-import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
+import { BannerId } from "./ids";
 import { isPlusAvailable } from "../utils";
 import { usePlusUrl } from "../plus/utils";
 import { ENABLE_PLUS_EU } from "../env";
@@ -83,11 +83,12 @@ function PlusLaunchAnnouncementBanner({
 }: {
   onDismissed: () => void;
 }) {
+  const bannerId = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
   const sendCTAEventToGA = useSendCTAEventToGA();
   const plusUrl = usePlusUrl();
 
   return (
-    <Banner id={PLUS_LAUNCH_ANNOUNCEMENT} onDismissed={onDismissed}>
+    <Banner id={bannerId} onDismissed={onDismissed}>
       {(ENABLE_PLUS_EU && (
         <p className="mdn-cta-copy">
           <a href={plusUrl} className="mdn-plus">
@@ -99,7 +100,7 @@ function PlusLaunchAnnouncementBanner({
             href="https://hacks.mozilla.org/2022/04/mdn-plus-now-available-in-more-markets"
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => sendCTAEventToGA(PLUS_LAUNCH_ANNOUNCEMENT)}
+            onClick={() => sendCTAEventToGA(bannerId)}
           >
             Learn more
           </a>{" "}
@@ -115,7 +116,7 @@ function PlusLaunchAnnouncementBanner({
             href="https://hacks.mozilla.org/2022/03/introducing-mdn-plus-make-mdn-your-own"
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => sendCTAEventToGA(PLUS_LAUNCH_ANNOUNCEMENT)}
+            onClick={() => sendCTAEventToGA(bannerId)}
           >
             Learn more
           </a>{" "}
@@ -134,19 +135,22 @@ export default function ActiveBanner({
   id,
   onDismissed,
 }: {
-  id: string;
+  id: BannerId;
   onDismissed: () => void;
 }) {
   const userData = useUserData();
 
-  if (id === PLUS_LAUNCH_ANNOUNCEMENT) {
-    return (
-      <>
-        {isPlusAvailable(userData) && (
-          <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
-        )}
-      </>
-    );
+  switch (id) {
+    case BannerId.PLUS_LAUNCH_ANNOUNCEMENT:
+      return (
+        <>
+          {isPlusAvailable(userData) && (
+            <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
+          )}
+        </>
+      );
+
+    default:
+      throw new Error(`Unrecognized banner to display (${id})`);
   }
-  throw new Error(`Unrecognized banner to display (${id})`);
 }

--- a/client/src/banners/banner-utils.ts
+++ b/client/src/banners/banner-utils.ts
@@ -1,7 +1,10 @@
 // Set a localStorage key with a timestamp the specified number of
 // days into the future. When the user dismisses a banner we use this
+
+import { BannerId } from "./ids";
+
 // to prevent the redisplay of the banner for a while.
-export function setEmbargoed(id: string, days: number) {
+export function setEmbargoed(id: BannerId, days: number) {
   try {
     const key = `banner.${id}.embargoed_until`;
     localStorage.setItem(
@@ -16,7 +19,7 @@ export function setEmbargoed(id: string, days: number) {
 // See whether the specified id was passed to setEmbargoed() fewer than the
 // specified number of days ago. We check this before displaying a banner
 // so a user does not see a banner they recently dismissed.
-export function isEmbargoed(id: string) {
+export function isEmbargoed(id: BannerId) {
   try {
     const key = `banner.${id}.embargoed_until`;
     const value = localStorage.getItem(key);

--- a/client/src/banners/ids.ts
+++ b/client/src/banners/ids.ts
@@ -1,6 +1,8 @@
 // The idea is that we'll add more like this and we might want to
 // leverage older keys to see if they got enrolled in previous versions.
-export const PLUS_IDv1 = "plus_banner_v1";
-export const PLUS_IDv2 = "plus_banner_v2";
-export const REDESIGN_ANNOUNCEMENT = "redesign_announcement";
-export const PLUS_LAUNCH_ANNOUNCEMENT = "plus_launch_announcement";
+export enum BannerId {
+  PLUS_IDv1 = "plus_banner_v1",
+  PLUS_IDv2 = "plus_banner_v2",
+  REDESIGN_ANNOUNCEMENT = "redesign_announcement",
+  PLUS_LAUNCH_ANNOUNCEMENT = "plus_launch_announcement",
+}

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -17,8 +17,6 @@ const ActiveBanner = React.lazy(() => import("./active-banner"));
 const currentBannerId: BannerId | null = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
 const daysToEmbargo = 7;
 
-export const hasActiveBanners = currentBannerId !== null;
-
 export function Banner() {
   if (currentBannerId && (CRUD_MODE || !isEmbargoed(currentBannerId))) {
     return (

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -14,7 +14,7 @@ import { BannerId } from "./ids";
 
 const ActiveBanner = React.lazy(() => import("./active-banner"));
 
-const currentBannerId: BannerId | null = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
+const currentBannerId: BannerId | null = null;
 const daysToEmbargo = 7;
 
 export const hasActiveBanners = currentBannerId !== null;

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -10,20 +10,23 @@ import { CRUD_MODE } from "../env";
 // <ActiveBanner>, at least the CSS will be ready.
 import "./banner.scss";
 
-import { PLUS_LAUNCH_ANNOUNCEMENT } from "./ids";
+import { BannerId } from "./ids";
 
 const ActiveBanner = React.lazy(() => import("./active-banner"));
 
-export const hasActiveBanners = true;
+const currentBannerId: BannerId | null = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
+const daysToEmbargo = 7;
+
+export const hasActiveBanners = currentBannerId !== null;
 
 export function Banner() {
-  if (CRUD_MODE || !isEmbargoed(PLUS_LAUNCH_ANNOUNCEMENT)) {
+  if (currentBannerId && (CRUD_MODE || !isEmbargoed(currentBannerId))) {
     return (
       <React.Suspense fallback={null}>
         <ActiveBanner
-          id={PLUS_LAUNCH_ANNOUNCEMENT}
+          id={currentBannerId}
           onDismissed={() => {
-            setEmbargoed(PLUS_LAUNCH_ANNOUNCEMENT, 7);
+            setEmbargoed(currentBannerId, daysToEmbargo);
           }}
         />
       </React.Suspense>

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -14,7 +14,7 @@ import { BannerId } from "./ids";
 
 const ActiveBanner = React.lazy(() => import("./active-banner"));
 
-const currentBannerId: BannerId | null = null;
+const currentBannerId: BannerId | null = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
 const daysToEmbargo = 7;
 
 export const hasActiveBanners = currentBannerId !== null;


### PR DESCRIPTION
## Summary

~~Disables the MDN Plus announcement banner, as discussed with @HerminaC on 2022-05-22.~~

Refactors the banners as follows:

1. Introduces a `BannerId` enum which has all the banner ids, instead of working with unrelated constants.
2. Replaces `hasActiveBanners` by `currentBannerId` variable (and remove its reference from `app.tsx`, which shouldn't care), to avoid repeating the current id all over the place.
3. Extracts `daysToEmbargo` variable.