### PR TITLE
fix(document): use --font-code for <code>

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -422,6 +422,7 @@ code,
 
 code {
   background: var(--code-background-inline);
+  font-family: var(--font-code);
   padding: 0.125rem 0.25rem;
   width: fit-content;
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6166 by specifying a font-family for code samples.

### Problem

The Japanese locale used a different (default) font.

### Solution

Specify `--font-code` for `<code>`.

---

## Screenshots


| Before | After |
| --- | --- |
| <img width="861" alt="image" src="https://user-images.githubusercontent.com/495429/189762462-1588d7e3-64ae-4a5e-8c14-328c1f3da639.png"> | <img width="861" alt="image" src="https://user-images.githubusercontent.com/495429/189762382-d27302e0-21ba-4486-af7b-5a1a03273c87.png"> |

---

## How did you test this change?

Opened http://localhost:3000/ja/docs/Web/HTML/Element/head#%E4%BE%8B locally.