### PR TITLE
Remap w3c.github.io/csswg-drafts to drafts.csswg.org during browser-specs lookup

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -646,11 +646,18 @@ function _addSingleSpecialSection(
     // from the browser-specs package
     const specifications = specURLs
       .map((specURL) => {
+        // BCD uses a new mirror for CSSWG Drafts, since drafts.csswg.org is down almost all the time. However, browser-specs still uses the old URLs.
+        // Remove `specURLSearch` and simply use `specURL` if https://github.com/w3c/browser-specs/issues/704 is resolved
+        const specURLSearch = specURL.replace(
+          "w3c.github.io/csswg-drafts",
+          "drafts.csswg.org"
+        );
+
         const spec = specs.find(
           (spec) =>
-            specURL.startsWith(spec.url) ||
-            specURL.startsWith(spec.nightly.url) ||
-            specURL.startsWith(spec.series.nightlyUrl)
+            specURLSearch.startsWith(spec.url) ||
+            specURLSearch.startsWith(spec.nightly.url) ||
+            specURLSearch.startsWith(spec.series.nightlyUrl)
         );
         const specificationsData = {
           bcdSpecificationURL: specURL,


### PR DESCRIPTION
Within the last release, a pull request was merged to BCD that replaces links to `drafts.csswg.org` with `w3c.github.io/csswg-drafts`.  This was done because `drafts.csswg.org` is almost always unavailable, leaving MDN readers (including and especially contributors) with no spec to refer to.  The downtime issues have persisted for over a year, with no end in sight.  Because of this, various developers have created their own mirrors with reliable build engines, including https://andreubotella.com/csswg-auto-build/, whose code was then used to create a new official mirror.

However, due to internal conflict with CSSWG members, the official mirror has not been added to browser-specs (https://github.com/w3c/browser-specs/issues/704).  As a result, any spec URLs using the new mirror will show "Unknown specification".  This PR adds a fix for this by mapping the URLs back to the broken `drafts.csswg.org` URLs during the search through browser-specs.

This fixes https://github.com/mdn/yari/issues/7173 and fixes https://github.com/mdn/content/issues/20772.
