### PR TITLE
chore(client): remove useCSRFMiddlewareToken hook

### DIFF
--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import useSWR from "swr";
 
 // This is a bit of a necessary hack!
 // The only reason this list is needed is because of the PageNotFound rendering.
@@ -15,38 +14,10 @@ import useSWR from "swr";
 // items, for example, will think the locale is `some-random-word` and make links
 // like `/some-random-word/docs/Web`.
 import { VALID_LOCALES } from "./constants";
-import { useUserData } from "./user-context";
-
-interface UserSettings {
-  csrfmiddlewaretoken: string;
-}
 
 export function useLocale() {
   const { locale } = useParams();
   return locale && VALID_LOCALES.has(locale) ? locale : "en-US";
-}
-
-export function useCSRFMiddlewareToken(): string {
-  const userData = useUserData();
-  const userSettingsAPIURL = React.useMemo(() => {
-    return userData && userData.isAuthenticated ? "/api/v1/settings/" : null;
-  }, [userData]);
-  const { data, error } = useSWR<UserSettings>(
-    userSettingsAPIURL,
-    async (url) => {
-      const response = await fetch(url);
-      if (!response.ok) {
-        throw new Error(`${response.status} on ${url}`);
-      }
-      return await response.json();
-    }
-  );
-
-  if (!error) {
-    return data?.csrfmiddlewaretoken ?? "";
-  } else {
-    return "";
-  }
 }
 
 export function useOnClickOutside(ref, handler) {

--- a/client/src/ui/atoms/signout/index.tsx
+++ b/client/src/ui/atoms/signout/index.tsx
@@ -1,14 +1,13 @@
 import { useLocation } from "react-router-dom";
 
 import { cleanupUserData } from "../../../user-context";
-import { useCSRFMiddlewareToken, useLocale } from "../../../hooks";
+import { useLocale } from "../../../hooks";
 import { KUMA_HOST } from "../../../env";
 
 import "./index.scss";
 import { Button } from "../button";
 
 export default function SignOut() {
-  const csrfMiddlewareToken = useCSRFMiddlewareToken();
   const locale = useLocale();
   const { pathname } = useLocation();
 
@@ -34,13 +33,6 @@ export default function SignOut() {
         cleanupUserData();
       }}
     >
-      {csrfMiddlewareToken && (
-        <input
-          type="hidden"
-          name="csrfmiddlewaretoken"
-          value={csrfMiddlewareToken}
-        />
-      )}
       <input type="hidden" name="next" value={next} />
       <Button
         type="secondary"

--- a/client/src/ui/molecules/notifications-watch-menu/index.tsx
+++ b/client/src/ui/molecules/notifications-watch-menu/index.tsx
@@ -5,7 +5,7 @@ import { NotificationsWatchMenuStart } from "./menu-start";
 
 import "./index.scss";
 import useSWR from "swr";
-import { useCSRFMiddlewareToken, useOnlineStatus } from "../../../hooks";
+import { useOnlineStatus } from "../../../hooks";
 import { DropdownMenu, DropdownMenuWrapper } from "../dropdown";
 import { ManageOrUpgradeDialogNotifications } from "../manage-upgrade-dialog";
 import { useUIStatus } from "../../../ui-context";
@@ -26,7 +26,6 @@ export const NotificationsWatchMenu = ({ doc }) => {
 
   const slug = doc.mdn_url; // Unique ID for the page
   const apiURL = `/api/v1/plus/watching/?url=${slug}`;
-  const csrfMiddlewareToken = useCSRFMiddlewareToken();
   const ui = useUIStatus();
   const { isOffline } = useOnlineStatus();
 
@@ -76,7 +75,6 @@ export const NotificationsWatchMenu = ({ doc }) => {
       method: "POST",
       body: JSON.stringify(postData),
       headers: {
-        "X-CSRFToken": csrfMiddlewareToken || "",
         "Content-Type": "application/json",
       },
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6846.

### Problem

The `/api/v1/settings` route no longer exists in rumba, so the `useCSRFMiddlewareToken` hook
no longer has any effect apart from triggering HTTP 404s.

Note: The "csrftoken" cookie is still available and being used.

### Solution

Remove the `useCSRFMiddlewareToken` hook and its usages.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
