### PR TITLE
ci(workflows): skip npm-publish if dependabot merged

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    if: github.triggering_actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Avoids our checks to fail on commits added to `main` by Dependabot.

### Problem

`NPM_AUTH_TOKEN` is a secret that is not available if the workflow was triggered by Dependabot [merging one of its own PRs].

### Solution

Skip the workflow, as it would fail anyway.

---

## Screenshots

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/495429/186412528-e04aa6fd-4235-402d-be18-c7a6b68fe791.png">

---

## How did you test this change?

Haven't tested, but a condition on the job is documented [here](https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository).

PS: Using `github.triggering_actor` allows us to still run the workflow manually:
<img width="718" alt="image" src="https://user-images.githubusercontent.com/495429/186412817-2e1e2da8-2abd-418a-9c85-f5ece56cfb7c.png">

