### PR TITLE
chore(syntax-highlight): add nolint aliases for html/js

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -59,8 +59,8 @@ const loadAllLanguages = lazy(() => {
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   // ["idl", "webidl"],  // block list
-  ["htmlnolint", "html"],
-  ["jsnolint", "js"],
+  ["html-nolint", "html"],
+  ["js-nolint", "js"],
   ["sh", "shell"],
 ]);
 

--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -59,7 +59,8 @@ const loadAllLanguages = lazy(() => {
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   // ["idl", "webidl"],  // block list
-  ["jssyntax", "js"],
+  ["htmlnolint", "html"]
+  ["jsnolint", "js"],
   ["sh", "shell"],
 ]);
 

--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -59,7 +59,7 @@ const loadAllLanguages = lazy(() => {
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   // ["idl", "webidl"],  // block list
-  ["htmlnolint", "html"]
+  ["htmlnolint", "html"],
   ["jsnolint", "js"],
   ["sh", "shell"],
 ]);


### PR DESCRIPTION
This PR replaces the Prism alias for `jssyntax` with `jsnolint`, and adds `htmlnolint`.

`jssyntax` was added in #6682, but we decided not to use it as it is too semantic, and we wanted to avoid a potentially long list of semantic aliases.

The idea is to have such code blocks styled by Prism with the right color scheme but skipped when linter run, like Markdownlint, or Prettier, as these blocks are not valid (for example our syntax box), or should not be formatted by linters (like examples of invalid code, or TML templates that require an unusual alignment).

In a meeting a couple of weeks ago, I understood that we have a consensus on these two names (we need `htmlnolint` for some templates in the Learning Area).

So, first: do we have a consensus? @Rumyra @wbamberg @Josh-Cena @elchi3 can you approve to mark your approval?

Once this is confirmed, let's ping the devs for a review.

Thank you all! (Consensus-decision making is sometimes a hard task, but it leads to much better solutions!)