### PR TITLE
Delete Exception.ejs

### DIFF
--- a/kumascript/macros/Exception.ejs
+++ b/kumascript/macros/Exception.ejs
@@ -1,9 +1,0 @@
-<%
-// Throw a MacroDeprecatedError flaw
-// Condition for removal: no more use in translated-content (May 2022: 22 occurrences)
-// 0 occurrences left in en-US
-mdn.deprecated();
-
-var id = "exception-" + $0;
-%>
-<a href="/<%-env.locale%>/docs/Web/API/DOMException#<%-id%>"><code><%- $0 %></code></a>


### PR DESCRIPTION
We removed `{{Exception}}` from mdn/content and deprecated it on yari (#6163).

The last occurrences of it got removed overnight from mdn/translated-content: https://github.com/orgs/mdn/discussions/64 

We can remove this macro.