### PR TITLE
chore(macros/Compat): support query array

### DIFF
--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -35,9 +35,10 @@ if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");
 }
 var depth = $1 || 1;
-var output = `<div class="bc-data" data-query="${query}" data-depth="${depth}">
+var queries = Array.isArray(query) ? query : [query];
+var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}">
   If you're able to see this, something went wrong on this page.
-</div>`;
+</div>`).join("\n");
 %>
 
 <%-output%>

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -41,4 +41,11 @@ describeMacro("Compat", function () {
     const result = await macro.call("api.feature");
     expect(lintHTML(result)).toBeFalsy();
   });
+
+  itMacro("Accepts an array", async (macro) => {
+    const result = await macro.call(["api.feature1", "api.feature2"]);
+    const dom = JSDOM.fragment(result);
+    assert.equal(dom.querySelectorAll("div.bc-data").length, 2);
+    expect(lintHTML(result)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
## Summary

MVP to support multiple Array values for the `browser-compat` frontmatter.

May supersede:

- https://github.com/mdn/yari/pull/5972
- https://github.com/mdn/yari/pull/6004
- https://github.com/mdn/yari/pull/6358

---

## Screenshots

<img width="892" alt="image" src="https://user-images.githubusercontent.com/495429/171874367-9089afbb-66c2-4ebc-be23-63f8da03a5c9.png">

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
