### PR TITLE
fix(pr-companion): remove redundant entries

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -167,13 +167,9 @@ def post_about_dangerous_content(
                     line += " (Note! This may be a new URL 👀)"
                 external_urls_list.append(line)
             comments.append((doc, "\n".join(external_urls_list)))
-        elif diff_lines:
-            comments.append((doc, "No *new* external URLs"))
-        else:
-            comments.append((doc, "No external URLs"))
 
-    heading = "## External URLs\n\n"
     if comments:
+        heading = "## External URLs\n\n"
         per_doc_comments = []
         for doc, comment in comments:
             lines = []
@@ -189,8 +185,6 @@ def post_about_dangerous_content(
 
             per_doc_comments.append("\n".join(lines))
         return heading + "\n---\n".join(per_doc_comments)
-    else:
-        return heading + "*no external links in the built pages* 👱🏽"
 
 
 def post_about_flaws(build_directory: Path, **config):
@@ -233,9 +227,8 @@ def post_about_flaws(build_directory: Path, **config):
             count += len(flaw)
         return count
 
-    heading = "## Flaws\n\n"
-
     if comments:
+        heading = "## Flaws\n\n"
         if docs_with_zero_flaws:
             heading += (
                 f"Note! *{docs_with_zero_flaws} "
@@ -260,8 +253,6 @@ def post_about_flaws(build_directory: Path, **config):
 
             per_doc_comments.append("\n".join(lines))
         return heading + "\n\n---\n\n".join(per_doc_comments)
-    else:
-        return heading + "*None!* 🎉"
 
 
 def get_built_docs(build_directory: Path):

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -178,10 +178,7 @@ def test_analyze_pr_dangerous_content_with_diff_file_not_matched():
                 diff_file=diff_file,
             ),
         )
-        assert "## External URLs" in comment
-        assert "No *new* external URLs" in comment
-        assert "https://www.mozilla.org" not in comment
-
+        assert not comment
 
 @patch("deployer.analyze_pr.Github")
 def test_analyze_pr_prefix_and_postcomment(mocked_github):

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -180,6 +180,7 @@ def test_analyze_pr_dangerous_content_with_diff_file_not_matched():
         )
         assert not comment
 
+
 @patch("deployer.analyze_pr.Github")
 def test_analyze_pr_prefix_and_postcomment(mocked_github):
     doc = {"doc": {"mdn_url": "/en-US/docs/Foo"}}


### PR DESCRIPTION
## Summary

We are trying to reduce the size of the comment created by our PR companion as much as possible.
We've started it by removing redundant stuff first. 

This PR aims to remove some logs that are not necessary: [[ref](https://github.com/orgs/mdn/discussions/51#discussioncomment-3606826)]
a. `No *new* external URLs` or `No external URLs`
b. `*no external links in the built pages* 👱🏽` (when no external URLs found)
c. `*None!* 🎉` (when there are no flaws)

### Problem

Logs mentioned in a. add 7 lines to the comment.
Logs b. and c. unnecessarily add a section to the comment.

### Solution

It is not necessary to tell contributors that there are no flaws or there are not new URLs. We need to tell only about errors.
- Do not show the section if there are no errors or new info.
- Do not include a log if there is no new URL.

## Screenshots

### Before

Huge comment size due to such logs:
![unwanted logs](https://camo.githubusercontent.com/ba8919df089be3c1511fdec60c992f73d4fb5bea78b7f04e062719d74429bfb9/68747470733a2f2f692e696d6775722e636f6d2f307164614f54492e706e67)
