### PR TITLE
Deprecate GeckoRelease

### DIFF
--- a/kumascript/macros/geckoRelease.ejs
+++ b/kumascript/macros/geckoRelease.ejs
@@ -1,5 +1,9 @@
 <%
 
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated()
+
 /* Appending a "+" to the version number you specify means that version and all later versions. */
 var geckoRelease = undefined;
 var arg = `${$0}`.trim();


### PR DESCRIPTION
We have removed `{{GeckoRelease}}` from mdn/content.

The last PR is there: mdn/content#19815

There is one left on the kitchensink page. @caugner : Should I remove it there, or should I replace it with something else?