### PR TITLE
fix: hydration errors for logged in users

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -1,5 +1,5 @@
 import { useUserData } from "../../../user-context";
-import { useLocale } from "../../../hooks";
+import { useIsServer, useLocale } from "../../../hooks";
 
 import "./index.scss";
 import { usePlusUrl } from "../../../plus/utils";
@@ -11,6 +11,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
 
   const plusUrl = usePlusUrl();
 
+  const isServer = useIsServer();
   const isAuthenticated = userData && userData.isAuthenticated;
 
   const plusMenu = {
@@ -26,12 +27,12 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         label: "Overview",
         url: plusUrl,
       },
-      ...(isAuthenticated
+      ...(!isServer && isAuthenticated
         ? [
             {
               description: "Your saved articles from across MDN",
               hasIcon: true,
-              iconClasses: "submenu-icon bookmarks-icon",
+              iconClasses: "submenu-icon",
               label: "Collections",
               url: `/${locale}/plus/collections`,
             },

--- a/client/src/ui/organisms/article-actions/index.tsx
+++ b/client/src/ui/organisms/article-actions/index.tsx
@@ -2,6 +2,7 @@ import { Button } from "../../atoms/button";
 import { NotificationsWatchMenu } from "../../molecules/notifications-watch-menu";
 import { LanguageMenu } from "../../molecules/language-menu";
 
+import { useIsServer } from "../../../hooks";
 import { useUserData } from "../../../user-context";
 
 import { Doc } from "../../../document/types";
@@ -20,6 +21,7 @@ export const ArticleActions = ({
   setShowArticleActionsMenu: (show: boolean) => void;
 }) => {
   const userData = useUserData();
+  const isServer = useIsServer();
   const isAuthenticated = userData && userData.isAuthenticated;
   const translations = doc.other_translations || [];
   const { native } = doc;
@@ -32,7 +34,8 @@ export const ArticleActions = ({
   // const translations = doc.other_translations || [];
 
   return (
-    (((translations && !!translations.length) || isAuthenticated) && (
+    (((translations && !!translations.length) ||
+      (!isServer && isAuthenticated)) && (
       <>
         <div
           className={`article-actions${
@@ -51,12 +54,12 @@ export const ArticleActions = ({
           </Button>
           <ul className="article-actions-entries">
             <>
-              {isAuthenticated && (
+              {!isServer && isAuthenticated && (
                 <li className="article-actions-entry">
                   <NotificationsWatchMenu doc={doc} />
                 </li>
               )}
-              {isAuthenticated && (
+              {!isServer && isAuthenticated && (
                 <li className="article-actions-entry">
                   <BookmarkContainer doc={doc} />
                 </li>

--- a/client/src/ui/organisms/top-navigation-main/index.tsx
+++ b/client/src/ui/organisms/top-navigation-main/index.tsx
@@ -5,6 +5,7 @@ import MainMenu from "../../molecules/main-menu";
 import { UserMenu } from "../../molecules/user-menu";
 import { Search } from "../../molecules/search";
 
+import { useIsServer } from "../../../hooks";
 import { useUserData } from "../../../user-context";
 
 import "./index.scss";
@@ -14,6 +15,7 @@ import { ThemeSwitcher } from "../../molecules/theme-switcher";
 
 export const TopNavigationMain = ({ isOpenOnMobile }) => {
   const userData = useUserData();
+  const isServer = useIsServer();
   const plusAvailable = isPlusAvailable(userData);
 
   return (
@@ -23,11 +25,14 @@ export const TopNavigationMain = ({ isOpenOnMobile }) => {
       <Search id="top-nav-search" />
       <ThemeSwitcher />
 
-      {(PLUS_IS_ENABLED && userData && userData.isAuthenticated && (
-        <>
-          <UserMenu />
-        </>
-      )) ||
+      {(PLUS_IS_ENABLED &&
+        !isServer &&
+        userData &&
+        userData.isAuthenticated && (
+          <>
+            <UserMenu />
+          </>
+        )) ||
         (plusAvailable && <AuthContainer />) || <></>}
     </div>
   );


### PR DESCRIPTION
## Summary

The PR #6403 fixed all the hydration errors for guest users. But there are still hydration errors for signed in users and users with subscription.
This PR fixes hydration errors for signed in users.

### Problem

SSR doesn't know whether a user is authenticated. But client knows the authentication status.
Current implementation of menus and navbar actions do not consider this fact.

### Solution

Put the features for signed in users behind `!isServer` check.

Also, in plus-menu/index.tsx file the class `bookmarks-icon` has not been defined or mentioned anywhere in the yari repo. So removed the redundant text.

## How did you test this change?

Firefox and chormium on Fedora 36.