### PR TITLE
 fix(bcd): check support without major limitation for flags/altname/prefix

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -106,7 +106,9 @@ export function isOnlySupportedWithAltName(
   return (
     support &&
     getFirst(support).alternative_name &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
+    !asList(support).some((item) =>
+      isFullySupportedWithoutMajorLimitation(item)
+    )
   );
 }
 
@@ -116,7 +118,9 @@ export function isOnlySupportedWithPrefix(
   return (
     support &&
     getFirst(support).prefix &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
+    !asList(support).some((item) =>
+      isFullySupportedWithoutMajorLimitation(item)
+    )
   );
 }
 
@@ -126,7 +130,9 @@ export function isOnlySupportedWithFlags(
   return (
     support &&
     getFirst(support).flags &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
+    !asList(support).some((item) =>
+      isFullySupportedWithoutMajorLimitation(item)
+    )
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/browser-compat-data/issues/16839, fixes https://github.com/mdn/browser-compat-data/issues/16833, fixes https://github.com/mdn/browser-compat-data/issues/17208

### Problem

If there is support without a prefix, altname, or flag, even if there is a note indicating a minor limitation with that support, don't show the symbol indicating the need for a flag, altname, or prefix.

### Solution

Check for support without major limitations, not just support without limitations

---

## Screenshots

### Before

![Screenshot from 2022-07-05 10-56-47](https://user-images.githubusercontent.com/29206584/177357544-74014416-12a7-4d75-9b3d-0228ec51c8b2.png)

### After

![Screenshot from 2022-07-05 10-56-50](https://user-images.githubusercontent.com/29206584/177357565-c0d686c5-0980-46da-b36c-2408d343e080.png)
