### PR TITLE
chore(macros/LearnSidebar): add Japanese translation(Angular Building)

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1568,7 +1568,7 @@ var text = mdn.localStringMap({
         'Styling_our_Angular_app': 'Angular アプリのスタイリング',
         'Creating_an_item_component': 'item コンポーネントの作成',
         'Filtering_our_to-do_items': 'To Do アイテムのフィルタリング',
-        'Building_Angular_applications_and_further_resources': 'Building Angular applications and further resources',
+        'Building_Angular_applications_and_further_resources': 'Angular アプリケーションのビルドとその他のリソース',
     'Server-side_website_programming' : 'Server-side website programming',
       'First_steps' : 'First steps',
         'First_steps_overview' : 'First steps overview',


### PR DESCRIPTION
## Summary

@schalkneethling
cc @hmatrjp @potappo 
- [Building Angular applications and further resources の翻訳 #637 ](https://github.com/mozilla-japan/translation/issues/637)  のPRです。

### Problem
still en-us only

### Solution

taranlate japanese for LearnSidebar.ejs


### Before

still en-us only

### After

add taranlate japanese for LearnSidebar.ejs


