### PR TITLE
chore(macros): deprecate {{warning}} macro

### DIFF
--- a/kumascript/macros/warning.ejs
+++ b/kumascript/macros/warning.ejs
@@ -1,5 +1,9 @@
 <%
 
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated();
+
 var s_warning = mdn.localString({
     "en-US": "Warning:",
     "de": "Achtung:",


### PR DESCRIPTION
## Summary

`{{warning}}` macro has been removed from mdn/content (mdn/content#20015).

It's time to deprecate it.

> Note: there are some escaped `{{warning}}` macros in issue template:
>
> https://github.com/mdn/content/blob/1c8f3af9f3c9e7caf084fd9072c263b86e25ac1b/files/en-us/mdn/community/issues/index.md?plain=1#L19-L35