### PR TITLE
chore(stylelint): add stylelint-order plugin

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,8 @@
     "stylelint-config-recommended",
     "stylelint-config-sass-guidelines",
     "stylelint-a11y/recommended",
-    "stylelint-prettier/recommended"
+    "stylelint-prettier/recommended",
+    "stylelint-order"
   ],
   "plugins": ["stylelint-scss"],
   "rules": {
@@ -20,6 +21,7 @@
       {
         "ignore": ["class"]
       }
-    ]
+    ],
+    "order/properties-alphabetical-order": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-recommended": "^5.0.0",
     "stylelint-config-sass-guidelines": "^8.0.0",
+    "stylelint-order": "^5.0.0",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^3.21.0",
     "swr": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9947,6 +9947,11 @@ postcss-sorting@^5.0.1:
     lodash "^4.17.14"
     postcss "^7.0.17"
 
+postcss-sorting@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-sorting/-/postcss-sorting-7.0.1.tgz#923b5268451cf2d93ebf8835e17a6537757049a5"
+  integrity sha512-iLBFYz6VRYyLJEJsBJ8M3TCqNcckVzz4wFounSc5Oez35ogE/X+aoC5fFu103Ot7NyvjU3/xqIXn93Gp3kJk4g==
+
 postcss-svgo@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-5.1.0.tgz#0a317400ced789f233a28826e77523f15857d80d"
@@ -9980,7 +9985,7 @@ postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.2.14, postcss@^8.4.12, postcss@^8.4.13, postcss@^8.4.4, postcss@^8.4.7:
+postcss@^8.2.14, postcss@^8.3.11, postcss@^8.4.12, postcss@^8.4.13, postcss@^8.4.4, postcss@^8.4.7:
   version "8.4.14"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.14.tgz#ee9274d5622b4858c1007a74d76e42e56fd21caf"
   integrity sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==
@@ -11655,6 +11660,14 @@ stylelint-order@^4.0.0:
     lodash "^4.17.15"
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
+
+stylelint-order@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-order/-/stylelint-order-5.0.0.tgz#abd20f6b85ac640774cbe40e70d3fe9c6fdf4400"
+  integrity sha512-OWQ7pmicXufDw5BlRqzdz3fkGKJPgLyDwD1rFY3AIEfIH/LQY38Vu/85v8/up0I+VPiuGRwbc2Hg3zLAsJaiyw==
+  dependencies:
+    postcss "^8.3.11"
+    postcss-sorting "^7.0.1"
 
 stylelint-prettier@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## Summary
Adds "stylelint-order" configuration to warn people before committing errors.

### Problem
Currently, there is no "alphabetically order" config in stylelint. This causing wrongly ordered css properties.

### Solution
Adding `stylelint-order` plugin and making `order/properties-alphabetical-order: true` will resolve this issue. `order/properties-alphabetical-order` is auto-fixable problem; so it won't be cause any problem when stylelint activate properly.

---
## Screenshots
### After

![image](https://user-images.githubusercontent.com/11398393/171674510-e92d59b1-594c-45be-879c-5816770de988.png)
---

## How did you test this change?
There is two way to test this change.

#### CLI method
- Run `yarn stylelint "**/*.scss"` from root folder.

#### Editor method
##### Visual Studio Code
1. Add official stylelint extension to your editor via [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) or extensions tab.
2. Open your `settings.json` file by pressing `F1` and `Open Settings (JSON)`
3. Add `"stylelint.validate": ["css", "less", "postcss", "scss"]` to configuration.

## Caveats
- Visual Studio Code might throw an error like `stylelint v13.x.x isn't supported` but skip that.
- Official stylelint plugin doesn't support `scss` by default. You have to open that feature.
- It might takes time to fix non-autofixable problems.
- We should add stylelint to `lintstaged` or `husky` config in the future.