### PR TITLE
fix(pr-companion): fold sections with count

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -94,7 +94,7 @@ def post_about_deployment(build_directory: Path, **config):
 
     if links:
         if len(links) > 5:
-            heading = f"<details><summary><b>Preview URLs ({len(links)} pages)</b></summary>\n\n"
+            heading = f"<details><summary><b>Preview URLs</b> ({len(links)} pages)</summary>\n\n"
             return heading + "\n".join(links) + "\n\n</details>"
         else:
             heading = "<b>Preview URLs</b>\n\n"
@@ -177,7 +177,7 @@ def post_about_dangerous_content(
 
     if comments:
         heading = (
-            f"\n<details><summary><b>External URLs ({total_urls})</b></summary>\n\n"
+            f"\n<details><summary><b>External URLs</b> ({total_urls})</summary>\n\n"
         )
         per_doc_comments = []
         for doc, comment in comments:
@@ -233,11 +233,9 @@ def post_about_flaws(build_directory: Path, **config):
         comments.append((doc, "\n".join(flaws_list)))
 
     def count_flaws(flaws):
-        nonlocal total_flaws
         count = 0
         for flaw in flaws.values():
             count += len(flaw)
-        total_flaws += count
         return count
 
     if comments:
@@ -253,13 +251,14 @@ def post_about_flaws(build_directory: Path, **config):
             lines.append(f"Title: `{doc['title']}`")
             flaw_count = count_flaws(doc["flaws"])
             if flaw_count:
+                total_flaws += flaw_count
                 lines.append(f"Flaw count: {flaw_count}")
             lines.append("")
             lines.append(comment)
 
             per_doc_comments.append("\n".join(lines))
 
-        heading = f"\n<details><summary><b>Flaws ({total_flaws})</b></summary>\n\n"
+        heading = f"\n<details><summary><b>Flaws</b> ({total_flaws})</summary>\n\n"
 
         if docs_with_zero_flaws:
             heading += (

--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -93,12 +93,14 @@ def post_about_deployment(build_directory: Path, **config):
     links.sort()
 
     if links:
-        heading = (
-            f"<details><summary><h4>Preview URLs ({len(links)})</h4></summary>\n\n"
-        )
-        return heading + "\n".join(links) + "\n</details>"
+        if len(links) > 5:
+            heading = f"<details><summary><b>Preview URLs ({len(links)} pages)</b></summary>\n\n"
+            return heading + "\n".join(links) + "\n\n</details>"
+        else:
+            heading = "<b>Preview URLs</b>\n\n"
+            return heading + "\n".join(links)
 
-    return heading + "*seems not a single file was built!* 🙀"
+    return "*seems not a single file was built!* 🙀"
 
 
 def mdn_url_to_dev_url(prefix, mdn_url):
@@ -174,7 +176,9 @@ def post_about_dangerous_content(
             total_urls += len(external_urls_list)
 
     if comments:
-        heading = f"\n---\n<details><summary><h4>External URLs ({total_urls})</h4></summary>\n\n"
+        heading = (
+            f"\n<details><summary><b>External URLs ({total_urls})</b></summary>\n\n"
+        )
         per_doc_comments = []
         for doc, comment in comments:
             lines = []
@@ -189,7 +193,7 @@ def post_about_dangerous_content(
             lines.append("")
 
             per_doc_comments.append("\n".join(lines))
-        return heading + "\n---\n".join(per_doc_comments) + "</details>"
+        return heading + "\n---\n".join(per_doc_comments) + "\n</details>"
 
 
 def post_about_flaws(build_directory: Path, **config):
@@ -255,9 +259,7 @@ def post_about_flaws(build_directory: Path, **config):
 
             per_doc_comments.append("\n".join(lines))
 
-        heading = (
-            f"\n---\n<details><summary><h4>Flaws ({total_flaws})</h4></summary>\n\n"
-        )
+        heading = f"\n<details><summary><b>Flaws ({total_flaws})</b></summary>\n\n"
 
         if docs_with_zero_flaws:
             heading += (
@@ -266,7 +268,7 @@ def post_about_flaws(build_directory: Path, **config):
                 "that don't need to be listed. 🎉*\n\n"
             )
 
-        return heading + "\n\n---\n\n".join(per_doc_comments) + "\n</details>"
+        return heading + "\n\n---\n\n".join(per_doc_comments) + "\n\n</details>"
 
 
 def get_built_docs(build_directory: Path):

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -37,9 +37,25 @@ def test_analyze_pr_prefix():
     doc = {"doc": {"mdn_url": "/en-US/docs/Foo"}}
     with mock_build_directory(doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, prefix="pr007"))
-        assert "<details><summary><h4>Preview URLs (1)</h4></summary>" in comment
+        assert "<b>Preview URLs</b>" in comment
         assert (
             "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
+            in comment
+        )
+
+
+def test_analyze_pr_preview_urls():
+    doc1 = {"doc": {"mdn_url": "/en-US/docs/Foo1"}}
+    doc2 = {"doc": {"mdn_url": "/en-US/docs/Foo2"}}
+    doc3 = {"doc": {"mdn_url": "/en-US/docs/Foo3"}}
+    doc4 = {"doc": {"mdn_url": "/en-US/docs/Foo4"}}
+    doc5 = {"doc": {"mdn_url": "/en-US/docs/Foo5"}}
+    doc6 = {"doc": {"mdn_url": "/en-US/docs/Foo6"}}
+    with mock_build_directory(doc1, doc2, doc3, doc4, doc5, doc6) as build_directory:
+        comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, prefix="pr007"))
+        assert "<details><summary><b>Preview URLs (6 pages)</b></summary>" in comment
+        assert (
+            "- [/en-US/docs/Foo6](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo6)\n\n</details>"
             in comment
         )
 
@@ -68,10 +84,10 @@ def test_analyze_pr_flaws():
     }
     with mock_build_directory(no_flaws_doc, doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, analyze_flaws=True))
-        assert "<details><summary><h4>Flaws (2)</h4></summary>" in comment
+        assert "<details><summary><b>Flaws (2)</b></summary>" in comment
         assert "1 document with no flaws that don't need to be listed" in comment
         assert "Flaw count: 2" in comment
-        assert len(comment.split("\n---\n")) == 2
+        assert len(comment.split("\n---\n")) == 1
         assert "- **faux_pas**:" in comment
         assert "  - `Socks in sandals`" in comment
         assert "  - `Congrats on losing your cat`" in comment
@@ -102,7 +118,7 @@ def test_analyze_pr_dangerous_content():
         comment = analyze_pr(
             build_directory, dict(DEFAULT_CONFIG, analyze_dangerous_content=True)
         )
-        assert "<details><summary><h4>External URLs (1)</h4></summary>" in comment
+        assert "<details><summary><b>External URLs (1)</b></summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 
@@ -140,7 +156,7 @@ def test_analyze_pr_dangerous_content_with_diff_file_matched():
                 diff_file=diff_file,
             ),
         )
-        assert "<details><summary><h4>External URLs (1)</h4></summary>" in comment
+        assert "<details><summary><b>External URLs (1)</b></summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 
@@ -189,7 +205,7 @@ def test_analyze_pr_prefix_and_postcomment(mocked_github):
             build_directory,
             dict(DEFAULT_CONFIG, prefix="pr007", pr_number=123, github_token="abc123"),
         )
-        assert "<details><summary><h4>Preview URLs (1)</h4></summary>" in comment
+        assert "<b>Preview URLs</b>" in comment
         assert (
             "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
             in comment

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -53,7 +53,7 @@ def test_analyze_pr_preview_urls():
     doc6 = {"doc": {"mdn_url": "/en-US/docs/Foo6"}}
     with mock_build_directory(doc1, doc2, doc3, doc4, doc5, doc6) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, prefix="pr007"))
-        assert "<details><summary><b>Preview URLs (6 pages)</b></summary>" in comment
+        assert "<details><summary><b>Preview URLs</b> (6 pages)</summary>" in comment
         assert (
             "- [/en-US/docs/Foo6](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo6)\n\n</details>"
             in comment
@@ -84,7 +84,7 @@ def test_analyze_pr_flaws():
     }
     with mock_build_directory(no_flaws_doc, doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, analyze_flaws=True))
-        assert "<details><summary><b>Flaws (2)</b></summary>" in comment
+        assert "<details><summary><b>Flaws</b> (2)</summary>" in comment
         assert "1 document with no flaws that don't need to be listed" in comment
         assert "Flaw count: 2" in comment
         assert len(comment.split("\n---\n")) == 1
@@ -118,7 +118,7 @@ def test_analyze_pr_dangerous_content():
         comment = analyze_pr(
             build_directory, dict(DEFAULT_CONFIG, analyze_dangerous_content=True)
         )
-        assert "<details><summary><b>External URLs (1)</b></summary>" in comment
+        assert "<details><summary><b>External URLs</b> (1)</summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 
@@ -156,7 +156,7 @@ def test_analyze_pr_dangerous_content_with_diff_file_matched():
                 diff_file=diff_file,
             ),
         )
-        assert "<details><summary><b>External URLs (1)</b></summary>" in comment
+        assert "<details><summary><b>External URLs</b> (1)</summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 

--- a/deployer/src/deployer/test_analyze_pr.py
+++ b/deployer/src/deployer/test_analyze_pr.py
@@ -37,7 +37,7 @@ def test_analyze_pr_prefix():
     doc = {"doc": {"mdn_url": "/en-US/docs/Foo"}}
     with mock_build_directory(doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, prefix="pr007"))
-        assert "## Preview URLs" in comment
+        assert "<details><summary><h4>Preview URLs (1)</h4></summary>" in comment
         assert (
             "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
             in comment
@@ -68,10 +68,10 @@ def test_analyze_pr_flaws():
     }
     with mock_build_directory(no_flaws_doc, doc) as build_directory:
         comment = analyze_pr(build_directory, dict(DEFAULT_CONFIG, analyze_flaws=True))
-        assert "## Flaws" in comment
+        assert "<details><summary><h4>Flaws (2)</h4></summary>" in comment
         assert "1 document with no flaws that don't need to be listed" in comment
         assert "Flaw count: 2" in comment
-        assert len(comment.split("\n---\n")) == 1
+        assert len(comment.split("\n---\n")) == 2
         assert "- **faux_pas**:" in comment
         assert "  - `Socks in sandals`" in comment
         assert "  - `Congrats on losing your cat`" in comment
@@ -102,7 +102,7 @@ def test_analyze_pr_dangerous_content():
         comment = analyze_pr(
             build_directory, dict(DEFAULT_CONFIG, analyze_dangerous_content=True)
         )
-        assert "## External URLs" in comment
+        assert "<details><summary><h4>External URLs (1)</h4></summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 
@@ -140,7 +140,7 @@ def test_analyze_pr_dangerous_content_with_diff_file_matched():
                 diff_file=diff_file,
             ),
         )
-        assert "## External URLs" in comment
+        assert "<details><summary><h4>External URLs (1)</h4></summary>" in comment
         assert "  - <https://www.peterbe.com> (1 time)" in comment
 
 
@@ -189,7 +189,7 @@ def test_analyze_pr_prefix_and_postcomment(mocked_github):
             build_directory,
             dict(DEFAULT_CONFIG, prefix="pr007", pr_number=123, github_token="abc123"),
         )
-        assert "## Preview URLs" in comment
+        assert "<details><summary><h4>Preview URLs (1)</h4></summary>" in comment
         assert (
             "- [/en-US/docs/Foo](https://pr007.content.dev.mdn.mozit.cloud/en-US/docs/Foo)"
             in comment


### PR DESCRIPTION
## Summary

We are trying to reduce the size of the comment created by our PR companion as much as possible. The redundant stuff has been removed.

This PR aims to reduce the comment height further by folding the sections using `<details>` tag.

### Problem

Not everyone is interested in all the sections. Showing all the section in full increases the height of the comment tremendously.

### Solution

Put the sections in `<details>` tags so that contributors will expand only the required sections.
Also show section summary in the title to give overall idea without opening the section.

## Screenshots

See [the first comment](https://github.com/mdn/yari/pull/7110#issuecomment-1242667057) below this post for the sample output.

---
**Note:** The PR aims to get the feel of folded sections. This is not the final change. Final changes will be done after [the community discussion](https://github.com/orgs/mdn/discussions/51) concludes.