### PR TITLE
Add a background color to good/bad codeblock examples

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -462,6 +462,8 @@ pre {
 }
 
 .example-bad {
+  background-color: var(--background-critical);
+
   &::after {
     background-color: var(--icon-critical);
     mask-image: url("../assets/icons/no.svg");
@@ -469,6 +471,8 @@ pre {
 }
 
 .example-good {
+  background-color: var(--background-success);
+
   &::after {
     background-color: var(--icon-success);
     mask-image: url("../assets/icons/checkmark.svg");


### PR DESCRIPTION
This PR adds a green and red tint respectively to the background of good/bad example codeblocks.  This helps distinguish good vs. bad examples much better, as the icons in the corner are easily missable at a glance.

Before:
<img width="639" alt="Screen Shot 2022-08-10 at 19 56 52" src="https://user-images.githubusercontent.com/5179191/184057652-f4bde5e3-fed0-4721-a3a6-ef0df2832da1.png">

After:
<img width="640" alt="Screen Shot 2022-08-10 at 19 57 08" src="https://user-images.githubusercontent.com/5179191/184057688-7d0ea21e-c71a-4784-a281-1ab28c645450.png">