### PR TITLE
fix(retired-locale-note): link de/pl to GitHub discussion

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -174,6 +174,8 @@ export function Document(props /* TODO: define a TS interface for this */) {
     return null;
   }
 
+  const retiredLocale = searchParams.get("retiredLocale");
+
   return (
     <>
       <div className="main-document-header-container">
@@ -187,9 +189,9 @@ export function Document(props /* TODO: define a TS interface for this */) {
           <LocalizedContentNote isActive={doc.isActive} locale={locale} />
         </div>
       ) : (
-        searchParams.get("retiredLocale") && (
+        retiredLocale && (
           <div className="container">
-            <RetiredLocaleNote />
+            <RetiredLocaleNote locale={retiredLocale} />
           </div>
         )
       )}

--- a/client/src/document/molecules/retired-locale-note/index.tsx
+++ b/client/src/document/molecules/retired-locale-note/index.tsx
@@ -1,14 +1,25 @@
 import { NoteBanner } from "../note-banner";
 
-export function RetiredLocaleNote() {
+function getUrlByLocale(locale: string): string {
+  switch (locale) {
+    case "de":
+    case "pl":
+      return "https://github.com/orgs/mdn/discussions/147";
+
+    default:
+      return "https://hacks.mozilla.org/2021/03/mdn-localization-in-march-tier-1-locales-unfrozen-and-future-plans/";
+  }
+}
+
+export function RetiredLocaleNote({ locale }: { locale: string }) {
+  const url = getUrlByLocale(locale);
+
   return (
     <NoteBanner
       linkText={
         "The page you requested has been retired, so we've sent you to the English equivalent."
       }
-      url={
-        "https://hacks.mozilla.org/2021/03/mdn-localization-in-march-tier-1-locales-unfrozen-and-future-plans/"
-      }
+      url={url}
       type={"neutral"}
     />
   );


### PR DESCRIPTION
## Summary

Updates the link that appears when visiting a URL belonging to the newly retired German and Polish locales:
<img width="765" alt="image" src="https://user-images.githubusercontent.com/495429/187505104-1f1d2453-3ac6-482f-ae9e-7f8212911862.png">


### Problem

It was unconditionally linking to https://hacks.mozilla.org/2021/03/mdn-localization-in-march-tier-1-locales-unfrozen-and-future-plans/, which doesn't mention the retirement of German and Polish.

### Solution

For German and Polish, link to https://github.com/orgs/mdn/discussions/147 instead.

---

## How did you test this change?

Tested locally by visiting http://localhost:5042/de/docs/Learn/HTML and http://localhost:5042/fa/docs/Learn/HTML
