### PR TITLE
fix(check_redirects): make the checks fail fast

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -75,32 +75,28 @@ program
     tryOrExit(({ args, options, logger }) => {
       const { locales } = args;
       const { strict } = options;
-      let fine = true;
       if (strict) {
         for (const locale of locales) {
           try {
             Redirect.validateLocale(locale, strict);
             logger.info(chalk.green(`✓ redirects for ${locale} looking good!`));
           } catch (e) {
-            logger.info(
+            logger.error(
               chalk.red(`_redirects.txt for ${locale} is causing issues: ${e}`)
             );
-            fine = false;
+            throw new Error("🔥 Errors loading redirects 🔥");
           }
         }
       } else {
         try {
           Redirect.load(locales, true);
         } catch (e) {
-          logger.info(chalk.red(`Unable to load redirects: ${e}`));
-          fine = false;
+          logger.error(chalk.red(`Unable to load redirects: ${e}`));
+          throw new Error("🔥 Errors loading redirects 🔥");
         }
       }
-      if (fine) {
-        logger.info(chalk.green("🍾 All is well in the world of redirects 🥂"));
-      } else {
-        throw new Error("🔥 Errors loading redirects 🔥");
-      }
+
+      logger.info(chalk.green("🍾 All is well in the world of redirects 🥂"));
     })
   )
 

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -81,18 +81,16 @@ program
             Redirect.validateLocale(locale, strict);
             logger.info(chalk.green(`✓ redirects for ${locale} looking good!`));
           } catch (e) {
-            logger.error(
-              chalk.red(`_redirects.txt for ${locale} is causing issues: ${e}`)
+            throw new Error(
+              `_redirects.txt for ${locale} is causing issues: ${e}`
             );
-            throw new Error("🔥 Errors loading redirects 🔥");
           }
         }
       } else {
         try {
           Redirect.load(locales, true);
         } catch (e) {
-          logger.error(chalk.red(`Unable to load redirects: ${e}`));
-          throw new Error("🔥 Errors loading redirects 🔥");
+          throw new Error(`Unable to load redirects: ${e}`);
         }
       }
 


### PR DESCRIPTION
## Summary

Wrapping original error and failing at the end, after all the checks are done, makes it hard to figure out what went wrong.
Refer https://github.com/mdn/translated-content/pull/8171#issuecomment-1256879734


### Problem

The check run https://github.com/mdn/translated-content/actions/runs/3114446745/jobs/5050295335 failed with following log:
```log
Run yarn content validate-redirects --strict
yarn run v1.22.19
$ env-cmd --silent cross-env CONTENT_ROOT=files yari-tool validate-redirects --strict
Skipping: non en-us locale: /en-US/docs/Secciones_y_contornos_de_un_documento_HTML5	/es/docs/Sections_and_Outlines_of_an_HTML5_document
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Getting_started_with_WebGL/Commencer_avec_le_WebGL	/fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL/Commencer_avec_le_WebGL	/fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL	/fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL	/fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/video	/es/docs/Web/HTML/Elemento/video
Skipping: non en-us locale: /en-US/docs/zh-n/JavaScript/Reference/Global_Objects/String/quote	/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/quote
info: ✓ redirects for en-us looking good!
Skipping: non es locale: /es/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example	/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear	/es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly	/es/docs/WebAssembly/JavaScript_interface
info: _redirects.txt for es is causing issues: Error: Invalid redirect for /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear -> /es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features or /es/docs/Web/JavaScript/Reference/Global_Objects/null -> /es/docs/Web/JavaScript/Reference/Operators/null
info: ✓ redirects for fr looking good!
info: ✓ redirects for ja looking good!
info: ✓ redirects for ko looking good!
info: ✓ redirects for pt-br looking good!
info: ✓ redirects for ru looking good!
info: ✓ redirects for zh-cn looking good!
Skipping: non zh-tw locale: /zh-TW/docs/Web/API/Detecting_device_orientation	/en-US/docs/Web/Events/Detecting_device_orientation
Skipping: non zh-tw locale: /zh-TW/docs/WebAPI/Detecting_device_orientation	/en-US/docs/Web/Events/Detecting_device_orientation
info: ✓ redirects for zh-tw looking good!

error: 🔥 Errors loading redirects 🔥

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
Error: Process completed with exit code 1.
```

There are no colors in GitHub's run logs.
The log before the error `🔥 Errors loading redirects 🔥` message said all went well: `info: ✓ redirects for zh-tw looking good!`.
So the PR author failed to figure out what actually went wrong:

> ![chat](https://user-images.githubusercontent.com/87750369/192084984-e513645d-2a8d-4835-a4a2-562202bd5b95.png)


### Solution

**Fail fast:** we do not have to continue checking remaining locales if one fails.
**Fail on the spot:** delaying the reporting makes it hard to figure out what and where is went wrong.

---

## Screenshots

### Before

```log
❯ yarn tool validate-redirects --strict
yarn run v1.22.19
$ ts-node tool/cli.ts validate-redirects --strict
Skipping: non en-us locale: /en-US/docs/Secciones_y_contornos_de_un_documento_HTML5     /es/docs/Sections_and_Outlines_of_an_HTML5_document
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Getting_started_with_WebGL/Commencer_avec_le_WebGL    /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL/Commencer_avec_le_WebGL   /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL    /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL        /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/video   /es/docs/Web/HTML/Elemento/video
Skipping: non en-us locale: /en-US/docs/zh-n/JavaScript/Reference/Global_Objects/String/quote   /zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/quote
info: ✓ redirects for en-us looking good!
Skipping: non es locale: /es/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example      /en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear        /es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly  /es/docs/WebAssembly/JavaScript_interface
info: _redirects.txt for es is causing issues: Error: Invalid redirect for /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear -> /es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features or /es/docs/Web/JavaScript/Reference/Global_Objects/null -> /es/docs/Web/JavaScript/Reference/Operators/null
info: ✓ redirects for fr looking good!
info: ✓ redirects for ja looking good!
info: ✓ redirects for ko looking good!
info: ✓ redirects for pt-br looking good!
info: ✓ redirects for ru looking good!
info: ✓ redirects for zh-cn looking good!
Skipping: non zh-tw locale: /zh-TW/docs/Web/API/Detecting_device_orientation    /en-US/docs/Web/Events/Detecting_device_orientation
Skipping: non zh-tw locale: /zh-TW/docs/WebAPI/Detecting_device_orientation     /en-US/docs/Web/Events/Detecting_device_orientation
info: ✓ redirects for zh-tw looking good!

error: 🔥 Errors loading redirects 🔥

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```



### After

```log
❯ yarn tool validate-redirects --strict
yarn run v1.22.19
$ ts-node tool/cli.ts validate-redirects --strict
Skipping: non en-us locale: /en-US/docs/Secciones_y_contornos_de_un_documento_HTML5     /es/docs/Sections_and_Outlines_of_an_HTML5_document
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Getting_started_with_WebGL/Commencer_avec_le_WebGL    /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL/Commencer_avec_le_WebGL   /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/Web/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL    /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/WebGL/Getting_started_with_WebGL/Commencer_avec_le_WebGL        /fr/docs/Web/API/WebGL_API/Tutorial/Commencer_avec_WebGL
Skipping: non en-us locale: /en-US/docs/video   /es/docs/Web/HTML/Elemento/video
Skipping: non en-us locale: /en-US/docs/zh-n/JavaScript/Reference/Global_Objects/String/quote   /zh-CN/docs/Web/JavaScript/Reference/Global_Objects/String/quote
info: ✓ redirects for en-us looking good!
Skipping: non es locale: /es/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example      /en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear        /es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features
removing orphaned redirect (from exists): /es/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly  /es/docs/WebAssembly/JavaScript_interface

error: _redirects.txt for es is causing issues: Error: Invalid redirect for /es/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear -> /es/docs/conflicting/Web/JavaScript/Reference/Deprecated_and_obsolete_features or /es/docs/Web/JavaScript/Reference/Global_Objects/null -> /es/docs/Web/JavaScript/Reference/Operators/null


error: 🔥 Errors loading redirects 🔥

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```


---

## How did you test this change?

In terminal using command `yarn tool validate-redirects --strict`