### PR TITLE
fix(macros/CSSSyntax): handle combination of hash mark + curly brackets

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -175,8 +175,8 @@ function getPropertySyntax(propertyName) {
   }
   // the "#" multipler can be followed by the curly brackets, we want to annotate them separately
   if (multiplierName.startsWith("#{")) {
-    const info1 =  syntaxDescriptions[multiplierName[0]];
-    const info2 =  syntaxDescriptions["{}"];
+    const info1 = syntaxDescriptions["#"];
+    const info2 = syntaxDescriptions["{}"];
     const link1 = `<a href="${valueDefinitionUrl}#${info1.fragment}" title="${info1.tooltip}">${multiplierName[0]}</a>`;
     const link2 = `<a href="${valueDefinitionUrl}#${info2.fragment}" title="${info2.tooltip}">${multiplierName.slice(1)}</a>`;
     return `${link1}${link2}`;

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -41,7 +41,7 @@ const syntaxDescriptions = {
   },
   '{}': {
     fragment: 'curly_braces',
-    tooltip: mdn.localString({ 'en-US': 'Curly braces: encloses two integers defining the minimal and maximal numbers of occurrences of the entity' })
+    tooltip: mdn.localString({ 'en-US': 'Curly braces: encloses two integers defining the minimal and maximal numbers of occurrences of the entity, or a single integer defining the exact number required' })
   },
   '#': {
     fragment: 'hash_mark',
@@ -165,12 +165,20 @@ function getPropertySyntax(propertyName) {
   if (multiplierName.startsWith('{')) {
     key = '{}';
   }
-  // these two multiplier combinations can appear, and in this case we want links to both parts
+  // these two multiplier combinations can appear, we want to annotate them separately
   if (multiplierName === '+#' || multiplierName === '#?') {
     const info1 =  syntaxDescriptions[multiplierName[0]];
     const info2 =  syntaxDescriptions[multiplierName[1]];
     const link1 = `<a href="${valueDefinitionUrl}#${info1.fragment}" title="${info1.tooltip}">${multiplierName[0]}</a>`;
     const link2 = `<a href="${valueDefinitionUrl}#${info2.fragment}" title="${info2.tooltip}">${multiplierName[1]}</a>`;
+    return `${link1}${link2}`;
+  }
+  // the "#" multipler can be followed by the curly brackets, we want to annotate them separately
+  if (multiplierName.startsWith("#{")) {
+    const info1 =  syntaxDescriptions[multiplierName[0]];
+    const info2 =  syntaxDescriptions["{}"];
+    const link1 = `<a href="${valueDefinitionUrl}#${info1.fragment}" title="${info1.tooltip}">${multiplierName[0]}</a>`;
+    const link2 = `<a href="${valueDefinitionUrl}#${info2.fragment}" title="${info2.tooltip}">${multiplierName.slice(1)}</a>`;
     return `${link1}${link2}`;
   }
   const info = syntaxDescriptions[key];


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Fixes a problem with the CSSSyntax macro reported by Jean-Yves, but not filed AFAIK.

Update CSSSyntax to handle the combination of a hash and curly brackets, like `#{3}`: https://web.archive.org/web/20220424210922/https://drafts.csswg.org/css-values/#component-multipliers

@teoli2003 , this ought to fix the syntax for [`clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp#formal_syntax).

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

The `csssyntax` macro can't handle the combination of the `#` and `{}` notations.

This combination is described in the spec (https://drafts.csswg.org/css-values/#component-multipliers):

> A hash mark (#) indicates that the preceding type, word, or group occurs one or more times, separated by comma tokens (which may optionally be surrounded by [white space](https://www.w3.org/TR/css-syntax/#whitespace) and/or comments). **It may optionally be followed by the curly brace forms, above, to indicate precisely how many times the repetition occurs, like `<length>#{1,4}`.** 

This in particular caused the formal syntax to be broken in the page for [`clamp()`](https://developer.mozilla.org/en-US/docs/Web/CSS/clamp), whose [definition combined these notations](https://web.archive.org/web/20220424210922/https://drafts.csswg.org/css-values/#calc-syntax):

```
clamp( <calc-sum>#{3} )
```

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Update CSSSyntax.ejs to understand this combination, and to provide separate annotations for both the `#` and the curly braces.

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

<img width="228" alt="Screen Shot 2022-09-05 at 3 28 20 PM" src="https://user-images.githubusercontent.com/432915/188517455-991345ef-19e4-4e89-904c-b7054af4b6fc.png">

### After

<!-- Replace this line with your screenshot (or video). -->

<img width="733" alt="Screen Shot 2022-09-05 at 1 19 12 PM" src="https://user-images.githubusercontent.com/432915/188517485-a71f6398-405b-4928-b528-1f5a0b1f1082.png">

## How did you test this change?

Tested locally with various CSS pages. I think `clamp()` is the only one which had the original problem, but I tried several other pages to check for regressions.

