### PR TITLE
feat(compat): list polyfills

### DIFF
--- a/build/document-extractor.js
+++ b/build/document-extractor.js
@@ -324,6 +324,7 @@ function _addSingleSpecialSection($) {
 
   let dataQuery = null;
   let hasMultipleQueries = false;
+  let polyfillURLs = null;
   let specURLsString = "";
   let specialSectionType = null;
   if ($.find("div.bc-data").length) {
@@ -332,6 +333,8 @@ function _addSingleSpecialSection($) {
     // Macro adds "data-query", but some translated-content still uses "id".
     dataQuery = elem.attr("data-query") || elem.attr("id");
     hasMultipleQueries = elem.attr("data-multiple") === "true";
+    // Add polyfills info
+    polyfillURLs = elem.attr("data-polyfills");
   } else if ($.find("div.bc-specs").length) {
     specialSectionType = "specifications";
     dataQuery = $.find("div.bc-specs").attr("data-bcd-query");
@@ -460,6 +463,7 @@ function _addSingleSpecialSection($) {
           data,
           query,
           browsers,
+          polyfillURLs,
         },
       },
     ];

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -16,6 +16,7 @@ import { Doc } from "../../../libs/types/document";
 import { Prose } from "./ingredients/prose";
 import { LazyBrowserCompatibilityTable } from "./lazy-bcd-table";
 import { SpecificationSection } from "./ingredients/spec-section";
+import { PolyfillsSubSection } from "./ingredients/polyfills-subsection";
 
 // Misc
 // Sub-components
@@ -235,10 +236,16 @@ function RenderDocumentBody({ doc }) {
       return <Prose key={section.value.id} section={section.value} />;
     } else if (section.type === "browser_compatibility") {
       return (
-        <LazyBrowserCompatibilityTable
-          key={`browser_compatibility${i}`}
-          {...section.value}
-        />
+        <>
+          <LazyBrowserCompatibilityTable
+            key={`browser_compatibility${i}`}
+            {...section.value}
+          />
+          <PolyfillsSubSection
+            id={"polyfills"}
+            polyfillURLs={section.value.polyfillURLs}
+          />
+        </>
       );
     } else if (section.type === "specifications") {
       return (

--- a/client/src/document/ingredients/polyfills-subsection.tsx
+++ b/client/src/document/ingredients/polyfills-subsection.tsx
@@ -1,0 +1,63 @@
+import { DisplayH2, DisplayH3 } from "./utils";
+
+const ALLOWED_POLYFILL_SERVICE = [
+  {
+    baseURL: "https://github.com/zloirock/core-js",
+    serviceURL: "",
+    serviceName: "core-js",
+  },
+  {
+    baseURL: "https://github.com/Financial-Times/polyfill-service",
+    serviceURL: "http://polyfill.io",
+    serviceName: "polyfill.io",
+  },
+  {
+    baseURL: "https://formatjs.io/docs/polyfills",
+    serviceURL: "https://formatjs.io/",
+    serviceName: "formatjs.io",
+  },
+  {
+    baseURL: "https://github.com/tc39/",
+    serviceURL: "https://github.com/tc39/",
+    serviceName: "TC39",
+  },
+  {
+    baseURL: "https://github.com/w3c",
+    serviceURL: "https://github.com/w3c",
+    serviceName: "W3C",
+  },
+];
+
+function polyfillService(url) {
+  return ALLOWED_POLYFILL_SERVICE.find((entry) =>
+    url.startsWith(entry.baseURL)
+  );
+}
+
+export function PolyfillsSubSection({
+  id,
+  polyfillURLs,
+}: {
+  id: string;
+  polyfillURLs: string;
+}) {
+  const title = "Polyfills";
+
+  const service = polyfillService(polyfillURLs);
+  if (service === undefined) {
+    return (
+      <>
+        <DisplayH3 id={id} title={title} />
+        Error: Polyfill url not in allowed list.
+      </>
+    );
+  } else {
+    return (
+      <>
+        <DisplayH3 id={id} title={title} />A{" "}
+        <a href={polyfillURLs}> polyfill</a> for this feature is available at{" "}
+        <a href={service.serviceURL}>{service.serviceName}</a>.
+      </>
+    );
+  }
+}

--- a/client/src/document/ingredients/polyfills-subsection.tsx
+++ b/client/src/document/ingredients/polyfills-subsection.tsx
@@ -1,4 +1,4 @@
-import { DisplayH2, DisplayH3 } from "./utils";
+import { DisplayH3 } from "./utils";
 
 const ALLOWED_POLYFILL_SERVICE = [
   {

--- a/client/src/document/ingredients/polyfills-subsection.tsx
+++ b/client/src/document/ingredients/polyfills-subsection.tsx
@@ -62,5 +62,5 @@ export function PolyfillsSubSection({
       );
     }
   }
-  return "";
+  return <></>;
 }

--- a/client/src/document/ingredients/polyfills-subsection.tsx
+++ b/client/src/document/ingredients/polyfills-subsection.tsx
@@ -41,23 +41,26 @@ export function PolyfillsSubSection({
   id: string;
   polyfillURLs: string;
 }) {
-  const title = "Polyfills";
+  if (polyfillURLs) {
+    const title = "Polyfills";
 
-  const service = polyfillService(polyfillURLs);
-  if (service === undefined) {
-    return (
-      <>
-        <DisplayH3 id={id} title={title} />
-        Error: Polyfill url not in allowed list.
-      </>
-    );
-  } else {
-    return (
-      <>
-        <DisplayH3 id={id} title={title} />A{" "}
-        <a href={polyfillURLs}> polyfill</a> for this feature is available at{" "}
-        <a href={service.serviceURL}>{service.serviceName}</a>.
-      </>
-    );
+    const service = polyfillService(polyfillURLs);
+    if (service === undefined) {
+      return (
+        <>
+          <DisplayH3 id={id} title={title} />
+          Error: Polyfill url not in allowed list.
+        </>
+      );
+    } else {
+      return (
+        <>
+          <DisplayH3 id={id} title={title} />A{" "}
+          <a href={polyfillURLs}> polyfill</a> for this feature is available at{" "}
+          <a href={service.serviceURL}>{service.serviceName}</a>.
+        </>
+      );
+    }
   }
+  return "";
 }

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -37,7 +37,7 @@ if (!query) {
 }
 
 // Read 'polyfills' key
-const polyfill = env['polyfills'];
+const polyfill = env['polyfills'] || "";
 
 const depth = $1 || 1;
 const queries = Array.isArray(query) ? query : [query];

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -30,13 +30,20 @@ Example calls
 
 */
 
-var query = $0 || env['browser-compat'];
+// Read 'browser-compat' key
+const query = $0 || env['browser-compat'];
 if (!query) {
   throw new Error("No first query argument or 'browser-compat' front-matter value passed");
 }
-var depth = $1 || 1;
-var queries = Array.isArray(query) ? query : [query];
-var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}" data-multiple="${queries.length > 1}">
+
+// Read 'polyfills' key
+const polyfill = env['polyfills'];
+
+const depth = $1 || 1;
+const queries = Array.isArray(query) ? query : [query];
+
+//output = polyfills;
+var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}" data-multiple="${queries.length > 1}" data-polyfills="${polyfills}">
   If you're able to see this, something went wrong on this page.
 </div>`).join("\n");
 %>

--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -37,12 +37,11 @@ if (!query) {
 }
 
 // Read 'polyfills' key
-const polyfill = env['polyfills'] || "";
+const polyfills = env['polyfills'] || "";
 
 const depth = $1 || 1;
 const queries = Array.isArray(query) ? query : [query];
 
-//output = polyfills;
 var output = queries.map(query => `<div class="bc-data" data-query="${query}" data-depth="${depth}" data-multiple="${queries.length > 1}" data-polyfills="${polyfills}">
   If you're able to see this, something went wrong on this page.
 </div>`).join("\n");


### PR DESCRIPTION
This is the unblocking PR for one of our Quarterly projects: we want to store polyfills only inside a YAML entry (`polyfills`) and display a sentence about them below the Compat Table.

This PR:
- create and read the YAML Key
- add a React subsection below the Compat table.
- populate this subsection with a sentence and a link.

We only authorize URLs from an allowlist to be used for this YAML header. We extend it a bit, but it should already cover the whole of web/javascript.
