### PR TITLE
fix(menu): remove misleading ARIA attributes

### DIFF
--- a/client/src/ui/molecules/menu/index.tsx
+++ b/client/src/ui/molecules/menu/index.tsx
@@ -18,7 +18,6 @@ export const Menu = ({ menu, isOpen, toggle }: MenuProps) => {
         id={buttonId}
         className="top-level-entry menu-toggle"
         aria-controls={submenuId}
-        aria-haspopup="menu"
         aria-expanded={isOpen}
         onClick={() => {
           toggle(menu.id);

--- a/client/src/ui/molecules/submenu/index.tsx
+++ b/client/src/ui/molecules/submenu/index.tsx
@@ -39,7 +39,6 @@ export const Submenu = ({
       className={`${isDropdown ? "dropdown-list" : "submenu"} ${menuEntry.id} ${
         defaultHidden ? "hidden" : ""
       } ${extraClasses || ""}`}
-      role="menu"
       aria-labelledby={`${menuEntry.id}-button`}
     >
       {menuEntry.items &&
@@ -48,7 +47,6 @@ export const Submenu = ({
           return (
             <li
               key={key}
-              role="menuitem"
               className={`${item.extraClasses || ""} ${
                 isDropdown ? "dropdown-item" : ""
               }`}
@@ -61,7 +59,6 @@ export const Submenu = ({
                   className={`submenu-item ${
                     item.url.startsWith("https://") ? "external" : ""
                   }`}
-                  role="menuitem"
                 >
                   {item.hasIcon && <div className={item.iconClasses} />}
                   {item.dot && (


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Partly fixes #6870.

### Problem

Our primary navigation menu uses misleading ARIA attributes:

- `aria-haspopup` for a button that doesn't trigger a popup.
- `role="menu"` and `role="menuitem"` for elements that don't behave like a menu.

### Solution

Remove those ARIA attributes in those specific locations.

---

## Screenshots

_No visual changes._

---

## How did you test this change?

Verified via "View Page source" that the attributes are no longer present on the specific elements.
