### PR TITLE
fix(bcd): apply mobile style only to bc-table

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
@@ -1,26 +1,28 @@
 // Style for mobile.
 
 @media screen and (max-width: $screen-sm - 1px) {
-  thead {
-    display: none;
-  }
+  .bc-table {
+    thead {
+      display: none;
+    }
 
-  td.bc-support {
-    border-left-width: 0;
-    display: block;
-  }
+    td.bc-support {
+      border-left-width: 0;
+      display: block;
+    }
 
-  .bc-feature,
-  .bc-support > button,
-  .bc-history > td {
-    align-content: center;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
+    .bc-feature,
+    .bc-support > button,
+    .bc-history > td {
+      align-content: center;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
 
-  .bc-history-desktop {
-    display: none;
+    .bc-history-desktop {
+      display: none;
+    }
   }
 
   .table-scroll {


### PR DESCRIPTION
# Summary

Fixes #6514 by properly containing the BCD-related style that hides the header of the BCD table.

### Problem

Some tables were missing their headers on mobile, because BCD-related styles were leaking into unrelated areas.

### Solution

Wrap the styles in a local selector.

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="361" alt="image" src="https://user-images.githubusercontent.com/495429/189756726-fe0abc3c-5b9d-4f99-bd44-e0923ae0da54.png"> | <img width="361" alt="image" src="https://user-images.githubusercontent.com/495429/189756646-03665bbe-d08d-4e91-a0c4-b422472811e7.png"> |

---

## How did you test this change?

Opened http://localhost:3000/en-US/docs/Web/HTTP/Headers/Cache-Control#cache_directives locally in responsive mode.
