### PR TITLE
chore(on-github): use localized issue templates for translated-content

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -95,7 +95,10 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
     locale !== "en-US"
       ? "/mdn/translated-content/issues/new"
       : "/mdn/content/issues/new";
-  sp.set("template", "page-report.yml");
+  sp.set(
+    "template",
+    locale !== "en-US" ? `page-report-${locale}.yml` : "page-report.yml"
+  );
   sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

This modifies the "Report on GitHub" link for localized pages to use translated issue templates (e.g. `page-report-fr.yml` for French). Part of mdn/translated-content#8918.

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->
Currently, all locales use the English `page-report.yml` template, but MDN viewers may prefer to read instructions and/or to create issues in a locale language.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

A `page-report-<locale>.yml` will be added for each active locale on the `translated-content` repo. The "Report on GitHub" link will point to `page-report-<locale>.yml` on localized pages and `page-report.yml` on en-US pages.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

I tested this with `yarn dev` on my local machine.