### PR TITLE
fix(form): prevent selects from overflowing

### DIFF
--- a/client/src/ui/atoms/form/index.scss
+++ b/client/src/ui/atoms/form/index.scss
@@ -65,7 +65,9 @@
     width: 16px;
   }
 
+  select,
   label {
+    text-overflow: ellipsis;
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary

Prevent `<select>`s from overflowing, and use ellipsis ("...") in case of overflow instead of clipping.

Fixes [MP-93](https://mozilla-hub.atlassian.net/browse/MP-93).

### Problem

The Collection select overflows for a very long collection name.

### Solution

Limit its width and add ellipsis if it overflows.

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="478" alt="image" src="https://user-images.githubusercontent.com/495429/189341041-6d4b3d94-5e1c-4790-bde1-897158aa4c51.png"> | <img width="478" alt="image" src="https://user-images.githubusercontent.com/495429/189341118-af0b5196-8179-498f-bd22-7f3db506e1cb.png"> |


---

## How did you test this change?

As rumba is currently refusing to run for me locally, I tested it as follows: Open https://developer.allizom.org/en-US/docs/Learn/CSS (logged in as Supporter), apply the CSS changes manually.