### PR TITLE
feat: add `noreferrer` and `target=_blank` to external link for built contents

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -118,7 +118,7 @@ function injectLoadingLazyAttributes($) {
 
 /**
  * For every `<a href="http...">` make it
- * `<a href="http..." class="external" and rel="noopener">`
+ * `<a href="http..." class="external" and rel="noopener noreferrer" target="_blank">`
  *
  *
  * @param {Cheerio document instance} $

--- a/build/index.ts
+++ b/build/index.ts
@@ -136,8 +136,9 @@ function postProcessExternalLinks($) {
     $a.addClass("external");
     const rel = ($a.attr("rel") || "").split(" ");
     if (!rel.includes("noopener")) {
-      rel.push("noopener");
+      rel.push("noopener", "noreferrer");
       $a.attr("rel", rel.join(" "));
+      $a.attr("target", "_blank");
     }
   });
 }


### PR DESCRIPTION
## Summary

As is a title.

### Problem

An external link in contents that are built by `build/index.js` hasn't `noreferrer` and `target=_blank`.

### Solution

Add  `noreferrer` and `target=_blank` to external link built by `build/index.js`.

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/11273093/184637014-88589966-a61a-4f25-a450-ce08290530fe.png)

### After

![after](https://user-images.githubusercontent.com/11273093/184637038-76697ecd-f34d-425a-8c6e-8dca53258311.png)

---

## How did you test this change?

1. Change the source core.
2. Run locally
3. Check manually

---

Thank you :)