### PR TITLE
Remove HPKP from HTTP Sidebar

### DIFF
--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -313,7 +313,6 @@ var text = mdn.localStringMap({
             <summary><%=text['Security']%></summary>
             <ol>
                 <li><a href="/<%=locale%>/docs/Web/HTTP/CSP">Content Security Policy (CSP)</a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Public_Key_Pinning">HTTP Public Key Pinning (HPKP)</a></li>
                 <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/Strict-Transport-Security">HTTP Strict Transport Security (HSTS)</a></li>
                 <li><a href="/<%=locale%>/docs/Web/HTTP/Cookies#Secure_and_HttpOnly_cookies">Cookie security</a></li>
                 <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/X-Content-Type-Options">X-Content-Type-Options</a></li>


### PR DESCRIPTION

## Summary

Removes the link to HTTP Public Key Pinning (HPKP) from the HTTPSidebar macro. Fixes https://github.com/mdn/yari/issues/7224.

### Problem

https://github.com/mdn/yari/issues/7224 explains well what the problem is and the suggested solution.

### Solution

Remove the link to the page.

## Screenshots

### Before

<img width="303" alt="Screen Shot 2022-09-23 at 6 13 38 PM" src="https://user-images.githubusercontent.com/432915/192074055-1935b136-61fb-4a01-97a4-73058f084788.png">

### After

<img width="285" alt="Screen Shot 2022-09-23 at 6 13 48 PM" src="https://user-images.githubusercontent.com/432915/192074062-262e579e-a5ef-4483-812e-359a6ccf5db3.png">

---

## How did you test this change?

Ran yarn dev, visited http://localhost:3000/en-US/docs/Web/HTTP/Headers .
