### PR TITLE
fix(build/spas): filter recently merged contributions

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -246,11 +246,7 @@ export async function buildSPAs(options) {
 
   // Build all the home pages in all locales.
   // Fetch merged content PRs for the latest contribution section.
-  const pullRequestsData = (await got(
-    "https://api.github.com/search/issues?q=repo:mdn/content+is:pr+is:merged+sort:updated&per_page=10"
-  ).json()) as {
-    items: any[];
-  };
+  const recentContributions = await fetchRecentContributions();
 
   // Fetch latest Hacks articles.
   const latestNews = await fetchLatestNews();
@@ -294,17 +290,7 @@ export async function buildSPAs(options) {
 
       const url = `/${locale}/`;
       const hyData = {
-        recentContributions: {
-          items: pullRequestsData.items.map(
-            ({ number, title, updated_at, pull_request: { html_url } }) => ({
-              number,
-              title,
-              updated_at,
-              url: html_url,
-            })
-          ),
-          repo: { name: "mdn/content", url: "https://github.com/mdn/content" },
-        },
+        recentContributions,
         featuredContributor,
         latestNews,
         featuredArticles,
@@ -334,6 +320,26 @@ export async function buildSPAs(options) {
   if (!options.quiet) {
     console.log(`Built ${buildCount} SPA related files`);
   }
+}
+
+async function fetchRecentContributions() {
+  const pullRequestsData = (await got(
+    "https://api.github.com/search/issues?q=repo:mdn/content+is:pr+is:merged+sort:updated&per_page=10"
+  ).json()) as {
+    items: any[];
+  };
+
+  return {
+    items: pullRequestsData.items.map(
+      ({ number, title, updated_at, pull_request: { html_url } }) => ({
+        number,
+        title,
+        updated_at,
+        url: html_url,
+      })
+    ),
+    repo: { name: "mdn/content", url: "https://github.com/mdn/content" },
+  };
 }
 
 async function fetchLatestNews() {

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -323,9 +323,16 @@ export async function buildSPAs(options) {
 }
 
 async function fetchRecentContributions() {
-  const pullRequestsData = (await got(
-    "https://api.github.com/search/issues?q=repo:mdn/content+is:pr+is:merged+sort:updated&per_page=10"
-  ).json()) as {
+  const twoDaysAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+  const pullRequestsQuery = [
+    "repo:mdn/content",
+    "is:pr",
+    "is:merged",
+    `merged:>${twoDaysAgo.toISOString()}`,
+    "sort:updated",
+  ].join("+");
+  const pullRequestUrl = `https://api.github.com/search/issues?q=${pullRequestsQuery}&per_page=10`;
+  const pullRequestsData = (await got(pullRequestUrl).json()) as {
     items: any[];
   };
 


### PR DESCRIPTION
## Summary

Prevents PRs from showing up in "Recent contributions" that have been merged long time ago.

### Problem

Activity on old PRs resets the `updated` timestamp, so they show up in our "Recent contributions", and GitHub doesn't support sorting by `merged` yet.

### Solution

Additionally filter the PRs to only show those that have been merged in the last 48 hours (usually there are always more than 10).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

Note that the first item is PR 1 (!), caused by [this comment](https://github.com/mdn/content/pull/1#issuecomment-1235481669).

<img width="863" alt="image" src="https://user-images.githubusercontent.com/495429/188152285-de065c6d-010c-4e30-90a6-0af64ad30120.png">

### After

<img width="863" alt="image" src="https://user-images.githubusercontent.com/495429/188152513-1a895993-8efe-43a0-9bbb-8d8572c1a400.png">


---

## How did you test this change?

Ran `yarn tool spas` once on `main` (see Before screenshot) and once on this branch (see After screenshot).