### PR TITLE
chore: document deprecated link macro

### DIFF
--- a/kumascript/macros/Link.deprecated.md
+++ b/kumascript/macros/Link.deprecated.md
@@ -1,0 +1,21 @@
+# `{{ link }}` deprecated
+
+The Link macro has [been deprecated](https://github.com/mdn/yari/pull/6865) and
+should no longer be used. Any occurances that still exist in actively maintained
+content should be replaced with a plain Markdown style link.
+
+## How to replace the macro
+
+A common usage of the macro is as follows:
+
+```js
+The {{Link("/en-US/docs/Web/JavaScript/Guide")}} on MDN
+```
+
+This can be replace with the following Markdown:
+
+```md
+The [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide) on MDN
+```
+
+The text for the link matches the title of the page it links to.

--- a/kumascript/macros/Link.deprecated.md
+++ b/kumascript/macros/Link.deprecated.md
@@ -12,7 +12,7 @@ A common usage of the macro is as follows:
 The {{Link("/en-US/docs/Web/JavaScript/Guide")}} on MDN
 ```
 
-This can be replace with the following Markdown:
+This can be replaced with the following Markdown:
 
 ```md
 The [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide) on MDN

--- a/kumascript/macros/Link.ejs
+++ b/kumascript/macros/Link.ejs
@@ -5,7 +5,7 @@
 //  $0  Page link
 
 // Throw a MacroDeprecatedError flaw
- mdn.deprecated()
+ mdn.deprecated("The 'Link' macro is deprecated. See https://github.com/orgs/mdn/discussions/187 for details.")
 
 let page = await wiki.getPage($0);
 let title = page.title;


### PR DESCRIPTION
This adds documentation on replacing any remaining instances of the `{{link}}` macro. It also updates the `deprecated` call to point to the discussion about removing the macro. In the discussion, we will link to the documentation added here.

Part of https://github.com/mdn/mdn/issues/241