### PR TITLE
feat(macros): localize DeprecatedBadge

### DIFF
--- a/kumascript/macros/DeprecatedBadge.ejs
+++ b/kumascript/macros/DeprecatedBadge.ejs
@@ -3,13 +3,18 @@
     Parameters : none
 */
 
-var titleAttrValue = mdn.localString({
-    "en-US": "This deprecated API should no longer be used, but will probably still work.",
-    "fr"   : "Cette API obsolète ne doit plus être utilisée, mais elle peut continuer à fonctionner.",
-    "ru"   : "Это устаревшее API больше не должно использоваться, но оно по-прежнему может работать.",
-    "ja"   : "これは非推奨の API です。まだ動作しているかもしれませんが、もう使用するべきではありません。"
+const title = mdn.localString({
+    "en-US": "Deprecated. Not for use in new websites.",
+    "zh-CN": "已弃用。请不要在新的网站中使用。",
+    "zh-TW": "已正式宣告棄用。請不要在新的網站中使用。"
+});
+
+const abbreviation = mdn.localString({
+    "en-US": "Deprecated",
+    "zh-CN": "已弃用",
+    "zh-TW": "已正式宣告棄用"
 });
 %>
-<abbr class="icon icon-deprecated" title="Deprecated. Not for use in new websites.">
-    <span class="visually-hidden">Deprecated</span>
+<abbr class="icon icon-deprecated" title="<%= title %>">
+    <span class="visually-hidden"><%= abbreviation %></span>
 </abbr>

--- a/kumascript/macros/DeprecatedBadge.ejs
+++ b/kumascript/macros/DeprecatedBadge.ejs
@@ -6,13 +6,13 @@
 const title = mdn.localString({
     "en-US": "Deprecated. Not for use in new websites.",
     "zh-CN": "已弃用。请不要在新的网站中使用。",
-    "zh-TW": "已正式宣告棄用。請不要在新的網站中使用。"
+    "zh-TW": "已棄用。請不要在新的網站中使用。"
 });
 
 const abbreviation = mdn.localString({
     "en-US": "Deprecated",
     "zh-CN": "已弃用",
-    "zh-TW": "已正式宣告棄用"
+    "zh-TW": "已棄用"
 });
 %>
 <abbr class="icon icon-deprecated" title="<%= title %>">


### PR DESCRIPTION
## Summary

support localization for {{DeprecatedBadge}} macro which is used by {{APIRef}}, {{Deprecated_Inline}}, etc.

### Problem

This macro should support l10n. But it won't. (the `title` and `abbreviation` is fixed with en-US text)

### Solution

use `mdn.localString` to select l10n `title` and `abbreviation` for this macro.

---

## Screenshots

In <http://localhost:5042/zh-CN/docs/MDN/Writing_guidelines/Page_structures/Macros/Commonly_used_macros#已弃用>

### Before

![image](https://user-images.githubusercontent.com/15844309/186548895-5d7de6dd-f78e-4dfb-9b07-78d5671b4003.png)

### After

![image](https://user-images.githubusercontent.com/15844309/186548830-0944a9cd-ae94-47b9-8865-fd6d240c56ff.png)

---

## How did you test this change?

run `yarn dev` and check the rendered html.
