### PR TITLE
Make Specifications work as expected with multiple BCD queries

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -366,7 +366,7 @@ function _addSingleSpecialSection($) {
     }
     return _buildSpecialBCDSection();
   } else if (specialSectionType === "specifications") {
-    if (data === undefined && specURLsString === "") {
+    if (query === undefined && specURLsString === "") {
       return [
         {
           type: specialSectionType,
@@ -536,24 +536,29 @@ function _addSingleSpecialSection($) {
     // For a BCD feature, it can either be a string or an array of strings.
     let specURLs = [];
 
-    if (data) {
-      // If 'data' is non-null, that means we have data for a BCD feature
-      // that we can extract spec URLs from.
-      for (const [key, compat] of Object.entries(data)) {
-        if (key === "__compat" && compat.spec_url) {
-          if (Array.isArray(compat.spec_url)) {
-            specURLs = compat.spec_url;
-          } else {
-            specURLs.push(compat.spec_url);
+    for (const feature of query.split(",").map((id) => id.trim())) {
+      const { data } = packageBCD(feature);
+      console.log("got here; data");
+      console.log(data);
+      if (data) {
+        // If 'data' is non-null, that means we have data for a BCD feature
+        // that we can extract spec URLs from.
+        for (const [key, compat] of Object.entries(data)) {
+          if (key === "__compat" && compat.spec_url) {
+            if (Array.isArray(compat.spec_url)) {
+              specURLs.push(...compat.spec_url);
+            } else {
+              specURLs.push(compat.spec_url);
+            }
           }
         }
       }
-    }
 
-    if (specURLsString !== "") {
-      // If specURLsString is non-empty, then it has the string contents of
-      // the document’s 'spec-urls' frontmatter key: one or more URLs.
-      specURLs.push(...specURLsString.split(",").map((url) => url.trim()));
+      if (specURLsString !== "") {
+        // If specURLsString is non-empty, then it has the string contents
+        // of the document’s 'spec-urls' frontmatter key: one or more URLs.
+        specURLs.push(...specURLsString.split(",").map((url) => url.trim()));
+      }
     }
 
     // Use BCD specURLs to look up more specification data


### PR DESCRIPTION
Without this change, if there are multiple BCD features (array value in `browser-compat`), the Specifications section isn’t populated as expected.

There are two commits in this branch; the second commit addresses the case of some features — e.g., `css.properties.justify-content` — which have no compat data themselves but have subfeatures with compat data. In the case where we’re processing a browser-compat value which is an array, unless we explicitly check for the `__compat`-less-feature-with-subfeatures case, and handle it, we can end up with expected specifications being entirely missing from the rendered Specifications section.

The commits here are ports of https://github.com/mdn/yari/pull/6358/commits/4ddd22a and https://github.com/mdn/yari/pull/6358/commits/8829336.
