### PR TITLE
Deprecate {{event}} macro

### DIFF
--- a/kumascript/macros/event.ejs
+++ b/kumascript/macros/event.ejs
@@ -7,6 +7,12 @@
 /*   parameter will be used */
 /* @param [optional] */
 /*   An anchor to link to on the page. Link text will display as $0.$2 or $1.$2 */
+
+// Deprecated; link directly to the event on a specific interface in /docs/Web/API/
+
+// Condition for removal: no more use in translated-content (August 2022: 7477 occurrences)
+// 0 occurrences left in en-US
+mdn.deprecated();
  
 /* get a page's language (Don't use page.language!) */
 var lang = env.locale;


### PR DESCRIPTION
This PR deprecates the `{{event}}` macro.  All of the uses in English content are now removed, leaving the localized content.
