### PR TITLE
:warning: fix: Update the script hash on the main page

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -78,7 +78,7 @@ const scriptSrcValues = [
   // - Previous hash (to avoid cache invalidation issues):
   "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
   // - Current hash:
-  "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
+  "'sha256-uogddBLIKmJa413dyT0iPejBg3VFcO+4x6B+vw3jng0='",
 ];
 const CSP_DIRECTIVES = {
   "default-src": ["'self'"],


### PR DESCRIPTION
:warning: #6352 introduced a wrong hash for the current script on the main page (index.html). At the moment the current and previous hashes are exactly the same.

In Firefox seeing following error:
```
Content Security Policy: The page’s settings blocked the loading of a resource at inline (“script-src”). Source: document.body.addEventListener("load",(t=>{t.target.classList.contains("interactive")&&t.target.setAttribute("data-readystate","complete")}),{capture:!0});const c={light:"#ffffff",dark:"#1b1b1b"};if(window&&document.documentElement)try{const t=window.localStorage.getItem("theme");t&&(document.documentElement.className=t,document.documentElement.style.backgroundColor=c[t])}catch(t){console.warn("Unable to read theme from localStorage",t)}.
```
***
The hash for the latest script:
```
<script>document.body.addEventListener("load",(t=>{t.target.classList.contains("interactive")&&t.target.setAttribute("data-readystate","complete")}),{capture:!0});const c={light:"#ffffff",dark:"#1b1b1b"};if(window&&document.documentElement)try{const t=window.localStorage.getItem("theme");t&&(document.documentElement.className=t,document.documentElement.style.backgroundColor=c[t])}catch(t){console.warn("Unable to read theme from localStorage",t)}</script>
```
...is `'sha256-uogddBLIKmJa413dyT0iPejBg3VFcO+4x6B+vw3jng0='`