### PR TITLE
Add jssyntax as Prism alias for syntax boxes

### DIFF
--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -37,7 +37,7 @@ const loadAllLanguages = lazy(() => {
 // Prism expects. It'd be hard to require that content writers
 // have to stick to the exact naming conventions that Prism uses
 // because Prism is an implementation detail.
-const ALIASES = new Map([["sh", "shell"]]);
+const ALIASES = new Map([["sh", "shell"], ["jssyntax", "js"]]);
 
 // Over the years we have accumulated some weird <pre> tags whose
 // brush is more or less "junk".

--- a/build/syntax-highlight.js
+++ b/build/syntax-highlight.js
@@ -37,7 +37,10 @@ const loadAllLanguages = lazy(() => {
 // Prism expects. It'd be hard to require that content writers
 // have to stick to the exact naming conventions that Prism uses
 // because Prism is an implementation detail.
-const ALIASES = new Map([["sh", "shell"], ["jssyntax", "js"]]);
+const ALIASES = new Map([
+  ["sh", "shell"],
+  ["jssyntax", "js"],
+]);
 
 // Over the years we have accumulated some weird <pre> tags whose
 // brush is more or less "junk".


### PR DESCRIPTION
See mdn/mdn-community#149.

This adds an alias in Prism for `js`: `jssyntax`.

The plan is to use it with syntax boxes (Web APIs and JS) that have pseudo-JS. We want them to be highlighted as JavaScript by Prism, but distinct so that tools like Prettier and ESLint can skip them.