### PR TITLE
fix(bcd): list descendant features even if parent has no data

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -137,6 +137,9 @@
   .bc-feature-depth-2 {
     border-left-width: 8px;
   }
+  .bc-feature-depth-3 {
+    border-left-width: 16px;
+  }
 }
 
 .bc-head-txt-label {

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -137,6 +137,7 @@
   .bc-feature-depth-2 {
     border-left-width: 8px;
   }
+
   .bc-feature-depth-3 {
     border-left-width: 16px;
   }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -70,29 +70,22 @@ export function listFeatures(
     findAllCompatDepths(identifier, compatDepths, "");
     firstCompatDepth = Math.min(...compatDepths);
   }
-  for (const [subName, subIdentifier] of Object.entries(identifier)) {
-    if (subName !== "__compat") {
-      if ((subIdentifier as BCD.Identifier).__compat) {
-        features.push({
-          name: parentName ? `${parentName}.${subName}` : subName,
-          compat: (subIdentifier as BCD.Identifier).__compat!,
-          depth: depth + 1,
-        });
-      }
-      if (
-        (subIdentifier as BCD.Identifier).__compat ||
-        depth + 1 < firstCompatDepth
-      ) {
-        features.push(
-          ...listFeatures(
-            subIdentifier as BCD.Identifier,
-            subName,
-            "",
-            depth + 1,
-            firstCompatDepth
-          )
-        );
-      }
+  for (const subName of Object.keys(identifier)) {
+    if (subName === "__compat") {
+      continue;
+    }
+    const subIdentifier = identifier[subName];
+    if (subIdentifier.__compat) {
+      features.push({
+        name: parentName ? `${parentName}.${subName}` : subName,
+        compat: subIdentifier.__compat,
+        depth: depth + 1,
+      });
+    }
+    if (subIdentifier.__compat || depth + 1 < firstCompatDepth) {
+      features.push(
+        ...listFeatures(subIdentifier, subName, "", depth + 1, firstCompatDepth)
+      );
     }
   }
   return features;

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -47,10 +47,10 @@ export function listFeatures(
   }
 
   for (const [subName, subIdentifier] of Object.entries(identifier)) {
-    if (subName !== "__compat" && (subIdentifier as BCD.Identifier).__compat) {
+    if (subName !== "__compat") {
       features.push({
         name: parentName ? `${parentName}.${subName}` : subName,
-        compat: (subIdentifier as BCD.Identifier).__compat!,
+        compat: (subIdentifier as BCD.Identifier).__compat || { support: {} },
         depth: depth + 1,
       });
       features.push(


### PR DESCRIPTION
## Summary

Fixes #5041

### Problem

When parent and children had no compatibility data, grandchild data was not shown

### Solution

Show the grandchildren only when neither the parent nor its immediate children have any data. Determine at what depth we have the first data, then show that depth + 1.

---

## Screenshots

### Before

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels#browser_compatibility **unchanged**:
![Screenshot from 2022-09-15 14-58-26](https://user-images.githubusercontent.com/29206584/190487112-be69f8cc-30ed-4fd8-87c1-fafda686179b.png)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility **unchanged**:
![Screenshot from 2022-09-16 16-18-24](https://user-images.githubusercontent.com/29206584/190726075-98f674a8-03e8-4a38-8423-3efedf551745.png)
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools#browser_compatibility:
![Screenshot from 2022-09-15 15-00-01](https://user-images.githubusercontent.com/29206584/190487408-2603b02a-90a3-468f-b9ce-c829a46bd261.png)
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy#browser_compatibility:
![Screenshot from 2022-09-15 15-02-30](https://user-images.githubusercontent.com/29206584/190487773-ae13194f-e35d-4a7e-94ce-cd91eeebf13c.png)

### After

http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels#browser_compatibility **unchanged**:
![Screenshot from 2022-09-16 16-16-12](https://user-images.githubusercontent.com/29206584/190725737-13eaaa94-c428-45db-9626-5e894a0ad8fb.png)
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#browser_compatibility **unchanged**:
![Screenshot from 2022-09-16 16-18-24](https://user-images.githubusercontent.com/29206584/190726075-98f674a8-03e8-4a38-8423-3efedf551745.png)
http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools#browser_compatibility:
![Screenshot from 2022-09-16 16-17-04](https://user-images.githubusercontent.com/29206584/190725859-32ebe616-a1c6-468a-a71f-f216ac28bfe3.png)
http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/API/privacy#browser_compatibility:
![Screenshot from 2022-09-16 16-17-29](https://user-images.githubusercontent.com/29206584/190725929-59f84d08-fc15-4667-9418-c7f578099b3f.png)