### PR TITLE
fix(macros): correct the links in {{CSSInfo}} macro

### DIFF
--- a/kumascript/macros/xref_csscomputed.ejs
+++ b/kumascript/macros/xref_csscomputed.ejs
@@ -1,15 +1,4 @@
 <%
-let page = mdn.localString({
-    "en-US": "computed_value",
-    "de"   : "berechneter_Wert",
-    "es"   : "Valor_calculado",
-    "fr"   : "Valeur_calcul%c3%a9e",
-    "ja"   : "computed_value",
-    "pl"   : "warto%c5%9b%c4%87_wyliczona",
-    "zh-CN": "computed_value",
-    "ru"   : "computed_value"
-});
-
 let linkText = mdn.localString({
     "en-US": "Computed value",
     "de"   : "Berechneter Wert",
@@ -20,7 +9,5 @@ let linkText = mdn.localString({
     "zh-CN": "计算值",
     "ru"   : "Обработка значения"
 });
-
-let link = "<a href=\"/" + env.locale + "/docs/Web/CSS/$1$\">$2$</a>";
 %>
-<%- mdn.replacePlaceholders(link, [page, linkText]) %>
+<%- `<a href="/${env.locale}/docs/Web/CSS/computed_value">${linkText}</a>` %>

--- a/kumascript/macros/xref_cssinherited.ejs
+++ b/kumascript/macros/xref_cssinherited.ejs
@@ -1,17 +1,4 @@
 <%
-let page = mdn.localString({
-    "en-US": "inheritance",
-    "de"   : "Vererbung",
-    "es"   : "inheritance",
-    "fr"   : "H%c3%a9ritage",
-    "ja"   : "inheritance",
-    "ko"   : "inheritance",
-    "pl"   : "dziedziczenie",
-    "zh-CN": "inheritance",
-    "zh-TW": "inheritance",
-    "ru"   : "inheritance"
-});
-
 let linkText = mdn.localString({
     "en-US": "Inherited",
     "de"   : "Vererbt",
@@ -24,7 +11,5 @@ let linkText = mdn.localString({
     "zh-TW": "繼承與否",
     "ru"   : "Наследуется"
 });
-
-let link = "<a href=\"/" + env.locale + "/docs/Web/CSS/$1$\">$2$</a>";
 %>
-<%- mdn.replacePlaceholders(link, [page, linkText]) %>
+<%- `<a href="/${env.locale}/docs/Web/CSS/inheritance">${linkText}</a>` %>

--- a/kumascript/macros/xref_cssinitial.ejs
+++ b/kumascript/macros/xref_cssinitial.ejs
@@ -12,4 +12,4 @@ let linkText = mdn.localString({
     "ru"   : "Начальное значение"
 });
 %>
-<%- `<a href="/${env.locale}/docs/Web/CSS/initial_value\">${linkText}</a>` %>
+<%- `<a href="/${env.locale}/docs/Web/CSS/initial_value">${linkText}</a>` %>

--- a/kumascript/macros/xref_cssinitial.ejs
+++ b/kumascript/macros/xref_cssinitial.ejs
@@ -1,17 +1,4 @@
 <%
-let page = mdn.localString({
-    "en-US": "initial_value",
-    "de"   : "Initialwert",
-    "es"   : "Valor_inicial",
-    "fr"   : "Valeur_initiale",
-    "ja"   : "initial_value",
-    "ko"   : "initial_value",
-    "pl"   : "warto%c5%9b%c4%87_pocz%c4%85tkowa",
-    "zh-CN": "initial_value",
-    "zh-TW": "%e9%a0%90%e8%a8%ad%e5%80%bc",
-    "ru"   : "initial_value"
-});
-
 let linkText = mdn.localString({
     "en-US": "Initial value",
     "de"   : "Initialwert",
@@ -24,7 +11,5 @@ let linkText = mdn.localString({
     "zh-TW": "預設值",
     "ru"   : "Начальное значение"
 });
-
-let link = "<a href=\"/" + env.locale + "/docs/Web/CSS/$1$\">$2$</a>";
 %>
-<%- mdn.replacePlaceholders(link, [page, linkText]) %>
+<%- `<a href="/${env.locale}/docs/Web/CSS/initial_value\">${linkText}</a>` %>


### PR DESCRIPTION
## Summary

For the same document, they have the same slug for both `en-US` and `l10n`. So the URL in `{{CSSInfo}}` macro should be updated.

### Problem

see **Screenshots**.

### Solution

update URLs.

## Screenshots

run `yarn dev` and check this url: `http://localhost:5042/zh-TW/docs/Web/CSS/border-color#formal_definition_%E8%AA%9E%E6%B3%95%E5%AE%9A%E7%BE%A9`

### Before

![image](https://user-images.githubusercontent.com/15844309/178094631-b286bc56-e7a5-4d8f-88ab-fb0a42ecacd8.png)

### After

![image](https://user-images.githubusercontent.com/15844309/178094611-ec77ad63-8018-4c48-9071-4ed01b0ca1b8.png)

## How did you test this change?

see rendered page in browser.
