### PR TITLE
fix: remove padding from live sample frame

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -328,7 +328,6 @@ iframe {
     background: #fff;
     border: 1px solid var(--border-primary);
     border-radius: var(--elem-radius);
-    padding: 1rem;
     width: 100%;
   }
 }


### PR DESCRIPTION
Remove padding from live sample frame to address the problem highlighted in the following discussion:
https://github.com/orgs/mdn/discussions/127