### PR TITLE
fix(macros): inconsistent sidebar icon placement

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -180,20 +180,21 @@ function buildSublist(pages, title) {
 
     result += '<li>';
 
+    var pageBadges = '';
     if (hasTag(aPage, 'Experimental')) {
-        result += badges.ExperimentalBadge;
+        pageBadges += badges.ExperimentalBadge;
     }
 
     if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
-        result += badges.NonStandardBadge;
+        pageBadges += badges.NonStandardBadge;
     }
 
     if (hasTag(aPage, 'Deprecated')) {
-        result += badges.DeprecatedBadge;
+        pageBadges += badges.DeprecatedBadge;
     }
 
     if (hasTag(aPage, 'Obsolete')) {
-        result += badges.ObsoleteBadge;
+        pageBadges += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
     }
 
@@ -202,9 +203,9 @@ function buildSublist(pages, title) {
     }
 
     if (slug == aPage.slug) {
-        result += '<em><code>' + title + '</code></em>'
+        result += '<em>' + pageBadges + ' <code>' + title + '</code></em>'
     } else {
-        result += web.smartLink(url, null, `<code>${title}</code>`, APIHref, null, "APIRef");
+        result += pageBadges + web.smartLink(url, null, `<code>${title}</code>`, APIHref, null, "APIRef");
     }
 
     if (rtlLocales.indexOf(locale) != -1) {

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -170,20 +170,21 @@ function buildSublist(pages, title, opened) {
         });
     }
 
+    var pageBadges = '';
     if (containsTag(aPage, 'Experimental')) {
-        result += badges.ExperimentalBadge;
+        pageBadges += badges.ExperimentalBadge;
     }
 
     if (containsTag(aPage, 'Non-standard') || containsTag(aPage, 'Non Standard')) {
-        result += badges.NonStandardBadge;
+        pageBadges += badges.NonStandardBadge;
     }
 
     if (containsTag(aPage, 'Deprecated')) {
-        result += badges.DeprecatedBadge;
+        pageBadges += badges.DeprecatedBadge;
     }
 
     if (containsTag(aPage, 'Obsolete')) {
-        result += badges.ObsoleteBadge;
+        pageBadges += badges.ObsoleteBadge;
         result += '<s class="obsoleteElement">';
     }
 
@@ -192,9 +193,9 @@ function buildSublist(pages, title, opened) {
     }
 
     if (slug == aPage.slug) {
-        result += '<em><code>' + aPage.title + '</code></em>'
+        result += '<em>' + pageBadges + ' <code>' + aPage.title + '</code></em>'
     } else {
-        result += web.smartLink(url, null, `<code>${title}</code>`, aPage.slug, slug_stdlib, "JSRef");
+        result += pageBadges + web.smartLink(url, null, `<code>${title}</code>`, aPage.slug, slug_stdlib, "JSRef");
     }
 
     if (rtlLocales.indexOf(locale) != -1) {

--- a/kumascript/macros/WebExtAPISidebar.ejs
+++ b/kumascript/macros/WebExtAPISidebar.ejs
@@ -54,22 +54,23 @@ function buildSublist(pages, title, ignoreBadges) {
 
     result += '<li>';
 
+    var pageBadges = '';
     if (!ignoreBadges) {
 
         if (hasTag(aPage, 'Experimental')) {
-            result += badges.ExperimentalBadge;
+            pageBadges += badges.ExperimentalBadge;
         }
 
         if (hasTag(aPage, 'Non-standard') || hasTag(aPage, 'Non Standard')) {
-            result += badges.NonStandardBadge;
+            pageBadges += badges.NonStandardBadge;
         }
 
         if (hasTag(aPage, 'Deprecated')) {
-            result += badges.DeprecatedBadge;
+            pageBadges += badges.DeprecatedBadge;
         }
 
         if (hasTag(aPage, 'Obsolete')) {
-            result += badges.ObsoleteBadge;
+            pageBadges += badges.ObsoleteBadge;
             result += '<s class="obsoleteElement">';
         }
     }
@@ -79,9 +80,9 @@ function buildSublist(pages, title, ignoreBadges) {
     }
 
     if (slug == aPage.slug) {
-        result += '<em><code>' + apiComponentName + '</code></em>'
+        result += '<em>' + pageBadges + ' <code>' + apiComponentName + '</code></em>'
     } else {
-        result += '<a href="' + url + '"><code>' + apiComponentName + '</code></a>';
+        result += pageBadges + '<a href="' + url + '"><code>' + apiComponentName + '</code></a>';
     }
 
     if (rtlLocales.indexOf(locale) != -1) {


### PR DESCRIPTION
## Summary

Fixes #6719.


### Problem

The icons (badges) would "jump" to their own line for the sidebar item of the current page.
Observable on pages like:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contextMenu
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/arguments


### Solution

Accumulate the badges in their own variable, then put them inside the ``<em>`` tag. This ensures "the same line" placement.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://user-images.githubusercontent.com/6942070/181693306-94bbf432-61df-47ae-8af0-137eb42b0abd.png)
![image](https://user-images.githubusercontent.com/6942070/181693404-7fb96d63-abc9-4358-ac79-9e8739c9700d.png)


### After

![image](https://user-images.githubusercontent.com/6942070/181693506-5d2662a6-f9e5-461f-97c0-e8a8101ea7a9.png)
![image](https://user-images.githubusercontent.com/6942070/181693594-4f364ac7-6cea-4679-b5d2-67e1bebae8ad.png)


---

## How did you test this change?

I made sure to visit appropriate sections of the website while editing the files to make sure they apply to the correct templates.
The fix works as expected, in all sections of the side it's applicable to.

## Additional notes

I was [made aware](https://github.com/mdn/yari/issues/6719#issuecomment-1187009882) of an [ongoing](https://github.com/mdn/yari/discussions/4033) [discussion](https://github.com/mdn/mdn-community/discussions/69) that [includes this problem](https://github.com/mdn/yari/issues/1721#issuecomment-1120865965).

The motivation for this PR is to apply an obvious fix to a specific problem all while the discussions may take the time to settle and rework everything eventually.