### PR TITLE
ci: add sitemap generate in dev build

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -163,6 +163,9 @@ jobs:
           # would upload the whole content of client/build
           du -sh client/build
 
+          # Generate sitemap index file
+          yarn build --sitemap-index
+
       - name: Deploy with deployer
         env:
           # Set the CONTENT_ROOT first


### PR DESCRIPTION
## Summary

I've ignored the dev build. Add sitemap generate in this workflow.

See: #6791

## How did you test this change?

None.
