### PR TITLE
fix: links in mdnsidebar

### DIFF
--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -229,15 +229,15 @@ const text = mdn.localStringMap({
             <details>
                 <summary><%=text['Community_guide']%></summary>
                 <ol>
-                    <li><ahref="<%=baseURL%>Community"><%=text['Comm_overview']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Contributing"><%=text['Contributing']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Open_source_etiquette"><%=text['Open_source']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Discussions"><%=text['Discuss']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Learn_forum"><%=text['Learn']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Issues"><%=text['Issues']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Pull_requests"><%=text['PRs']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Mdn_content"><%=text['Content']%></a></li>
-                    <li><ahref="<%=baseURL%>Community/Users_teams"><%=text['Users']%></a></li>
+                    <li><a href="<%=baseURL%>Community"><%=text['Comm_overview']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Contributing"><%=text['Contributing']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Open_source_etiquette"><%=text['Open_source']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Discussions"><%=text['Discuss']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Learn_forum"><%=text['Learn']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Issues"><%=text['Issues']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Pull_requests"><%=text['PRs']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Mdn_content"><%=text['Content']%></a></li>
+                    <li><a href="<%=baseURL%>Community/Users_teams"><%=text['Users']%></a></li>
                 </ol>
             </details>
         </li>
@@ -246,13 +246,13 @@ const text = mdn.localStringMap({
             <details>
                 <summary><%=text['Writing_guide']%></summary>
                 <ol>
-                    <li><ahref="<%=baseURL%>Writing_guidelines"><%=text['Write_overview']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/What_we_write"><%=text['What_write']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/Writing_style_guide"><%=text['Style_guide']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/Howto"><%=text['Howto']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/Page_structures"><%=text['Structures']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/Attrib_copyright_license"><%=text['Attrib']%></a></li>
-                    <li><ahref="<%=baseURL%>Writing_guidelines/Experimental_deprecated_obsolete"><%=text['Exper']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines"><%=text['Write_overview']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/What_we_write"><%=text['What_write']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/Writing_style_guide"><%=text['Style_guide']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/Howto"><%=text['Howto']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/Page_structures"><%=text['Structures']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/Attrib_copyright_license"><%=text['Attrib']%></a></li>
+                    <li><a href="<%=baseURL%>Writing_guidelines/Experimental_deprecated_obsolete"><%=text['Exper']%></a></li>
                 </ol>
             </details>
         </li>


### PR DESCRIPTION
Fixes the link syntax in the `mdnsidebar`. ~~For some reason Prettier changes `<a href=...` to `<ahref=...`~~ - Turns out it was a different extension causing the problem.