### PR TITLE
Support formal syntax for types and functions as well as properties

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -70,9 +70,8 @@ for (const spec of Object.values(parsedWebRef)) {
 }
 
 /**
- * Get the formal syntax and properly formatted name for an item,
- * depending on its type.
- * Currently this supports properties and types
+ * Get the formal syntax and properly formatted name for an item.
+ * Currently we support CSS properties and CSS data types.
  */
 function getNameAndSyntax() {
   // get the item name from the page slug
@@ -82,8 +81,8 @@ function getNameAndSyntax() {
   // get syntax for a CSS property
     itemSyntax = getPropertySyntax(itemName, parsedWebRef);
   } else if (env.tags.includes("CSS Data Type")) {
-  // get syntax for a CSS type
-    // some CSS type slugs have a `_value` suffix
+  // get syntax for a CSS data type
+    // some CSS data type slugs have a `_value` suffix
     if (itemName.endsWith("_value")) {
       itemName = itemName.replace("_value", "");
     }

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -69,13 +69,40 @@ for (const spec of Object.values(parsedWebRef)) {
   valuespaces = {...valuespaces, ...spec.valuespaces};
 }
 
-// get the property name from the page slug
-let itemName = $0 || env.slug.split('/').pop().toLowerCase();
+/**
+ * Get the formal syntax and properly formatted name for an item,
+ * depending on its type.
+ * Currently this supports properties and types
+ */
+function getNameAndSyntax() {
+  // get the item name from the page slug
+  let itemName = $0 || env.slug.split('/').pop().toLowerCase();
+  let itemSyntax;
+  if (env.tags.includes("CSS Property")) {
+  // get syntax for a CSS property
+    itemSyntax = getPropertySyntax(itemName, parsedWebRef);
+  } else if (env.tags.includes("CSS Data Type")) {
+  // get syntax for a CSS type
+    // some CSS type slugs have a `_value` suffix
+    if (itemName.endsWith("_value")) {
+      itemName = itemName.replace("_value", "");
+      console.log(itemName)
+    }
+    // not all types have an entry in the syntax
+    if (valuespaces[`<${itemName}>`]) {
+      itemSyntax = valuespaces[`<${itemName}>`].value;
+      itemName = `&lt;${itemName}&gt;`;
+    }
+  }
+  return {
+    name: itemName,
+    syntax: itemSyntax
+  }
+}
 
 /**
  * Get the formal syntax for a property from the webref data, given:
  * @param {string} itemName - the name of the property
- * @param {object} parsedWebRef - the webref data
  */
 function getPropertySyntax(itemName) {
   // 1) get all specs which list this property
@@ -331,30 +358,13 @@ function writeFormalSyntax(itemName, itemSyntax) {
 
 let output = '';
 
-let itemSyntax = '';
+const {name, syntax} = getNameAndSyntax();
 
-if (env.tags.includes("CSS Property")) {
-// get syntax for a CSS property
-itemSyntax = getPropertySyntax(itemName, parsedWebRef);
-} else if (env.tags.includes("CSS Data Type")) {
-// get syntax for a CSS type
-// some CSS type slugs have a `_value` suffix
-  if (itemName.endsWith("_value")) {
-    itemName = itemName.replace("_value", "");
-    console.log(itemName)
-  }
-// not all types have an entry in the syntax
-  if (valuespaces[`<${itemName}>`]) {
-    itemSyntax = valuespaces[`<${itemName}>`].value;
-    itemName = `&lt;${itemName}&gt;`;
-  }
-}
-
-if (!itemSyntax) {
+if (!syntax) {
   output = 'Error: could not find syntax for this item';
 } else {
   // write it out
-  output = writeFormalSyntax(itemName, itemSyntax);
+  output = writeFormalSyntax(name, syntax);
 }
 %>
 <%-output%>

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -70,19 +70,19 @@ for (const spec of Object.values(parsedWebRef)) {
 }
 
 // get the property name from the page slug
-const propertyName = $0 || env.slug.split('/').pop().toLowerCase();
+let itemName = $0 || env.slug.split('/').pop().toLowerCase();
 
 /**
  * Get the formal syntax for a property from the webref data, given:
- * @param {string} propertyName - the name of the property
+ * @param {string} itemName - the name of the property
  * @param {object} parsedWebRef - the webref data
  */
-function getPropertySyntax(propertyName) {
+function getPropertySyntax(itemName) {
   // 1) get all specs which list this property
   let specsForProp = [];
   for (const [shortname, data] of Object.entries(parsedWebRef)) {
     const propNames = Object.keys(data.properties);
-    if (propNames.includes(propertyName)) {
+    if (propNames.includes(itemName)) {
       specsForProp.push(shortname);
     }
   }
@@ -92,7 +92,7 @@ function getPropertySyntax(propertyName) {
   }
   // 3) If we now have only one spec, return the syntax it lists
   if (specsForProp.length === 1) {
-    return parsedWebRef[specsForProp[0]].properties[propertyName].value;
+    return parsedWebRef[specsForProp[0]].properties[itemName].value;
   }
   // 4) If we still have > 1 spec, assume that:
   // - one of them is the base spec, which defines `values`,
@@ -100,11 +100,11 @@ function getPropertySyntax(propertyName) {
   let syntax = '';
   let newSyntaxes = '';
   for (const specName of specsForProp) {
-    const baseValue = parsedWebRef[specName].properties[propertyName].value;
+    const baseValue = parsedWebRef[specName].properties[itemName].value;
     if (baseValue) {
       syntax = baseValue;
     }
-    const newValues = parsedWebRef[specName].properties[propertyName].newValues;
+    const newValues = parsedWebRef[specName].properties[itemName].newValues;
     if (newValues) {
       newSyntaxes += ` | ${newValues}`;
     }
@@ -272,11 +272,11 @@ function getTypesForSyntaxes(syntaxes, constituents) {
  * Given an item (such as a CSS property), fetch all the types that participate
  * in its formal syntax definition, either directly or transitively.
  */
-function getConstituentTypes(propertySyntax) {
+function getConstituentTypes(itemSyntax) {
   const allConstituents = [];
   let oldConstituentsLength = 0;
   // get all the types in the top-level syntax
-  let constituentSyntaxes = [propertySyntax];
+  let constituentSyntaxes = [itemSyntax];
 
   // while an iteration added more types...
   while (true) {
@@ -304,18 +304,18 @@ function getConstituentTypes(propertySyntax) {
 /**
  * Write out the complete formal syntax for a property.
  *
- * This includes the property's own syntax, described in `propertySyntax`,
+ * This includes the property's own syntax, described in `itemSyntax`,
  * and also the syntax for any types that participate in the definition of
  * the property.
  */
-function writeFormalSyntax(propertySyntax) {
+function writeFormalSyntax(itemName, itemSyntax) {
   let output = '';
   output += '<pre>';
   // write the syntax for the property
-  output += renderSyntax(propertyName, propertySyntax);
+  output += renderSyntax(itemName, itemSyntax);
   output += '<br/>';
   // collect all the constituent types for the property
-  const types = getConstituentTypes(propertySyntax);
+  const types = getConstituentTypes(itemSyntax);
 
   // and write each one out
   for (const type of types) {
@@ -331,14 +331,30 @@ function writeFormalSyntax(propertySyntax) {
 
 let output = '';
 
-// get the syntax for this property
-const propertySyntax = getPropertySyntax(propertyName, parsedWebRef);
+let itemSyntax = '';
 
-if (!propertySyntax) {
+if (env.tags.includes("CSS Property")) {
+// get syntax for a CSS property
+itemSyntax = getPropertySyntax(itemName, parsedWebRef);
+} else if (env.tags.includes("CSS Data Type")) {
+// get syntax for a CSS type
+// some CSS type slugs have a `_value` suffix
+  if (itemName.endsWith("_value")) {
+    itemName = itemName.replace("_value", "");
+    console.log(itemName)
+  }
+// not all types have an entry in the syntax
+  if (valuespaces[`<${itemName}>`]) {
+    itemSyntax = valuespaces[`<${itemName}>`].value;
+    itemName = `&lt;${itemName}&gt;`;
+  }
+}
+
+if (!itemSyntax) {
   output = 'Error: could not find syntax for this item';
 } else {
   // write it out
-  output = writeFormalSyntax(propertySyntax);
+  output = writeFormalSyntax(itemName, itemSyntax);
 }
 %>
 <%-output%>

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -101,14 +101,14 @@ function getNameAndSyntax() {
 
 /**
  * Get the formal syntax for a property from the webref data, given:
- * @param {string} itemName - the name of the property
+ * @param {string} propertyName - the name of the property
  */
-function getPropertySyntax(itemName) {
+function getPropertySyntax(propertyName) {
   // 1) get all specs which list this property
   let specsForProp = [];
   for (const [shortname, data] of Object.entries(parsedWebRef)) {
     const propNames = Object.keys(data.properties);
-    if (propNames.includes(itemName)) {
+    if (propNames.includes(propertyName)) {
       specsForProp.push(shortname);
     }
   }
@@ -118,7 +118,7 @@ function getPropertySyntax(itemName) {
   }
   // 3) If we now have only one spec, return the syntax it lists
   if (specsForProp.length === 1) {
-    return parsedWebRef[specsForProp[0]].properties[itemName].value;
+    return parsedWebRef[specsForProp[0]].properties[propertyName].value;
   }
   // 4) If we still have > 1 spec, assume that:
   // - one of them is the base spec, which defines `values`,
@@ -126,11 +126,11 @@ function getPropertySyntax(itemName) {
   let syntax = '';
   let newSyntaxes = '';
   for (const specName of specsForProp) {
-    const baseValue = parsedWebRef[specName].properties[itemName].value;
+    const baseValue = parsedWebRef[specName].properties[propertyName].value;
     if (baseValue) {
       syntax = baseValue;
     }
-    const newValues = parsedWebRef[specName].properties[itemName].newValues;
+    const newValues = parsedWebRef[specName].properties[propertyName].newValues;
     if (newValues) {
       newSyntaxes += ` | ${newValues}`;
     }

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -328,11 +328,11 @@ function getConstituentTypes(itemSyntax) {
 }
 
 /**
- * Write out the complete formal syntax for a property.
+ * Write out the complete formal syntax for an item.
  *
- * This includes the property's own syntax, described in `itemSyntax`,
+ * This includes the item's own syntax, described in `itemSyntax`,
  * and also the syntax for any types that participate in the definition of
- * the property.
+ * the item.
  */
 function writeFormalSyntax(itemName, itemSyntax) {
   let output = '';

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -86,7 +86,6 @@ function getNameAndSyntax() {
     // some CSS type slugs have a `_value` suffix
     if (itemName.endsWith("_value")) {
       itemName = itemName.replace("_value", "");
-      console.log(itemName)
     }
     // not all types have an entry in the syntax
     if (valuespaces[`<${itemName}>`]) {

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -71,25 +71,28 @@ for (const spec of Object.values(parsedWebRef)) {
 
 /**
  * Get the formal syntax and properly formatted name for an item.
- * Currently we support CSS properties and CSS data types.
  */
 function getNameAndSyntax() {
   // get the item name from the page slug
-  let itemName = $0 || env.title;
+  let itemName = $0 || env.slug.split('/').pop().toLowerCase();
   let itemSyntax;
   if (env.tags.includes("CSS Property")) {
     // get syntax for a CSS property
     itemSyntax = getPropertySyntax(itemName, parsedWebRef);
   } else if (env.tags.includes("CSS Data Type")) {
     // get syntax for a CSS data type
+    // some CSS data type slugs have a `_value` suffix
+    if (itemName.endsWith("_value")) {
+      itemName = itemName.replace("_value", "");
+    }
+    itemName = `<${itemName}>`;
     // not all types have an entry in the syntax
     if (valuespaces[itemName]) {
       itemSyntax = valuespaces[itemName].value;
     }
   } else if (env.tags.includes("CSS Function")) {
     // get syntax for a CSS function
-    // CSS function titles omit the angled brackets
-    itemName = `<${itemName}>`;
+    itemName = `<${itemName}()>`;
     // not all types have an entry in the syntax
     if (valuespaces[itemName]) {
       itemSyntax = valuespaces[itemName].value;

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -75,21 +75,24 @@ for (const spec of Object.values(parsedWebRef)) {
  */
 function getNameAndSyntax() {
   // get the item name from the page slug
-  let itemName = $0 || env.slug.split('/').pop().toLowerCase();
+  let itemName = $0 || env.title;
   let itemSyntax;
   if (env.tags.includes("CSS Property")) {
-  // get syntax for a CSS property
+    // get syntax for a CSS property
     itemSyntax = getPropertySyntax(itemName, parsedWebRef);
   } else if (env.tags.includes("CSS Data Type")) {
-  // get syntax for a CSS data type
-    // some CSS data type slugs have a `_value` suffix
-    if (itemName.endsWith("_value")) {
-      itemName = itemName.replace("_value", "");
-    }
+    // get syntax for a CSS data type
     // not all types have an entry in the syntax
-    if (valuespaces[`<${itemName}>`]) {
-      itemSyntax = valuespaces[`<${itemName}>`].value;
-      itemName = `&lt;${itemName}&gt;`;
+    if (valuespaces[itemName]) {
+      itemSyntax = valuespaces[itemName].value;
+    }
+  } else if (env.tags.includes("CSS Function")) {
+    // get syntax for a CSS function
+    // CSS function titles omit the angled brackets
+    itemName = `<${itemName}>`;
+    // not all types have an entry in the syntax
+    if (valuespaces[itemName]) {
+      itemSyntax = valuespaces[itemName].value;
     }
   }
   return {
@@ -260,6 +263,8 @@ function renderTerms(terms, combinator) {
  */
 function renderSyntax(type, syntax) {
   // write out the name of this type
+  type = type.replaceAll('<', '&lt;');
+  type = type.replaceAll('>', '&gt;');
   let output = `<span class="token property" id="${type}">${type} = </span><br/>`;
 
   const ast = definitionSyntax.parse(syntax);


### PR DESCRIPTION
This is a piece of https://github.com/orgs/mdn/discussions/138. I thought it might be good to implement this in little pieces. Each piece is still useful.

This PR just adds support for CSS data types and CSS functions as well as CSS properties, and means you can add a formal syntax section to, say, https://developer.mozilla.org/en-US/docs/web/css/easing-function or https://developer.mozilla.org/en-US/docs/web/css/color_value or https://developer.mozilla.org/en-US/docs/web/css/gradient.

Follow-ups to this could:

1. change the way syntax is rendered so that when rendering the syntax for a type that's a constituent part of a property (or another type) we just link to the other page instead of embedding the whole syntax. This would mean, for example, that in https://developer.allizom.org/en-US/docs/Web/CSS/background-image#formal_syntax, rather than writing out all the syntax for `<gradient>`, we just link to https://developer.mozilla.org/en-US/docs/web/css/gradient.
2. support other CSS entities

These next steps are a bit more tricky though because

a) we don't have pages for all constituent types
b) we would have to worry about the presentation of the syntax becoming too fragmentary, so readers have to chase across too many pages to get a complete picture
c) our directory structure for CSS is a bit chaotic, so building links to things could get complicated.

But this PR at least seems like an obviously good change.
