### PR TITLE
CSS formal syntax rendering: clamp space-padding to line length

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -109,7 +109,7 @@ function getPropertySyntax(propertyName) {
       newSyntaxes += ` | ${newValues}`;
     }
   }
-  // Concatenate new values on to values to return a single syntax string
+  // Concatenate newValues onto values to return a single syntax string
   if (newSyntaxes) {
     syntax += newSyntaxes;
   }
@@ -204,13 +204,18 @@ function renderTerms(terms, combinator) {
     });
   }
 
-  const maxTermLength = Math.max(...renderedTerms.map(t => t.length));
+  // we will space-pad all terms to the length of the longest term,
+  // so that lines are aligned, but padding must not cause lines to wrap,
+  // so the target width is clamped to the line length.
+  const maxLineLength = 50;
+  let maxTermLength = Math.max(...renderedTerms.map(t => t.length));
+  maxTermLength = Math.min(maxTermLength, maxLineLength);
 
   // write out the translated terms, padding with spaces for alignment
   // and separating terms using their combinator symbol
   for (let i = 0; i < renderedTerms.length; i++) {
     const termText = renderedTerms[i].text;
-    const spaceCount = (maxTermLength + 2) - renderedTerms[i].length;
+    const spaceCount = Math.max(2, (maxTermLength + 2) - renderedTerms[i].length);
     let combinatorText = '';
     if (combinator && combinator !== " ") {
       const info = syntaxDescriptions[combinator];


### PR DESCRIPTION
This is a tweak to the pretty-printing for CSS syntax.

Currently it figures out the length of the longest term and pads all terms to that length. This works well usually, but if the longest term is longer than the width of the box, then it forces all terms to wrap, as seen in https://developer.mozilla.org/en-US/docs/Web/CSS/font#formal_syntax for example:

<img width="761" alt="Screen Shot 2022-06-24 at 9 02 37 AM" src="https://user-images.githubusercontent.com/432915/175573683-4b57a017-d939-4335-af73-d8830d34314a.png">

This PR clamps the amount of padding, so that padded lines never exceed 50 characters:

<img width="759" alt="Screen Shot 2022-06-24 at 9 05 55 AM" src="https://user-images.githubusercontent.com/432915/175574255-7dcbd6f2-49b9-46c6-be16-f9408d93914e.png">

Not fantastic, but better I think.