### PR TITLE
chore: update NPM packaging ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,8 @@ yarn-error.log*
 /kumascript/coverage/
 /kumascript/node_modules/
 /testing/node_modules/
-/build/*.js
-/build/*.js.map
+/build/**/*.js
+/build/**/*.js.map
 /client/build
 /client/src/**/*.js
 /client/src/**/*.js.map
@@ -39,10 +39,12 @@ yarn-error.log*
 /content/*.js.map
 /filecheck/*.js
 /filecheck/*.js.map
-/kumascript/*.js
-/kumascript/*.js.map
-/markdown/*.js
-/markdown/*.js.map
+/libs/types/*.js
+/libs/types/*.js.map
+/kumascript/**/*.js
+/kumascript/**/*.js.map
+/markdown/**/*.js
+/markdown/**/*.js.map
 /server/*.js
 /server/*.js.map
 /ssr/dist/

--- a/.npmignore
+++ b/.npmignore
@@ -6,40 +6,25 @@
 # And we don't want to have maintain both. So right before it runs the
 # `npm publish` step it will combine these two files.
 
-/node_modules/
-client/node_modules/
-ssr/node_modules/
-kumascript/node_modules/
-content/node_modules/
-server/node_modules/
-
-# This won't be relevant or needed once the content is gone.
-/content/files/en-us/
-
+CODE_OF_CONDUCT.md
 /deployer
-kumascript/tests
-testing/
-import/
-/mdn-web-docs.svg
-.github/
 /docs/
+/mdn-web-docs.svg
+kumascript/tests
 README.md
-client/search-experimentation.js
-yarn-error.log
-content/files/
+scripts/
+testing/
+*.log
 
 # Since we ship the built stuff, we actually no longer need any of the source
 client/src/
+*.ts
 
 # Build/Dev files
-.eslint*
-.prettier*
-.stylelint*
-.flake8
-tsconfig.json
+.*
+*.test.ts
+*.tgz
+**/node_modules/**
+*config.js
 Procfile.*
-webpack.config.js
-jest.config.js
-*.test.js
-.storybook/
-.nvmrc
+tsconfig*.json

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "filecheck": "cd filecheck && ts-node cli.ts",
     "m2h": "ts-node markdown/m2h/cli.ts",
     "md": "echo 'The HTML to Markdown conversion command has been moved to https://github.com/mdn/markdown!' && exit 1",
-    "prepack": "yarn build:dist",
+    "prepack": "yarn build:ssr && yarn build:dist",
     "prepare": "husky install",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Update the ignores for NPM publishing.
- Removes all the dot files and folders from the package
- Ignore all the TS files
- Re-ignore the rename *.test.js files


### Problem

Fixed the publish that had an implicit SSR build that wouldn't work running `git clean -fdx` followed by `yarn pack` because there are still some direct `ssr/dist/main` imports after the Typescript conversion that require the built files

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
