### PR TITLE
Hide Internet Explorer in BCD tables

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -71,6 +71,9 @@ function gatherPlatformsAndBrowsers(
     browsers = browsers.filter((browser) => browser !== "nodejs");
   }
 
+  // Hide Internet Explorer compatibility data
+  browsers = browsers.filter((browser) => browser !== "ie");
+
   return [platforms, [...browsers]];
 }
 


### PR DESCRIPTION
This PR updates the rendered BCD tables to hide Internet Explorer's compatibility data, since Internet Explorer is dead.  Although IE is still available for enterprise customers and through Edge's "IE Mode", no new website should be written for IE support, so hiding IE's compatibility should help dissuade web developers from writing new IE-compatible websites.
