### PR TITLE
feat(macros): localize NonStandardBadge

### DIFF
--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -1,18 +1,16 @@
 <%
 /* Inserts a badge indicating a term or API is non-standard.
 
-    Parameters:
-        $0  If specified and non-zero, a small badge is displayed.
+    Parameters: none
 
 */
 
-var titleAttrValue = mdn.localString({
-    "fr": "Cette API n'a pas été standardisée.",
-    "ja": "この API は標準化されていません。",
-    "ru": "Это API не было стандартизировано.",
-    "en-US": "This API has not been standardized."
+var title = mdn.localString({
+    "en-US": "Non-standard. Check cross-browser support before using.",
+    "zh-CN": "非标准的。请在使用前检查跨浏览器支持。",
+    "zh-TW": "非標準的。請在使用前檢查跨瀏覽器支援。"
 });
 %>
-<abbr class="icon icon-nonstandard" title="Non-standard. Check cross-browser support before using.">
+<abbr class="icon icon-nonstandard" title="<%= title %>">
     <span class="visually-hidden">Non-Standard</span>
 </abbr>

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -5,12 +5,18 @@
 
 */
 
-var title = mdn.localString({
+const title = mdn.localString({
     "en-US": "Non-standard. Check cross-browser support before using.",
     "zh-CN": "非标准的。请在使用前检查跨浏览器支持。",
     "zh-TW": "非標準的。請在使用前檢查跨瀏覽器支援。"
 });
+
+const abbreviation = mdn.localString({
+    "en-US": "Non-standard",
+    "zh-CN": "非标准",
+    "zh-TW": "非標準"
+});
 %>
 <abbr class="icon icon-nonstandard" title="<%= title %>">
-    <span class="visually-hidden">Non-Standard</span>
+    <span class="visually-hidden"><%= abbreviation %></span>
 </abbr>

--- a/kumascript/macros/NonStandardBadge.ejs
+++ b/kumascript/macros/NonStandardBadge.ejs
@@ -7,8 +7,8 @@
 
 const title = mdn.localString({
     "en-US": "Non-standard. Check cross-browser support before using.",
-    "zh-CN": "非标准的。请在使用前检查跨浏览器支持。",
-    "zh-TW": "非標準的。請在使用前檢查跨瀏覽器支援。"
+    "zh-CN": "非标准。请在使用前检查跨浏览器支持。",
+    "zh-TW": "非標準。請在使用前檢查跨瀏覽器支援。"
 });
 
 const abbreviation = mdn.localString({


### PR DESCRIPTION
## Summary

support localization for `{{NonStandardBadge}}` macro which is used by `{{APIRef}}`, `{{Non-standard_Inline}}`, etc.

### Problem

This macro should support l10n. But it won't. (the `title` is fixed with an `en-US` text)

### Solution

using `mdn.localString` to select a l10n title for this macro.

---

## Screenshots

test on this pr: mdn/translated-content#6699

### Before

Non-standard_Inline:

![image](https://user-images.githubusercontent.com/15844309/177439186-2e513cb5-d2a7-4bdf-9a71-07f09d762bd1.png)

APIRef:

![image](https://user-images.githubusercontent.com/15844309/177439215-77fc55f7-5076-44ec-ad65-94cc00cd26dc.png)

### After

Non-standard_Inline:

![image](https://user-images.githubusercontent.com/15844309/177439269-16470899-eb59-4bbf-a068-7d608e9176c8.png)

APIRef:

![image](https://user-images.githubusercontent.com/15844309/177439301-25b4639d-251d-4690-9179-8247406982fe.png)

## How did you test this change?

see renderd html.
