### PR TITLE
Fix icons displayed in BCD cells

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -268,12 +268,14 @@ function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
   }
 
   const icons = [
-    isOnlySupportedWithPrefix(support) && <Icon key="prefix" name="prefix" />,
+    isOnlySupportedWithPrefix(supportItem) && (
+      <Icon key="prefix" name="prefix" />
+    ),
     hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
-    isOnlySupportedWithAltName(support) && (
+    isOnlySupportedWithAltName(supportItem) && (
       <Icon key="altname" name="altname" />
     ),
-    isOnlySupportedWithFlags(support) && (
+    isOnlySupportedWithFlags(supportItem) && (
       <Icon key="disabled" name="disabled" />
     ),
   ].filter(Boolean);

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -7,9 +7,6 @@ import {
   hasNoteworthyNotes,
   isFullySupportedWithoutLimitation,
   isNotSupportedAtAll,
-  isOnlySupportedWithAltName,
-  isOnlySupportedWithFlags,
-  isOnlySupportedWithPrefix,
   isTruthy,
   versionIsPreview,
   SupportStatementExtended,
@@ -268,16 +265,10 @@ function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
   }
 
   const icons = [
-    isOnlySupportedWithPrefix(supportItem) && (
-      <Icon key="prefix" name="prefix" />
-    ),
+    supportItem.prefix && <Icon key="prefix" name="prefix" />,
     hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
-    isOnlySupportedWithAltName(supportItem) && (
-      <Icon key="altname" name="altname" />
-    ),
-    isOnlySupportedWithFlags(supportItem) && (
-      <Icon key="disabled" name="disabled" />
-    ),
+    supportItem.alternative_name && <Icon key="altname" name="altname" />,
+    supportItem.flags && <Icon key="disabled" name="disabled" />,
   ].filter(Boolean);
 
   return icons.length ? <div className="bc-icons">{icons}</div> : null;

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -99,37 +99,6 @@ function hasMajorLimitation(support: BCD.SimpleSupportStatement) {
     support.version_removed
   );
 }
-
-export function isOnlySupportedWithAltName(
-  support: BCD.SupportStatement | undefined
-) {
-  return (
-    support &&
-    getFirst(support).alternative_name &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
-  );
-}
-
-export function isOnlySupportedWithPrefix(
-  support: BCD.SupportStatement | undefined
-) {
-  return (
-    support &&
-    getFirst(support).prefix &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
-  );
-}
-
-export function isOnlySupportedWithFlags(
-  support: BCD.SupportStatement | undefined
-) {
-  return (
-    support &&
-    getFirst(support).flags &&
-    !asList(support).some((item) => isFullySupportedWithoutLimitation(item))
-  );
-}
-
 export function isFullySupportedWithoutLimitation(
   support: BCD.SimpleSupportStatement
 ) {


### PR DESCRIPTION
This PR fixes the rendering of the `prefix`, `altname` and `flags` icons on BCD cells to ensure they aren't unintentionally shown when not applicable.  This should help reduce issues and confusion such as https://github.com/mdn/browser-compat-data/issues/17208.
