### PR TITLE
refactor(markdown): convert to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ yarn-error.log*
 /client/src/**/*.js.map
 /filecheck/*.js
 /filecheck/*.js.map
+/markdown/*.js
+/markdown/*.js.map
 /server/*.js
 /server/*.js.map
 /ssr/dist/

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -204,7 +204,7 @@ export async function buildSPAs(options) {
       const markdown = fs.readFileSync(filepath, "utf-8");
 
       const frontMatter = frontmatter<DocFrontmatter>(markdown);
-      const rawHTML = await m2h(frontMatter.body, locale);
+      const rawHTML = await m2h(frontMatter.body, { locale });
 
       const { sections, toc } = splitSections(rawHTML);
 

--- a/markdown/index.js
+++ b/markdown/index.js
@@ -1,7 +1,0 @@
-const util = require("./utils");
-const m2h = require("./m2h");
-
-module.exports = {
-  ...util,
-  ...m2h,
-};

--- a/markdown/index.ts
+++ b/markdown/index.ts
@@ -1,0 +1,2 @@
+export * from "./utils";
+export * from "./m2h";

--- a/markdown/m2h/cli.ts
+++ b/markdown/m2h/cli.ts
@@ -25,8 +25,8 @@ function tryOrExit(f: Function) {
   };
 }
 
-function buildLocaleMap(locale) {
-  let localesMap = new Map();
+function buildLocaleMap(locale: string) {
+  let localesMap = new Map<string, string>();
   if (locale !== "all") {
     localesMap = new Map([[locale.toLowerCase(), locale]]);
   }

--- a/markdown/m2h/cli.ts
+++ b/markdown/m2h/cli.ts
@@ -1,14 +1,19 @@
-const fm = require("front-matter");
-const { program } = require("@caporal/core");
-const chalk = require("chalk");
-const { Document } = require("../../content");
-const { saveFile } = require("../../content/document");
-const { VALID_LOCALES } = require("../../libs/constants");
+import fm from "front-matter";
+import { program } from "@caporal/core";
+import chalk from "chalk";
+import { Document } from "../../content";
+import { saveFile } from "../../content/document";
+import { VALID_LOCALES } from "../../libs/constants";
 
-const { m2h } = require("./");
+import { m2h } from "./";
 
-function tryOrExit(f) {
-  return async ({ options = {}, ...args }) => {
+interface CliOptions {
+  v?: boolean;
+  verbose?: boolean;
+}
+
+function tryOrExit(f: Function) {
+  return async ({ options = {}, ...args }: { options: CliOptions }) => {
     try {
       await f({ options, ...args });
     } catch (error) {

--- a/markdown/m2h/handlers/code.ts
+++ b/markdown/m2h/handlers/code.ts
@@ -1,14 +1,14 @@
-const u = require("unist-builder");
+import u from "unist-builder";
 
 /**
  * Transform a markdown code block into a <pre>.
  * Adding the highlight tags as classes prefixed by "brush:"
  */
-function code(h, node) {
+export function code(h, node) {
   var value = node.value ? node.value + "\n" : "";
   const lang = node.lang;
   const meta = (node.meta || "").split(" ");
-  const props = {};
+  const props: { className?: string | string[] } = {};
 
   if (lang) {
     props.className = ["brush:", lang.toLowerCase(), ...meta];
@@ -28,5 +28,3 @@ function code(h, node) {
 
   return h(node.position, "pre", props, [u("text", value)]);
 }
-
-module.exports = code;

--- a/markdown/m2h/handlers/dl.ts
+++ b/markdown/m2h/handlers/dl.ts
@@ -1,8 +1,8 @@
-const { all, wrap } = require("./mdast-util-to-hast-utils");
+import { all, wrap } from "./mdast-util-to-hast-utils";
 
-const DEFINITION_PREFIX = ": ";
+export const DEFINITION_PREFIX = ": ";
 
-function isDefinitionList(node) {
+export function isDefinitionList(node) {
   return (
     !node.ordered &&
     node.children.every((listItem) => {
@@ -28,7 +28,7 @@ function isDefinitionList(node) {
   );
 }
 
-function asDefinitionList(h, node) {
+export function asDefinitionList(h, node) {
   const children = node.children.flatMap((listItem) => {
     const terms = listItem.children.slice(0, -1);
     const definition =
@@ -60,5 +60,3 @@ function asDefinitionList(h, node) {
   });
   return h(node, "dl", {}, wrap(children, true));
 }
-
-module.exports = { DEFINITION_PREFIX, isDefinitionList, asDefinitionList };

--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -57,7 +57,7 @@ function getNotecardType(node, locale) {
   return type == "warning" || type == "note" || type == "callout" ? type : null;
 }
 
-export function buildLocalizedHandlers(locale) {
+export function buildLocalizedHandlers(locale: string) {
   /* This is only used for the Notecard parsing where the "magit" word depends on the locale */
   return {
     code,

--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { DEFAULT_LOCALE } = require("../../../libs/constants");
-const code = require("./code");
+const { code } = require("./code");
 const { asDefinitionList, isDefinitionList } = require("./dl");
 const { one, all, wrap } = require("./mdast-util-to-hast-utils");
 
@@ -57,7 +57,7 @@ function getNotecardType(node, locale) {
   return type == "warning" || type == "note" || type == "callout" ? type : null;
 }
 
-function buildLocalizedHandlers(locale) {
+export function buildLocalizedHandlers(locale) {
   /* This is only used for the Notecard parsing where the "magit" word depends on the locale */
   return {
     code,
@@ -105,7 +105,7 @@ function buildLocalizedHandlers(locale) {
 
       const name = node.ordered ? "ol" : "ul";
 
-      const props = {};
+      const props: { start?: number } = {};
       if (typeof node.start === "number" && node.start !== 1) {
         props.start = node.start;
       }
@@ -122,5 +122,3 @@ function buildLocalizedHandlers(locale) {
     },
   };
 }
-
-module.exports = buildLocalizedHandlers;

--- a/markdown/m2h/handlers/mdast-util-to-hast-utils.ts
+++ b/markdown/m2h/handlers/mdast-util-to-hast-utils.ts
@@ -3,7 +3,7 @@ These functions are more-or-less verbatim from https://github.com/syntax-tree/md
 Unfortunately the module was not exporting them, so they needed to be copied.
  */
 
-const u = require("unist-builder");
+import u from "unist-builder";
 
 function text(node) {
   const data = node.data || {};
@@ -27,7 +27,7 @@ function returnNode(h, node) {
   return node.children ? { ...node, children: all(h, node) } : node;
 }
 
-function one(h, node, parent) {
+export function one(h, node, parent) {
   const type = node && node.type;
   let fn;
 
@@ -46,7 +46,7 @@ function one(h, node, parent) {
   return (typeof fn === "function" ? fn : unknown)(h, node, parent);
 }
 
-function all(h, parent) {
+export function all(h, parent) {
   const nodes = parent.children || [];
   let values = [];
   let result;
@@ -77,8 +77,8 @@ function all(h, parent) {
   return values;
 }
 
-function wrap(nodes, loose) {
-  const result = [];
+export function wrap(nodes, loose) {
+  const result: any[] = [];
   let index = -1;
 
   if (loose) {
@@ -96,5 +96,3 @@ function wrap(nodes, loose) {
 
   return result;
 }
-
-module.exports = { one, all, wrap };

--- a/markdown/m2h/index.ts
+++ b/markdown/m2h/index.ts
@@ -1,13 +1,13 @@
-const unified = require("unified");
-const parse = require("remark-parse");
-const remark2rehype = require("remark-rehype");
-const stringify = require("rehype-stringify");
-const gfm = require("remark-gfm");
-const raw = require("rehype-raw");
-const format = require("rehype-format");
+import unified from "unified";
+import parse from "remark-parse";
+import remark2rehype from "remark-rehype";
+import stringify from "rehype-stringify";
+import gfm from "remark-gfm";
+import raw from "rehype-raw";
+import format from "rehype-format";
 
-const buildLocalizedHandlers = require("./handlers");
-const { decodeKS, encodeKS } = require("../utils");
+import { buildLocalizedHandlers } from "./handlers";
+import { decodeKS, encodeKS } from "../utils";
 
 function makeProcessor(options) {
   const localizedHandlers = buildLocalizedHandlers(options.locale);
@@ -25,7 +25,7 @@ function makeProcessor(options) {
   return processor;
 }
 
-async function m2h(md, options) {
+export async function m2h(md, options) {
   const ksEncoded = encodeKS(md);
   const processor = makeProcessor(options);
 
@@ -33,15 +33,10 @@ async function m2h(md, options) {
   return decodeKS(String(file));
 }
 
-function m2hSync(md, options) {
+export function m2hSync(md, options) {
   const ksEncoded = encodeKS(md);
   const processor = makeProcessor(options);
 
   const file = processor.processSync(ksEncoded);
   return decodeKS(String(file));
 }
-
-module.exports = {
-  m2h,
-  m2hSync,
-};

--- a/markdown/m2h/index.ts
+++ b/markdown/m2h/index.ts
@@ -9,7 +9,11 @@ import format from "rehype-format";
 import { buildLocalizedHandlers } from "./handlers";
 import { decodeKS, encodeKS } from "../utils";
 
-function makeProcessor(options) {
+interface ProcessorOptions {
+  locale?: string;
+}
+
+function makeProcessor(options: ProcessorOptions) {
   const localizedHandlers = buildLocalizedHandlers(options.locale);
   const processor = unified()
     .use(parse)
@@ -25,7 +29,7 @@ function makeProcessor(options) {
   return processor;
 }
 
-export async function m2h(md, options) {
+export async function m2h(md: string, options: ProcessorOptions) {
   const ksEncoded = encodeKS(md);
   const processor = makeProcessor(options);
 
@@ -33,7 +37,7 @@ export async function m2h(md, options) {
   return decodeKS(String(file));
 }
 
-export function m2hSync(md, options) {
+export function m2hSync(md: string, options: ProcessorOptions) {
   const ksEncoded = encodeKS(md);
   const processor = makeProcessor(options);
 

--- a/markdown/m2h/index.ts
+++ b/markdown/m2h/index.ts
@@ -18,7 +18,7 @@ function makeProcessor(options) {
       handlers: localizedHandlers,
       allowDangerousHtml: true,
     })
-    .use(raw, { allowDangerousHtml: true })
+    .use(raw)
     .use(stringify, { allowDangerousHtml: true })
     .use(format);
 

--- a/markdown/tsconfig.json
+++ b/markdown/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."]
+}

--- a/markdown/utils/index.ts
+++ b/markdown/utils/index.ts
@@ -1,20 +1,20 @@
 const KS_RE = /{{([^}]*)}}/g;
 
-function encodeKS(raw) {
+export function encodeKS(raw) {
   return raw.replace(
     KS_RE,
     (_, ks) => `{{${Buffer.from(ks).toString("base64")}}}`
   );
 }
 
-function decodeKS(raw) {
+export function decodeKS(raw) {
   return raw.replace(
     KS_RE,
     (_, ks) => `{{${Buffer.from(ks, "base64").toString()}}}`
   );
 }
 
-module.exports = {
+export default {
   encodeKS,
   decodeKS,
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "yarn build:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",
     "filecheck": "cd filecheck && ts-node cli.ts",
-    "m2h": "node markdown/m2h/cli.js",
+    "m2h": "ts-node markdown/m2h/cli.ts",
     "md": "echo 'The HTML to Markdown conversion command has been moved to https://github.com/mdn/markdown!' && exit 1",
     "prepack": "yarn build:dist",
     "prepare": "husky install",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -4,5 +4,5 @@
     "module": "CommonJS",
     "sourceMap": true
   },
-  "include": ["build", "filecheck", "server", "tool"]
+  "include": ["build", "filecheck", "markdown", "server", "tool"]
 }


### PR DESCRIPTION
## Summary

Converts `/markdown` to TypeScript.

~~⚠️ Blocked by:~~
- https://github.com/mdn/yari/pull/6683
- https://github.com/mdn/yari/pull/7006