### PR TITLE
Add headings to BCD tables in multi-table output case

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -323,6 +323,7 @@ function _addSingleSpecialSection($) {
   }
 
   let dataQuery = null;
+  let hasMultipleQueries = false;
   let specURLsString = "";
   let specialSectionType = null;
   if ($.find("div.bc-data").length) {
@@ -330,6 +331,7 @@ function _addSingleSpecialSection($) {
     const elem = $.find("div.bc-data");
     // Macro adds "data-query", but some translated-content still uses "id".
     dataQuery = elem.attr("data-query") || elem.attr("id");
+    hasMultipleQueries = elem.attr("data-multiple") === "true";
   } else if ($.find("div.bc-specs").length) {
     specialSectionType = "specifications";
     dataQuery = $.find("div.bc-specs").attr("data-bcd-query");
@@ -443,6 +445,11 @@ function _addSingleSpecialSection($) {
       }
     }
 
+    if (hasMultipleQueries) {
+      title = query;
+      id = query;
+      isH3 = true;
+    }
     return [
       {
         type: "browser_compatibility",

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -36,7 +36,7 @@ if (!query) {
 }
 var depth = $1 || 1;
 var queries = Array.isArray(query) ? query : [query];
-var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}">
+var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}" data-multiple="${queries.length > 1}">
   If you're able to see this, something went wrong on this page.
 </div>`).join("\n");
 %>


### PR DESCRIPTION
See https://github.com/mdn/yari/pull/6464#pullrequestreview-995065446. When a `browser-compat` value contains multiple BCD queries (feature names), so that the output has multiple BCD tables, this change causes a heading to be shown before each table — in order to make clear exactly which feature the table shows compat data for.

For the patch in the PR branch as currently written, the contet of the heading is the full BCD query (feature name).

The main rationale for using the full BCD query rather than a portion of it or the BCD `description` field for the feature is that in some cases, the only way to disambiguate some BCD features from one another is by showing the BCD query.

Consider https://pr16267.content.dev.mdn.mozit.cloud/en-US/docs/Web/Security/Subresource_Integrity#browser_compatibility (https://github.com/mdn/content/pull/16267/files#diff-58e33a19ce64773c6540bf790766a75bc7624ac76633c75a0b7ce9dd6fdd36f5) for example. The output for that is two tables which both have only the single word `integrity` in their table header rows in BCD.


![image](https://user-images.githubusercontent.com/194984/172121521-7d60472b-58e0-490c-9682-e5f0edae1874.png)

And at https://github.com/mdn/browser-compat-data/blob/main/html/elements/script.json#L251 and https://github.com/mdn/browser-compat-data/blob/main/html/elements/link.json#L437 we can see that neither feature has a `description` field to distinguish it from the other.

So, unless we show the BCD query in the heading, there’s no way for readers to know which table is for which feature.

And while it may look a bit odd to have the raw BCD query string as heading, note that these headings will only be shown in a very small subset of the MDN articles — at most, in the 62 articles in https://github.com/mdn/content/pull/16267/files. But it’s likely we will end up deciding that even some of those should not actually have BCD tables to begin with.

So, given that we currently have 8620 articles with BCD tables, less than 1% of the articles need these heading and will have the headings shown.