### PR TITLE
fix(pr-companion): shorten the preview links

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -88,7 +88,8 @@ def post_about_deployment(build_directory: Path, **config):
     links = []
     for doc in get_built_docs(build_directory):
         url = mdn_url_to_dev_url(config["prefix"], doc["mdn_url"])
-        links.append(f"- {url}")
+        mdn_url = doc["mdn_url"]
+        links.append(f"- [{mdn_url}]({url})")
     links.sort()
 
     heading = "## Preview URLs\n\n"
@@ -99,7 +100,7 @@ def post_about_deployment(build_directory: Path, **config):
 
 
 def mdn_url_to_dev_url(prefix, mdn_url):
-    template = "[{mdn_url}](https://{prefix}.content.dev.mdn.mozit.cloud{mdn_url})"
+    template = "https://{prefix}.content.dev.mdn.mozit.cloud{mdn_url}"
     return template.format(prefix=prefix, mdn_url=mdn_url)
 
 

--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -88,7 +88,7 @@ def post_about_deployment(build_directory: Path, **config):
     links = []
     for doc in get_built_docs(build_directory):
         url = mdn_url_to_dev_url(config["prefix"], doc["mdn_url"])
-        links.append(f"- <{url}>")
+        links.append(f"- {url}")
     links.sort()
 
     heading = "## Preview URLs\n\n"
@@ -99,7 +99,7 @@ def post_about_deployment(build_directory: Path, **config):
 
 
 def mdn_url_to_dev_url(prefix, mdn_url):
-    template = "https://{prefix}.content.dev.mdn.mozit.cloud{mdn_url}"
+    template = "[{mdn_url}](https://{prefix}.content.dev.mdn.mozit.cloud{mdn_url})"
     return template.format(prefix=prefix, mdn_url=mdn_url)
 
 

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -38,7 +38,10 @@ def test_analyze_pr_prefix():
     with mock_build_directory(doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, prefix="pr007"))
         assert "## Preview URLs" in comment
-        assert "- <https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo>" in comment
+        assert (
+            "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
+            in comment
+        )
 
 
 def test_analyze_pr_flaws():
@@ -189,7 +192,10 @@ def test_analyze_pr_prefix_and_postcomment(mocked_github):
             dict(DEFAULT_CONFIG, prefix="pr007", pr_number=123, github_token="abc123"),
         )
         assert "## Preview URLs" in comment
-        assert "- <https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo>" in comment
+        assert (
+            "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
+            in comment
+        )
 
     mocked_github().get_repo().get_issue().create_comment.assert_called()
 


### PR DESCRIPTION
The PR addresses: https://github.com/orgs/mdn/discussions/51#discussioncomment-3525961
> Links don't need to appear fully qualified (with host and everything).

This will shorten the link texts. For example:
from
https://pr20099.content.dev.mdn.mozit.cloud/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering

to
[/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering](https://pr20099.content.dev.mdn.mozit.cloud/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_conditional_rendering)
