### PR TITLE
fix: interactive iframe post message error

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -97,6 +97,17 @@
 
   <body>
     <script>
+      document.body.addEventListener(
+        "load",
+        (e) => {
+          if (e.target.classList.contains("interactive")) {
+            e.target.setAttribute("data-readystate", "complete");
+          }
+        },
+        { capture: true }
+      );
+    </script>
+    <script>
       /**
        * If we modify this script, we must update the CSP hash as follows:
        * 1. Run `yarn build:client`

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -97,17 +97,6 @@
 
   <body>
     <script>
-      document.body.addEventListener(
-        "load",
-        (e) => {
-          if (e.target.classList.contains("interactive")) {
-            e.target.setAttribute("data-readystate", "complete");
-          }
-        },
-        { capture: true }
-      );
-    </script>
-    <script>
       /**
        * If we modify this script, we must update the CSP hash as follows:
        * 1. Run `yarn build:client`
@@ -119,6 +108,16 @@
        * 7. Remove the old "previous" hash and replace it with the old "current" hash.
        * 8. Replace the old "current" hash with the new hash (from step 5).
        */
+      document.body.addEventListener(
+        "load",
+        (e) => {
+          if (e.target.classList.contains("interactive")) {
+            e.target.setAttribute("data-readystate", "complete");
+          }
+        },
+        { capture: true }
+      );
+
       const c = { light: "#ffffff", dark: "#1b1b1b" };
       if (window && document.documentElement) {
         const o = window.localStorage.getItem("theme");

--- a/client/src/ui/molecules/theme-switcher/index.tsx
+++ b/client/src/ui/molecules/theme-switcher/index.tsx
@@ -6,7 +6,7 @@ import { Submenu } from "../submenu";
 import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 
 import "./index.scss";
-import { postToIEx, switchTheme } from "../../../utils";
+import { switchTheme } from "../../../utils";
 
 type ThemeButton = {
   id: string;
@@ -50,7 +50,6 @@ export const ThemeSwitcher = () => {
 
     if (theme) {
       switchTheme(theme, setActiveTheme);
-      postToIEx(theme);
     }
   }, [activeTheme]);
 

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -43,12 +43,13 @@ export function postToIEx(theme: string) {
   const iexFrame = document.querySelector(".interactive") as HTMLIFrameElement;
 
   if (iexFrame) {
-    iexFrame.contentWindow?.postMessage(
-      { theme: theme },
-      window?.mdnWorker?.settings?.preferOnline === false
-        ? window.location.origin
-        : IEX_DOMAIN
-    );
+    if (iexFrame.getAttribute("data-readystate") === "complete") {
+      const origin =
+        window?.mdnWorker?.settings?.preferOnline === false
+          ? window.location.origin
+          : IEX_DOMAIN;
+      iexFrame.contentWindow?.postMessage({ theme: theme }, origin);
+    }
   }
 }
 

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -85,7 +85,7 @@ const scriptSrcValues = [
    * we must always update the CSP hash (see instructions there).
    */
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
+  "'sha256-ryRT1qGpDn+Y+tJ6gmb6XWaV28URicWtYzcBXNv1i+U='",
   // - Current hash:
   "'sha256-R1d+R+j7z1re3EpSIuqRpflohOvTm3fAxKvfEiXgC1o='",
 ];

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -85,7 +85,7 @@ const scriptSrcValues = [
    * we must always update the CSP hash (see instructions there).
    */
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-ryRT1qGpDn+Y+tJ6gmb6XWaV28URicWtYzcBXNv1i+U='",
+  "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
   // - Current hash:
   "'sha256-R1d+R+j7z1re3EpSIuqRpflohOvTm3fAxKvfEiXgC1o='",
 ];

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -87,7 +87,7 @@ const scriptSrcValues = [
   // - Previous hash (to avoid cache invalidation issues):
   "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
   // - Current hash:
-  "'sha256-ryRT1qGpDn+Y+tJ6gmb6XWaV28URicWtYzcBXNv1i+U='",
+  "'sha256-R1d+R+j7z1re3EpSIuqRpflohOvTm3fAxKvfEiXgC1o='",
 ];
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -85,9 +85,9 @@ const scriptSrcValues = [
    * we must always update the CSP hash (see instructions there).
    */
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-x6Tv+AdV5e6dcolO0TEo+3BG4H2nG2ACjyG8mz6QCes='",
-  // - Current hash:
   "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
+  // - Current hash:
+  "'sha256-ryRT1qGpDn+Y+tJ6gmb6XWaV28URicWtYzcBXNv1i+U='",
 ];
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6727.

Pages with interactive examples throw following error because yari tries to send theme change message before the iframe content is loaded:
> Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://interactive-examples.mdn.mozilla.net') does not match the recipient window's origin ('https://developer.mozilla.org').


### Problem

Steps to reproduce:
1. Open page https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit.
2. Set them to "Dark".
3. Do force page reload using ` Ctrl + F5`.
4. In the logs you'll see the error message.

The problem is the iframe content takes time to load but yari starts sending theme change message multiple times. The iframe with empty content throws origin mismatch error.
Also, yari sends the message multiple times due code error.

### Solution

Call postMessage on the iframe only if the content is loaded. But with SSR involved it's bit trickier.
Finding out the content finished loading, for other origin iframe, is not possible without using `onload` event. And with SSR it's not possible to use onload event inside the React. Because browser immediately starts loading the iframe came directly from server, and useEffect events registration inside React happens after components are rendered. More info [here](https://github.com/facebook/react/issues/15446).

So, [as suggested](https://github.com/facebook/react/issues/15446#issuecomment-666774533) by Dan, we can listen for the iframe load event on document body and register the load finished.

## Screenshots

## Before

![error](https://i.imgur.com/sxrt8ey.png)

## How did you test this change?

On a Chromium browser on Fedora.