### PR TITLE
fix: redundant word 'navigation' in breadcrumb nav

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.tsx
+++ b/client/src/ui/molecules/breadcrumbs/index.tsx
@@ -9,7 +9,7 @@ export const Breadcrumbs = ({ parents }: { parents: DocParent[] }) => {
   }
 
   return (
-    <nav className="breadcrumbs-container" aria-label="Breadcrumb navigation">
+    <nav className="breadcrumbs-container" aria-label="Breadcrumb">
       <ol
         typeof="BreadcrumbList"
         vocab="https://schema.org/"


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary
Fixes #6581 

### Problem
(Originally discovered by inspecting the HTML of the webpage)
Using the Windows 10 Narrator app, I visited the [production MDN article about the navigation role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/navigation_role). On this page, I navigated through the landmarks (Capslock + D) until I got to the breadcrumbs landmark, and it read out "Breadcrumb navigation, navigation landmark."

### Solution
The solution was to remove the redundant word `"navigation"` from the `aria-label` of the affected `nav` element.

## How did you test this change?
I followed the steps in the quick setup section of this repo's readme to load my change into the browser. I then followed the same steps as described in the section `Problem`. The narrator read the nav out as "Breadcrumb, navigation landmark."