### PR TITLE
refactor(sync-translated-content): move from /build to /tool

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -12,6 +12,7 @@ import {
   CONTRIBUTOR_SPOTLIGHT_ROOT,
   BUILD_OUT_ROOT,
 } from "../libs/env";
+import { DocFrontmatter } from "../libs/types/document";
 // eslint-disable-next-line n/no-missing-require
 import { renderHTML } from "../ssr/dist/main";
 import { default as got } from "got";
@@ -20,18 +21,6 @@ import cheerio from "cheerio";
 import { findByURL } from "../content/document";
 import { buildDocument } from ".";
 import { NewsItem } from "../client/src/homepage/latest-news";
-
-export interface DocFrontmatter {
-  contributor_name?: string;
-  folder_name?: string;
-  is_featured?: boolean;
-  img_alt?: string;
-  usernames?: any;
-  quote?: any;
-  title?: string;
-  slug?: string;
-  original_slug?: string;
-}
 
 const dirname = __dirname;
 

--- a/content/document.ts
+++ b/content/document.ts
@@ -25,7 +25,7 @@ import {
 } from "./utils";
 export { urlToFolderPath, MEMOIZE_INVALIDATE } from "./utils";
 import * as Redirect from "./redirect";
-import { DocFrontmatter } from "../build/spas";
+import { DocFrontmatter } from "../libs/types";
 
 function buildPath(localeFolder: string, slug: string) {
   return path.join(localeFolder, slugToFolder(slug));

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -159,6 +159,18 @@ export interface Doc {
   noIndexing?: boolean;
 }
 
+export interface DocFrontmatter {
+  contributor_name?: string;
+  folder_name?: string;
+  is_featured?: boolean;
+  img_alt?: string;
+  usernames?: any;
+  quote?: any;
+  title?: string;
+  slug?: string;
+  original_slug?: string;
+}
+
 export type Section = ProseSection | SpecificationsSection | BCDSection;
 
 export interface ProseSection {

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -10,9 +10,6 @@ const chalk = require("chalk");
 const { prompt } = require("inquirer");
 const openEditor = require("open-editor");
 const open = require("open");
-const {
-  syncAllTranslatedContent,
-} = require("../build/sync-translated-content");
 const log = require("loglevel");
 const cheerio = require("cheerio");
 
@@ -33,6 +30,7 @@ const {
 const { runMakePopularitiesFile } = require("./popularities");
 const { runOptimizeClientBuild } = require("./optimize-client-build");
 const { runBuildRobotsTxt } = require("./build-robots-txt");
+const { syncAllTranslatedContent } = require("./sync-translated-content");
 const kumascript = require("../kumascript");
 
 const PORT = parseInt(process.env.SERVER_PORT || "5042");

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -20,7 +20,7 @@ import {
   VALID_LOCALES,
 } from "../libs/constants";
 import { CONTENT_ROOT, CONTENT_TRANSLATED_ROOT } from "../libs/env";
-import { DocFrontmatter } from "./spas";
+import { DocFrontmatter } from "../build/spas";
 
 const CONFLICTING = "conflicting";
 const ORPHANED = "orphaned";

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -20,7 +20,7 @@ import {
   VALID_LOCALES,
 } from "../libs/constants";
 import { CONTENT_ROOT, CONTENT_TRANSLATED_ROOT } from "../libs/env";
-import { DocFrontmatter } from "../build/spas";
+import { DocFrontmatter } from "../libs/types/document";
 
 const CONFLICTING = "conflicting";
 const ORPHANED = "orphaned";


### PR DESCRIPTION
## Summary

Moves `build/sync-translated-content.ts` to `tool/sync-translated-content.ts`, because it is only used by `tool/cli.ts`.

After this change, `tool/` no longer depends on `build/`! 🎉 

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn tool sync-translated-content` locally.