### PR TITLE
fix(build): prevent doc.title = null

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -443,7 +443,7 @@ async function buildDocument(document, documentOptions = {}) {
     $("[data-flaw-src]").removeAttr("data-flaw-src");
   }
 
-  doc.title = metadata.title;
+  doc.title = metadata.title || "";
   doc.mdn_url = document.url;
   doc.locale = metadata.locale;
   doc.native = LANGUAGES.get(doc.locale.toLowerCase()).native;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Avoids Rumba to fail if a document has a null title.

### Problem

There is a [document in translated-content ](https://github.com/mdn/translated-content/blob/36c6660dc8732a0a2977352de479129c90697670/files/de/web/html/element/u/index.html#L2) that has an empty title, and this causes some Rumba search requests to fail.

### Solution

Avoid that `doc.title = null` by using the empty string as a fallback.

---

## How did you test this change?

Trivial change, didn't test.
