### PR TITLE
Suppress formal syntax expansion for <color> and <gradient>

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -25,7 +25,7 @@ const slugMap = {
   "<position>": "position_value"
 }
 
-// Used for building links and tooltips for parts of the value definition syntax
+// Descriptions used for building links and tooltips for parts of the value definition syntax
 const syntaxDescriptions = {
   '*': {
     fragment: 'asterisk',
@@ -171,21 +171,20 @@ function renderNode(name, node) {
       encoded = encoded.replaceAll('>', '&gt;');
       // add CSS class: we use "property" because there isn't one for types
       const span = `<span class="token property">${encoded}</span>`;
-      // if this type is not included in the syntax, or it is in "typesToLink",
-      // then link to its dedicated page
-      if ((valuespaces[name] && valuespaces[name].value) &&
-          (!typesToLink.includes(name))) {
+      // If the type is not included in the syntax, or is in "typesToLink",
+      // link to its dedicated page (don't expand it)
+      if (valuespaces[name]?.value && !typesToLink.includes(name)) {
         return span;
       } else {
         let slug;
-        // slugMap is for when we can't derive the slug from the name
+        // If the name is in slugMap, we can't derive the slug from the name
         if (slugMap[name]) {
           slug = slugMap[name];
         } else {
-          // the slug does not include the angle brackets
+          // The slug should not include the angle brackets
           slug = name.replaceAll('<', '');
           slug = slug.replaceAll('>', '');
-          // also remove the range in square brackets, as in "<number [0,∞]>"
+          // The slug should not contain the range in square brackets, as in "<number [0,∞]>"
           slug = slug.replace(/\[.*\]/, '');
         }
         return `<a href="/${locale}/docs/Web/CSS/${slug}">${span}</a>`;
@@ -305,12 +304,11 @@ function renderSyntax(type, syntax) {
 function getTypesForSyntaxes(syntaxes, constituents) {
 
   function processNode(node) {
-    // we want to ignore the constituent parts of "typesToLink" types
+    // Ignore the constituent parts of "typesToLink" types
     if (typesToLink.includes(`<${node.name}>`)) {
       return;
     }
-    if (node.type === 'Type' &&
-       (!constituents.includes(node.name))) {
+    if (node.type === 'Type' && !constituents.includes(node.name)) {
       constituents.push(node.name);
     }
   }
@@ -343,10 +341,10 @@ function getConstituentTypes(itemSyntax) {
     // get the syntaxes for all newly added constituents,
     // and then get the types in those syntaxes
     constituentSyntaxes = [];
-    for (let constituent of allConstituents.slice(oldConstituentsLength)) {
-      let constituentSyntaxEntry = valuespaces[`<${constituent}>`];
+    for (const constituent of allConstituents.slice(oldConstituentsLength)) {
+      const constituentSyntaxEntry = valuespaces[`<${constituent}>`];
 
-      if (constituentSyntaxEntry && constituentSyntaxEntry.value) {
+      if (constituentSyntaxEntry?.value) {
         constituentSyntaxes.push(constituentSyntaxEntry.value);
       }
     }

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -314,7 +314,7 @@ function getTypesForSyntaxes(syntaxes, constituents) {
   }
 
   for (const syntax of syntaxes) {
-    let ast = definitionSyntax.parse(syntax);
+    const ast = definitionSyntax.parse(syntax);
     definitionSyntax.walk(ast, processNode);
   }
 

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -16,6 +16,15 @@ const locale = env.locale;
 // URL where we describe value definition syntax
 const valueDefinitionUrl = `/${locale}/docs/Web/CSS/Value_definition_syntax`;
 
+// CSS types for which we want to link to another page, and not expand the syntax
+const typesToLink = ["<color>", "<gradient>"];
+
+// Map item names onto slugs, in cases where the slug can't be derived from the name
+const slugMap = {
+  "<color>": "color_value",
+  "<position>": "position_value"
+}
+
 // Used for building links and tooltips for parts of the value definition syntax
 const syntaxDescriptions = {
   '*': {
@@ -162,15 +171,23 @@ function renderNode(name, node) {
       encoded = encoded.replaceAll('>', '&gt;');
       // add CSS class: we use "property" because there isn't one for types
       const span = `<span class="token property">${encoded}</span>`;
-      // if this type is not included in the syntax, link to its dedicated page
-      if (valuespaces[name] && valuespaces[name].value) {
+      // if this type is not included in the syntax, or it is in "typesToLink",
+      // then link to its dedicated page
+      if ((valuespaces[name] && valuespaces[name].value) &&
+          (!typesToLink.includes(name))) {
         return span;
       } else {
-        // the slug does not include the angle brackets
-        let slug = name.replaceAll('<', '');
-        slug = slug.replaceAll('>', '');
-        // also remove the range in square brackets, as in "<number [0,∞]>"
-        slug = slug.replace(/\[.*\]/, '')
+        let slug;
+        // slugMap is for when we can't derive the slug from the name
+        if (slugMap[name]) {
+          slug = slugMap[name];
+        } else {
+          // the slug does not include the angle brackets
+          slug = name.replaceAll('<', '');
+          slug = slug.replaceAll('>', '');
+          // also remove the range in square brackets, as in "<number [0,∞]>"
+          slug = slug.replace(/\[.*\]/, '');
+        }
         return `<a href="/${locale}/docs/Web/CSS/${slug}">${span}</a>`;
       }
     }
@@ -288,6 +305,10 @@ function renderSyntax(type, syntax) {
 function getTypesForSyntaxes(syntaxes, constituents) {
 
   function processNode(node) {
+    // we want to ignore the constituent parts of "typesToLink" types
+    if (typesToLink.includes(`<${node.name}>`)) {
+      return;
+    }
     if (node.type === 'Type' &&
        (!constituents.includes(node.name))) {
       constituents.push(node.name);
@@ -323,7 +344,6 @@ function getConstituentTypes(itemSyntax) {
     // and then get the types in those syntaxes
     constituentSyntaxes = [];
     for (let constituent of allConstituents.slice(oldConstituentsLength)) {
-
       let constituentSyntaxEntry = valuespaces[`<${constituent}>`];
 
       if (constituentSyntaxEntry && constituentSyntaxEntry.value) {


### PR DESCRIPTION
This PR implements a sort of pragmatic version of one of the ideas in https://github.com/orgs/mdn/discussions/138 .

In that discussion is was suggested that when rendering formal syntax, instead of expanding out all the CSS types that we could, we should not expand out types that had their own separate MDN page, and instead just link to those pages.

A reason for wanting to do this is to make the formal syntax shorter, which is a good thing especially as pretty-printing has made it much longer than it used to be.

But as mentioned in https://github.com/orgs/mdn/discussions/138#discussioncomment-3035090, doing this for *every* type risks making formal syntax too fragmentary, forcing readers to chase across many pages to get a complete picture.

So instead this PR suppresses "inline expansion" only for the `<color>` and `<gradient>` types. The reason for choosing them is that they are very long and (especially `<color>`) very common, so the formal syntax tends to be very repetitive.

Before this PR, for example, the formal syntax for `border` looks like:

![Screen Shot 2022-08-12 at 17 03 44](https://user-images.githubusercontent.com/432915/184455111-fe8aa5e0-45e8-48ca-9446-1979d61cb941.png)

Afterwards, it looks like:

![Screen Shot 2022-08-12 at 17 02 34](https://user-images.githubusercontent.com/432915/184455058-40157fc5-7a3c-445d-9b18-57de15db0391.png)

I think the second one is quite a lot more useful for most people.

@Rumyra , @teoli2003 , would be happy to hear your thoughts.
