### PR TITLE
use async fs in buildDocument loop

### DIFF
--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -99,10 +99,17 @@ describe("fixing flaws", () => {
       .split("\n")
       .filter((line) => regexPattern.test(line));
     expect(dryRunNotices.length).toBe(4);
-    expect(dryRunNotices[0]).toContain(path.join(pattern, "bad_pre_tags"));
-    expect(dryRunNotices[1]).toContain(path.join(pattern, "deprecated_macros"));
-    expect(dryRunNotices[2]).toContain(path.join(pattern, "images"));
-    expect(dryRunNotices[3]).toContain(pattern);
+    const allDryRunNotices = dryRunNotices.join();
+    expect(allDryRunNotices).toContain(
+      path.join(pattern, "bad_pre_tags", "index.html")
+    );
+    expect(allDryRunNotices).toContain(
+      path.join(pattern, "deprecated_macros", "index.html")
+    );
+    expect(allDryRunNotices).toContain(
+      path.join(pattern, "images", "index.html")
+    );
+    expect(allDryRunNotices).toContain(path.join(pattern, "index.html"));
     const dryrunFiles = getChangedFiles(tempContentDir);
     expect(dryrunFiles.length).toBe(0);
   });

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -1248,18 +1248,19 @@ test("chicken_and_egg page should build with flaws", () => {
   const { doc } = JSON.parse(fs.readFileSync(jsonFile, "utf-8")) as {
     doc: Doc;
   };
-  expect(doc.flaws.macros.length).toBe(1);
+  expect(doc.flaws.macros.length).toBeGreaterThanOrEqual(1);
   // The filepath will be that of the "egg" or the "chicken" page.
   // Let's not try to predict which one exactly, because that'd mean this
   // test would need to use the exact same sort order as the glob used
   // when we ran "yarn build" to set up the build fixtures.
-  const flaw = doc.flaws.macros[0];
-  expect(flaw.name).toBe("MacroExecutionError");
-  expect(
-    flaw.errorStack.includes(
-      "documents form a circular dependency when rendering"
-    )
-  ).toBeTruthy();
+  for (const flaw of doc.flaws.macros) {
+    expect(flaw.name).toBe("MacroExecutionError");
+    expect(
+      flaw.errorStack.includes(
+        "documents form a circular dependency when rendering"
+      )
+    ).toBeTruthy();
+  }
 });
 
 test("404 page", () => {


### PR DESCRIPTION
this results in a ~10% speedup on my machine

didn't throw the sitemap and search index stuff in `Promise.all`s yet, as they're only iterating over each locale, so I don't imagine we'll get a huge speed-up there

next up is async-ing the reading of files in this document loop, which is a bit convoluted because the `Document.read` function isn't async