### PR TITLE
fix(404): handle going back to 404

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -108,10 +108,10 @@ export function App(appProps) {
   const initialPathname = React.useRef(pathname);
 
   React.useEffect(() => {
-    if (initialPathname.current !== pathname) {
-      setPageNotFound(false);
-    }
-  }, [pathname]);
+    setPageNotFound(
+      appProps.pageNotFound && initialPathname.current === pathname
+    );
+  }, [appProps.pageNotFound, pathname]);
 
   const isServer = useIsServer();
 


### PR DESCRIPTION
## Summary

Fixes #6161.

### Problem

https://github.com/mdn/yari/pull/6437 fixed an issue regarding navigating away from a SSR 404, by toggling a state in that case. However, the other direction was not fixed, i.e. going back to the page that the SSR 404 referred to.

### Solution

Consider `pageNotFound` again if the SSR page was a 404 and the new pathname is the same as the original pathname.

---

## How did you test this change?

1. Opened http://localhost:5042/en-US/docs/404 locally.
2. Typed in "Web" in the search.
3. Opened a found page via keyboard.
4. Go back via browser UI.
