### PR TITLE
fix(bcd): show "more" icon only for 2+ entries

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -259,7 +259,9 @@ function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
     hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
     supportItem.alternative_name && <Icon key="altname" name="altname" />,
     supportItem.flags && <Icon key="disabled" name="disabled" />,
-    Array.isArray(support) && <Icon key="more" name="more" />,
+    Array.isArray(support) && support.length > 1 && (
+      <Icon key="more" name="more" />
+    ),
   ].filter(Boolean);
 
   return icons.length ? <div className="bc-icons">{icons}</div> : null;

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -4,6 +4,7 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getCurrentSupport,
+  hasMore,
   hasNoteworthyNotes,
   isFullySupportedWithoutLimitation,
   isNotSupportedAtAll,
@@ -259,9 +260,7 @@ function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
     hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
     supportItem.alternative_name && <Icon key="altname" name="altname" />,
     supportItem.flags && <Icon key="disabled" name="disabled" />,
-    Array.isArray(support) && support.length > 1 && (
-      <Icon key="more" name="more" />
-    ),
+    hasMore(support) && <Icon key="more" name="more" />,
   ].filter(Boolean);
 
   return icons.length ? <div className="bc-icons">{icons}</div> : null;

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -92,7 +92,7 @@ function getActiveLegendItems(
         }
       }
 
-      if (Array.isArray(browserSupport)) {
+      if (Array.isArray(browserSupport) && browserSupport.length > 1) {
         legendItems.add("more");
       }
     }

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -4,6 +4,7 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getFirst,
+  hasMore,
   hasNoteworthyNotes,
   listFeatures,
   versionIsPreview,
@@ -92,7 +93,7 @@ function getActiveLegendItems(
         }
       }
 
-      if (Array.isArray(browserSupport) && browserSupport.length > 1) {
+      if (hasMore(browserSupport)) {
         legendItems.add("more");
       }
     }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -61,6 +61,10 @@ export function listFeatures(
   return features;
 }
 
+export function hasMore(support: BCD.SupportStatement | undefined) {
+  return Array.isArray(support) && support.length > 1;
+}
+
 export function versionIsPreview(
   version: BCD.VersionValue | string | undefined,
   browser: BCD.BrowserStatement


### PR DESCRIPTION
This PR is a quick follow-up to #6777.  In between the creation and merge of that PR, there were some updates to the rest of the code that makes the `support` object an array even for single-item support statements.  This PR updates the code to verify that the support statement is an array AND has more than one item in it before displaying the "more" icon.
