### PR TITLE
Deprecate Compat/Specifications macro parameters

### DIFF
--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -30,6 +30,11 @@ Example calls
 
 */
 
+if ($0) {
+  throw new Error(`Calling the Compat macro with any arguments is
+  deprecated; instead use the 'browser-compat' front-matter key.`);
+}
+
 var query = $0 || env['browser-compat'];
 if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -31,7 +31,7 @@ Example calls
 */
 
 if ($0) {
-  throw new Error(`Calling the Compat macro with any arguments is
+  mdn.deprecated(`Calling the Compat macro with any arguments is
   deprecated; instead use the 'browser-compat' front-matter key.`);
 }
 

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -13,6 +13,12 @@ Example calls
 
 */
 
+if ($0) {
+  throw new Error(`Calling the Specifications macro with any arguments is
+  deprecated; instead use either the 'browser-compat' or 'spec-urls'
+  front-matter key.`);
+}
+
 var query = $0 || env['browser-compat'];
 var specURLs = env['spec-urls'] || "";
 if (!query && !specURLs) {

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -14,7 +14,7 @@ Example calls
 */
 
 if ($0) {
-  throw new Error(`Calling the Specifications macro with any arguments is
+  mdn.deprecated(`Calling the Specifications macro with any arguments is
   deprecated; instead use either the 'browser-compat' or 'spec-urls'
   front-matter key.`);
 }

--- a/kumascript/tests/macros/Compat.test.js
+++ b/kumascript/tests/macros/Compat.test.js
@@ -20,7 +20,8 @@ fs.readdirSync(fixture_dir).forEach(function (fn) {
 
 describeMacro("Compat", function () {
   itMacro("Outputs a simple div tag", async (macro) => {
-    const result = await macro.call("api.feature");
+    macro.ctx.env["browser-compat"] = "api.feature";
+    const result = await macro.call();
     const dom = JSDOM.fragment(result);
     assert.equal(dom.querySelector("div.bc-data").id, "");
     assert.equal(dom.querySelector("div.bc-data").dataset.query, "api.feature");
@@ -31,19 +32,15 @@ describeMacro("Compat", function () {
     );
   });
 
-  itMacro("Outputs the data-depth on the second parameter", async (macro) => {
-    const result = await macro.call("api.feature", 2);
-    const dom = JSDOM.fragment(result);
-    assert.equal(dom.querySelector("div.bc-data").dataset.depth, "2");
-  });
-
   itMacro("Outputs valid HTML", async (macro) => {
-    const result = await macro.call("api.feature");
+    macro.ctx.env["browser-compat"] = "api.feature";
+    const result = await macro.call();
     expect(lintHTML(result)).toBeFalsy();
   });
 
   itMacro("Accepts an array", async (macro) => {
-    const result = await macro.call(["api.feature1", "api.feature2"]);
+    macro.ctx.env["browser-compat"] = ["api.feature1", "api.feature2"];
+    const result = await macro.call();
     const dom = JSDOM.fragment(result);
     assert.equal(dom.querySelectorAll("div.bc-data").length, 2);
     expect(lintHTML(result)).toBeFalsy();

--- a/kumascript/tests/macros/Specifications.test.js
+++ b/kumascript/tests/macros/Specifications.test.js
@@ -4,8 +4,9 @@ const jsdom = require("jsdom");
 const { JSDOM } = jsdom;
 
 describeMacro("Specifications", function () {
-  itMacro("Outputs a simple div tag", async (macro) => {
-    const result = await macro.call("api.feature");
+  itMacro("Outputs a simple div tag (browser-compat case)", async (macro) => {
+    macro.ctx.env["browser-compat"] = "api.feature";
+    const result = await macro.call();
     const dom = JSDOM.fragment(result);
     assert.equal(
       dom.querySelector("div.bc-specs").dataset.bcdQuery,
@@ -17,8 +18,57 @@ describeMacro("Specifications", function () {
     );
   });
 
-  itMacro("Outputs valid HTML", async (macro) => {
-    const result = await macro.call("api.feature");
+  itMacro("Outputs a simple div tag (spec-urls case)", async (macro) => {
+    macro.ctx.env["spec-urls"] = "https://example.com";
+    const result = await macro.call();
+    const dom = JSDOM.fragment(result);
+    assert.equal(
+      dom.querySelector("div.bc-specs").getAttribute("data-spec-urls"),
+      "https://example.com"
+    );
+    assert.equal(
+      dom.querySelector("div.bc-specs").textContent.trim(),
+      "If you're able to see this, something went wrong on this page."
+    );
+  });
+
+  itMacro("Outputs valid HTML (browser-compat case)", async (macro) => {
+    macro.ctx.env["browser-compat"] = "api.feature";
+    const result = await macro.call();
+    expect(lintHTML(result)).toBeFalsy();
+  });
+
+  itMacro("Outputs valid HTML (spec-urls case)", async (macro) => {
+    macro.ctx.env["spec-urls"] = "https://example.com";
+    const result = await macro.call();
+    expect(lintHTML(result)).toBeFalsy();
+  });
+
+  itMacro("Accepts an array from browser-compat", async (macro) => {
+    macro.ctx.env["browser-compat"] = ["api.feature1", "api.feature2"];
+    const result = await macro.call();
+    const dom = JSDOM.fragment(result);
+    assert.equal(
+      dom
+        .querySelector("div.bc-specs")
+        .getAttribute("data-bcd-query")
+        .split(",").length,
+      2
+    );
+    expect(lintHTML(result)).toBeFalsy();
+  });
+
+  itMacro("Accepts an array from spec-urls", async (macro) => {
+    macro.ctx.env["spec-urls"] = ["https://a.com", "https://b.com"];
+    const result = await macro.call();
+    const dom = JSDOM.fragment(result);
+    assert.equal(
+      dom
+        .querySelector("div.bc-specs")
+        .getAttribute("data-spec-urls")
+        .split(",").length,
+      2
+    );
     expect(lintHTML(result)).toBeFalsy();
   });
 });

--- a/testing/content/files/en-us/web/api/page_visibility_api/index.html
+++ b/testing/content/files/en-us/web/api/page_visibility_api/index.html
@@ -1,6 +1,7 @@
 ---
 title: Page Visibility API
 slug: Web/API/Page_Visibility_API
+browser-compat: api.Document.visibilityState
 tags:
   - API
   - DOM
@@ -18,4 +19,4 @@ tags:
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Document.visibilityState")}}</p>
+<p>{{Compat}}</p>

--- a/testing/content/files/en-us/web/badbcdqueries/index.html
+++ b/testing/content/files/en-us/web/badbcdqueries/index.html
@@ -1,8 +1,9 @@
 ---
 title: Bad BCD Queries
 slug: Web/BadBCDQueries
+browser-compat: api.Does.Not.exist
 ---
 
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
-<p>{{Compat("api.Does.Not.exist")}}</p>
+<p>{{Compat}}</p>

--- a/testing/content/files/en-us/web/bcd_table_extraction/index.html
+++ b/testing/content/files/en-us/web/bcd_table_extraction/index.html
@@ -1,6 +1,7 @@
 ---
 title: BCD table extraction
 slug: Web/BCD_Table_Extraction
+browser-compat: javascript.operators.optional_chaining
 ---
 
 <p>
@@ -17,7 +18,7 @@ slug: Web/BCD_Table_Extraction
 <h2 id="Browser_compatibility">Browser compatibility</h2>
 
 <div>
-  <p>{{Compat("javascript.operators.optional_chaining")}}</p>
+  <p>{{Compat}}</p>
 </div>
 
 <h3 id="Implementation_Progress">Implementation Progress</h3>


### PR DESCRIPTION
In current MDN article content, we no longer have any `Compat` or `Specifications` macros which have arguments — instead all articles use the `browser-compat` frontmatter key or the `spec-urls` frontmatter key.

And in no cases is it any longer necessary to ever call the `Compat` or `Specifications` macros with any arguments — instead in all cases, the `browser-compat` and `spec-urls` frontmatter keys can be used; therefore, it’s appropriate to report flaws for any new cases where a PR adds content that has arguments in `Compat` or `Specifications` macro calls.