### PR TITLE
MP-120: display error message from rumba

### DIFF
--- a/client/src/plus/collections/api.ts
+++ b/client/src/plus/collections/api.ts
@@ -93,8 +93,13 @@ function useLoading<T>(res: SWRResponse<T>) {
 async function fetcher<T>(key: string | undefined): Promise<T> {
   if (!key) throw Error("Invalid key");
   const response = await fetch(key);
-  if (!response.ok) throw Error(`${response.status}: ${response.statusText}`);
-  return response.json();
+  let data: any;
+  try {
+    data = await response.json();
+  } catch {}
+  if (!response.ok)
+    throw Error(data?.message || `${response.status}: ${response.statusText}`);
+  return data;
 }
 
 async function poster<B, R>(key: string | undefined, body: B): Promise<R>;
@@ -108,12 +113,13 @@ async function poster(key: string | undefined, body: any): Promise<any> {
       "content-type": "application/json",
     },
   });
-  if (!response.ok) throw Error(`${response.status}: ${response.statusText}`);
+  let data: any;
   try {
-    return await response.json();
-  } catch {
-    return response;
-  }
+    data = await response.json();
+  } catch {}
+  if (!response.ok)
+    throw Error(data?.error || `${response.status}: ${response.statusText}`);
+  return data || response;
 }
 
 async function deleter(key: string | undefined): Promise<Response> {

--- a/client/src/plus/collections/collection.tsx
+++ b/client/src/plus/collections/collection.tsx
@@ -99,6 +99,9 @@ export default function CollectionComponent() {
           <NoteCard type="error">
             <h4>Error</h4>
             <p>{collectionError.message}</p>
+            <Button href="../" type="secondary">
+              Go Back
+            </Button>
           </NoteCard>
         ) : (
           <Loading />


### PR DESCRIPTION
add additional link to go back on collection page

testing requires fully disabling the service worker, otherwise it'll interfere in the error responses

![Screen Shot 2022-09-21 at 12 51 28](https://user-images.githubusercontent.com/755354/191497314-5977a5a7-c234-430e-bdda-672c74465779.png)
![Screen Shot 2022-09-21 at 12 51 13](https://user-images.githubusercontent.com/755354/191497316-271cb640-d62d-4c26-94f3-ed4005c134f1.png)
