### PR TITLE
fix(content/document): let `roots` as rest parameters of read

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -426,7 +426,7 @@ export function findByURL(url: string, ...args: string[]) {
   if (!bareURL.toLowerCase().includes("/docs/")) {
     return;
   }
-  const doc = read(urlToFolderPath(bareURL), ...args);
+  const doc = read(urlToFolderPath(bareURL), args);
   if (doc && hash) {
     return { ...doc, url: `${doc.url}#${hash}` };
   }
@@ -593,18 +593,14 @@ export function remove(
   locale: string,
   { recursive = false, dry = false, redirect = "" } = {}
 ) {
-  const root = getRoot(locale);
+  const root = getRoot(locale, `cannot find root of locale: ${locale}`);
   const url = buildURL(locale, slug);
   let redirectUrl = redirect;
   if (redirect && !redirect.match("^http(s)?://")) {
     redirectUrl = buildURL(locale, redirect);
   }
 
-  const roots = [CONTENT_ROOT];
-  if (CONTENT_TRANSLATED_ROOT) {
-    roots.push(CONTENT_TRANSLATED_ROOT);
-  }
-  const { metadata, fileInfo } = findByURL(url, ...roots) || {};
+  const { metadata, fileInfo } = findByURL(url, root) || {};
   if (!metadata) {
     throw new Error(`document does not exists: ${url}`);
   }

--- a/content/document.ts
+++ b/content/document.ts
@@ -175,176 +175,173 @@ export function getFolderPath(metadata, root: string | null = null) {
   );
 }
 
-export const read = memoize(
-  (folderOrFilePath: string, roots: string[] = ROOTS) => {
-    let filePath = null;
-    let folder = null;
-    let root = null;
-    let locale = null;
-
-    if (fs.existsSync(folderOrFilePath)) {
-      filePath = folderOrFilePath;
-
-      // It exists, but it is sane?
-      if (
-        !(
-          filePath.endsWith(HTML_FILENAME) ||
-          filePath.endsWith(MARKDOWN_FILENAME)
-        )
-      ) {
-        throw new Error(`'${filePath}' is not a HTML or Markdown file.`);
-      }
-
-      root = roots.find((possibleRoot) => filePath.startsWith(possibleRoot));
-      if (root) {
-        folder = filePath
-          .replace(root + path.sep, "")
-          .replace(path.sep + HTML_FILENAME, "")
-          .replace(path.sep + MARKDOWN_FILENAME, "");
-        locale = extractLocale(filePath.replace(root + path.sep, ""));
-      } else {
-        // The file exists but it doesn't appear to belong to any of our roots.
-        // That could happen if you pass in a file that is something completely
-        // different not a valid file anyway.
-        throw new Error(
-          `'${filePath}' does not appear to exist in any known content roots.`
-        );
-      }
-    } else {
-      folder = folderOrFilePath;
-      for (const possibleRoot of roots) {
-        const possibleMarkdownFilePath = path.join(
-          possibleRoot,
-          getMarkdownPath(folder)
-        );
-        if (fs.existsSync(possibleMarkdownFilePath)) {
-          root = possibleRoot;
-          filePath = possibleMarkdownFilePath;
-          break;
-        }
-        const possibleHTMLFilePath = path.join(
-          possibleRoot,
-          getHTMLPath(folder)
-        );
-        if (fs.existsSync(possibleHTMLFilePath)) {
-          root = possibleRoot;
-          filePath = possibleHTMLFilePath;
-          break;
-        }
-      }
-      if (!filePath) {
-        return;
-      }
-      locale = extractLocale(folder);
-    }
-
-    if (filePath.includes(" ")) {
-      throw new Error(
-        `Folder contains whitespace which is not allowed (${util.inspect(
-          filePath
-        )})`
-      );
-    }
-    if (filePath.includes("\u200b")) {
-      throw new Error(
-        `Folder contains zero width whitespace which is not allowed (${filePath})`
-      );
-    }
-    // Use Boolean() because otherwise, `isTranslated` might become `undefined`
-    // rather than an actuall boolean value.
-    const isTranslated = Boolean(
-      CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT)
-    );
-
-    const rawContent = fs.readFileSync(filePath, "utf-8");
-    if (!rawContent) {
-      throw new Error(`${filePath} is an empty file`);
-    }
-
-    // This is very useful in CI where every page gets built. If there's an
-    // accidentally unresolved git conflict, that's stuck in the content,
-    // bail extra early.
-    if (
-      // If the document itself, is a page that explains and talks about git merge
-      // conflicts, i.e. a false positive, those angled brackets should be escaped
-      /^<<<<<<< HEAD\n/m.test(rawContent) &&
-      /^=======\n/m.test(rawContent) &&
-      /^>>>>>>>/m.test(rawContent)
-    ) {
-      throw new Error(`${filePath} contains git merge conflict markers`);
-    }
-
-    const {
-      attributes: metadata,
-      body: rawBody,
-      bodyBegin: frontMatterOffset,
-    } = fm<DocFrontmatter>(rawContent);
-
-    const url = `/${locale}/docs/${metadata.slug}`;
-
-    const isActive = ACTIVE_LOCALES.has(locale.toLowerCase());
-
-    // The last-modified is always coming from the git logs. Independent of
-    // which root it is.
-    const gitHistory = getGitHistories(root, locale).get(
-      path.relative(root, filePath)
-    );
-    let modified = null;
-    let hash = null;
-    if (gitHistory) {
-      if (
-        gitHistory.merged &&
-        gitHistory.merged.modified &&
-        gitHistory.merged.hash
-      ) {
-        modified = gitHistory.merged.modified;
-        hash = gitHistory.merged.hash;
-      } else {
-        modified = gitHistory.modified;
-        hash = gitHistory.hash;
-      }
-    }
-    // Use the wiki histories for a list of legacy contributors.
-    const wikiHistory = getWikiHistories(root, locale).get(url);
-    if (!modified && wikiHistory && wikiHistory.modified) {
-      modified = wikiHistory.modified;
-    }
-    const fullMetadata = {
-      metadata: {
-        ...metadata,
-        // This is our chance to record and remember which keys were actually
-        // dug up from the front-matter.
-        // It matters because the keys in front-matter are arbitrary.
-        // Meaning, if a document contains `foo: bar` as a front-matter key/value
-        // we need to take note of that and make sure we preserve that if we
-        // save the metadata back (e.g. fixable flaws).
-        frontMatterKeys: Object.keys(metadata),
-        locale,
-        popularity: getPopularities().get(url) || 0.0,
-        modified,
-        hash,
-        contributors: wikiHistory ? wikiHistory.contributors : [],
-      },
-      url,
-    };
-
-    return {
-      ...fullMetadata,
-      // ...{ rawContent },
-      rawContent, // HTML or Markdown whole string with all the front-matter
-      rawBody, // HTML or Markdown string without the front-matter
-      isMarkdown: filePath.endsWith(MARKDOWN_FILENAME),
-      isTranslated,
-      isActive,
-      fileInfo: {
-        folder,
-        path: filePath,
-        frontMatterOffset,
-        root,
-      },
-    };
+export const read = memoize((folderOrFilePath: string, ...roots: string[]) => {
+  if (roots.length === 0) {
+    roots = ROOTS;
   }
-);
+  let filePath: string = null;
+  let folder: string = null;
+  let root: string = null;
+  let locale: string = null;
+
+  if (fs.existsSync(folderOrFilePath)) {
+    filePath = folderOrFilePath;
+
+    // It exists, but it is sane?
+    if (
+      !(
+        filePath.endsWith(HTML_FILENAME) || filePath.endsWith(MARKDOWN_FILENAME)
+      )
+    ) {
+      throw new Error(`'${filePath}' is not a HTML or Markdown file.`);
+    }
+
+    root = roots.find((possibleRoot) => filePath.startsWith(possibleRoot));
+    if (root) {
+      folder = filePath
+        .replace(root + path.sep, "")
+        .replace(path.sep + HTML_FILENAME, "")
+        .replace(path.sep + MARKDOWN_FILENAME, "");
+      locale = extractLocale(filePath.replace(root + path.sep, ""));
+    } else {
+      // The file exists but it doesn't appear to belong to any of our roots.
+      // That could happen if you pass in a file that is something completely
+      // different not a valid file anyway.
+      throw new Error(
+        `'${filePath}' does not appear to exist in any known content roots.`
+      );
+    }
+  } else {
+    folder = folderOrFilePath;
+    for (const possibleRoot of roots) {
+      const possibleMarkdownFilePath = path.join(
+        possibleRoot,
+        getMarkdownPath(folder)
+      );
+      if (fs.existsSync(possibleMarkdownFilePath)) {
+        root = possibleRoot;
+        filePath = possibleMarkdownFilePath;
+        break;
+      }
+      const possibleHTMLFilePath = path.join(possibleRoot, getHTMLPath(folder));
+      if (fs.existsSync(possibleHTMLFilePath)) {
+        root = possibleRoot;
+        filePath = possibleHTMLFilePath;
+        break;
+      }
+    }
+    if (!filePath) {
+      return;
+    }
+    locale = extractLocale(folder);
+  }
+
+  if (filePath.includes(" ")) {
+    throw new Error(
+      `Folder contains whitespace which is not allowed (${util.inspect(
+        filePath
+      )})`
+    );
+  }
+  if (filePath.includes("\u200b")) {
+    throw new Error(
+      `Folder contains zero width whitespace which is not allowed (${filePath})`
+    );
+  }
+  // Use Boolean() because otherwise, `isTranslated` might become `undefined`
+  // rather than an actuall boolean value.
+  const isTranslated = Boolean(
+    CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT)
+  );
+
+  const rawContent = fs.readFileSync(filePath, "utf-8");
+  if (!rawContent) {
+    throw new Error(`${filePath} is an empty file`);
+  }
+
+  // This is very useful in CI where every page gets built. If there's an
+  // accidentally unresolved git conflict, that's stuck in the content,
+  // bail extra early.
+  if (
+    // If the document itself, is a page that explains and talks about git merge
+    // conflicts, i.e. a false positive, those angled brackets should be escaped
+    /^<<<<<<< HEAD\n/m.test(rawContent) &&
+    /^=======\n/m.test(rawContent) &&
+    /^>>>>>>>/m.test(rawContent)
+  ) {
+    throw new Error(`${filePath} contains git merge conflict markers`);
+  }
+
+  const {
+    attributes: metadata,
+    body: rawBody,
+    bodyBegin: frontMatterOffset,
+  } = fm<DocFrontmatter>(rawContent);
+
+  const url = `/${locale}/docs/${metadata.slug}`;
+
+  const isActive = ACTIVE_LOCALES.has(locale.toLowerCase());
+
+  // The last-modified is always coming from the git logs. Independent of
+  // which root it is.
+  const gitHistory = getGitHistories(root, locale).get(
+    path.relative(root, filePath)
+  );
+  let modified = null;
+  let hash = null;
+  if (gitHistory) {
+    if (
+      gitHistory.merged &&
+      gitHistory.merged.modified &&
+      gitHistory.merged.hash
+    ) {
+      modified = gitHistory.merged.modified;
+      hash = gitHistory.merged.hash;
+    } else {
+      modified = gitHistory.modified;
+      hash = gitHistory.hash;
+    }
+  }
+  // Use the wiki histories for a list of legacy contributors.
+  const wikiHistory = getWikiHistories(root, locale).get(url);
+  if (!modified && wikiHistory && wikiHistory.modified) {
+    modified = wikiHistory.modified;
+  }
+  const fullMetadata = {
+    metadata: {
+      ...metadata,
+      // This is our chance to record and remember which keys were actually
+      // dug up from the front-matter.
+      // It matters because the keys in front-matter are arbitrary.
+      // Meaning, if a document contains `foo: bar` as a front-matter key/value
+      // we need to take note of that and make sure we preserve that if we
+      // save the metadata back (e.g. fixable flaws).
+      frontMatterKeys: Object.keys(metadata),
+      locale,
+      popularity: getPopularities().get(url) || 0.0,
+      modified,
+      hash,
+      contributors: wikiHistory ? wikiHistory.contributors : [],
+    },
+    url,
+  };
+
+  return {
+    ...fullMetadata,
+    // ...{ rawContent },
+    rawContent, // HTML or Markdown whole string with all the front-matter
+    rawBody, // HTML or Markdown string without the front-matter
+    isMarkdown: filePath.endsWith(MARKDOWN_FILENAME),
+    isTranslated,
+    isActive,
+    fileInfo: {
+      folder,
+      path: filePath,
+      frontMatterOffset,
+      root,
+    },
+  };
+});
 
 export function update(url: string, rawBody: string, metadata) {
   const folder = urlToFolderPath(url);
@@ -426,7 +423,7 @@ export function findByURL(url: string, ...args: string[]) {
   if (!bareURL.toLowerCase().includes("/docs/")) {
     return;
   }
-  const doc = read(urlToFolderPath(bareURL), args);
+  const doc = read(urlToFolderPath(bareURL), ...args);
   if (doc && hash) {
     return { ...doc, url: `${doc.url}#${hash}` };
   }

--- a/content/document.ts
+++ b/content/document.ts
@@ -418,7 +418,7 @@ export function update(url: string, rawBody: string, metadata) {
   }
 }
 
-export function findByURL(url: string, ...args: string[]) {
+export function findByURL(url: string, ...args: (string | Symbol)[]) {
   const [bareURL, hash = ""] = url.split("#", 2);
   if (!bareURL.toLowerCase().includes("/docs/")) {
     return;

--- a/kumascript/index.ts
+++ b/kumascript/index.ts
@@ -41,7 +41,7 @@ export async function render(
   urlsSeen.add(urlLC);
   const prerequisiteErrorsByKey = new Map();
   const document = invalidateCache
-    ? Document.findByURL(url, Document.MEMOIZE_INVALIDATE.toString())
+    ? Document.findByURL(url, Document.MEMOIZE_INVALIDATE)
     : Document.findByURL(url);
   if (!document) {
     throw new Error(
@@ -58,7 +58,7 @@ export async function render(
       .replace(`/${metadata.locale.toLowerCase()}/`, `/${DEFAULT_LOCALE}/`);
 
     const parentDocument = invalidateCache
-      ? Document.findByURL(parentURL, Document.MEMOIZE_INVALIDATE.toString())
+      ? Document.findByURL(parentURL, Document.MEMOIZE_INVALIDATE)
       : Document.findByURL(parentURL);
     if (parentDocument) {
       metadata = { ...parentDocument.metadata, ...metadata };


### PR DESCRIPTION
## Summary

Fixes: #7196.

### Problem

~It seems that the `findByURL` doesn't pass roots as a string array. Just fix this.~ refeactor the `read` function: pass roots as rest parameters.

And for the `remove` function, we can search with the specific root (not both `en-us` and `l10n`). And we can throw error when the locale is not specified (or not exists).

### Solution

Minor fixes.

---

## Screenshots

### Before

for en-US (`yarn tool delete Web/API/ShadowRoot/onslotchange --redirect=Web/API/HTMLSlotElement/slotchange_event`)

![image](https://user-images.githubusercontent.com/15844309/191141138-72bda4f1-ee98-4431-b618-d9224e4eece8.png)

for fr (`yarn tool delete conflicting/Glossary/Firefox_OS fr --redirect Glossary/Boot2Gecko`)

![image](https://user-images.githubusercontent.com/15844309/191141204-b5f89a18-0297-4dc4-83f5-6bf5d4f553a9.png)

### After

for en-US:

![image](https://user-images.githubusercontent.com/15844309/191140950-082a2a7b-ca2e-4d32-9d23-056cda5e1aad.png)

for fr:

![image](https://user-images.githubusercontent.com/15844309/191141035-f0f4b8b0-4621-4585-b2e5-08eb801cdb37.png)

---

## How did you test this change?

run `yarn tool delete`
