### PR TITLE
Remove color-profile attribute from list of SVG elements

### DIFF
--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -72,7 +72,6 @@ if (s_svg_href) {  %>
    <ol>
      <li><%-await wrapSVGElement("circle")%></li>
      <li><%-await wrapSVGElement("clipPath")%></li>
-     <li class="deprecatedElement"><%-await wrapSVGElement("color-profile")%></li>
      <li><%-await wrapSVGElement("cursor")%></li>
    </ol>
  </li>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/7169.

### Problem

The SVGRef sidebar tries to list all SVG Elements, and tries to include a link to https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-profile , which is an attribute, so ends up being a broken link. 

### Solution

Removes the link to https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/color-profile .

A better, much harder, solution would be to write a single sidebar for SVG, that includes all the elements, attributes, and tutorials.

## Screenshots

### Before

<img width="304" alt="Screen Shot 2022-09-15 at 6 48 20 PM" src="https://user-images.githubusercontent.com/432915/190539278-5f81c62a-8b52-4110-bc94-5a1c511b49ca.png">

### After

<img width="272" alt="Screen Shot 2022-09-15 at 6 48 32 PM" src="https://user-images.githubusercontent.com/432915/190539299-9e248dcf-8439-4de1-a6e6-d7cb73c0f4da.png">


---

## How did you test this change?

Ran `yarn dev` and visited some pages under /SVG.
