### PR TITLE
fix(macros): remove write to /tmp

### DIFF
--- a/kumascript/src/api/web.js
+++ b/kumascript/src/api/web.js
@@ -162,7 +162,6 @@ module.exports = {
       flawAttribute = ` data-flaw-src="${util.htmlEscape(flaw.macroSource)}"`;
     }
     // Let's get a potentially localized title for when the document is missing.
-    fs.appendFileSync("/tmp/reads.log", `titleWhenMissing\n`, "utf-8");
     const titleWhenMissing = this.mdn.getLocalString(
       this.web.getJSONData("L10n-Common"),
       "summary"


### PR DESCRIPTION
## Summary

Fixes #6802.

### Problem

The `smartLink()` function wrote to a `/tmp/read.log` file, but /tmp is not available on Windows, which broke macros. Also, the file being written to was not actually used.

### Solution

Stop writing to that file. (Other locations use `tempy`, but since we don't read that file anywhere, we can just omit the write.)

---

## How did you test this change?

Verified that the {{APIRef}} macro renders again on http://localhost:5042/en-US/docs/Web/API/SVGStyleElement.