### PR TITLE
fix(plus): add breadcrumbs for Collections/Notifications/Settings

### DIFF
--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -6,9 +6,7 @@ import { TOC } from "../../document/organisms/toc";
 import { DocParent, Toc } from "../../../../libs/types/document";
 import { PageNotFound } from "../../page-not-found";
 import { Loading } from "../../ui/atoms/loading";
-import { useUIStatus } from "../../ui-context";
-import { Button } from "../../ui/atoms/button";
-import { Breadcrumbs } from "../../ui/molecules/breadcrumbs";
+import { ArticleActionsContainer } from "../../ui/organisms/article-actions-container";
 
 interface StaticPageDoc {
   id: string;
@@ -36,7 +34,6 @@ function StaticPage({
   title = "MDN",
   sidebarHeader = <></>,
 }: StaticPageProps) {
-  const { isSidebarOpen, setIsSidebarOpen } = useUIStatus();
   const baseURL = `/${locale}/${slug}`;
   const featureJSONUrl = `${baseURL}/index.json`;
   const { data: { hyData } = {}, error } = useSWR<{ hyData: StaticPageDoc }>(
@@ -70,22 +67,9 @@ function StaticPage({
 
   return (
     <>
-      <div className="article-actions-container">
-        <div className="container">
-          <Button
-            extraClasses="sidebar-button"
-            icon="sidebar"
-            type="action"
-            onClickHandler={() => setIsSidebarOpen(!isSidebarOpen)}
-          />
-
-          {
-            <Breadcrumbs
-              parents={[...parents, { uri: baseURL, title: hyData.title }]}
-            />
-          }
-        </div>
-      </div>
+      <ArticleActionsContainer
+        parents={[...parents, { uri: baseURL, title: hyData.title }]}
+      />
 
       <div className="main-wrapper">
         <SidebarContainer doc={hyData}>

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -15,6 +15,13 @@ import { DocParent } from "../../../libs/types/document";
 const OfferOverview = React.lazy(() => import("./offer-overview"));
 const Collections = React.lazy(() => import("./collections"));
 
+interface LayoutProps {
+  withoutContainer?: boolean;
+  withSSR?: boolean;
+  parents?: DocParent[];
+  children: React.ReactNode;
+}
+
 export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
   React.useEffect(() => {
     document.title = pageTitle || MDN_PLUS_TITLE;
@@ -36,12 +43,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
     withSSR = false,
     parents = undefined,
     children,
-  }: {
-    withoutContainer?: boolean;
-    withSSR?: boolean;
-    parents?: DocParent[];
-    children: React.ReactNode;
-  }) {
+  }: LayoutProps) {
     const inner = (
       <>
         {isServer ? (

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useLocation, useParams } from "react-router-dom";
 
 import { useIsServer } from "../hooks";
 import { Loading } from "../ui/atoms/loading";
@@ -9,6 +9,8 @@ import Notifications from "./notifications";
 import { MDN_PLUS_TITLE } from "../constants";
 import { Settings } from "../settings";
 import PlusDocs from "./plus-docs";
+import { ArticleActionsContainer } from "../ui/organisms/article-actions-container";
+import { DocParent } from "../../../libs/types/document";
 
 const OfferOverview = React.lazy(() => import("./offer-overview"));
 const Collections = React.lazy(() => import("./collections"));
@@ -18,6 +20,9 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
     document.title = pageTitle || MDN_PLUS_TITLE;
   }, [pageTitle]);
 
+  const { locale = "en-US" } = useParams();
+  const { pathname } = useLocation();
+
   const isServer = useIsServer();
   const loading = (
     <Loading
@@ -26,7 +31,17 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
     />
   );
 
-  function Layout({ withoutContainer = false, withSSR = false, children }) {
+  function Layout({
+    withoutContainer = false,
+    withSSR = false,
+    parents = undefined,
+    children,
+  }: {
+    withoutContainer?: boolean;
+    withSSR?: boolean;
+    parents?: DocParent[];
+    children: React.ReactNode;
+  }) {
     const inner = (
       <>
         {isServer ? (
@@ -44,9 +59,14 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
     return withoutContainer ? (
       inner
     ) : (
-      <MainContentContainer>{inner}</MainContentContainer>
+      <>
+        {parents && <ArticleActionsContainer parents={parents} />}
+        <MainContentContainer>{inner}</MainContentContainer>
+      </>
     );
   }
+
+  const parents = [{ uri: `/${locale}/plus`, title: MDN_PLUS_TITLE }];
 
   return (
     <Routes>
@@ -61,7 +81,9 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="collections/*"
         element={
-          <Layout>
+          <Layout
+            parents={[...parents, { uri: pathname, title: "Collections" }]}
+          >
             <Collections />
           </Layout>
         }
@@ -69,7 +91,9 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="notifications/*"
         element={
-          <Layout>
+          <Layout
+            parents={[...parents, { uri: pathname, title: "Notifications" }]}
+          >
             <div className="notifications girdle">
               <Notifications />
             </div>
@@ -79,7 +103,9 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="/settings"
         element={
-          <Layout>
+          <Layout
+            parents={[...parents, { uri: pathname, title: "My Settings" }]}
+          >
             <Settings {...props} />
           </Layout>
         }

--- a/client/src/ui/organisms/article-actions-container/index.tsx
+++ b/client/src/ui/organisms/article-actions-container/index.tsx
@@ -4,13 +4,19 @@ import { Breadcrumbs } from "../../molecules/breadcrumbs";
 import { ArticleActions } from "../article-actions";
 import { Button } from "../../atoms/button";
 
-import { Doc } from "../../../../../libs/types/document";
+import { Doc, DocParent } from "../../../../../libs/types/document";
 
 import { useUIStatus } from "../../../ui-context";
 
 import "./index.scss";
 
-export const ArticleActionsContainer = ({ doc }: { doc: Doc }) => {
+export const ArticleActionsContainer = ({
+  doc,
+  parents = doc?.parents,
+}: {
+  doc?: Doc;
+  parents?: DocParent[];
+}) => {
   const [showArticleActionsMenu, setShowArticleActionsMenu] =
     React.useState(false);
   const { isSidebarOpen, setIsSidebarOpen } = useUIStatus();
@@ -26,13 +32,15 @@ export const ArticleActionsContainer = ({ doc }: { doc: Doc }) => {
         />
 
         {/* if we have breadcrumbs for the current page, continue rendering the section */}
-        {doc.parents && <Breadcrumbs parents={doc.parents} />}
+        {parents && <Breadcrumbs parents={parents} />}
 
-        <ArticleActions
-          doc={doc}
-          showArticleActionsMenu={showArticleActionsMenu}
-          setShowArticleActionsMenu={setShowArticleActionsMenu}
-        />
+        {doc && (
+          <ArticleActions
+            doc={doc}
+            showArticleActionsMenu={showArticleActionsMenu}
+            setShowArticleActionsMenu={setShowArticleActionsMenu}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds breadcrumbs for Collections/Notifications/Settings in MDN Plus.

### Problem

MDN Plus did not have breadcrumbs (except for the "Documentation" section).

### Solution

Make it easy to add breadcrumbs to non-Doc pages.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/495429/193187593-8290e4fc-a155-4b0b-b367-3a44cfd19e11.png">

### After

<img width="1438" alt="image" src="https://user-images.githubusercontent.com/495429/193187549-082c6c02-22e9-42b5-bf00-c7ffffc69d36.png">


---

## How did you test this change?

Checked out these pages locally:

- http://localhost:3000/en-US/plus/collections
- http://localhost:3000/en-US/plus/notifications
- http://localhost:3000/en-US/plus/settings