### PR TITLE
fix(breadcrumbs): disable flex-shrink of chevron icon

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -25,12 +25,12 @@
         background-color: var(--icon-secondary);
         content: "";
         display: block;
+        flex-shrink: 0;
         height: 12px;
         mask-image: url("../../../assets/icons/chevron.svg");
         mask-size: 12px;
         transform: rotate(-90deg);
         width: 12px;
-        flex-shrink: 0;
       }
     }
 

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -30,6 +30,7 @@
         mask-size: 12px;
         transform: rotate(-90deg);
         width: 12px;
+        flex-shrink: 0;
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes #6452

### Problem
Chevron icon's width value should not change according to his parents' width.

### Solution
Adding `flex-shrink: 0` should protect its' width value.

---

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/11398393/171645683-8fe2029f-e777-493b-b2f9-8f8525fd488b.png)

### After
![image](https://user-images.githubusercontent.com/11398393/171645557-b5b71aae-c590-4ea3-8327-93398d352165.png)


---

## How did you test this change?
1. Run on your local environment
2. Go to page which has more than 2 breadcrumb item. [Click here](http://localhost:5042/en-US/docs/Glossary/Hoisting) to shortcut.
3. Display page in responsive view
