### PR TITLE
build(deps): drop node 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,6 @@
     "workbox-webpack-plugin": "^6.5.4"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16.0.0 || >=18.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Drops support for Node.js 17, which is is EOL since 2022-06-01.

See: https://github.com/nodejs/Release/#end-of-life-releases