### PR TITLE
build: transpile /tool in-place before npm publish + declare binaries `yari-{build,filecheck,server,tool}`

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,7 +57,6 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: |
           yarn build:prepare
-          yarn build:dist
 
       - name: Dry-run publish to see which files are included
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -57,6 +57,7 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: |
           yarn build:prepare
+          yarn build:dist
 
       - name: Dry-run publish to see which files are included
         run: |

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -56,6 +56,7 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: |
           yarn build:prepare
+          yarn build:dist
 
       - name: Build and install tarball
         run: |

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -68,6 +68,10 @@ jobs:
           cd mdn/content
           yarn add file:$TARBALL
 
+      - name: (mdn/content) yarn yari-build --help
+        working-directory: mdn/content
+        run: yarn yari-build --help
+
       - name: (mdn/content) yarn yari-filecheck --help
         working-directory: mdn/content
         run: yarn yari-filecheck --help

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Start Yari from mock content repo
         working-directory: mdn/content
         run: |
+          yarn @mdn/yari
           yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
       - name: View some URLs on localhost:5042

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -56,7 +56,6 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: |
           yarn build:prepare
-          yarn build:dist
 
       - name: Build and install tarball
         run: |

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -69,12 +69,17 @@ jobs:
           cd mdn/content
           yarn add file:$TARBALL
 
-      - name: Start Yari from mock content repo
+      - name: (mdn/content) yarn yari-filecheck --help
         working-directory: mdn/content
-        run: |
-          yarn yari-filecheck --help
-          yarn yari-tool --help
-          yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
+        run: yarn yari-filecheck --help
+
+      - name: (mdn/content) yarn yari-tool
+        working-directory: mdn/content
+        run: yarn yari-tool --help
+
+      - name: (mdn/content) yarn start
+        working-directory: mdn/content
+        run: yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
       - name: View some URLs on localhost:5042
         run: |

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Start Yari from mock content repo
         working-directory: mdn/content
         run: |
-          yarn @mdn/yari
+          npx @mdn/yari
           yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
       - name: View some URLs on localhost:5042

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -72,7 +72,8 @@ jobs:
       - name: Start Yari from mock content repo
         working-directory: mdn/content
         run: |
-          npx @mdn/yari
+          yarn yari-filecheck --help
+          yarn yari-tool --help
           yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
 
       - name: View some URLs on localhost:5042

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ yarn-error.log*
 /kumascript/coverage/
 /kumascript/node_modules/
 /testing/node_modules/
-/client/build/
+/client/build
+/dist
 /ssr/dist/
 
 # These are an effect of the dumper still producing all locales

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,11 @@ yarn-error.log*
 /kumascript/node_modules/
 /testing/node_modules/
 /client/build
-/dist
+/client/src/**/*.js
+/client/src/**/*.js.map
 /ssr/dist/
+/tool/*.js
+/tool/*.js.map
 
 # These are an effect of the dumper still producing all locales
 # We haven't decided what to do with them but for now we're *not*

--- a/build/cli.js
+++ b/build/cli.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "MDN Web Docs",
   "bin": {
     "yari-filecheck": "filecheck/cli.js",
-    "yari-tool": "dist/tool/cli.js"
+    "yari-tool": "tool/cli.js"
   },
   "scripts": {
     "analyze": "source-map-explorer 'client/build/static/js/*.js'",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/mdn/yari",
   "license": "MPL-2.0",
   "author": "MDN Web Docs",
+  "bin": "dist/tool/cli.js",
   "scripts": {
     "analyze": "source-map-explorer 'client/build/static/js/*.js'",
     "analyze:css": "source-map-explorer 'client/build/static/css/*.css'",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint": "eslint .",
     "filecheck": "cd filecheck && node cli.js",
     "md": "ts-node markdown/cli.ts",
+    "prepack": "yarn build:dist",
     "prepare": "husky install",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "repository": "https://github.com/mdn/yari",
   "license": "MPL-2.0",
   "author": "MDN Web Docs",
-  "bin": "dist/tool/cli.js",
+  "bin": {
+    "yari-filecheck": "filecheck/cli.js",
+    "yari-tool": "dist/tool/cli.js"
+  },
   "scripts": {
     "analyze": "source-map-explorer 'client/build/static/js/*.js'",
     "analyze:css": "source-map-explorer 'client/build/static/css/*.css'",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "analyze:css": "source-map-explorer 'client/build/static/css/*.css'",
     "build": "cross-env NODE_ENV=production node build/cli.js",
     "build:client": "cd client && cross-env INLINE_RUNTIME_CHUNK=false node scripts/build.js",
+    "build:dist": "tsc -p tsconfig.dist.json",
     "build:prepare": "yarn build:client && yarn build:ssr && yarn tool optimize-client-build && yarn tool google-analytics-code && yarn tool popularities && yarn tool spas && yarn tool gather-git-history && yarn tool build-robots-txt",
     "build:ssr": "cd ssr && webpack --mode=production",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MPL-2.0",
   "author": "MDN Web Docs",
   "bin": {
+    "yari-build": "build/cli.js",
     "yari-filecheck": "filecheck/cli.js",
+    "yari-server": "server/index.js",
     "yari-tool": "tool/cli.js"
   },
   "scripts": {

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
 

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Doc } from "../client/src/document/types";
 
 const fs = require("fs");

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Doc } from "../client/src/document/types";
+import type { Doc } from "../client/src/document/types";
 
 const fs = require("fs");
 const path = require("path");

--- a/tool/tsconfig.json
+++ b/tool/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "skipLibCheck": true,
+    "importsNotUsedAsValues": "remove",
     "moduleResolution": "node"
   },
   "include": ["."]

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "sourceMap": true
+  },
+  "include": ["tool"]
+}

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,7 +4,7 @@
     "outDir": "dist",
     "skipLibCheck": true,
     "target": "ESNext",
-    "module": "ESNext",
+    "module": "CommonJS",
     "sourceMap": true
   },
   "include": ["tool"]

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,10 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "outDir": "dist",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "module": "CommonJS",
     "sourceMap": true
   },
-  "include": ["tool"]
+  "include": ["build", "filecheck", "tool"]
 }

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "outDir": "dist",
     "skipLibCheck": true,
-    "target": "ESNext",
     "module": "CommonJS",
     "sourceMap": true
   },

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,13 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "allowJs": true,
-    "outDir": "dist",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "module": "CommonJS",
     "sourceMap": true
   },
-  "include": ["build", "filecheck", "tool"]
+  "include": ["tool"]
 }


### PR DESCRIPTION
## Summary

This PR:

1. Adds a `build:dist` script that uses `tsconfig.dist.json` to transpile TypeScript in `/tool` in place (i.e. putting `cli.js` next to `cli.ts`).
2. Declares binaries `yari-build`, `yari-filecheck`, `yari-server` and `yari-tool` in `package.json`.
3. Updates the integration test (npm-published-simulation) to also run these binaries in the context of mdn/content.

**Note** that 1. is a compromise. It's not the perfect solution, but the best backward-compatible approach in terms of complexity. Transpiling to `/dist` or `/tool/dist` (using TypeScript's `outDir` option) doesn't work out of the box and would require us to enable `allowJS` as well, but then we would essentially end up mirroring the whole repository in `/dist`.

### Problem

Converting `/tool/` to TypeScript broke the scripts in mdn/content.

### Solution

Automatically transpile TypeScript, and declare binaries `yari-filecheck` and `yari-tool`.

---

## How did you test this change?

Added a `yarn @mdn/yari` call to the npm publish simulation.