### PR TITLE
test(csp): verify that inline scripts have CSP entry

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -100,7 +100,7 @@
       /**
        * If we modify this script, we must update the CSP hash as follows:
        * 1. Run `npx jest testing/tests/csp.test.ts --watch`
-       * 2. Open `libs/constants/index.js` and find the current hash in scriptSrcValues.
+       * 2. Open `libs/constants/index.js` and find the current hash in CSP_SCRIPT_SRC_VALUES.
        * 3. Remove the old "previous" hash and replace it with the old "current" hash.
        * 4. Replace the old "current" hash with the new hash from the failing test (step 1).
        */

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -99,14 +99,10 @@
     <script>
       /**
        * If we modify this script, we must update the CSP hash as follows:
-       * 1. Run `yarn build:client`
-       * 2. Open `client/build/index.html` and locate this (minified) <script> tag.
-       * 3. Copy the inner content of the <script> tag (excluding the script tags).
-       * 4. Open https://csplite.com/csp/sha/ and paste the content.
-       * 5. Copy the `sha256-...` hash.
-       * 6. Open `libs/constants/index.js` and find the current hash in scriptSrcValues.
-       * 7. Remove the old "previous" hash and replace it with the old "current" hash.
-       * 8. Replace the old "current" hash with the new hash (from step 5).
+       * 1. Run `npx jest testing/tests/csp.test.ts --watch`
+       * 2. Open `libs/constants/index.js` and find the current hash in scriptSrcValues.
+       * 3. Remove the old "previous" hash and replace it with the old "current" hash.
+       * 4. Replace the old "current" hash with the new hash from the failing test (step 1).
        */
       document.body.addEventListener(
         "load",

--- a/libs/constants/index.d.ts
+++ b/libs/constants/index.d.ts
@@ -4,7 +4,7 @@ export const RETIRED_LOCALES: Map<string, string>;
 export const DEFAULT_LOCALE: string;
 export const LOCALE_ALIASES: Map<string, string>;
 export const PREFERRED_LOCALE_COOKIE_NAME: string;
-export const scriptSrcValues: string[];
+export const CSP_SCRIPT_SRC_VALUES: string[];
 export const CSP_VALUE: string;
 export const FLAW_LEVELS: Readonly<Record<string, string>>;
 export const VALID_FLAW_CHECKS: Set<string>;

--- a/libs/constants/index.d.ts
+++ b/libs/constants/index.d.ts
@@ -4,6 +4,7 @@ export const RETIRED_LOCALES: Map<string, string>;
 export const DEFAULT_LOCALE: string;
 export const LOCALE_ALIASES: Map<string, string>;
 export const PREFERRED_LOCALE_COOKIE_NAME: string;
+export const scriptSrcValues: string[];
 export const CSP_VALUE: string;
 export const FLAW_LEVELS: Readonly<Record<string, string>>;
 export const VALID_FLAW_CHECKS: Set<string>;

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -59,7 +59,7 @@ const ACTIVE_LOCALES = new Set([
   "zh-tw",
 ]);
 
-const scriptSrcValues = [
+const CSP_SCRIPT_SRC_VALUES = [
   "'report-sample'",
   "'self'",
 
@@ -89,8 +89,8 @@ const scriptSrcValues = [
 ];
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],
-  "script-src": scriptSrcValues,
-  "script-src-elem": scriptSrcValues,
+  "script-src": CSP_SCRIPT_SRC_VALUES,
+  "script-src-elem": CSP_SCRIPT_SRC_VALUES,
   "style-src": ["'report-sample'", "'self'", "'unsafe-inline'"],
   "object-src": ["'none'"],
   "base-uri": ["'self'"],
@@ -222,7 +222,7 @@ module.exports = {
   LOCALE_ALIASES,
   PREFERRED_LOCALE_COOKIE_NAME,
 
-  scriptSrcValues,
+  CSP_SCRIPT_SRC_VALUES,
   CSP_VALUE,
 
   // build

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -64,17 +64,24 @@ const scriptSrcValues = [
   "'self'",
 
   "www.google-analytics.com/analytics.js",
-
-  "'sha256-JEt9Nmc3BP88wxuTZm9aKNu87vEgGmKW1zzy/vb1KPs='", // polyfill check
   "polyfill.io/v3/polyfill.min.js",
 
   "assets.codepen.io",
   "production-assets.codepen.io",
 
-  /**
-   * If we modify the inline script in `client/public/index.html`,
-   * we must always update the CSP hash (see instructions there).
+  /*
+   * Inline scripts (defined in `client/public/index.html`).
+   *
+   * If we modify them, we must always update their CSP hash here.
+   *
+   * Important: Please make sure to always keep an entry for the
+   * previous hash to avoid issues shortly after cache invalidation.
    */
+
+  // 1. Polyfill.
+  "'sha256-JEt9Nmc3BP88wxuTZm9aKNu87vEgGmKW1zzy/vb1KPs='",
+
+  // 2. Theme switching.
   // - Previous hash (to avoid cache invalidation issues):
   "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
   // - Current hash:
@@ -215,6 +222,7 @@ module.exports = {
   LOCALE_ALIASES,
   PREFERRED_LOCALE_COOKIE_NAME,
 
+  scriptSrcValues,
   CSP_VALUE,
 
   // build

--- a/testing/tests/csp.test.ts
+++ b/testing/tests/csp.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import crypto from "crypto";
-import { scriptSrcValues } from "../../libs/constants";
+import { CSP_SCRIPT_SRC_VALUES } from "../../libs/constants";
 
 describe("Content-Security-Policy", () => {
   test('All inline <script> tags must have a corresponding "script-src" CSP entry.', () => {
@@ -29,7 +29,7 @@ describe("Content-Security-Policy", () => {
     const inlineScriptCspValues = inlineScriptContents.map(cspValueOf);
 
     const missingInlineScriptCspValues = inlineScriptCspValues.filter(
-      (value) => !scriptSrcValues.includes(value)
+      (value) => !CSP_SCRIPT_SRC_VALUES.includes(value)
     );
 
     // If this assertion fails, an inline script in `client/public/index.html` was

--- a/testing/tests/csp.test.ts
+++ b/testing/tests/csp.test.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+import { scriptSrcValues } from "../../libs/constants";
+
+describe("Content-Security-Policy", () => {
+  test('All inline <script> tags must have a corresponding "script-src" CSP entry.', () => {
+    function cspValueOf(content: string) {
+      const algo = "sha256";
+      const hash = crypto.createHash(algo).update(content).digest("base64");
+      return `'${algo}-${hash}'`;
+    }
+
+    const indexHtmlPath = path.join("client", "build", "index.html");
+    const indexHtmlContent = fs.readFileSync(indexHtmlPath).toString();
+
+    const inlineScriptMatches = [
+      ...indexHtmlContent.matchAll(/(<script.*?>)(.*?)(<\/script>)/gi),
+    ];
+
+    const inlineScriptContents = inlineScriptMatches
+      .filter((match) => !match[1].includes("src="))
+      .map((match) => match[2]);
+
+    // If this assertion fails, an inline script was added to client/public/index.html`.
+    // Please consider merging it with the other inline script, or increment this number.
+    expect(inlineScriptContents).toHaveLength(2);
+
+    const inlineScriptCspValues = inlineScriptContents.map(cspValueOf);
+
+    const missingInlineScriptCspValues = inlineScriptCspValues.filter(
+      (value) => !scriptSrcValues.includes(value)
+    );
+
+    // If this assertion fails, an inline script in `client/public/index.html` was
+    // updated without updating the "script-src" CSP entry in `libs/constants/index.js`.
+    expect(missingInlineScriptCspValues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
# Summary

Prevents us from forgetting to update the CSP entry when we update the inline `<script>` tags in `client/public/index.html`, and makes it easier to review such changes.

### Problem

If we update inline `<script>` tags in `client/public/index.html`, we **always** have to update the corresponding CSP entry in `libs/constants/index.js`, but so far we didn't ensure this with a test.

### Solution

Adds a test that verifies that all inline script tags have a corresponding CSP entry.

PS: This also avoids having to manually calculate the hash, as the failing test will print it out.

---

## How did you test this change?

Ran `npx jest testing/tests/csp.test.ts --watch` locally and removed a required CSP value from `libs/constants/index.js`.
