### PR TITLE
fix(live-samples): restore padding, use content-box sizing, reduce MIN_HEIGHT to 24px

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -328,7 +328,9 @@ iframe {
     background: #fff;
     border: 1px solid var(--border-primary);
     border-radius: var(--elem-radius);
-    width: 100%;
+    box-sizing: content-box;
+    padding: 1rem;
+    width: calc(100% - 2rem);
   }
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -330,7 +330,7 @@ iframe {
     border-radius: var(--elem-radius);
     box-sizing: content-box;
     padding: 1rem;
-    width: calc(100% - 2rem);
+    width: calc(100% - 2rem - 2px);
   }
 }
 

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -36,15 +36,8 @@ var allowedFeatures = $6;
 var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
 var title = $0.replace(/[_]+/gm, " ");
 
-var MIN_HEIGHT = 60;
-// Forcibly make sure the height is at least `MIN_HEIGHT` pixels.
-// In old MDN, there was less padding in the live samples so it was then OK
-// to have a iframe height of 30px. This is too cramped and it's easier
-// and safer to make sure the height is at least 60px to make sure it
-// looks presently "uncramped" within our design system.
-// Note that if the 'height' is a string like '100%' it won't be a
-// problem because `parseInt('100%') := 100` which is more than `MIN_HEIGHT`
-// assuming it's value is less than 100.
+// 1.5rem * 16px/rem = 24px
+var MIN_HEIGHT = 24;
 if (height && parseInt(height) < MIN_HEIGHT) {
   height = MIN_HEIGHT;
 }

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -36,8 +36,15 @@ var allowedFeatures = $6;
 var hasScreenshot = (screenshotUrl && (screenshotUrl.length > 0));
 var title = $0.replace(/[_]+/gm, " ");
 
-// 1.5rem * 16px/rem = 24px
-var MIN_HEIGHT = 24;
+var MIN_HEIGHT = 60;
+// Forcibly make sure the height is at least `MIN_HEIGHT` pixels.
+// In old MDN, there was less padding in the live samples so it was then OK
+// to have a iframe height of 30px. This is too cramped and it's easier
+// and safer to make sure the height is at least 60px to make sure it
+// looks presently "uncramped" within our design system.
+// Note that if the 'height' is a string like '100%' it won't be a
+// problem because `parseInt('100%') := 100` which is more than `MIN_HEIGHT`
+// assuming it's value is less than 100.
 if (height && parseInt(height) < MIN_HEIGHT) {
   height = MIN_HEIGHT;
 }


### PR DESCRIPTION
## Summary

Restores the live sample design/layout, as intended by the redesign.

### Problem

The padding of live samples was removed in https://github.com/mdn/yari/pull/6506, following [this discussion](https://github.com/orgs/mdn/discussions/127), because it had caused scroll bars in some cases.

Unfortunately, the change caused a layout regression, as the samples have no longer been aligned with code blocks:

| Before (with padding) | After (without padding) |
|-------|-------|
| ![image](https://user-images.githubusercontent.com/495429/188730761-e86fd98e-792d-4383-af56-567dea17aaa3.png) | ![image](https://user-images.githubusercontent.com/495429/188730805-b20a3942-b288-4d5f-b9f0-c82db91b2bec.png) |
| ![image](https://user-images.githubusercontent.com/495429/188732630-fbbe6432-6d3f-44d0-bb29-774e804fa757.png) | ![image](https://user-images.githubusercontent.com/495429/188732770-9e8c6425-8eff-4178-8f4b-588a3cefc8ef.png) |

@OnkarRuikar tried to fix this in https://github.com/mdn/yari/pull/6561 using a box-shadow/outline workaround, but the result was not the same as before:

| Before (with padding) | After (with workaround) |
|-------|-------|
| ![image](https://user-images.githubusercontent.com/495429/188730761-e86fd98e-792d-4383-af56-567dea17aaa3.png) | ![image](https://user-images.githubusercontent.com/495429/188731385-b2ebbcdf-65ef-463b-ba7f-02782989cd33.png) |
| ![image](https://user-images.githubusercontent.com/495429/188732630-fbbe6432-6d3f-44d0-bb29-774e804fa757.png) | ![image](https://user-images.githubusercontent.com/495429/188732860-9ac4c6a6-e65d-4fef-adeb-07b0f519c770.png) |

### Solution

1. Restore the padding (1rem).
2. Use `box-sizing: content-box` to make sure the padding is not reduced from the iframe's dimension (as specified in the EmbedLiveSample macro calls).
3. (Follow-up) Reduce the width (by 2rem).
4. Reduce the enforced `MIN_HEIGHT` to 24px (equivalent to one line of text).

**Note**: Some live samples have a wrong height set, e.g. the `<label>` example has a height of 50px, even though it's just a single line, so 1 line * 1.5rem/line * 16px/rem = 24px would be the correct height.

| Before (with padding) | After (with padding/increased height) |
|-------|-------|
| ![image](https://user-images.githubusercontent.com/495429/188730761-e86fd98e-792d-4383-af56-567dea17aaa3.png) | ![image](https://user-images.githubusercontent.com/495429/188731686-5cd00449-3513-465a-b5f5-2d4de6a56622.png) |
| ![image](https://user-images.githubusercontent.com/495429/188732630-fbbe6432-6d3f-44d0-bb29-774e804fa757.png) | ![image](https://user-images.githubusercontent.com/495429/188732939-8eb81988-157e-4874-84db-9635fb888bbd.png) |

---

## Screenshots

(See above.)

---

## How did you test this change?

Ran `yarn dev` and checked out these pages:

1. http://localhost:3000/en-US/docs/Web/HTML/Element/label#examples
2. http://localhost:3000/en-US/docs/Web/API/SVGGeometryElement/isPointInStroke#examples
