### PR TITLE
fix(livesample): support nolint aliases

### DIFF
--- a/markdown/m2h/handlers/code.ts
+++ b/markdown/m2h/handlers/code.ts
@@ -1,12 +1,12 @@
 import u from "unist-builder";
 
 /**
- * Transform a markdown code block into a <pre>.
+ * Transform a Markdown code block into a <pre>.
  * Adding the highlight tags as classes prefixed by "brush:"
  */
 export function code(h, node) {
-  var value = node.value ? node.value + "\n" : "";
-  const lang = node.lang;
+  const value = node.value ? node.value + "\n" : "";
+  const lang = node.lang?.replace(/-nolint$/, "");
   const meta = (node.meta || "").split(" ");
   const props: { className?: string | string[] } = {};
 
@@ -18,7 +18,7 @@ export function code(h, node) {
 
   /*
    * Prism will inject a <code> element so we don't.
-   * If we wanna change this uncomment the following code:
+   * If we want to change this, uncomment the following code:
    */
   // const code = h(node, "code", props, [u("text", value)]);
   // if (node.meta) {


### PR DESCRIPTION
## Summary

Related to https://github.com/mdn/yari/pull/7017

Recently we introduced new aliases `js-nolint`, `html-nolint`, and `css-nolint` in order to avoid some code fences getting linted.
But current live sample code doesn't recognize the new language tags.

### Problem

The live sample code collector doesn't recognize `-nolint` language aliases.

### Solution

Widen the Cheerio CSS attribute style selector using [wild card](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#attrvalue_6) e.g. `pre[class*="${part}"]` 


## How did you test this change?

 Use same code for a live sample but with `-nolint` added to all language code fences.


cc/ @caugner @teoli2003 