### PR TITLE
feat(macros): localize ExperimentalBadge

### DIFF
--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -11,7 +11,7 @@ const title = mdn.localString({
     "ja": "Experimental. Expect behavior to change in the future.",
     "ko": "Experimental. Expect behavior to change in the future.",
     "pt-BR": "Experimental. Expect behavior to change in the future.",
-    "ru": "Experimental. Expect behavior to change in the future.",
+    "ru": "Экспериментальная возможность. Её поведение в будущем может измениться",
     "zh-CN": "实验性。预期行为可能会在未来发生变更。",
     "zh-TW": "實驗性質。行為可能會在未來發生變動。"
 });
@@ -23,7 +23,7 @@ const abbreviation = mdn.localString({
     "ja": "Experimental",
     "ko": "Experimental",
     "pt-BR": "Experimental",
-    "ru": "Experimental",
+    "ru": "Экспериментальная возможность",
     "zh-CN": "实验性",
     "zh-TW": "實驗性質"
 });

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -13,7 +13,7 @@ const title = mdn.localString({
     "pt-BR": "Experimental. Expect behavior to change in the future.",
     "ru": "Experimental. Expect behavior to change in the future.",
     "zh-CN": "实验性。预期行为可能会在未来发生变更。",
-    "zh-TW": "實驗性。預期行為可能會在未來发生變更。"
+    "zh-TW": "實驗性。行為可能會在未來發生變動。"
 });
 
 const abbreviation = mdn.localString({

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -13,7 +13,7 @@ const title = mdn.localString({
     "pt-BR": "Experimental. Expect behavior to change in the future.",
     "ru": "Experimental. Expect behavior to change in the future.",
     "zh-CN": "实验性。预期行为可能会在未来发生变更。",
-    "zh-TW": "實驗性。行為可能會在未來發生變動。"
+    "zh-TW": "實驗性質。行為可能會在未來發生變動。"
 });
 
 const abbreviation = mdn.localString({
@@ -25,7 +25,7 @@ const abbreviation = mdn.localString({
     "pt-BR": "Experimental",
     "ru": "Experimental",
     "zh-CN": "实验性",
-    "zh-TW": "實驗性"
+    "zh-TW": "實驗性質"
 });
 %>
 <abbr class="icon icon-experimental" title="<%= title %>">

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -6,7 +6,7 @@
 
 const title = mdn.localString({
     "en-US": "Experimental. Expect behavior to change in the future.",
-    "es": "Experimental. Expect behavior to change in the future.",
+    "es": "Experimental. Espere que el comportamiento cambie en el futuro.",
     "fr": "Expérimental. Le comportement attendu pourrait évoluer à l'avenir.",
     "ja": "Experimental. Expect behavior to change in the future.",
     "ko": "Experimental. Expect behavior to change in the future.",

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -2,16 +2,20 @@
 //
 // Inserts a badge indicating that a term or API is experimental.
 //
-// Parameters:
-//  $0  If specified and non-zero, a "small" version of the badge is displayed.
+// Parameters: none
 
-var titleAttrValue = mdn.localString({
-    "ja": "これは実験段階の API です。製品内のコードで使用しないようご注意ください。",
-    "ru": "Это экспериментальное API, которое не должно использоваться в рабочем коде.",
-    "zh-CN": "这是一个实验性的 API，请尽量不要在生产环境中使用它。",
-    "en-US": "This is an experimental API that should not be used in production code."
+const title = mdn.localString({
+    "en-US": "Experimental. Expect behavior to change in the future.",
+    "zh-CN": "实验性。预期行为可能会在未来发生变更。",
+    "zh-TW": "實驗性。預期行為可能會在未來发生變更。"
+});
+
+const abbreviation = mdn.localString({
+    "en-US": "Experimental",
+    "zh-CN": "实验性",
+    "zh-TW": "實驗性"
 });
 %>
-<abbr class="icon icon-experimental" title="Experimental. Expect behavior to change in the future.">
-    <span class="visually-hidden">Experimental</span>
+<abbr class="icon icon-experimental" title="<%= title %>">
+    <span class="visually-hidden"><%= abbreviation %></span>
 </abbr>

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -6,12 +6,24 @@
 
 const title = mdn.localString({
     "en-US": "Experimental. Expect behavior to change in the future.",
+    "es": "Experimental. Expect behavior to change in the future.",
+    "fr": "Experimental. Expect behavior to change in the future.",
+    "ja": "Experimental. Expect behavior to change in the future.",
+    "ko": "Experimental. Expect behavior to change in the future.",
+    "pt-BR": "Experimental. Expect behavior to change in the future.",
+    "ru": "Experimental. Expect behavior to change in the future.",
     "zh-CN": "实验性。预期行为可能会在未来发生变更。",
     "zh-TW": "實驗性。預期行為可能會在未來发生變更。"
 });
 
 const abbreviation = mdn.localString({
     "en-US": "Experimental",
+    "es": "Experimental",
+    "fr": "Experimental",
+    "ja": "Experimental",
+    "ko": "Experimental",
+    "pt-BR": "Experimental",
+    "ru": "Experimental",
     "zh-CN": "实验性",
     "zh-TW": "實驗性"
 });

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -7,7 +7,7 @@
 const title = mdn.localString({
     "en-US": "Experimental. Expect behavior to change in the future.",
     "es": "Experimental. Expect behavior to change in the future.",
-    "fr": "Experimental. Expect behavior to change in the future.",
+    "fr": "Expérimental. Le comportement attendu pourrait évoluer à l'avenir.",
     "ja": "Experimental. Expect behavior to change in the future.",
     "ko": "Experimental. Expect behavior to change in the future.",
     "pt-BR": "Experimental. Expect behavior to change in the future.",
@@ -19,7 +19,7 @@ const title = mdn.localString({
 const abbreviation = mdn.localString({
     "en-US": "Experimental",
     "es": "Experimental",
-    "fr": "Experimental",
+    "fr": "Expérimental",
     "ja": "Experimental",
     "ko": "Experimental",
     "pt-BR": "Experimental",

--- a/kumascript/macros/ExperimentalBadge.ejs
+++ b/kumascript/macros/ExperimentalBadge.ejs
@@ -9,7 +9,7 @@ const title = mdn.localString({
     "es": "Experimental. Espere que el comportamiento cambie en el futuro.",
     "fr": "Expérimental. Le comportement attendu pourrait évoluer à l'avenir.",
     "ja": "Experimental. Expect behavior to change in the future.",
-    "ko": "Experimental. Expect behavior to change in the future.",
+    "ko": "Experimental. 예상되는 동작은 향후 변경될 수 있습니다.",
     "pt-BR": "Experimental. Expect behavior to change in the future.",
     "ru": "Экспериментальная возможность. Её поведение в будущем может измениться",
     "zh-CN": "实验性。预期行为可能会在未来发生变更。",


### PR DESCRIPTION
## Summary

support localization for {{ExperimentalBadge}} macro which is used by {{APIRef}}, {{experimental_inline}}, etc.

### Problem

This macro should support localization. But it won't. (the `title` and `abbreviation` is fixed with en-US text)

### Solution

use `mdn.localString` to select l10n `title` and `abbreviation` for this macro. (Just like #6954)

---

## Screenshots

In <hocalhost:5042/zh-CN/docs/Web/API/CharacterData#方法>

### Before

![image](https://user-images.githubusercontent.com/15844309/188774268-2ff042c2-c7a8-4f28-9faf-21c88fb5ed28.png)

### After

![image](https://user-images.githubusercontent.com/15844309/188774209-2f306590-10ae-40fd-a2c0-f12499cbbee9.png)

---

## How did you test this change?

run `yarn dev` and check the rendered html.
