### PR TITLE
style(wikihistory): format with prettier, if available

### DIFF
--- a/content/document.js
+++ b/content/document.js
@@ -22,6 +22,7 @@ const {
   execGit,
   urlToFolderPath,
   MEMOIZE_INVALIDATE,
+  toPrettyJSON,
 } = require("./utils");
 const Redirect = require("./redirect");
 
@@ -61,7 +62,7 @@ function updateWikiHistory(localeContentRoot, oldSlug, newSlug = null) {
       // trailing newline character. So always doing in automation removes
       // the risk of a conflict at the last line from two independent PRs
       // that edit this file.
-      JSON.stringify(sorted, null, 2) + "\n"
+      toPrettyJSON(sorted)
     );
   }
 }

--- a/content/utils.js
+++ b/content/utils.js
@@ -102,6 +102,16 @@ function execGit(args, opts = {}, root = null) {
   return stdout.toString().trim();
 }
 
+function toPrettyJSON(value) {
+  const json = JSON.stringify(value, null, 2) + "\n";
+  try {
+    // eslint-disable-next-line node/no-unpublished-require
+    return require("prettier").format(json, { parser: "json" });
+  } catch (e) {
+    return json;
+  }
+}
+
 function urlToFolderPath(url) {
   const [, locale, , ...slugParts] = url.split("/");
   return path.join(locale.toLowerCase(), slugToFolder(slugParts.join("/")));
@@ -113,6 +123,7 @@ module.exports = {
   slugToFolder: (slug) => slugToFolder(slug, path.sep),
   memoize,
   execGit,
+  toPrettyJSON,
   urlToFolderPath,
   MEMOIZE_INVALIDATE,
 };


### PR DESCRIPTION
## Summary

Formats the `_wikihistory.json` with Prettier, if it is available.

Supersedes https://github.com/mdn/content/pull/20139.

### Problem

`yari-tool delete` update the `_wikihistory.json` file, but format it using `JSON.stringify()`, whereas mdn/content formats JSON files with prettier.

### Solution

Format the JSON with prettier.

---

## How did you test this change?

Updated `node_modules/@mdn/yari/content/document.js` in mdn/content accordingly and made sure that the changes to `_wikihistory.json` were only minimal.
