### PR TITLE
fix(ssr): escape colon in <title>

### DIFF
--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -24,7 +24,8 @@ function htmlEscape(s) {
     .replace(/"/gim, "&quot;")
     .replace(/</gim, "&lt;")
     .replace(/>/gim, "&gt;")
-    .replace(/'/gim, "&apos;");
+    .replace(/'/gim, "&apos;")
+    .replace(/:/gim, "&colon;");
 }
 
 function getHrefLang(locale, otherLocales) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/4961 by escaping the colon (`:`) in the `<title>` tag and the SEO fields.

### Problem

Google omits the first part of our HTML element titles:
<img width="902" alt="image" src="https://user-images.githubusercontent.com/495429/190476374-3eb7b4ae-2923-477c-8713-ca722963a90e.png">

Compare this with DuckDuckGo:

![image](https://user-images.githubusercontent.com/495429/190476458-b98b18e3-ded3-4476-b351-e672ef157f16.png)

### Solution

Apparently, escaping the colon does the trick and avoids that Google ignores it.

---

## Screenshots

(See above.)

---

## How did you test this change?

Didn't test, but others have tested this before in https://github.com/mdn/yari/issues/4961.