### PR TITLE
Use page types instead of tags in APIRef

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -76,17 +76,21 @@ var implementedBy = [];
 function collect(pageList) {
   for (var i in pageList) {
     var aPage = pageList[i];
-    if (hasTag(aPage, "Property")) {
+    switch(aPage.pageType) {
+      case "web-api-static-property":
+      case "web-api-instance-property":
         properties.push(aPage);
-    }
-    if (hasTag(aPage, "Method")) {
+        break;
+      case "web-api-static-method":
+      case "web-api-instance-method":
         methods.push(aPage);
-    }
-    if (hasTag(aPage, "Constructor")) {
+        break;
+      case "web-api-constructor":
         ctors.push(aPage);
-    }
-    if (hasTag(aPage, "Event")) {
+        break;
+      case "web-api-event":
         events.push(aPage);
+        break;
     }
   }
 }
@@ -171,7 +175,7 @@ function buildSublist(pages, title) {
     // in the sidebar. So for event pages we use the slug, which is supposed to be
     // in the form "eventname_event", and split off "_event" to leave us (hopefully)
     // with just "eventname" for the link text.
-    if (hasTag(aPage, 'Event')) {
+    if (aPage.pageType === 'web-api-event') {
         title = aPage.slug.split('/').pop();
         if (title.endsWith('_event')) {
             title = title.slice(0,-6);

--- a/kumascript/src/info.ts
+++ b/kumascript/src/info.ts
@@ -199,6 +199,7 @@ const info = {
       slug,
       title,
       tags: tags || [],
+      pageType: document.metadata["page-type"],
       translations: [], // TODO Object.freeze(buildTranslationObjects(data)),
       summary() {
         // Back in the old Kuma days we used to store the summary as another piece


### PR DESCRIPTION
## Summary

Use page-type instead of tags for the APIRef macro.

We recently defined and added page types for pages under Web/API: https://github.com/mdn/content/issues/16255 .

One of the purposes of this was to replace tags for describing the type of thing a page documented. @teoli2003 observed that it would be a good idea to start using page types as soon as possible, as this gives us an incentive to keep them maintained.

One easy way to start with this is to update the APIRef macro to use page types instead of tags to build the sidebar for Web/API pages: https://github.com/openwebdocs/project/issues/91. That's what this PR does.

Note that I also had to change KS to expose `page-type` to the macro.

## Screenshots

UI should look exactly the same, except in places where tags and page-type don't agree, in which case page-type should be more accurate.

## How did you test this change?

Ran yarn dev, looked at some Web/API pages, like:
http://localhost:3000/en-US/docs/Web/API/IntersectionObserver
http://localhost:3000/en-US/docs/Web/API/BackgroundFetchRegistration
http://localhost:3000/en-US/docs/Web/API/PerformanceEntry/entryType
http://localhost:3000/en-US/docs/Web/API/Window
http://localhost:3000/en-US/docs/Web/API/Request/clone
