### PR TITLE
fix(macros/DeprecatedGeneric): remove failing tests

### DIFF
--- a/kumascript/tests/macros/Deprecated.test.js
+++ b/kumascript/tests/macros/Deprecated.test.js
@@ -13,24 +13,6 @@ describeMacro("Deprecated_Inline", function () {
 </abbr>`
     );
   });
-  itMacro('"semver" string only (en-US)', function (macro) {
-    return assert.eventually.equal(
-      macro.call("1.9.2"),
-      `<span class="notecard inline deprecated" title="(Firefox 3.6 / Thunderbird 3.1 / Fennec 1.0)">Deprecated since Gecko 1.9.2</span>`
-    );
-  });
-  itMacro("Numeric version only (en-US)", function (macro) {
-    return assert.eventually.equal(
-      macro.call(45),
-      `<span class="notecard inline deprecated" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
-    );
-  });
-  itMacro("Gecko-prefixed version (en-US)", function (macro) {
-    return assert.eventually.equal(
-      macro.call("gecko45"),
-      `<span class="notecard inline deprecated" title="(Firefox 45 / Thunderbird 45 / SeaMonkey 2.42)">Deprecated since Gecko 45</span>`
-    );
-  });
   itMacro("HTML-prefixed version (en-US)", function (macro) {
     return assert.eventually.equal(
       macro.call("html4"),


### PR DESCRIPTION
## Summary

Follow-up to #6920.

### Problem

I removed an unused `DeprecatedGeneric` branch in #6920, which caused corresponding tests to fail, but the PR got merged anyways.

### Solution

Remove the corresponding tests, as `DeprecatedGeneric` is no longer used in that way.

---

## How did you test this change?

Looked through usages of `DeprecatedGeneric` via `rg -i DeprecatedGeneric content translated-content` and verified that it is no longer called with just a version number as the second parameter.
