### PR TITLE
fix: add "page-type" to optional front matter keys

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -85,6 +85,7 @@ function extractLocale(folder) {
 function saveFile(filePath, rawBody, metadata, frontMatterKeys = null) {
   const requiredFrontMatterKeys = ["title", "slug"];
   const optionalFrontMatterKeys = [
+    "page-type",
     "tags",
     "translation_of",
     "translation_of_original",


### PR DESCRIPTION
## Summary

Fixes: #6493.

### Problem

When use command in content repo: 

```bash
yarn content move Web/API/AbortController/signal Web/API/AbortController/signals
```

The `page-type` key in front matter will be moved after tags.

![image](https://user-images.githubusercontent.com/15844309/184465518-6fc93a23-248e-42e2-84f5-63cb6a26b2ab.png)

And I found the `page-type` is not included in `optionalFrontMatterKeys`:

https://github.com/mdn/yari/blob/60747895d4058455707fd5d269f3c57a6bb76bfd/content/document.js#L86-L113

So, the insertion of `page-type` is after the insertion of `tags` and `bcd`, and the iteration of object after ES 2015 is by insertion order (if keys are not number). Finally in the dump, this key is also after `tags` and `bcd`.

### Solution

Add the `page-type` key to `optionalFrontMatterKeys`, and before `tags` key.

---

## Screenshots

### Before

see above.

### After

![image](https://user-images.githubusercontent.com/15844309/184465842-bd2a1757-8e65-4276-8467-402c627f3d7b.png)

---

## How did you test this change?

run `yarn tool move Web/API/AbortController/signal Web/API/AbortController/sign -y` in yari.
