### PR TITLE
fix(content/document): preserve metadata spacing on write

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -132,7 +132,7 @@ export function saveFile(
     throw new Error("newSlug can not contain the '#' character");
   }
 
-  const combined = `---\n${yaml.dump(saveMetadata)}---\n${rawBody.trim()}\n`;
+  const combined = `---\n${yaml.dump(saveMetadata)}---\n\n${rawBody.trim()}\n`;
   fs.writeFileSync(filePath, combined);
 }
 

--- a/testing/content/files/en-us/markdown/tool/m2h/expected.html
+++ b/testing/content/files/en-us/markdown/tool/m2h/expected.html
@@ -4,6 +4,7 @@ slug: Markdown/Tool/M2H
 tags:
   - Tag1
 ---
+
 <p>This page is for testing the m2h tool. It's going to concentrate on areas where we implement custom stuff on top of the GFM conversion which is handled by Unified.</p>
 <h2>Hello</h2>
 <p>Let's test some Markdown.</p>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Prettier has been adding this spacing upstream, but files moved with Yari are undoing those changes

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
