### PR TITLE
ci(workflows): check commit signatures

### DIFF
--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -1,0 +1,36 @@
+name: "Commit signatures"
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch commits
+        run: curl -s "${{ github.event.pull_request._links.commits.href }}" > commits.json
+
+      - name: Filter unverified commits
+        run: jq '[.[].commit | select(.verification.verified == false)]' < commits.json > unverified-commits.json
+
+      - name: List unverified commits
+        run: jq '.[] | [{message, tree, author, committer, verification}]' < unverified-commits.json
+
+      - name: Result
+        run: |
+          COUNT="$(jq '. | length' < unverified-commits.json)"
+
+          if [[ "$COUNT" == "0" ]];
+          then
+            echo "✅ All commits are verified."
+            exit 0
+          fi
+
+          echo "❌ PR contains $COUNT unverified commit(s)!"
+          echo ""
+          echo "Please note that we require that all commits are signed."
+          echo "Please see the documentation about signed commits and how to sign yours on GitHub:"
+          echo "- https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification"
+          echo "- https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+          exit 1


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Adds a check that detects unsigned/unverified commits in PRs.

See:  #6130

### Problem

We regularly see unsigned/unverified commits in PRs, which is frustrating for both the PR author and us, because it delays the merge.

### Solution

Adds a check, so that PR authors can easily notice the unsigned/unverified commits themselves, and fix them.

---

## How did you test this change?

1. Committed unsigned commit to this PR, see: :x: https://github.com/mdn/yari/runs/7924608819?check_suite_focus=true
2. Then force-pushed a signed commit instead, see: ✅ https://github.com/mdn/yari/runs/7924654266?check_suite_focus=true
