### PR TITLE
fix(markdown): match folder only for h2m cli

### DIFF
--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -141,7 +141,7 @@ program
       console.log(
         `Starting HTML to Markdown conversion in ${options.mode} mode`
       );
-      let folderSearch = args.folder;
+      let folderSearch = args.folder + "/"; // add trailing slash to match folder only
       // replace '\' and '/' with '\\' to make this regexp works on Windows
       if (folderSearch && os.platform() === "win32") {
         folderSearch = folderSearch.replace(/\\|\//g, "\\\\");
@@ -162,14 +162,18 @@ program
         { offset: number; invalid: []; unhandled: [] }
       >();
       // replace '\' with '/' for Windows path
-      const slugPrefix = args.folder.toLowerCase().replace(/\\/g, "/");
+      const slugPrefix = args.folder.replace(/\\/g, "/");
       try {
         for (let doc of documents.iter()) {
           progressBar.increment();
           if (
             doc.isMarkdown ||
             // findAll's folderSearch is fuzzy which we don't want here
-            !doc.metadata.slug.toLowerCase().startsWith(slugPrefix)
+            !doc.fileInfo.folder
+              .split(/\\|\//) // split by '\' or '/'
+              .slice(1) // remove the locale
+              .join("/")
+              .startsWith(slugPrefix)
           ) {
             continue;
           }

--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
 const fm = require("front-matter");
 import { program } from "@caporal/core";
 import * as chalk from "chalk";
@@ -141,11 +142,14 @@ program
       console.log(
         `Starting HTML to Markdown conversion in ${options.mode} mode`
       );
-      let folderSearch = args.folder + "/"; // add trailing slash to match folder only
-      // replace '\' and '/' with '\\' to make this regexp works on Windows
-      if (folderSearch && os.platform() === "win32") {
-        folderSearch = folderSearch.replace(/\\|\//g, "\\\\");
+      let folder = args.folder?.replace(/\\|\//g, path.sep); // using correct path separator
+      // add trailing path separator (if not exists) to match folder
+      if (folder && !folder.endsWith(path.sep)) {
+        folder += path.sep;
       }
+      // replace '\' with '\\' to make this regexp works on Windows
+      const folderSearch =
+        os.platform() === "win32" ? folder?.replace(/\\/g, "\\\\") : folder;
       const documents = Document.findAll({
         folderSearch: folderSearch,
         locales: buildLocaleMap(options.locale),
@@ -161,19 +165,17 @@ program
         string,
         { offset: number; invalid: []; unhandled: [] }
       >();
-      // replace '\' with '/' for Windows path
-      const slugPrefix = args.folder.replace(/\\/g, "/");
+      const folderPrefix = folder?.slice(0, -1);
       try {
         for (let doc of documents.iter()) {
           progressBar.increment();
           if (
             doc.isMarkdown ||
             // findAll's folderSearch is fuzzy which we don't want here
-            !doc.fileInfo.folder
-              .split(/\\|\//) // split by '\' or '/'
-              .slice(1) // remove the locale
-              .join("/")
-              .startsWith(slugPrefix)
+            (folderPrefix &&
+              !doc.fileInfo.folder
+                .slice(doc.fileInfo.folder.indexOf(path.sep) + 1)
+                .startsWith(folderPrefix))
           ) {
             continue;
           }

--- a/markdown/cli.ts
+++ b/markdown/cli.ts
@@ -165,17 +165,16 @@ program
         string,
         { offset: number; invalid: []; unhandled: [] }
       >();
-      const folderPrefix = folder?.slice(0, -1);
       try {
         for (let doc of documents.iter()) {
           progressBar.increment();
           if (
             doc.isMarkdown ||
             // findAll's folderSearch is fuzzy which we don't want here
-            (folderPrefix &&
-              !doc.fileInfo.folder
+            (folder &&
+              !(doc.fileInfo.folder + path.sep)
                 .slice(doc.fileInfo.folder.indexOf(path.sep) + 1)
-                .startsWith(folderPrefix))
+                .startsWith(folder))
           ) {
             continue;
           }


### PR DESCRIPTION
## Summary

Fixes #6607.

### Problem

see issue.

### Solution

- for matching folder only, adding trailing slash to match folders only
- for working on some specific folder like `web/css/colon-moz-only-whitespace`, use `doc.fileInfo.folder` instead of `slug`

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15844309/175862598-2329e355-4c12-435f-b7c3-b705e47d20e4.png)

![image](https://user-images.githubusercontent.com/15844309/175862505-0b55a46b-471e-43fd-9a93-051e6b0efde4.png)

### After

![image](https://user-images.githubusercontent.com/15844309/175862443-9edcdade-0512-4497-ae3b-194dd9a9f788.png)

![image](https://user-images.githubusercontent.com/15844309/175862337-9e832020-abec-489a-b7a1-fe7a284f6387.png)
