### PR TITLE
fix: hydration error in Contribute component

### DIFF
--- a/client/src/community/index.tsx
+++ b/client/src/community/index.tsx
@@ -2,10 +2,10 @@ import { Quote } from "../ui/molecules/quote";
 import "./index.scss";
 
 const STATS = [
-  { number: "2005", legend: "year founded" },
-  { number: "45k", legend: "total contributors" },
-  { number: "200", legend: "commits per week" },
-  { number: ">95M", legend: "page views per month" },
+  { id: 1, number: "2005", legend: "year founded" },
+  { id: 2, number: "45k", legend: "total contributors" },
+  { id: 3, number: "200", legend: "commits per week" },
+  { id: 4, number: ">95M", legend: "page views per month" },
 ];
 
 export function Contribute() {
@@ -16,7 +16,7 @@ export function Contribute() {
           <h1>Community for a better Web</h1>
           <ul className="stats">
             {STATS.map((s) => (
-              <li>
+              <li key={s.id}>
                 <span className="number">{s.number}</span>
                 <span className="legend">{s.legend}</span>
               </li>
@@ -57,8 +57,7 @@ export function Contribute() {
         </p>
         <Quote
           name="Dan Appelquist"
-          title="Samsung Internet (charter member of the Product
-              Advisory Board)"
+          title="Samsung Internet (charter member of the Product Advisory Board)"
           extraClasses="pab dark"
         >
           MDN has a unique place right now as a vendor-neutral and authoritative


### PR DESCRIPTION
## Summary

Fixes hydration error in the Contribute component on community page.

### Problem

In file ./client/src/community/index.tsx, in `Quote` component, the title is split over two lines. The server sends the title as it is, i.e. with extra white spaces. But on client the white spaces are removed and the hydration complains about mismatch in title:
```
react-dom.production.min.js:118 Uncaught Error: Minified React error #425; visit https://reactjs.org/docs/error-decoder.html?invariant=425 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at Qr (react-dom.production.min.js:118:466)
    at yu (react-dom.production.min.js:205:127)
    at ys (react-dom.production.min.js:280:85)
    at bs (react-dom.production.min.js:279:450)
    at vs (react-dom.production.min.js:279:320)
    at ms (react-dom.production.min.js:279:180)
    at rs (react-dom.production.min.js:267:209)
    at _ (scheduler.production.min.js:13:203)
    at MessagePort.P (scheduler.production.min.js:14:128)
11react-dom.production.min.js:147 Uncaught Error: Minified React error #418; visit https://reactjs.org/docs/error-decoder.html?invariant=418 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at Mo (react-dom.production.min.js:147:278)
    at xl (react-dom.production.min.js:292:486)
    at bs (react-dom.production.min.js:279:389)
    at vs (react-dom.production.min.js:279:320)
    at ms (react-dom.production.min.js:279:180)
    at rs (react-dom.production.min.js:267:209)
    at _ (scheduler.production.min.js:13:203)
    at MessagePort.P (scheduler.production.min.js:14:128)
react-dom.production.min.js:292 Uncaught Error: Minified React error #423; visit https://reactjs.org/docs/error-decoder.html?invariant=423 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at xl (react-dom.production.min.js:292:155)
    at bs (react-dom.production.min.js:279:389)
    at vs (react-dom.production.min.js:279:320)
    at ms (react-dom.production.min.js:279:180)
    at as (react-dom.production.min.js:270:88)
    at rs (react-dom.production.min.js:267:429)
    at _ (scheduler.production.min.js:13:203)
    at MessagePort.P (scheduler.production.min.js:14:128)
```

### Solution

Simply make the title statement one line.

Note: also the list on the page gives warning about not having unique keys during development builds. So added ids to the data.

## How did you test this change?

Tested in a Chromium browser.