### PR TITLE
fix(live-samples): avoid iframe scrollbar, simulate inner padding

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -311,14 +311,14 @@ table {
   }
 }
 
-@mixin simulate-padding-border($padding: 0.25rem, $border-width: 1px) {
+@mixin rounded-border-with-inner-spacing($border-width: 1px) {
   border: none;
   border-radius: calc(var(--elem-radius) / 2);
-  box-shadow: 0 0 $border-width $padding #fff;
-  margin: 0 $padding;
+  box-shadow: 0 0 $border-width var(--elem-radius) #fff;
+  margin: 0 var(--elem-radius);
   outline: $border-width solid var(--border-primary);
-  outline-offset: $padding;
-  width: calc(100% - 2 * $padding);
+  outline-offset: var(--elem-radius);
+  width: calc(100% - 2 * var(--elem-radius));
 }
 
 iframe {
@@ -335,7 +335,7 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
-    @include simulate-padding-border();
+    @include rounded-border-with-inner-spacing();
     background: #fff;
   }
 }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -311,6 +311,16 @@ table {
   }
 }
 
+@mixin simulate-padding-border($padding: 0.25rem, $border-width: 1px) {
+  border: none;
+  border-radius: calc(var(--elem-radius) / 2);
+  box-shadow: 0 0 $border-width $padding #fff;
+  margin: 0 $padding;
+  outline: $border-width solid var(--border-primary);
+  outline-offset: $padding;
+  width: calc(100% - 2 * $padding);
+}
+
 iframe {
   border: 1px solid var(--border-primary);
   max-width: 100%;
@@ -325,14 +335,8 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
+    @include simulate-padding-border();
     background: #fff;
-    border: none;
-    border-radius: calc(var(--elem-radius) / 2);
-    box-shadow: 0 0 1px 0.25rem #fff;
-    margin-left: 0.25rem;
-    outline: 1px solid var(--border-primary);
-    outline-offset: 0.25rem;
-    width: calc(100% - 0.5rem);
   }
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -311,16 +311,6 @@ table {
   }
 }
 
-@mixin rounded-border-with-inner-spacing($border-width: 1px) {
-  border: none;
-  border-radius: calc(var(--elem-radius) / 2);
-  box-shadow: 0 0 $border-width var(--elem-radius) #fff;
-  margin: var(--elem-radius);
-  outline: $border-width solid var(--border-primary);
-  outline-offset: var(--elem-radius);
-  width: calc(100% - 2 * var(--elem-radius));
-}
-
 iframe {
   border: 1px solid var(--border-primary);
   max-width: 100%;
@@ -335,8 +325,14 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
-    @include rounded-border-with-inner-spacing();
     background: #fff;
+    border: none;
+    border-radius: calc(var(--elem-radius) / 2);
+    box-shadow: 0 0 1px 0.25rem #fff;
+    margin-left: 0.25rem;
+    outline: 1px solid var(--border-primary);
+    outline-offset: 0.25rem;
+    width: calc(100% - 0.5rem);
   }
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -315,7 +315,7 @@ table {
   border: none;
   border-radius: calc(var(--elem-radius) / 2);
   box-shadow: 0 0 $border-width var(--elem-radius) #fff;
-  margin: 0 var(--elem-radius);
+  margin: var(--elem-radius);
   outline: $border-width solid var(--border-primary);
   outline-offset: var(--elem-radius);
   width: calc(100% - 2 * var(--elem-radius));

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -325,10 +325,13 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
-    background: #fff;
-    border: 1px solid var(--border-primary);
-    border-radius: var(--elem-radius);
     width: 100%;
+    background: #fff;
+    border: none;
+    border-radius: calc(var(--elem-radius) / 2);
+    outline: 1px solid var(--border-primary);
+    outline-offset: 0.25rem;
+    box-shadow: 0 0 1px 0.25rem #fff;
   }
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -325,13 +325,14 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
-    width: 100%;
+    width: calc(100% - 0.5rem);
     background: #fff;
     border: none;
     border-radius: calc(var(--elem-radius) / 2);
     outline: 1px solid var(--border-primary);
     outline-offset: 0.25rem;
     box-shadow: 0 0 1px 0.25rem #fff;
+    margin-left: 0.25rem;
   }
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -325,14 +325,14 @@ iframe {
   &[src*="https://test262.report"],
   &.nobutton,
   &.sample-code-frame {
-    width: calc(100% - 0.5rem);
     background: #fff;
     border: none;
     border-radius: calc(var(--elem-radius) / 2);
-    outline: 1px solid var(--border-primary);
-    outline-offset: 0.25rem;
     box-shadow: 0 0 1px 0.25rem #fff;
     margin-left: 0.25rem;
+    outline: 1px solid var(--border-primary);
+    outline-offset: 0.25rem;
+    width: calc(100% - 0.5rem);
   }
 }
 


### PR DESCRIPTION
## Summary

The PR #6506 removed padding from the live sample iframe. But the scrollbars still remain:
![scrollbars](https://i.imgur.com/M56d8Ju.png)

### Problem

The scrollbar issue hasn't been completely fixed due to  1px border. 

### Solution

Use outline instead of border. Setting outline-offset gives feeling of padding.

## Screenshots

### Before
![scrollbars](https://i.imgur.com/M56d8Ju.png)

### After

Light mode
![light](https://i.imgur.com/CZm0nUm.png)

Dark mode
![dark](https://i.imgur.com/0ytGkvM.png)
The box-shadow fills the gap between the outline and iframe edges.


## How did you test this change?

In Firefox and chromium browsers on Fedora