### PR TITLE
fix(plus/notifications): don't wrap filters menu, allow to grow

### DIFF
--- a/client/src/plus/search-filter/index.scss
+++ b/client/src/plus/search-filter/index.scss
@@ -47,6 +47,6 @@
   .search-filter-category .dropdown-list.filters-menu {
     left: auto;
     right: 0;
-    width: 180px;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6551 by removing the fixed width of the Notifications' filter menu.

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="477" alt="image" src="https://user-images.githubusercontent.com/495429/189729246-4ac11daa-9f7f-4dc3-8fd4-ca933bd3e8c0.png">

### After

<img width="477" alt="image" src="https://user-images.githubusercontent.com/495429/189729504-79adf1b7-5e81-465f-b966-b5bed5423613.png">


---

## How did you test this change?

Applied the changes on https://developer.mozilla.org/en-US/plus/notifications.