### PR TITLE
chore(macros): delete {{Exception}} macro

### DIFF
--- a/kumascript/macros/Exception.ejs
+++ b/kumascript/macros/Exception.ejs
@@ -1,9 +1,0 @@
-<%
-// Throw a MacroDeprecatedError flaw
-// Condition for removal: no more use in translated-content (May 2022: 22 occurrences)
-// 0 occurrences left in en-US
-mdn.deprecated();
-
-var id = "exception-" + $0;
-%>
-<a href="/<%-env.locale%>/docs/Web/API/DOMException#<%-id%>"><code><%- $0 %></code></a>


### PR DESCRIPTION
## Summary

The `{{Exception}}` macro has been deprecated. And now, this macro has been removed from mdn/translated-content. I've run the command below to verify it:

```bash
rg -i "\{\{\s*Exception" -l | wc -l # got 0
```

![image](https://user-images.githubusercontent.com/15844309/186769639-706e88bd-a295-4801-b815-145591d3fbf6.png)

There is no `{{Exception}}` macro left in content and translated-content. It's time to remove it.

## Reference

https://github.com/orgs/mdn/discussions/64

## How did you test this change?

Verified by using `rg`.
