### PR TITLE
Remove archived link (Basic raycaster)

### DIFF
--- a/kumascript/macros/CanvasSidebar.ejs
+++ b/kumascript/macros/CanvasSidebar.ejs
@@ -26,7 +26,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'Optimizing the canvas',
     'Finale': 'Finale',
     'Examples': 'Examples',
-    'raycaster': 'A basic raycaster',
     'video_canvas': 'Manipulating video using canvas',
     'Interfaces': 'Interfaces',
     'Documentation': 'Documentation:',
@@ -50,7 +49,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'Optimiser le canevas',
     'Finale': 'Conclusion',
     'Examples': 'Exemples',
-    'raycaster': 'Un traceur de rayons simple',
     'video_canvas': 'Manipuler des vidéos avec un canevas',
     'Interfaces': 'Interfaces',
     'Documentation': 'Documentation\xa0:',
@@ -74,7 +72,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'canvas 的优化',
     'Finale': '终极',
     'Examples': '示例',
-    'raycaster': '一个基本的光线投射例子',
     'video_canvas': '在 canvas 中操作视频',
     'Interfaces': '接口',
     'Documentation': '文档:',
@@ -98,7 +95,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'Оптимизация canvas',
     'Finale': 'Заключение',
     'Examples': 'Примеры',
-    'raycaster': 'Простой излучатель лучей',
     'video_canvas': 'Манипяция видео с помощью canvas',
     'Interfaces': 'Интерфейсы',
     'Documentation': 'Документация:',
@@ -122,7 +118,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'canvas の最適化',
     'Finale': '最後に',
     'Examples': '例',
-    'raycaster': 'A basic raycaster',
     'video_canvas': 'canvas を用いた動画の操作',
     'Interfaces': 'インターフェイス',
     'Documentation': 'ドキュメント:',
@@ -146,7 +141,6 @@ var text = mdn.localStringMap({
     'Optimizing': 'Canvas 최적화하기',
     'Finale': 'Finale',
     'Examples': '예제',
-    'raycaster': '기본 raycaster',
     'video_canvas': 'Canvas를 사용해 비디오 조작하기',
     'Interfaces': '인터페이스',
     'Documentation': '문서:',
@@ -182,7 +176,6 @@ var text = mdn.localStringMap({
     <details open>
       <summary><%=text['Examples']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/A_basic_ray-caster"><%=text['raycaster']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/API/Canvas_API/Manipulating_video_using_canvas"><%=text['video_canvas']%></a></li>
       </ol>
     </details>


### PR DESCRIPTION
This link has been archived (and is in the MDN museum). It must be removed from the sidebar, too.