### PR TITLE
Use page type instead of tags for CSSSyntax macro

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -85,27 +85,29 @@ function getNameAndSyntax() {
   // get the item name from the page slug
   let itemName = $0 || env.slug.split('/').pop().toLowerCase();
   let itemSyntax;
-  if (env.tags.includes("CSS Property")) {
-    // get syntax for a CSS property
-    itemSyntax = getPropertySyntax(itemName, parsedWebRef);
-  } else if (env.tags.includes("CSS Data Type")) {
-    // get syntax for a CSS data type
-    // some CSS data type slugs have a `_value` suffix
-    if (itemName.endsWith("_value")) {
-      itemName = itemName.replace("_value", "");
-    }
-    itemName = `<${itemName}>`;
-    // not all types have an entry in the syntax
-    if (valuespaces[itemName]) {
-      itemSyntax = valuespaces[itemName].value;
-    }
-  } else if (env.tags.includes("CSS Function")) {
-    // get syntax for a CSS function
-    itemName = `<${itemName}()>`;
-    // not all types have an entry in the syntax
-    if (valuespaces[itemName]) {
-      itemSyntax = valuespaces[itemName].value;
-    }
+  switch (env["page-type"]) {
+    case "css-shorthand-property":
+    case "css-property":
+      itemSyntax = getPropertySyntax(itemName, parsedWebRef);
+      break;
+    case "css-type":
+      // some CSS data type slugs have a `_value` suffix
+      if (itemName.endsWith("_value")) {
+        itemName = itemName.replace("_value", "");
+      }
+      itemName = `<${itemName}>`;
+      // not all types have an entry in the syntax
+      if (valuespaces[itemName]) {
+        itemSyntax = valuespaces[itemName].value;
+      }
+      break;
+    case "css-function":
+      itemName = `<${itemName}()>`;
+      // not all functions have an entry in the syntax
+      if (valuespaces[itemName]) {
+        itemSyntax = valuespaces[itemName].value;
+      }
+      break;
   }
   return {
     name: itemName,


### PR DESCRIPTION
## Summary

Use page-type instead of tags for the CSSSyntax macro.

We recently defined and added page types for pages under Web/CSS: https://github.com/mdn/content/issues/15540 .

One of the purposes of this was to replace tags for describing the type of thing a page documented. @teoli2003 observed that it would be a good idea to start using page types as soon as possible, as this gives us an incentive to keep them maintained.

So this PR updates the CSSSyntax macro to use page types instead of tags.

## Screenshots

UI should look exactly the same, except in places where tags and page-type don't agree, in which case page-type should be more accurate.

## How did you test this change?

Ran yarn dev, looked at some Web/CSS pages. Really what we are testing is that the macro can figure out how to get the formal syntax from webref for each of the four kinds of thing: CSS shorthand properties, CSS properties, CSS types, CSS functions.
 
### Shorthand properties

http://localhost:3000/en-US/docs/Web/CSS/border#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/grid#formal_syntax

### Properties

http://localhost:3000/en-US/docs/Web/CSS/justify-content#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/margin-top#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/mask-clip#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/opacity#formal_syntax

## Types

http://localhost:3000/en-US/docs/Web/CSS/color_value#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/gradient#formal_syntax

## Functions

http://localhost:3000/en-US/docs/Web/CSS/clamp#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/min#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/max#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/transform-function/translateY#formal_syntax
