### PR TITLE
ci(dev-build): notify PRs about successful builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -224,6 +224,13 @@ jobs:
           PATHS: /*
         run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"
 
+      - name: Notify PRs about deployment
+        run: |
+          gh pr list -S "$GITHUB_SHA -is:merged" --json number --jq '.[].number' | xargs -i gh pr comment {} --body "Dev build for $GITHUB_SHA was deployed to: $DEPLOYMENT_URL" || true
+        env:
+          DEPLOYMENT_URL: https://${{ github.event.inputs.deployment_prefix }}.content.dev.mdn.mozit.cloud/
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Notifies PRs about [Dev builds](https://github.com/mdn/yari/actions/workflows/dev-build.yml) that we run from time to time to test PRs.

### Problem

So far, we have to wait for the Dev build to finish, manually construct the URL at which the build is available and write it in the PR to allow the PR author to participate in testing.

### Solution

Add a step to the Dev build to notify all PRs that include the built commit once the deployment succeeds.

---

## Screenshots

<img width="846" alt="image" src="https://user-images.githubusercontent.com/495429/186453585-0ce79649-7f84-4a1d-bb56-826ad7943c18.png">

---

## How did you test this change?

Commented out the actual build steps and ran just the notification step (see screenshot above).

See: https://github.com/mdn/yari/runs/7997530913?check_suite_focus=true#step:4:1