### PR TITLE
Allow alternate nightly spec URLs

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -650,6 +650,7 @@ function _addSingleSpecialSection(
           (spec) =>
             specURL.startsWith(spec.url) ||
             specURL.startsWith(spec.nightly.url) ||
+            spec.nightly.alternateUrls.some((s) => specURL.startsWith(s)) ||
             specURL.startsWith(spec.series.nightlyUrl)
         );
         const specificationsData = {


### PR DESCRIPTION
Within the last few releases, a pull request was merged to BCD that replaces links to `drafts.csswg.org` with `w3c.github.io/csswg-drafts`.  This was done because `drafts.csswg.org` is almost always unavailable, leaving MDN readers (including and especially contributors) with no spec to refer to.  The downtime issues have persisted for over a year, with no end in sight.  Because of this, various developers have created their own mirrors with reliable build engines, including https://andreubotella.com/csswg-auto-build/, whose code was then used to create a new official mirror.

As an unfortunate result, however, any spec URLs using the new mirror will show "Unknown specification".  This has been resolved in `browser-specs` by adding a new `alternateUrls` property that contains the URL to the mirror.  This PR taps into this new property, resolving the "unknown specification" issue.

This fixes https://github.com/mdn/yari/issues/7173 and fixes https://github.com/mdn/content/issues/20772.  This closes #7175 as irrelevant.
