### PR TITLE
fix(pr-companion): remove broken 'on GitHub' links

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -183,7 +183,6 @@ def post_about_dangerous_content(
             else:
                 lines.append(f"URL: `{doc['mdn_url']}`")
             lines.append(f"Title: `{doc['title']}`")
-            lines.append(f"[on GitHub]({doc['source']['github_url']})")
             lines.append("")
             lines.append(comment)
             lines.append("")
@@ -254,7 +253,6 @@ def post_about_flaws(build_directory: Path, **config):
             else:
                 lines.append(f"URL: `{doc['mdn_url']}`")
             lines.append(f"Title: `{doc['title']}`")
-            lines.append(f"[on GitHub]({doc['source']['github_url']})")
             if count_flaws(doc["flaws"]):
                 lines.append(f"Flaw count: {count_flaws(doc['flaws'])}")
             lines.append("")


### PR DESCRIPTION
## Summary

The "[on GitHub](https://github.com/mdn/content/blob/20417/merge/files/en-us/web/css/value_definition_syntax/index.md)" links produced by the PR companion are broken. And we simply need to remove them.

### Problem
Consider following URL for the discussion: (PR https://github.com/mdn/content/pull/20417)
`https://github.com/mdn/content/blob/20417/merge/files/en-us/web/css/value_definition_syntax/index.md?rgh-link-date=2022-09-08T04%3A15%3A01Z`


There are multiple issues that make the URL wrong:
1. The workflow [uses merge commit](https://github.com/mdn/content/blob/bff24d63155e704ab353e82c4f5963ca9da0d45c/.github/workflows/pr-test.yml#L26) instead of [pull request HEAD commit](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit). So the code uses the merge branch `20417/merge` instead of the contributor's branch in the URL, which is wrong.
2. The repo root has been hard coded to `mdn/content` but current Github URL scheme requires contributor's fork `OnkarRuikar/content`.

### Solution

Doing and testing all these changes in the main product code and the stable workflow just to give the link (which is available in next 'files' tab on GithHub anyway) is not worth the effort.
Also looks like the link has been broken since the beginning or for very long time so no one relies on the feature.

We can simply remove the link from `Flows` and `External URLs` sections.