### PR TITLE
fix(kumascript): don't always eval summary

### DIFF
--- a/kumascript/macros/GlossaryDisambiguation.ejs
+++ b/kumascript/macros/GlossaryDisambiguation.ejs
@@ -12,7 +12,7 @@ var ARTICLES  = [];
 (await page.subpagesExpand(env.url, 1)).forEach(function (p) {
     ARTICLES.push({
         title  : p.title,
-        summary: p.summary,
+        summary: p.summary(),
         url    : p.url,
     });
 });

--- a/kumascript/macros/HTMLRefTable.ejs
+++ b/kumascript/macros/HTMLRefTable.ejs
@@ -127,7 +127,7 @@ for(let page of HTMLDocPages) {
                                    template("HTMLelement", ['h5']),
                                    template("HTMLelement", ['h6'])
                                ])).join(', ')),
-            summary      : (p && p.summary) || "",
+            summary      : (p?.summary?.()) || "",
             deprecated   : hasCommonTag(tags, ['deprecated', 'obsolete']),
             experimental : hasCommonTag(tags, ['experimental']),
             html5        : hasCommonTag(tags, ['html5']),

--- a/kumascript/macros/SubpagesWithSummaries.ejs
+++ b/kumascript/macros/SubpagesWithSummaries.ejs
@@ -49,7 +49,7 @@ if (numTerms) {
 
         if (!page.hasTag(aPage, "junk") && (aPage.title != "Index")) {
             var title = aPage.title;
-            var summary = aPage.summary.replace(/<img[^>]*>/g," ");
+            var summary = aPage.summary().replace(/<img[^>]*>/g," ");
             var url = aPage.url;
 
             html += "<dt class='landingPageList'><a href='" + url + "'>" + title + "</a></dt><dd class='landingPageList'><p>" + summary + "</p></dd>";

--- a/kumascript/src/info.ts
+++ b/kumascript/src/info.ts
@@ -200,7 +200,7 @@ const info = {
       title,
       tags: tags || [],
       translations: [], // TODO Object.freeze(buildTranslationObjects(data)),
-      get summary() {
+      summary() {
         // Back in the old Kuma days we used to store the summary as another piece
         // of metadata on each document. It was always available, with any kumascript
         // macros rendered out.


### PR DESCRIPTION
The summary getter was being evaluated without being used. This was rather costly. Let's move to method.

