### PR TITLE
chore(macros/HTMLRefTable): fix typos

### DIFF
--- a/kumascript/macros/HTMLRefTable.ejs
+++ b/kumascript/macros/HTMLRefTable.ejs
@@ -59,8 +59,8 @@ let l10n = {
 // UTILS
 // -----
 
-// Simple function to turn a string into lower case. This especialy made to work
-// as a walking function for Array.prototypt.map
+// Simple function to turn a string into lower case. This is especially made to work
+// as a walking function for Array.prototype.map
 function lowerMe(S) {
     return S.toLowerCase();
 }


### PR DESCRIPTION
### Problem
Wrong typo of the words "especialy" instead of "especially" and "prototypt" instead of "prototype" and no verb to be before
the word "especially"

### Solution
"This is especially" instead of "This especialy"
and "prototype" instead of "prototypt".