### PR TITLE
chore(macros): deprecate {{source}}

### DIFF
--- a/kumascript/macros/source.ejs
+++ b/kumascript/macros/source.ejs
@@ -6,6 +6,8 @@
 //
 // If $1 isn't provided, the link itself is the link text
 
+mdn.deprecated();
+
 var url = "https://dxr.mozilla.org/mozilla-central/source/" + $0;
 var text = ($1 || $0);
 var styleStart = "";


### PR DESCRIPTION
## Summary

Deprecates the `{{source}}` macro, which is no longer used in content and already tracked for removal in translated-content: https://github.com/mdn/translated-content/issues/7178