### PR TITLE
fix(sidebar): open menu, highlight current page

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -48,6 +48,10 @@ export function extractSidebar($: cheerio.CheerioAPI, doc: Partial<Doc>) {
   search.find(`a[href='${doc.mdn_url}']`).each((_i, el) => {
     $(el).closest("details").prop("open", true);
     $(el).attr("aria-current", "page");
+    // Highlight, unless it already is highlighted (e.g. heading).
+    if ($(el).find("em,strong").length === 0) {
+      $(el).parent().wrapInner("<em></em>");
+    }
   });
 
   doc.sidebarHTML = search.html();

--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -3,6 +3,7 @@ import { packageBCD } from "./resolve-bcd";
 import * as bcd from "@mdn/browser-compat-data/types";
 import {
   BCDSection,
+  Doc,
   ProseSection,
   Section,
   SpecificationsSection,
@@ -36,14 +37,21 @@ type SectionsAndFlaws = [Section[], string[]];
  *
  * ...give or take some whitespace.
  */
-export function extractSidebar($: cheerio.CheerioAPI) {
+export function extractSidebar($: cheerio.CheerioAPI, doc: Partial<Doc>) {
   const search = $("#Quick_links");
+
   if (!search.length) {
-    return "";
+    doc.sidebarHTML = "";
   }
-  const sidebarHtml = search.html();
+
+  // Open menu and highlight current page.
+  search.find(`a[href='${doc.mdn_url}']`).each((_i, el) => {
+    $(el).closest("details").prop("open", true);
+    $(el).attr("aria-current", "page");
+  });
+
+  doc.sidebarHTML = search.html();
   search.remove();
-  return sidebarHtml;
 }
 
 export function extractSections($: cheerio.CheerioAPI): [Section[], string[]] {

--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -42,6 +42,7 @@ export function extractSidebar($: cheerio.CheerioAPI, doc: Partial<Doc>) {
 
   if (!search.length) {
     doc.sidebarHTML = "";
+    return;
   }
 
   // Open menu and highlight current page.

--- a/build/index.ts
+++ b/build/index.ts
@@ -492,7 +492,7 @@ export async function buildDocument(
   // Note that 'extractSidebar' will always return a string.
   // And if it finds a sidebar section, it gets removed from '$' too.
   // Also note, these operations mutate the `$`.
-  doc.sidebarHTML = extractSidebar($);
+  extractSidebar($, doc);
 
   // Check and scrutinize any local image references
   const fileAttachments = checkImageReferences(doc, $, options, document);

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -91,8 +91,11 @@
     background-color: var(--background-toc-active);
     border-left: 2px solid var(--category-color);
     display: inline-block;
+    font-style: normal;
+    font-weight: 600;
     hyphens: auto;
     padding: 0.25rem;
+    padding-left: 0.5rem;
     width: 100%;
   }
 
@@ -105,11 +108,6 @@
     &:hover,
     &:focus {
       text-decoration: underline;
-    }
-
-    &[aria-current="page"] {
-      background: var(--border-secondary);
-      border-radius: var(--elem-radius);
     }
   }
 

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -192,11 +192,7 @@ function buildSublist(pages, title, opened) {
         result += '<bdi>';
     }
 
-    if (slug == aPage.slug) {
-        result += '<em>' + pageBadges + ' <code>' + aPage.title + '</code></em>'
-    } else {
-        result += pageBadges + web.smartLink(url, null, `<code>${title}</code>`, aPage.slug, slug_stdlib, "JSRef");
-    }
+    result += pageBadges + web.smartLink(url, null, `<code>${title}</code>`, aPage.slug, slug_stdlib, "JSRef");
 
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';


### PR DESCRIPTION
## Summary

Highlights the current page in the sidebar, and expands the corresponding menu.

Fixes #5547.
Fixes #5641.

### Problem

1. The current page is not highlighted in the sidebar.
2. When opening a page from an expanded menu, the menu is collapsed again.

### Solution

1. Mark the current page with [aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current).
2. Open `<details>` elements that contain links to the current page.

---

## Screenshots

| Before | After |
|-------|-------|
| <img width="675" alt="image" src="https://user-images.githubusercontent.com/495429/188864171-a22a2521-69e1-4ac8-89da-ea43dda835dd.png"> | <img width="677" alt="image" src="https://user-images.githubusercontent.com/495429/189112863-c8eb0b71-395d-40c1-b3e1-5fecb19022cd.png">  |

---

## How did you test this change?

Opened these pages locally:

- http://localhost:3000/en-US/docs/Web/CSS/CSS_Animations
- http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Operators/Assignment
- http://localhost:3000/en-US/docs/Web/HTML/Global_attributes/class
- http://localhost:3000/en-US/docs/Web/HTTP/CSP
- http://localhost:3000/en-US/docs/Learn/CSS/Styling_text/Fundamentals
- http://localhost:3000/en-US/docs/Learn/HTML/Introduction_to_HTML/Creating_hyperlinks
- http://localhost:3000/en-US/docs/Learn/JavaScript/Building_blocks/conditionals