### PR TITLE
chore(deps): delete `node-gettext` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "mdast-util-from-markdown": "^0.8.5",
     "mdast-util-phrasing": "^2.0.0",
     "mdn-data": "^2.0.29",
-    "node-gettext": "^3.0.0",
     "open": "^8.4.0",
     "open-editor": "^3.0.0",
     "prismjs": "^1.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8313,11 +8313,6 @@ lodash.escaperegexp@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#64762c48618082518ac3df4ccf5d5886dae20347"
   integrity sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
-
 lodash.groupby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
@@ -9020,13 +9015,6 @@ node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
-
-node-gettext@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/node-gettext/-/node-gettext-3.0.0.tgz#6b3a253309aa1e53164646c6c644fcddd0d45c58"
-  integrity sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==
-  dependencies:
-    lodash.get "^4.4.2"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Summary

`node-gettext` seems unnecessary.

### Problem

It was installed in #4251 and used by `markdown/h2m/handlers/cards.ts`. But the current main branch does not contains `cards.ts` and any script does not require it.

> https://github.com/mdn/yari/pull/4251/files#diff-0f919606f76e72c94cf68c97d6f47295dee810ad44ab5625c5d3f8db06da576bR1

### Solution

delete it from `package.json`

---

## Screenshots

N/A

---

## How did you test this change?

1. delete `node-gettext` from `package.json`
2. run `yarn dev` and confirmed an operation complete without error
3. run `yarn build` and confirmed an operation complete without error
