### PR TITLE
fix(build): stop caching kumascript render

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -68,7 +68,7 @@ export function extractSections($: cheerio.CheerioAPI): [Section[], string[]] {
     })("div")
     .eq(0);
 
-  const body = $("#_body")[0] as cheerio.ParentNode;
+  const body = $("body")[0] as cheerio.ParentNode;
   const iterable = [...(body.childNodes as cheerio.Element[])];
 
   let c = 0;

--- a/build/index.ts
+++ b/build/index.ts
@@ -3,7 +3,6 @@ import fs from "fs";
 import path from "path";
 
 import chalk from "chalk";
-import * as cheerio from "cheerio";
 import {
   MacroLiveSampleError,
   MacroRedirectedLinkError,
@@ -30,7 +29,6 @@ import { formatNotecards } from "./format-notecards";
 import buildOptions from "./build-options";
 export { gather as gatherGitHistory } from "./git-history";
 export { buildSPAs } from "./spas";
-import { renderCache as renderKumascriptCache } from "../kumascript";
 import LANGUAGES_RAW from "../libs/languages";
 import { safeDecodeURIComponent } from "../kumascript/src/api/util";
 import { wrapTables } from "./wrap-tables";
@@ -291,7 +289,6 @@ export interface BuiltDocument {
 }
 
 interface DocumentOptions {
-  clearKumascriptRenderCache?: boolean;
   fixFlaws?: boolean;
   fixFlawsVerbose?: boolean;
 }
@@ -328,12 +325,9 @@ export async function buildDocument(
   }
 
   let flaws: any[] = [];
-  let renderedHtml = "";
+  let renderedHtml = null;
   const liveSamples: LiveSample[] = [];
 
-  if (options.clearKumascriptRenderCache) {
-    renderKumascriptCache.clear();
-  }
   try {
     [renderedHtml, flaws] = await kumascript.render(document.url);
   } catch (error) {
@@ -352,7 +346,7 @@ export async function buildDocument(
     throw error;
   }
 
-  const $ = cheerio.load(`<div id="_body">${renderedHtml}</div>`);
+  const $ = renderedHtml;
 
   const liveSamplePages = kumascript.buildLiveSamplePages(
     document.url,

--- a/build/index.ts
+++ b/build/index.ts
@@ -325,11 +325,11 @@ export async function buildDocument(
   }
 
   let flaws: any[] = [];
-  let renderedHtml = null;
+  let $ = null;
   const liveSamples: LiveSample[] = [];
 
   try {
-    [renderedHtml, flaws] = await kumascript.render(document.url);
+    [$, flaws] = await kumascript.render(document.url);
   } catch (error) {
     if (error.name === "MacroInvocationError") {
       // The source HTML couldn't even be parsed! There's no point allowing
@@ -345,8 +345,6 @@ export async function buildDocument(
     // Any other unexpected error re-thrown.
     throw error;
   }
-
-  const $ = renderedHtml;
 
   const liveSamplePages = kumascript.buildLiveSamplePages(
     document.url,

--- a/kumascript/index.ts
+++ b/kumascript/index.ts
@@ -110,7 +110,6 @@ export async function render(
   );
   if (urlsSeen?.size > 1) {
     // This means we recursed so let's cache this
-    console.log(`caching ${urlLC}: (${[...urlsSeen].join(",")})`);
     renderCache.set(urlLC, [
       tool.html(),
       // The prerequisite errors have already been updated with their own file information.

--- a/kumascript/src/api/util.ts
+++ b/kumascript/src/api/util.ts
@@ -323,6 +323,10 @@ export class HTMLTool {
   html() {
     return this.$.html();
   }
+
+  cheerio() {
+    return this.$;
+  }
 }
 
 // Utility functions are collected here. These are functions that are used

--- a/kumascript/tests/index.test.ts
+++ b/kumascript/tests/index.test.ts
@@ -95,7 +95,8 @@ describe("testing the main render() function", () => {
         },
       }[url];
     });
-    const [result, errors] = await render("/en-us/docs/web/a");
+    const [$, errors] = await render("/en-us/docs/web/a");
+    const result = $.html();
     // First, let's check the result.
     expect(result).toEqual(
       expect.stringContaining('{{nonExistentMacro("yada")}}')
@@ -104,7 +105,6 @@ describe("testing the main render() function", () => {
     expect(result).toEqual(
       expect.stringContaining('{{page("/en-US/docs/Web/B", "bogus-section")}}')
     );
-    const $ = cheerio.load(result);
     const brokenLink = $(
       'a.page-not-created[title^="The documentation about this has not yet been written"]'
     );

--- a/kumascript/tests/index.test.ts
+++ b/kumascript/tests/index.test.ts
@@ -1,4 +1,3 @@
-import cheerio from "cheerio";
 import { Document } from "../../content";
 import info from "../src/info";
 import { render } from "../index";

--- a/server/index.ts
+++ b/server/index.ts
@@ -41,13 +41,7 @@ async function buildDocumentFromURL(url) {
   if (!document) {
     return null;
   }
-  const documentOptions = {
-    // The only times the server builds on the fly is basically when
-    // you're in "development mode". And when you're not building
-    // to ship you don't want the cache to stand have any hits
-    // since it might prevent reading fresh data from disk.
-    clearKumascriptRenderCache: true,
-  };
+  const documentOptions = {};
   if (CONTENT_TRANSLATED_ROOT) {
     // When you're running the dev server and build documents
     // every time a URL is requested, you won't have had the chance to do


### PR DESCRIPTION
Apparently this doesn't change build time / actually improves it since we now can just parse less html (render now returns a `CheerioAPI` object).