### PR TITLE
fix(tests): stabilize flaky tests

### DIFF
--- a/testing/tests/developing.spec.ts
+++ b/testing/tests/developing.spec.ts
@@ -38,6 +38,9 @@ test.describe("Testing the kitchensink page", () => {
     expect(
       await page.isVisible("text=The MDN Content Kitchensink")
     ).toBeTruthy();
+
+    // Toolbar.
+    await page.waitForSelector("#_flaws");
     expect(
       await page.isVisible("text=No known flaws at the moment")
     ).toBeTruthy();

--- a/testing/tests/headless.sitesearch.spec.ts
+++ b/testing/tests/headless.sitesearch.spec.ts
@@ -76,7 +76,11 @@ test.describe("Site search", () => {
     expect(await page.isVisible('a:has-text("Next")')).toBeTruthy();
     expect(await page.isVisible("text=Serial 9")).toBeTruthy();
     expect(await page.isVisible('a:has-text("Previous")')).toBeFalsy();
+
+    // Page 2.
     await page.click('a:has-text("Next")');
+    await page.waitForLoadState("networkidle");
+
     expect(await page.isVisible("text=(page 2)")).toBeTruthy();
     expect(await page.isVisible("text=Serial 10")).toBeTruthy();
     expect(await page.isVisible("text=Serial 19")).toBeTruthy();


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/en-US/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Ensure the code is formatted: `yarn prettier --write .`
-->

## Summary

Fixes https://github.com/mdn/yari/issues/6960.
Fixes https://github.com/mdn/yari/issues/6990.

### Problem

There are two flaky tests that fail from time to time.

### Solution

Stabilize these tests by waiting for `networkidle` or a selector respectively.

---

## How did you test this change?

Hard to test, as the test failures are random.
