### PR TITLE
fix(bcd): Don't include IE specific compatibility in the legend

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -25,6 +25,8 @@ const ISSUE_METADATA_TEMPLATE = `
 </details>
 `;
 
+export const HIDDEN_BROWSERS = ["ie"];
+
 /**
  * Return a list of platforms and browsers that are relevant for this category &
  * data.
@@ -72,7 +74,7 @@ function gatherPlatformsAndBrowsers(
   }
 
   // Hide Internet Explorer compatibility data
-  browsers = browsers.filter((browser) => browser !== "ie");
+  browsers = browsers.filter((browser) => !HIDDEN_BROWSERS.includes(browser));
 
   return [platforms, [...browsers]];
 }

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -1,6 +1,7 @@
 import { useContext } from "react";
 import type BCD from "@mdn/browser-compat-data/types";
 import { BrowserInfoContext } from "./browser-info";
+import { HIDDEN_BROWSERS } from "./index";
 import {
   asList,
   getFirst,
@@ -53,7 +54,7 @@ function getActiveLegendItems(
     for (const [browser, browserSupport] of Object.entries(
       feature.compat.support
     )) {
-      if (browser === "ie") {
+      if (HIDDEN_BROWSERS.includes(browser)) {
         continue;
       }
       if (!browserSupport) {

--- a/client/src/document/ingredients/browser-compatibility-table/legend.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/legend.tsx
@@ -53,6 +53,9 @@ function getActiveLegendItems(
     for (const [browser, browserSupport] of Object.entries(
       feature.compat.support
     )) {
+      if (browser === "ie") {
+        continue;
+      }
       if (!browserSupport) {
         legendItems.add("no");
         continue;


### PR DESCRIPTION
## Summary

Following up from #6602, don't include IE legend items (note: I'm not fully sure if I agree with IE having been removed already, but nonetheless now that it's done these legend items constitute a bug).

### Problem

The legend could include symbols not present in the visible BCD if only IE had the indicated support.

### Solution

Skip IE checks when adding to the legend.

---

## Screenshots

### Before

https://developer.mozilla.org/en-US/docs/Web/CSS/isolation#browser_compatibility
![Screenshot from 2022-09-08 15-34-37](https://user-images.githubusercontent.com/29206584/189210405-df952e64-2e47-469f-bf3a-f1505a92585f.png)

### After

http://localhost:3000/en-US/docs/Web/CSS/isolation#browser_compatibility
![Screenshot from 2022-09-08 15-34-21](https://user-images.githubusercontent.com/29206584/189210422-e6216ca3-2132-4a61-a834-07d9a7f8ba2b.png)
