### PR TITLE
Add Markdown localizations for Polish

### DIFF
--- a/markdown/localizations/pl.json
+++ b/markdown/localizations/pl.json
@@ -1,0 +1,18 @@
+{
+  "translations": {
+    "": {
+      "card_note_label": {
+        "msgid": "card_note_label",
+        "msgstr": ["Uwaga:"]
+      },
+      "card_warning_label": {
+        "msgid": "card_warning_label",
+        "msgstr": ["Ważne:"]
+      },
+      "card_callout_label": {
+        "msgid": "card_callout_label",
+        "msgstr": ["Obserwacja:"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the Markdown blockquote localization in Polish.  The strings come from analyzing the Polish files themselves.  This should help if Polish is ever unfrozen.