### PR TITLE
fix(macros): add Overview items via ListSubpagesForSidebar, enable for JsSidebar

### DIFF
--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -410,37 +410,37 @@ var text = mdn.localStringMap({
   <li class="toggle">
     <details <%=state('Objects')%>>
        <summary><%=text['Global_Objects']%></summary>
-        <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Global_Objects', 1])%>
+        <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Global_Objects', true, true])%>
     </details>
   </li>
   <li class="toggle">
     <details <%=state('Operators')%>>
       <summary><%=text['Operators']%></summary>
-      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Operators', 1])%>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Operators', true, true])%>
     </details>
   </li>
   <li class="toggle">
     <details <%=state('Statements')%>>
       <summary><%=text['Statements']%></summary>
-      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Statements', 1])%>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Statements', true, true])%>
     </details>
   </li>
   <li class="toggle">
     <details <%=state('Functions')%>>
       <summary><%=text['Functions']%></summary>
-      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Functions', 1])%>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Functions', true, true])%>
     </details>
   </li>
   <li class="toggle">
     <details <%=state('Classes')%>>
       <summary><%=text['Classes']%></summary>
-      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Classes', 1])%>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Classes', true, true])%>
     </details>
   </li>
   <li class="toggle">
     <details <%=state('Errors')%>>
       <summary><%=text['Errors']%></summary>
-      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Errors', 1])%>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/JavaScript/Reference/Errors', true, true])%>
     </details>
   </li>
   <li class="toggle">

--- a/kumascript/macros/ListSubpagesForSidebar.ejs
+++ b/kumascript/macros/ListSubpagesForSidebar.ejs
@@ -17,7 +17,7 @@
 
 var path = $0;
 var locale = env.locale;
-var parent = $2 ? 1 : 0;
+var includeParent = $2 ? 1 : 0;
 var startDelim = $3;
 var endDelim = $4;
 
@@ -26,7 +26,8 @@ if (path.substr(-1, 1) === '/') {
     path = path.slice(0, -1);
 }
 
-var pages = await page.subpagesExpand(path, -1, parent);
+var parent = await wiki.getPage(path);
+var pages = includeParent ? [parent, ...parent.subpages] : [...parent.subpages];
 var containsTag = page.hasTag;
 var htmlEscape = kuma.htmlEscape;
 

--- a/kumascript/macros/ListSubpagesForSidebar.ejs
+++ b/kumascript/macros/ListSubpagesForSidebar.ejs
@@ -26,8 +26,21 @@ if (path.substr(-1, 1) === '/') {
     path = path.slice(0, -1);
 }
 
+const overview = mdn.localString({
+    'en-US': 'Overview',
+    'es': 'Generalidades',
+    'fr': 'Aperçu',
+    'ja': 'の概要',
+    'ko': '개요',
+    'ru': 'Обзор',
+    'zh-CN': '概述',
+});
+
 var parent = await wiki.getPage(path);
-var pages = includeParent ? [parent, ...parent.subpages] : [...parent.subpages];
+var pages = includeParent ? [{
+    ...parent,
+    title: overview
+}, ...parent.subpages] : [...parent.subpages];
 var containsTag = page.hasTag;
 var htmlEscape = kuma.htmlEscape;
 


### PR DESCRIPTION
## Summary

Fixes #6724.

### Problem

The `JsSidebar` macro was listing subpages, but omitting links to the parent page (Overview). Even though the `ListSubpagesForSidebar` supported a parameter to include the parent page, it didn't work expected, displaying the parent page **instead of** its subpages.

### Solution

1. Fix the `ListSubpagesForSidebar` macro to list _both_ the parent page _and_ its subpages, if requested.
2. Update the `JsSidebar` to use the aforementioned parameter to include the parent page (Overview).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

| Before | After |
| ------ | ------ |
| ![image](https://user-images.githubusercontent.com/495429/188748891-1efc914b-eca7-4f83-80f0-bfc18f9e5d75.png) | ![image](https://user-images.githubusercontent.com/495429/188748787-e9ff4016-c549-4bf9-a8ea-a6f5e2bcab67.png) | 

---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Functions locally and expanded the "References" menus.