### PR TITLE
fix(search): hide results unless focused

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -266,7 +266,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
         ? [nothingFoundItem]
         : [...resultItems, onlineSearch],
     inputValue,
-    isOpen: inputValue !== "",
+    isOpen: isFocused,
     defaultIsOpen: isFocused,
     defaultHighlightedIndex: 0,
     onSelectedItemChange: ({ type, selectedItem }) => {
@@ -461,6 +461,15 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
             e.preventDefault();
           }
         },
+        onFocus: () => {
+          onChangeIsFocused(true);
+        },
+        onBlur: (e) => {
+          if (!e.currentTarget.contains(e.relatedTarget)) {
+            // focus has moved outside of container
+            onChangeIsFocused(false);
+          }
+        },
       })}
     >
       <label
@@ -479,12 +488,6 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
             : "search-input-field",
           name: "q",
           onMouseOver: initializeSearchIndex,
-          onFocus: () => {
-            onChangeIsFocused(true);
-          },
-          onBlur: () => {
-            onChangeIsFocused(false);
-          },
           onKeyDown(event) {
             if (event.key === "Escape" && inputRef.current) {
               onChangeInputValue("");


### PR DESCRIPTION
Follow up to https://github.com/mdn/yari/pull/5988#issuecomment-1146144938

Quoting from the original:

> Summary
> Problem
> 
> Search results from the top navigation search are permanently visible if the search input is not empty. To hide the search results, the user has to manually reset the search input.
> 
> This also means that those search results were visible on the dedicated search page, because the search input is prefilled with the search query parameter.
> Solution
> 
> Show the search results only while the search input has focus, i.e. hide them as soon as the search input no longer has focus.