### PR TITLE
Fix redirect validation output

### DIFF
--- a/content/redirect.js
+++ b/content/redirect.js
@@ -238,7 +238,7 @@ function loadLocaleAndAdd(
       const [a1, a2] = a[i] || [];
       const [b1, b2] = b[i] || [];
       if (a1 !== b1 || a2 !== b2) {
-        return [a1, b1, a2, b2];
+        return [a1, a2, b1, b2];
       }
     }
     return null;
@@ -282,8 +282,8 @@ function validateLocale(locale, strict = false) {
   // To validate strict we check if there is something to fix.
   const { changed } = loadLocaleAndAdd(localeLC, [], { fix: strict, strict });
   if (changed) {
-    const [a1, b1, a2, b2] = changed;
-    throw new Error(`Invalid redirect for ${a1} -> ${b1} or ${a2} -> ${b2}`);
+    const [a1, a2, b1, b2] = changed;
+    throw new Error(`Invalid redirect for ${a1} -> ${a2} or ${b1} -> ${b2}`);
   }
 }
 


### PR DESCRIPTION
This PR fixes the output for the redirect validation script, ensuring that the pairs are properly displayed.

Before:
```
info: _redirects.txt for en-us is causing issues: Error: Invalid redirect for /en-US/docs/Web/API/GlobalEventHandlers/onselectstart -> /en-US/docs/Web/API/GlobalFetch/GlobalFetch.fetch() or /en-US/docs/Web/API/HTMLInputElement/selectstart_event -> /en-US/docs/Web/API/fetch
```

After:
```
info: _redirects.txt for en-us is causing issues: Error: Invalid redirect for /en-US/docs/Web/API/GlobalEventHandlers/onselectstart -> /en-US/docs/Web/API/HTMLInputElement/selectstart_event or /en-US/docs/Web/API/GlobalFetch/GlobalFetch.fetch() -> /en-US/docs/Web/API/fetch
```
