### PR TITLE
MP-69 MP-70 add loading and error states to collections

### DIFF
--- a/client/src/plus/collections/v2/collection.tsx
+++ b/client/src/plus/collections/v2/collection.tsx
@@ -79,7 +79,6 @@ function ItemComponent({
   const [showDropdown, setShowDropdown] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
   const [showDelete, setShowDelete] = useState(false);
-  const [formItem, setFormItem] = useState(item);
 
   const breadcrumbs = item.parents
     .slice(0, -1)
@@ -88,36 +87,6 @@ function ItemComponent({
       // remove duplicated titles
       (title, index, titles) => title !== titles[index + 1]
     );
-
-  const deleteHandler = async (e: React.MouseEvent) => {
-    e.preventDefault();
-    await deleteItem(item, mutate);
-    setShowDelete(false);
-  };
-
-  const changeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormItem({ ...formItem, [name]: value.trimStart() });
-  };
-
-  const cancelEditHandler = (e: React.MouseEvent | React.KeyboardEvent) => {
-    e.preventDefault();
-    setFormItem(item);
-    setShowEdit(false);
-  };
-
-  const saveHandler = async (e: React.BaseSyntheticEvent) => {
-    e.preventDefault();
-    await editItem(formItem, mutate);
-    setShowEdit(false);
-  };
-
-  const enterHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      saveHandler(e);
-    }
-  };
 
   return (
     <article key={item.url}>
@@ -169,83 +138,12 @@ function ItemComponent({
             </ul>
           </DropdownMenu>
         </DropdownMenuWrapper>
-        <MDNModal
-          isOpen={showEdit}
-          size="small"
-          onRequestClose={cancelEditHandler}
-        >
-          <header className="modal-header">
-            <h2 className="modal-heading">Edit item</h2>
-            <Button
-              onClickHandler={cancelEditHandler}
-              type="action"
-              icon="cancel"
-              extraClasses="close-button"
-            />
-          </header>
-          <div className="modal-body">
-            <form className="mdn-form" onSubmit={saveHandler}>
-              <div className="mdn-form-item">
-                <label htmlFor="item-title">Title:</label>
-                <input
-                  id="item-title"
-                  name="title"
-                  value={formItem.title}
-                  onChange={changeHandler}
-                  onKeyDown={enterHandler}
-                  autoComplete="off"
-                  type="text"
-                  required={true}
-                />
-              </div>
-              <div className="mdn-form-item">
-                <label htmlFor="item-notes">Notes:</label>
-                <input
-                  id="item-notes"
-                  name="notes"
-                  value={formItem.notes}
-                  onChange={changeHandler}
-                  onKeyDown={enterHandler}
-                  autoComplete="off"
-                  type="text"
-                />
-              </div>
-              <div className="mdn-form-item is-button-row">
-                <Button buttonType="submit">Save</Button>
-                <Button onClickHandler={cancelEditHandler} type="secondary">
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          </div>
-        </MDNModal>
-        <MDNModal
-          isOpen={showDelete}
-          size="small"
-          onRequestClose={() => setShowDelete(false)}
-        >
-          <header className="modal-header">
-            <h2 className="modal-heading">Delete item</h2>
-            <Button
-              onClickHandler={() => setShowDelete(false)}
-              type="action"
-              icon="cancel"
-              extraClasses="close-button"
-            />
-          </header>
-          <div className="modal-body">
-            Are you sure you want to delete "{item.title}" from your collection?
-            <div className="mdn-form-item is-button-row">
-              <Button onClickHandler={deleteHandler}>Delete</Button>
-              <Button
-                onClickHandler={() => setShowDelete(false)}
-                type="secondary"
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        </MDNModal>
+        <ItemEdit show={showEdit} setShow={setShowEdit} {...{ item, mutate }} />
+        <ItemDelete
+          show={showDelete}
+          setShow={setShowDelete}
+          {...{ item, mutate }}
+        />
       </header>
       <div className="breadcrumbs">{breadcrumbs.join(" > ")}</div>
       {item.notes && <p>{item.notes}</p>}
@@ -255,5 +153,133 @@ function ItemComponent({
         </time>
       </footer>
     </article>
+  );
+}
+
+function ItemEdit({
+  show,
+  setShow,
+  item,
+  mutate,
+}: {
+  show: boolean;
+  setShow: React.Dispatch<React.SetStateAction<boolean>>;
+  item: Item;
+  mutate: KeyedMutator<Item[][]>;
+}) {
+  const [formItem, setFormItem] = useState(item);
+
+  const changeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormItem({ ...formItem, [name]: value.trimStart() });
+  };
+
+  const cancelHandler = (e: React.MouseEvent | React.KeyboardEvent) => {
+    e.preventDefault();
+    setFormItem(item);
+    setShow(false);
+  };
+
+  const saveHandler = async (e: React.BaseSyntheticEvent) => {
+    e.preventDefault();
+    await editItem(formItem, mutate);
+    setShow(false);
+  };
+
+  const enterHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      saveHandler(e);
+    }
+  };
+
+  return (
+    <MDNModal isOpen={show} size="small" onRequestClose={cancelHandler}>
+      <header className="modal-header">
+        <h2 className="modal-heading">Edit item</h2>
+        <Button
+          onClickHandler={cancelHandler}
+          type="action"
+          icon="cancel"
+          extraClasses="close-button"
+        />
+      </header>
+      <div className="modal-body">
+        <form className="mdn-form" onSubmit={saveHandler}>
+          <div className="mdn-form-item">
+            <label htmlFor="item-title">Title:</label>
+            <input
+              id="item-title"
+              name="title"
+              value={formItem.title}
+              onChange={changeHandler}
+              onKeyDown={enterHandler}
+              autoComplete="off"
+              type="text"
+              required={true}
+            />
+          </div>
+          <div className="mdn-form-item">
+            <label htmlFor="item-notes">Notes:</label>
+            <input
+              id="item-notes"
+              name="notes"
+              value={formItem.notes}
+              onChange={changeHandler}
+              onKeyDown={enterHandler}
+              autoComplete="off"
+              type="text"
+            />
+          </div>
+          <div className="mdn-form-item is-button-row">
+            <Button buttonType="submit">Save</Button>
+            <Button onClickHandler={cancelHandler} type="secondary">
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+    </MDNModal>
+  );
+}
+
+function ItemDelete({
+  show,
+  setShow,
+  item,
+  mutate,
+}: {
+  show: boolean;
+  setShow: React.Dispatch<React.SetStateAction<boolean>>;
+  item: Item;
+  mutate: KeyedMutator<Item[][]>;
+}) {
+  const deleteHandler = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    await deleteItem(item, mutate);
+    setShow(false);
+  };
+
+  return (
+    <MDNModal isOpen={show} size="small" onRequestClose={() => setShow(false)}>
+      <header className="modal-header">
+        <h2 className="modal-heading">Delete item</h2>
+        <Button
+          onClickHandler={() => setShow(false)}
+          type="action"
+          icon="cancel"
+          extraClasses="close-button"
+        />
+      </header>
+      <div className="modal-body">
+        Are you sure you want to delete "{item.title}" from your collection?
+        <div className="mdn-form-item is-button-row">
+          <Button onClickHandler={deleteHandler}>Delete</Button>
+          <Button onClickHandler={() => setShow(false)} type="secondary">
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </MDNModal>
   );
 }

--- a/client/src/plus/collections/v2/index.scss
+++ b/client/src/plus/collections/v2/index.scss
@@ -62,6 +62,11 @@
     }
   }
 
+  .notecard,
+  .generic-loading {
+    grid-column: 1/-1;
+  }
+
   article {
     border: 1px solid var(--border-secondary);
     border-radius: var(--elem-radius);

--- a/client/src/ui/atoms/modal/index.scss
+++ b/client/src/ui/atoms/modal/index.scss
@@ -8,6 +8,13 @@
   bottom: 0;
   background-color: var(--modal-backdrop-color);
   z-index: var(--z-index-top);
+
+  &.wait {
+    &,
+    * {
+      cursor: wait !important;
+    }
+  }
 }
 
 .modal-content {
@@ -33,6 +40,11 @@
 
 .modal-body {
   padding: 1rem;
+
+  .notecard {
+    margin: 0;
+    margin-bottom: 1rem;
+  }
 }
 
 .modal-heading {

--- a/client/src/ui/atoms/modal/index.tsx
+++ b/client/src/ui/atoms/modal/index.tsx
@@ -6,12 +6,13 @@ if (process.env.NODE_ENV !== "test") ReactModal.setAppElement("#root");
 
 interface ModalProps extends ReactModal.Props {
   size?: "small";
+  extraOverlayClassName?: string;
 }
 
 export default function MDNModal(props: ModalProps) {
   return (
     <ReactModal
-      overlayClassName="modal-overlay"
+      overlayClassName={`modal-overlay ${props.extraOverlayClassName || ""}`}
       className={`modal-content ${props.className || ""} ${
         props.size ? `is-${props.size}` : ""
       }`}

--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -32,6 +32,13 @@
       z-index: var(--z-index-mid);
     }
 
+    &.wait {
+      &,
+      * {
+        cursor: wait !important;
+      }
+    }
+
     .header {
       display: block;
       font-family: var(--font-body);
@@ -68,6 +75,20 @@
 
       &:last-child {
         padding-bottom: 1rem;
+      }
+    }
+
+    .notecard {
+      margin: var(--gutter-padding);
+      margin-bottom: 0;
+
+      &::before {
+        top: 1.37rem;
+      }
+
+      p {
+        padding: 0;
+        margin: 0;
       }
     }
 


### PR DESCRIPTION
first commit moves the item edit/delete modals into separate components to keep the logic simpler

the second adds the loading and error states, as well as changing post/delete methods to work much more like get methods: so they become hooks, and have `isPending` and `error` keys, to avoid having to manage this state in the components themselves (this is what I was originally doing, and it was very messy)
this works a lot like [the useSWRMutation hook coming in the next version of useSWR](https://github.com/vercel/swr/releases/tag/2.0.0-beta.0) which should make migration easier

I'd suggest reviewing the commits separately, otherwise the diff is a bit unwieldy

disabled button styling is messed up, there's a separate issue for that here: https://mozilla-hub.atlassian.net/browse/MP-101
