### PR TITLE
chore(syntax-highlight): add nolint alias for CSS

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -59,6 +59,7 @@ const loadAllLanguages = lazy(() => {
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   // ["idl", "webidl"],  // block list
+  ["css-nolint", "css"],
   ["html-nolint", "html"],
   ["js-nolint", "js"],
   ["sh", "shell"],


### PR DESCRIPTION
- Same as https://github.com/mdn/yari/pull/7017 but for CSS
- Addresses https://github.com/mdn/content/pull/20655#pullrequestreview-1105538164

> The idea is to have such code blocks styled by Prism with the right color scheme but skipped when linter run, like Markdownlint, or Prettier, as these blocks are not valid (for example our syntax box), or should not be formatted by linters (like examples of invalid code, or TML templates that require an unusual alignment).

We are finding may places where manual formatting is more readable than the Prettier. For example,
```
.multiple {
  box-shadow: 1px 1px 1px black,
              2px 2px 1px black,
              3px 3px 1px red,
              4px 4px 1px red,
              5px 5px 1px black,
              6px 6px 1px black;
}
```
We need `css-nolint` for such cases and for `example-bad` code fences.
Also, CSS syntax section needs this. e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-inner-spin-button#syntax

cc/ @teoli2003, @caugner 