### PR TITLE
fix(macros/CSS_Ref): start new set of columns for each character in index

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -501,14 +501,14 @@ pre {
   ul {
     margin: 0.5rem 0 2rem;
 
+    @media screen and (min-width: $screen-xl) {
+      columns: 3;
+      margin-bottom: 0.5rem;
+    }
+
     li {
       margin: 0.5rem 0;
     }
-  }
-
-  @media screen and (min-width: $screen-xl) {
-    columns: 3;
-    margin-bottom: 0.5rem;
   }
 
   .icon-experimental,

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -486,18 +486,6 @@ pre {
 .index {
   margin-bottom: 1rem;
 
-  h3 {
-    background-color: var(--background-secondary);
-    border-radius: 0.5rem;
-    font-size: var(--type-heading-h4-font-size-mobile);
-    font-weight: var(--font-body-strong-weight);
-    padding: 0.5rem 1rem;
-
-    @media screen and (min-width: $screen-md) {
-      font-size: var(--type-heading-h4-font-size);
-    }
-  }
-
   ul {
     margin: 0.5rem 0 2rem;
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -491,11 +491,10 @@ pre {
 
     @media screen and (min-width: $screen-xl) {
       columns: 3;
-      margin-bottom: 0.5rem;
     }
 
     li {
-      margin: 0.5rem 0;
+      margin: 0 0 0.5rem 0;
     }
   }
 

--- a/kumascript/macros/CSS_Ref.ejs
+++ b/kumascript/macros/CSS_Ref.ejs
@@ -538,7 +538,8 @@ for (let characterIndex in characters) {
     let character = characters[characterIndex];
 
     if (groupingType === "alphabetically") {
-        output += `<span>${character}</span><ul>`;
+        output += `<h3>${character}</h3>`;
+        output += '<ul>';
     }
 
     for (let i = 0; i < index[character].length; i++) {


### PR DESCRIPTION
## Summary

Starts a new set of columns for each character in the (`CSS_Ref`) index.

Fixes #6601.

### Problem

The whole index was distributed among 3 (very long) columns, making them very hard to read/navigate.

### Solution

1. Create columns on the character-level, not on the whole index.
2. Use `<h3>` again for the characters, dropping the pre-redesign style (background-color with rounded corner).

---

## Screenshots

| Before | After |
| ------ | ------ |
| <img width="779" alt="image" src="https://user-images.githubusercontent.com/495429/188894700-c701764e-4a92-4fff-975d-cfa27220963d.png"> | <img width="779" alt="image" src="https://user-images.githubusercontent.com/495429/188894615-691b0db6-5934-43af-bf17-2a98e8ab8a26.png"> | 

---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/Web/CSS/Reference#index locally.
