### PR TITLE
Add Markdown localizations for German

### DIFF
--- a/markdown/localizations/de.json
+++ b/markdown/localizations/de.json
@@ -1,0 +1,18 @@
+{
+  "translations": {
+    "": {
+      "card_note_label": {
+        "msgid": "card_note_label",
+        "msgstr": ["Hinweis:"]
+      },
+      "card_warning_label": {
+        "msgid": "card_warning_label",
+        "msgstr": ["Warnung:"]
+      },
+      "card_callout_label": {
+        "msgid": "card_callout_label",
+        "msgstr": ["Bemerkung:"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds localizations for Note/Warning/Callout for Markdown conversion.  The strings come from the localized files themselves, and will help future translators if the German locale is ever unfrozen.
