### PR TITLE
Use `page-report.yml` for locales

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -72,24 +72,6 @@ const METADATA_TEMPLATE = `
 </details>
 `;
 
-const NEW_ISSUE_TEMPLATE = `
-MDN URL: https://developer.mozilla.org$PATHNAME
-
-#### What information was incorrect, unhelpful, or incomplete?
-
-
-#### Specific section or headline?
-
-
-#### What did you expect to see?
-
-
-#### Did you test this? If so, how?
-
-
-${METADATA_TEMPLATE}
-  `.trim();
-
 function fillMetadata(string, doc) {
   const { folder, github_url, last_commit_url } = doc.source;
   return string
@@ -109,24 +91,10 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   const url = new URL("https://github.com/");
   const sp = new URLSearchParams();
 
-  if (locale !== "en-US") {
-    url.pathname = "/mdn/translated-content/issues/new";
-
-    const body = fillMetadata(NEW_ISSUE_TEMPLATE, doc);
-    sp.set("body", body);
-
-    const maxLength = 50;
-    const titleShort =
-      doc.title.length > maxLength
-        ? `${doc.title.slice(0, maxLength)}…`
-        : doc.title;
-    sp.set("title", `Issue with "${titleShort}": (short summary here please)`);
-  } else {
-    url.pathname = "/mdn/content/issues/new";
-    sp.set("template", "page-report.yml");
-    sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
-    sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
-  }
+  url.pathname = (locale !== "en-US") ? "/mdn/translated-content/issues/new" : "/mdn/content/issues/new";
+  sp.set("template", "page-report.yml");
+  sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
+  sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
 
   url.search = sp.toString();
 

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -91,7 +91,10 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   const url = new URL("https://github.com/");
   const sp = new URLSearchParams();
 
-  url.pathname = (locale !== "en-US") ? "/mdn/translated-content/issues/new" : "/mdn/content/issues/new";
+  url.pathname =
+    locale !== "en-US"
+      ? "/mdn/translated-content/issues/new"
+      : "/mdn/content/issues/new";
   sp.set("template", "page-report.yml");
   sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Updates the "Report on GitHub" link for localized pages to use the new `page-report.yml` template (this may require more discussion). **This should be merged together with mdn/translated-content#8538.**

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

`translated-content` is still using the old issue template, which is less descriptive and less instructive than the new `page-report.yml` used on `content`.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

This PR modifies the `NewIssueOnGitHubLink` to create an issue using `page-report.yml` on translated-content, and not only on `content` (The YAML template will be added on `translated-content` in mdn/translated-content#8538).

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

I tested on my local machine with a `yarn dev` server.