### PR TITLE
build(deps): delete `fast-xml-parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "dotenv": "^16.0.1",
     "ejs": "^3.1.8",
     "express": "^4.18.1",
-    "fast-xml-parser": "^4.0.9",
     "fdir": "^5.2.0",
     "file-type": "^16.5.4",
     "front-matter": "^4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5680,13 +5680,6 @@ fast-xml-parser@^3.19.0:
   dependencies:
     strnum "^1.0.4"
 
-fast-xml-parser@^4.0.9:
-  version "4.0.9"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.9.tgz#3a81dab7b4952b8d38f0136d28bd055b80ed6512"
-  integrity sha512-4G8EzDg2Nb1Qurs3f7BpFV4+jpMVsdgLVuG1Uv8O2OHJfVCg7gcA53obuKbmVqzd4Y7YXVBK05oJG7hzGIdyzg==
-  dependencies:
-    strnum "^1.0.5"
-
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
@@ -11856,7 +11849,7 @@ strip-outer@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.2"
 
-strnum@^1.0.4, strnum@^1.0.5:
+strnum@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
   integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==


### PR DESCRIPTION
## Summary

The `fast-xml-parser` is unnecessary dependency.

### Problem

Any scripts do not reference the `fast-xml-parser`.

- The `fast-xml-parser` installed [PR 2917](https://github.com/mdn/yari/pull/2917/files#diff-68f18456493b71321a584edd84d146d973d1c7a224bf178b707609bdd8e6822cR2) for `build/feedparser.js`.
- But, the `build/feedparser.js` has been deleted [PR 5337](https://github.com/mdn/yari/pull/5337/files#diff-68f18456493b71321a584edd84d146d973d1c7a224bf178b707609bdd8e6822cL6).

### Solution

Delete the `fast-xml-parser` from dependencies.

## Screenshots

N/A

## How did you test this change?

N/A

---

Thank you :)