### PR TITLE
ci(testing): separate lint from test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:
@@ -40,6 +40,31 @@ jobs:
 
       - name: Lint ESLint
         run: yarn eslint
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: "yarn"
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cached-node_modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}-${{ hashFiles('.github/workflows/testing.yml') }}
+
+      - name: Install all yarn packages
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
+        run: |
+          yarn --frozen-lockfile
 
       - name: Unit testing client
         run: yarn test:client

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# Script equivalent of .github/workflows/testing.yml -> lint
+
+set -e
+
+echo "-------------------------"
+echo "Install all yarn packages"
+echo "-------------------------"
+
+yarn --frozen-lockfile
+
+echo "-------------"
+echo "Lint prettier"
+echo "-------------"
+
+yarn prettier-check
+
+echo "-----------"
+echo "Lint ESLint"
+echo "-----------"
+
+yarn eslint

--- a/scripts/testing.sh
+++ b/scripts/testing.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-# Script equivalent of .github/workflows/testing.yml
+# Script equivalent of .github/workflows/testing.yml -> test
 
 set -e
 
@@ -9,18 +9,6 @@ echo "Install all yarn packages"
 echo "-------------------------"
 
 yarn --frozen-lockfile
-
-echo "-------------"
-echo "Lint prettier"
-echo "-------------"
-
-yarn prettier-check
-
-echo "-----------"
-echo "Lint ESLint"
-echo "-----------"
-
-yarn eslint
 
 echo "-------------------"
 echo "Unit testing client"


### PR DESCRIPTION
## Summary

Splits up the testing workflow into two lint and test jobs.

### Problem

If there are linting errors, the tests are not run.

### Solution

Separate linting from testing.

---

## How did you test this change?

See checks of this PR.