### PR TITLE
Deprecate `{{css_key_concepts}}`

### DIFF
--- a/kumascript/macros/CSS_key_concepts.ejs
+++ b/kumascript/macros/CSS_key_concepts.ejs
@@ -1,4 +1,5 @@
 <%
+mdn.deprecated();
 switch(env.locale) {
     case "de":
 %>CSS Schlüsselkonzepte:


### PR DESCRIPTION
## Summary

This intends to deprecate a macro (prudent step before effective deletion)

### Problem

This macro only creates links and should be removed

### Solution

Added `mdn.deprecated()` as in other cases of such deprecation.

## How did you test this change?

I didn't

## See also

https://github.com/mdn/content/pull/19105
https://github.com/mdn/translated-content/pull/7334