### PR TITLE
feat(page-not-found): suggest search terms

### DIFF
--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -6,6 +6,7 @@ import { Doc } from "../../../libs/types";
 import NoteCard from "../ui/molecules/notecards";
 
 import LANGUAGES_RAW from "../../../libs/languages";
+import { RETIRED_LOCALES } from "../../../libs/constants";
 
 const LANGUAGES = new Map(
   Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
@@ -114,5 +115,79 @@ export default function FallbackLink({ url }: { url: string }) {
     // Should we say something??
   }
 
-  return null;
+  const isRetiredLocale = RETIRED_LOCALES.has(locale.toLowerCase());
+
+  if (isRetiredLocale) {
+    return (
+      <NoteCard type="warning" extraClasses="fallback-document">
+        <p>
+          The{" "}
+          <strong>
+            {LANGUAGES.get(locale.toLowerCase())?.English} ({locale})
+          </strong>{" "}
+          locale has been retired, and this page doesn't exist in English.
+        </p>
+
+        <p>
+          You may find an archived version of this page in one of these
+          repositories:
+          <ul>
+            <li>
+              <a
+                className="external"
+                href={`https://github.com/mdn/retired-content`}
+              >
+                mdn/retired-content
+              </a>{" "}
+              for pages that were available when the locale was retired,
+            </li>
+            <li>
+              <a
+                className="external"
+                href={`https://github.com/mdn/retired-archived-content`}
+              >
+                mdn/retired-archived-content
+              </a>{" "}
+              for pages that had already been archived before.
+            </li>
+          </ul>
+        </p>
+      </NoteCard>
+    );
+  }
+
+  const locationParts = location.pathname
+    .split("/")
+    .filter((part) => part && ![locale, "docs"].includes(part));
+  const normalizedLocationParts = locationParts
+    .map((part) => part.replace(/_/g, " "))
+    .reverse();
+
+  return (
+    <NoteCard type="info" extraClasses="fallback-document">
+      <p>
+        The page you requested doesn't exist, but you could try a site search
+        for:
+        <ul>
+          {normalizedLocationParts.map((part) => (
+            <li>
+              <a href={`/${locale}/search?q=${encodeURIComponent(part)}`}>
+                <code>{part}</code>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </p>
+      <p>
+        If this page was archived, you may find it in the{" "}
+        <a
+          className="external"
+          href={`https://github.com/mdn/archived-content/tree/main/files/${locale.toLowerCase()}`}
+        >
+          archived-content
+        </a>{" "}
+        repository.
+      </p>
+    </NoteCard>
+  );
 }

--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -178,16 +178,6 @@ export default function FallbackLink({ url }: { url: string }) {
           ))}
         </ul>
       </p>
-      <p>
-        If this page was archived, you may find it in the{" "}
-        <a
-          className="external"
-          href={`https://github.com/mdn/archived-content/tree/main/files/${locale.toLowerCase()}`}
-        >
-          archived-content
-        </a>{" "}
-        repository.
-      </p>
     </NoteCard>
   );
 }

--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -109,10 +109,6 @@ export default function FallbackLink({ url }: { url: string }) {
         </p>
       </NoteCard>
     );
-  } else if (document === null) {
-    // It means the lookup "worked" in principle, but there wasn't an English
-    // document there. Bummer. But at least we tried.
-    // Should we say something??
   }
 
   const isRetiredLocale = RETIRED_LOCALES.has(locale.toLowerCase());

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -130,6 +130,10 @@
     margin-top: 0;
   }
 
+  & > *:last-child *:last-child {
+    margin-bottom: 0;
+  }
+
   h1,
   h2,
   h3,


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6629.
Fixes https://github.com/mdn/yari/issues/5853.

### Problem

When users access a page that no longer exists and doesn't have a redirect in place, they are essentially stuck.

### Solution

Suggest users to search the site for the URL paths beginning from the right, ~~and mention the https://github.com/mdn/archived-content repository where removed content can be found~~.

---

## Screenshots

Example: http://localhost:3000/en-US/Core_JavaScript_1.5_Guide/Exception_Handling_Statements/try...catch_Statement

### Before

<img width="812" alt="image" src="https://user-images.githubusercontent.com/495429/188605006-8a10e90e-43d2-4886-964f-31aaffefbca5.png">

### After

<img width="807" alt="image" src="https://user-images.githubusercontent.com/495429/197600187-946312b3-bc9e-440d-9ad7-ca6bb3ba19d1.png">


---

## How did you test this change?

Opened http://localhost:3000/en-US/Core_JavaScript_1.5_Guide/Exception_Handling_Statements/try...catch_Statement locally.
