### PR TITLE
MP-96 clear new collection modal

### DIFF
--- a/client/src/plus/collections/v2/new-edit-collection-modal.tsx
+++ b/client/src/plus/collections/v2/new-edit-collection-modal.tsx
@@ -44,7 +44,7 @@ export default function NewEditCollectionModal({
         ? await editCollection(collection)
         : await createCollection(collection);
     if (onClose) onClose(savedCollection.id);
-    setCollection(savedCollection);
+    setCollection(editingCollection ? savedCollection : defaultCollection);
     setShow(false);
   };
 


### PR DESCRIPTION
the previous fix meant that the modal wouldn't be cleared after creating a new collection
