### PR TITLE
fix(a11y): increase contrast of code sample punctuation/comments

### DIFF
--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -187,10 +187,10 @@ $mdn-theme-light-shadow-01: 0px 1px 2px rgba(43, 42, 51, 0.05);
 $mdn-theme-light-shadow-02: 0px 1px 6px rgba(43, 42, 51, 0.1);
 
 $mdn-theme-light-code-token-tag: $mdn-color-light-theme-blue-60;
-$mdn-theme-light-code-token-punctuation: $mdn-color-neutral-40;
+$mdn-theme-light-code-token-punctuation: $mdn-color-neutral-50;
 $mdn-theme-light-code-token-attribute-name: $mdn-color-light-theme-red-60;
 $mdn-theme-light-code-token-attribute-value: $mdn-color-light-theme-green-60;
-$mdn-theme-light-code-token-comment: $mdn-color-neutral-40;
+$mdn-theme-light-code-token-comment: $mdn-color-neutral-50;
 $mdn-theme-light-code-token-default: $mdn-color-neutral-90;
 $mdn-theme-light-code-token-selector: $mdn-color-light-theme-violet-60;
 $mdn-theme-light-code-background-inline: $mdn-color-neutral-light-80;
@@ -229,10 +229,10 @@ $mdn-theme-dark-field-focus-border: $mdn-color-white;
 $mdn-theme-dark-focus-01: 0px 0px 0px 3px rgba(251, 251, 254, 0.5);
 
 $mdn-theme-dark-code-token-tag: $mdn-color-dark-theme-blue-20;
-$mdn-theme-dark-code-token-punctuation: $mdn-color-neutral-40;
+$mdn-theme-dark-code-token-punctuation: $mdn-color-neutral-30;
 $mdn-theme-dark-code-token-attribute-name: $mdn-color-dark-theme-red-30;
 $mdn-theme-dark-code-token-attribute-value: $mdn-color-dark-theme-green-30;
-$mdn-theme-dark-code-token-comment: $mdn-color-neutral-40;
+$mdn-theme-dark-code-token-comment: $mdn-color-neutral-30;
 $mdn-theme-dark-code-token-default: $mdn-color-white;
 $mdn-theme-dark-code-token-selector: $mdn-color-dark-theme-violet-30;
 $mdn-theme-dark-code-background-inline: $mdn-color-neutral-80;


### PR DESCRIPTION
## Summary

Fixes #6534 by increasing the contrast of punctuation and comments in code samples.

### Problem

The punctuation and comments did not have enough contrast against the background color.

### Solution

Make them brighter in dark theme, and lighter in light theme.

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="287" alt="image" src="https://user-images.githubusercontent.com/495429/189733951-279b9f7a-0f13-4367-9ee5-a59ff34932c8.png"> | <img width="287" alt="image" src="https://user-images.githubusercontent.com/495429/189733989-07c486bf-a138-4b99-8515-3d209d459f4f.png"> |
| <img width="287" alt="image" src="https://user-images.githubusercontent.com/495429/189734077-43cc3301-2c08-4d0e-8b69-31b805103d60.png"> | <img width="287" alt="image" src="https://user-images.githubusercontent.com/495429/189734112-5d830ed9-fd3f-4c11-b763-0c38a2bdf72f.png"> |


---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#objects_and_properties locally and compared it against https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects#objects_and_properties