### PR TITLE
chore(macros/LearnSidebar): add MathML tutorial

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -168,6 +168,11 @@ var text = mdn.localStringMap({
       'Accessible_multimedia' : 'Accessible multimedia',
       'Mobile_accessibility' : 'Mobile accessibility',
       'Assessment_Accessibility_troubleshooting' : 'Assessment: Accessibility troubleshooting',
+    'MathML_Writing_mathematics' : 'MathML — Writing mathematics with MathML',
+      'MathML_first_steps': 'MathML first steps',
+        'MathML_first_steps_overview': 'MathML first steps overview',
+        'Getting_started_with_MathML': 'Getting started with MathML',
+        'Assessment_Three_famous_mathematical_formulas': 'Assessment: Three famous mathematical formulas',
     'Tools_and_testing' : 'Tools and testing',
       'Cross_browser_testing' : 'Cross browser testing',
         'Cross_browser_testing_overview' : 'Cross browser testing overview',
@@ -1870,6 +1875,17 @@ var text = mdn.localStringMap({
             <li><a href="<%=baseURL%>Accessibility/Accessibility_troubleshooting"><%=text['Assessment_Accessibility_troubleshooting']%></a></li>
         </ol>
     </details>
+  </li>
+  <li data-default-state="<%=currentPageIsUnder('MathML')%>"><a href="<%=baseURL%>MathML"><strong><%=text['MathML_Writing_mathematics']%></strong></a></li>
+  <li class="toggle">
+      <details <%=currentPageIsUnder('MathML/First_steps')%>>
+          <summary><%=text['MathML_first_steps']%></summary>
+          <ol>
+            <li><a href="<%=baseURL%>MathML/First_steps"><%=text['MathML_first_steps_overview']%></a></li>
+            <li><a href="<%=baseURL%>MathML/First_steps/Getting_started"><%=text['Getting_started_with_MathML']%></a></li>
+            <li><a href="<%=baseURL%>MathML/First_steps/Three_famous_mathematical_formulas"><%=text['Assessment_Three_famous_mathematical_formulas']%></a></li>
+          </ol>
+      </details>
   </li>
   <li><a href="<%=baseURL%>Tools_and_testing"><strong><%=text['Tools_and_testing']%></strong></a></li>
   <li class="toggle">


### PR DESCRIPTION
## Summary

MDN learn pages [1] have a sidebar to quickly access various sections (HTML, CSS, JavaScript, etc). This PR adds the corresponding ones for the MathML tutorial added in [2]. Fixes #6952.

[1] https://developer.mozilla.org/en-US/docs/Learn
[2] https://github.com/mdn/content/pull/19467

### Problem

MathML tutorial is not accessible from the learn sidebar, so users cannot find it from the Learn pages.

### Solution

Add links for the MathML tutorial to existing sidebar.

## Screenshots

### Before

![yarn-before](https://user-images.githubusercontent.com/567455/188550613-d25894af-ba31-4b37-a1f2-e8947de2617c.jpg)

### After

![yarn-after](https://user-images.githubusercontent.com/567455/188550642-1a2fd31a-ac6d-4c4b-8f05-811da7ece170.jpg)

## How did you test this change?

I used `yarn dev` and opened a few subpages of http://localhost:3000/en-US/docs/Learn ; checking the added MathML sections properly display in the sidebar and that the links are not broken, and that one can fold/unfold the "MathML first steps" subsections by clicking on it. 