### PR TITLE
fix: make the sitemap generator work with spread build

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -213,6 +213,9 @@ jobs:
 
           du -sh client/build
 
+          # Generate sitemap index file
+          yarn build --sitemap-index
+
       - name: Deploy with deployer
         env:
           GITHUB_SHA: ${{ env.GITHUB_SHA }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -211,6 +211,9 @@ jobs:
 
           du -sh client/build
 
+          # Generate sitemap index file
+          yarn build --sitemap-index
+
       - name: Deploy with deployer
         env:
           GITHUB_SHA: ${{ env.GITHUB_SHA }}

--- a/build/cli.js
+++ b/build/cli.js
@@ -322,7 +322,9 @@ program
 
         if (!options.quiet) {
           console.log(
-            chalk.green(`Sitemap index file built with [${locales}].`)
+            chalk.green(
+              `Sitemap index file built with locales: ${locales.join(", ")}.`
+            )
           );
         }
         return;


### PR DESCRIPTION
## Summary

Fixes: #6738.

### Problem

The sitemap was generated twice, and will only include the specific locales.

https://github.com/mdn/yari/blob/e3b755e1cacbc84a57a09dca3e80e3f35549ed8d/.github/workflows/prod-build.yml#L201-L207

For example, when we run a job, like:

```bash
yarn build --locale     en-us --locale     ja --locale     fr & 
build1=$! 
yarn build --not-locale en-us --not-locale ja --not-locale fr & 
build2=$! 

wait build1
wait build2
```

and the first job takes more time. Then, the `sitemap.xml` will only include `en-US`, `fr`, and `ja` (see: <https://developer.mozilla.org/sitemap.xml>).

### Solution

To generate the sitemap with all built locales in spread build:

1. collect all existed `sitemap.xml.gz` in `BUILD_OUT_ROOT`
2. generate `sitemap.xml` with collected `sitemap.xml.gz` filepaths.
