### PR TITLE
fix(kumascript): improve MacroInvocationError display

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -345,7 +345,7 @@ export async function buildDocument(
       // message.
       error.updateFileInfo(document.fileInfo);
       throw new Error(
-        `MacroInvocationError trying to parse ${error.filepath}, line ${error.line} column ${error.column} (${error.error.message})`
+        `MacroInvocationError trying to parse file.\n\nFile:    ${error.filepath}\nMessage: ${error.error.message}\n\n${error.sourceContext}`
       );
     }
     // Any other unexpected error re-thrown.

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -610,3 +610,8 @@ kbd {
   font-size: 0.825rem;
   padding: 0.25rem;
 }
+
+.loading-error pre {
+  overflow-y: scroll;
+  white-space: pre;
+}

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -272,7 +272,7 @@ function LoadingError({ error }) {
           </p>
         ) : (
           <p>
-            <code>{error.toString()}</code>
+            <pre>{error.toString()}</pre>
           </p>
         )}
         <p>

--- a/kumascript/src/errors.ts
+++ b/kumascript/src/errors.ts
@@ -47,34 +47,8 @@ export class SourceCodeError {
     ].join("\n");
   }
 
-  updateOffset(value) {
-    // Update the "offset" property to account for things like front-matter in the
-    // source. If the offset changes, this method will update related information.
-    // NOTE: We're not using a getter/setter for "offset", which would be a more
-    //       robust interface, so that the code that converts this instance to/from
-    //       JSON can remain simple.
-    if (this.offset !== value) {
-      // First, let's calculate the change in offset.
-      const offsetDelta = value - this.offset;
-      // Now, let's update things. First, the offset itself.
-      this.offset += offsetDelta;
-      // Next, let's update the line number.
-      this.line += offsetDelta;
-      // Finally, let's update the line numbers in the source context to reflect the new offset.
-      this.sourceContext = this.sourceContext.replace(
-        /^\s{0,4}(\d{1,5}) \| /gm,
-        (match, p1) => {
-          return `${(parseInt(p1) + offsetDelta).toString().padStart(5)} | `;
-        }
-      );
-    }
-  }
-
   updateFileInfo(fileInfo) {
     this.filepath = fileInfo.path;
-    // The extra `- 1` is because of the added newline that
-    // is only present because of the serialized linebreak.
-    this.updateOffset(fileInfo.frontMatterOffset - 1);
     return this;
   }
 
@@ -83,18 +57,10 @@ export class SourceCodeError {
   // doesn't really make sense. Perhaps we can modify this function to
   // show the relevant context in a more useful way.
   getSourceContext(source) {
-    function arrow(column) {
-      let arrow = "";
-      for (let i = 0; i < column + 7; i++) {
-        arrow += "-";
-      }
-      return `${arrow}^`;
-    }
+    const arrow = (line) => (line === this.line ? ">" : " ");
+    const arrowLine = (column) => " ".repeat(column + 3) + "^";
 
-    function formatLine(i, line) {
-      const lnum = `      ${i + 1}`.substr(-5);
-      return `${lnum} | ${line}`;
-    }
+    const formatLine = (i, lineSource) => `${arrow(i + 1)} | ${lineSource}`;
 
     const lines = source.split("\n");
 
@@ -110,7 +76,7 @@ export class SourceCodeError {
     for (let i = startLine; i < endLine; i++) {
       context.push(formatLine(i, lines[i]));
       if (i == errorLine) {
-        context.push(arrow(this.column));
+        context.push(arrowLine(this.column));
       }
     }
     return context.join("\n");
@@ -118,8 +84,7 @@ export class SourceCodeError {
 
   toString() {
     return (
-      `${this.name} error on ${this.macroName} ` +
-      `at line ${this.line}, column ${this.column} in:\n` +
+      `${this.name} error on ${this.macroName}:\n` +
       `${this.sourceContext}\nOriginal error: ${this.error.message}`
     );
   }

--- a/kumascript/src/errors.ts
+++ b/kumascript/src/errors.ts
@@ -47,8 +47,34 @@ export class SourceCodeError {
     ].join("\n");
   }
 
+  updateOffset(value) {
+    // Update the "offset" property to account for things like front-matter in the
+    // source. If the offset changes, this method will update related information.
+    // NOTE: We're not using a getter/setter for "offset", which would be a more
+    //       robust interface, so that the code that converts this instance to/from
+    //       JSON can remain simple.
+    if (this.offset !== value) {
+      // First, let's calculate the change in offset.
+      const offsetDelta = value - this.offset;
+      // Now, let's update things. First, the offset itself.
+      this.offset += offsetDelta;
+      // Next, let's update the line number.
+      this.line += offsetDelta;
+      // Finally, let's update the line numbers in the source context to reflect the new offset.
+      this.sourceContext = this.sourceContext.replace(
+        /^\s{0,4}(\d{1,5}) \| /gm,
+        (match, p1) => {
+          return `${(parseInt(p1) + offsetDelta).toString().padStart(5)} | `;
+        }
+      );
+    }
+  }
+
   updateFileInfo(fileInfo) {
     this.filepath = fileInfo.path;
+    // The extra `- 1` is because of the added newline that
+    // is only present because of the serialized linebreak.
+    this.updateOffset(fileInfo.frontMatterOffset - 1);
     return this;
   }
 


### PR DESCRIPTION
## Summary

Fixes #7106 by improving the way `MacroInvocationError`s are displayed (both in the command line and in the browser).

### Problem

Macro errors were always confusing and hard to locate, because the shown line number did not correspond to the Markdown file.

### Solution

Remove the line numbers in favor of showing the source context (+/- 2 lines).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="788" alt="image" src="https://user-images.githubusercontent.com/495429/189684124-bbd03fd9-962f-4333-84d9-b8a6670d180d.png">

### After

<img width="788" alt="image" src="https://user-images.githubusercontent.com/495429/189683777-d1fa75b9-d07b-4106-846f-871f06244060.png">

---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/MDN/Kitchensink locally and introduced a syntax error in my local mdn/content checkout by removing the second `"` in this line:

https://github.com/mdn/content/blob/6fdcfb2bb5862d89d84cc511cf31a0e4fffc72bf/files/en-us/mdn/kitchensink/index.md?plain=1#L300