### PR TITLE
fix(search-utils): focus search with Ctrl-K, not Ctrl-Shift-K 

### DIFF
--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -18,7 +18,8 @@ export function useFocusViaKeyboard(
       const keyPressed = event.key;
       const ctrlOrMetaPressed = event.ctrlKey || event.metaKey;
       const isSlash = keyPressed === "/" && !ctrlOrMetaPressed;
-      const isCtrlK = keyPressed.toLowerCase() === "k" && ctrlOrMetaPressed;
+      const isCtrlK =
+        keyPressed === "k" && ctrlOrMetaPressed && !event.shiftKey;
       const isTextField = ["TEXTAREA", "INPUT"].includes(target.tagName);
       if ((isSlash || isCtrlK) && !isTextField) {
         if (input && document.activeElement !== input) {

--- a/client/src/search-utils.ts
+++ b/client/src/search-utils.ts
@@ -12,13 +12,14 @@ export function useFocusViaKeyboard(
   inputRef: React.RefObject<null | HTMLInputElement>
 ) {
   useEffect(() => {
-    function focusOnSearchMaybe(event) {
+    function focusOnSearchMaybe(event: KeyboardEvent) {
       const input = inputRef.current;
+      const target = event.target as HTMLElement;
       const keyPressed = event.key;
       const ctrlOrMetaPressed = event.ctrlKey || event.metaKey;
       const isSlash = keyPressed === "/" && !ctrlOrMetaPressed;
       const isCtrlK = keyPressed.toLowerCase() === "k" && ctrlOrMetaPressed;
-      const isTextField = ["TEXTAREA", "INPUT"].includes(event.target.tagName);
+      const isTextField = ["TEXTAREA", "INPUT"].includes(target.tagName);
       if ((isSlash || isCtrlK) && !isTextField) {
         if (input && document.activeElement !== input) {
           event.preventDefault();


### PR DESCRIPTION
# Summary

Restricts the search shortcut to <kbd>Ctrl</kbd>+<kbd>K</kbd>, excluding <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> which is already used by Firefox to toggle the web console.

Fixes #6964.

### Problem

<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd> focuses the search field on MDN instead of opening the web console.

### Solution

Make sure that only <kbd>Ctrl</kbd>+<kbd>K</kbd> focuses the search field on MDN.

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn dev` and verified with Firefox on Mac OS that Ctrl-Shift-K no longer focuses the search field. (It didn't open the web console though, because the shortcut is Ctrl-Alt-K on Mac OS.)
