### PR TITLE
fix(macros/htmlattrdef): use inline-block for self-link

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -165,6 +165,10 @@ main {
   display: none;
 }
 
+.inline-block {
+  display: inline-block;
+}
+
 pre {
   white-space: pre-wrap;
   white-space: -moz-pre-wrap;

--- a/kumascript/macros/htmlattrdef.ejs
+++ b/kumascript/macros/htmlattrdef.ejs
@@ -1,2 +1,2 @@
 <%/* Example: <span class="script">htmlattrdef("placeholder")</span> */%>
-<a id="attr-<%=$0%>" href="#attr-<%=$0%>"><b><code><%=$0%></code></b></a>
+<a id="attr-<%=$0%>" class="inline-block" href="#attr-<%=$0%>"><b><code><%=$0%></code></b></a>


### PR DESCRIPTION
## Summary

Fixes #6427 by making the self-referencing anchor an inline-block.

### Problem

We use a `scroll-margin-top` to make sure targeted anchors display below our sticky header, but Safari seems to ignore `scroll-margin-top` for inline elements (see [here](https://stackoverflow.com/a/73120680)), so the targeted anchor ends up behind the sticky header.

### Solution

Make the anchor an inline-block via a newly introduced utility class.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="726" alt="image" src="https://user-images.githubusercontent.com/495429/189754036-57e1903d-b7b7-4763-b3e8-b03d3d079fc2.png">

### After

<img width="726" alt="image" src="https://user-images.githubusercontent.com/495429/189753982-11ccdeee-5ff4-4961-8d30-90ed91c343ba.png">


---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/Web/HTML/Element/button#attr-autocomplete locally in Safari.
