### PR TITLE
chore(macros/SectionOnPage): add l10n-zh translation

### DIFF
--- a/kumascript/macros/SectionOnPage.ejs
+++ b/kumascript/macros/SectionOnPage.ejs
@@ -55,6 +55,12 @@ switch(lang) {
     case "ru":
         text = `<a href="${url}">${section}</a> в <a href="${$0}">${title}</a>`;
         break;
+    case "zh-CN":
+        text = `<a href="${$0}">${title}</a> 中的 <a href="${url}">${section}</a>`;
+        break;
+    case "zh-TW":
+        text = `<a href="${$0}">${title}</a> 中的 <a href="${url}">${section}</a>`;
+        break;
     default:
         text = `<a href="${url}">${section}</a> in <a href="${$0}">${title}</a>`;
         break;


### PR DESCRIPTION
## Summary

add l10n-zh translation for `{{SectionOnPage}}` macro.

## Screenshots

### After

In `http://localhost:5042/zh-CN/docs/Web/API/Clipboard/write`

![image](https://user-images.githubusercontent.com/15844309/188298778-cfb42606-fd50-48c5-83ec-32e61aa69a03.png)

---

## How did you test this change?

Run `yarn dev`.
