### PR TITLE
fix(flaws): overflowing content in broken links

### DIFF
--- a/client/src/document/toolbar/index.scss
+++ b/client/src/document/toolbar/index.scss
@@ -29,10 +29,6 @@
     }
   }
 
-  .toggle-show-flaws {
-    white-space: nowrap;
-  }
-
   @media screen and (min-width: $screen-md) {
     margin: 0 0 2rem 0;
   }


### PR DESCRIPTION
## Summary

As is the title.

### Problem

A `broken links` content is overflowing.

### Solution

Remove `white-space: nowrap;`

---

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/11273093/174427906-bea19f31-9b2d-4b94-bfc9-0757db05513e.jpg)


### After

![after](https://user-images.githubusercontent.com/11273093/174427911-fbf5bc97-8a69-44fc-ba22-5856ff267be4.jpg)

---

## How did you test this change?

run `yarn dev` locally and check it manually.

---

Thank you :)