### PR TITLE
fix(sync-translated-content): don't add index.* duplicates

### DIFF
--- a/build/sync-translated-content.js
+++ b/build/sync-translated-content.js
@@ -95,6 +95,14 @@ function resolve(slug) {
   return slug;
 }
 
+function mdOrHtmlExists(filePath) {
+  const { dir, name } = path.parse(filePath);
+  return (
+    fs.existsSync(path.join(dir, name) + ".md") ||
+    fs.existsSync(path.join(dir, name) + ".html")
+  );
+}
+
 function syncTranslatedContent(inFilePath, locale) {
   if (!CONTENT_TRANSLATED_ROOT) {
     throw new Error(
@@ -185,17 +193,17 @@ function syncTranslatedContent(inFilePath, locale) {
     metadata.slug = `${ORPHANED}/${metadata.slug}`;
     status.moved = true;
     filePath = getFilePath();
-    if (fs.existsSync(filePath)) {
+    if (mdOrHtmlExists(filePath)) {
       log.log(`${inFilePath} → ${filePath}`);
       throw new Error(`file: ${filePath} already exists!`);
     }
-  } else if (fs.existsSync(filePath)) {
+  } else if (mdOrHtmlExists(filePath)) {
     `unrooting ${inFilePath} (conflicting translation)`;
     metadata.slug = `${CONFLICTING}/${metadata.slug}`;
     status.conflicting = true;
     status.moved = true;
     filePath = getFilePath();
-    if (fs.existsSync(filePath)) {
+    if (mdOrHtmlExists(filePath)) {
       metadata.slug = `${metadata.slug}_${crypto
         .createHash("md5")
         .update(oldMetadata.slug)

--- a/build/sync-translated-content.js
+++ b/build/sync-translated-content.js
@@ -96,10 +96,10 @@ function resolve(slug) {
 }
 
 function mdOrHtmlExists(filePath) {
-  const { dir, name } = path.parse(filePath);
+  const dir = path.dirname(filePath);
   return (
-    fs.existsSync(path.join(dir, name) + ".md") ||
-    fs.existsSync(path.join(dir, name) + ".html")
+    fs.existsSync(path.join(dir, MARKDOWN_FILENAME) ||
+    fs.existsSync(path.join(dir, HTML_FILENAME)
   );
 }
 

--- a/build/sync-translated-content.js
+++ b/build/sync-translated-content.js
@@ -98,8 +98,8 @@ function resolve(slug) {
 function mdOrHtmlExists(filePath) {
   const dir = path.dirname(filePath);
   return (
-    fs.existsSync(path.join(dir, MARKDOWN_FILENAME) ||
-    fs.existsSync(path.join(dir, HTML_FILENAME)
+    fs.existsSync(path.join(dir, MARKDOWN_FILENAME)) ||
+    fs.existsSync(path.join(dir, HTML_FILENAME))
   );
 }
 


### PR DESCRIPTION
verified by re-running https://github.com/mdn/translated-content/commit/91eded2a25d22ae38523a72053575fea1f25297b
which introduced the duplicates files/ja/web/api/window/blur_event.html and files/ja/web/api/window/focus_event.html

```
vscode@d47eeeeb9bfd:/workspace/translated-content$ git checkout 91eded2a25d22ae38523a72053575fea1f25297b~1
HEAD is now at b950fc2622 Translation: DOMException [es] - Fix #6334 (#6471)
vscode@d47eeeeb9bfd:/workspace/translated-content$ cd ../yari/
vscode@d47eeeeb9bfd:/workspace/yari$ yarn tool sync-translated-content
[...]
vscode@d47eeeeb9bfd:/workspace/yari$ cd ../translated-content/
vscode@d47eeeeb9bfd:/workspace/translated-content$ ls files/ja/web/api/window/blur_event
index.md
vscode@d47eeeeb9bfd:/workspace/translated-content$ ls files/ja/conflicting/web/api/window/blur_event
index.html
vscode@d47eeeeb9bfd:/workspace/translated-content$ ls files/ja/web/api/window/focus_event
index.md
vscode@d47eeeeb9bfd:/workspace/translated-content$ ls files/ja/conflicting/web/api/window/focus_event
index.html
```

blocks https://github.com/mdn/translated-content/pull/6580
