### PR TITLE
feat(macros/CSSSyntax): support at-rules and at-rule descriptors

### DIFF
--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -79,64 +79,39 @@ for (const spec of Object.values(parsedWebRef)) {
 }
 
 /**
- * Get the formal syntax and properly formatted name for an item.
+ * Get the spec shortnames for an item, given:
+ * @param {string} itemName - the name of the item
+ * @param {string} itemType - this can only be "properties" or "atrules"
  */
-function getNameAndSyntax() {
-  // get the item name from the page slug
-  let itemName = $0 || env.slug.split('/').pop().toLowerCase();
-  let itemSyntax;
-  switch (env["page-type"]) {
-    case "css-shorthand-property":
-    case "css-property":
-      itemSyntax = getPropertySyntax(itemName, parsedWebRef);
-      break;
-    case "css-type":
-      // some CSS data type slugs have a `_value` suffix
-      if (itemName.endsWith("_value")) {
-        itemName = itemName.replace("_value", "");
-      }
-      itemName = `<${itemName}>`;
-      // not all types have an entry in the syntax
-      if (valuespaces[itemName]) {
-        itemSyntax = valuespaces[itemName].value;
-      }
-      break;
-    case "css-function":
-      itemName = `<${itemName}()>`;
-      // not all functions have an entry in the syntax
-      if (valuespaces[itemName]) {
-        itemSyntax = valuespaces[itemName].value;
-      }
-      break;
+function getSpecsForItem(itemName, itemType) {
+  // 1) Get all specs which list this item
+  let specsForItem = [];
+  for (const [shortname, data] of Object.entries(parsedWebRef)) {
+    const itemNames = Object.keys(data[itemType]);
+    if (itemNames.includes(itemName)) {
+      specsForItem.push(shortname);
+    }
   }
-  return {
-    name: itemName,
-    syntax: itemSyntax
+  // 2) If we have more than one spec, filter out specs that end "-n" where n is a number
+  if (specsForItem.length > 1) {
+    specsForItem = specsForItem.filter( specName => !(/-\d+$/.test(specName)) );
   }
+  return specsForItem;
 }
+
 
 /**
  * Get the formal syntax for a property from the webref data, given:
  * @param {string} propertyName - the name of the property
  */
-function getPropertySyntax(propertyName) {
-  // 1) get all specs which list this property
-  let specsForProp = [];
-  for (const [shortname, data] of Object.entries(parsedWebRef)) {
-    const propNames = Object.keys(data.properties);
-    if (propNames.includes(propertyName)) {
-      specsForProp.push(shortname);
-    }
-  }
-  // 2) If we have more than one spec, filter out specs that end "-n" where n is a number
-  if (specsForProp.length > 1) {
-    specsForProp = specsForProp.filter( specName => !(/-\d+$/.test(specName)) );
-  }
-  // 3) If we now have only one spec, return the syntax it lists
+ function getPropertySyntax(propertyName) {
+  // Get all specs which list this property
+  const specsForProp = getSpecsForItem(propertyName, "properties");
+  // If we have only one spec, return the syntax it lists
   if (specsForProp.length === 1) {
     return parsedWebRef[specsForProp[0]].properties[propertyName].value;
   }
-  // 4) If we still have > 1 spec, assume that:
+  // If we have > 1 spec, assume that:
   // - one of them is the base spec, which defines `values`,
   // - the others define incremental additions as `newValues`
   let syntax = '';
@@ -156,6 +131,88 @@ function getPropertySyntax(propertyName) {
     syntax += newSyntaxes;
   }
   return syntax;
+}
+
+/**
+ * Get the formal syntax for an at-rule from the webref data, given:
+ * @param {string} atRuleName - the name of the at-rule
+ */
+function getAtRuleSyntax(atRuleName) {
+  // An at-rule may appear in more than one spec: for example, if extra descriptors
+  // are defined in different specs. But we assume that the at-rule's own syntax,
+  // defined in the `value` property, only appears in one of them.
+  const specs = getSpecsForItem(atRuleName, "atrules");
+  for (const spec of specs) {
+    if (parsedWebRef[spec].atrules[atRuleName].value) {
+      return parsedWebRef[spec].atrules[atRuleName].value;
+    }
+  }
+  return '';
+}
+
+/**
+ * Get the formal syntax for an at-rule descriptor from the webref data, given:
+ * @param {string} atRuleDescriptorName - the name of the at-rule descriptor
+ */
+function getAtRuleDescriptorSyntax(atRuleDescriptorName) {
+  // We assume that the at-rule descriptor page is directly under
+  // the page for its at-rule.
+  const atRuleName = env.slug.split('/').at(-2);
+  const specs = getSpecsForItem(atRuleName, "atrules");
+  // Look through all the specs that define the at-rule, for the one
+  // that defines this descriptor.
+  for (const spec of specs) {
+    const atRule = parsedWebRef[spec].atrules[atRuleName];
+    for (const descriptor of atRule.descriptors) {
+      if (descriptor.name === atRuleDescriptorName) {
+        return descriptor.value;
+      }
+    }
+  }
+  return '';
+}
+
+/**
+ * Get the formal syntax and properly formatted name for an item.
+ */
+function getNameAndSyntax() {
+  // get the item name from the page slug
+  let itemName = $0 || env.slug.split('/').pop().toLowerCase();
+  let itemSyntax;
+  switch (env["page-type"]) {
+    case "css-shorthand-property":
+    case "css-property":
+      itemSyntax = getPropertySyntax(itemName);
+      break;
+    case "css-type":
+      // some CSS data type slugs have a `_value` suffix
+      if (itemName.endsWith("_value")) {
+        itemName = itemName.replace("_value", "");
+      }
+      itemName = `<${itemName}>`;
+      // not all types have an entry in the syntax
+      if (valuespaces[itemName]) {
+        itemSyntax = valuespaces[itemName].value;
+      }
+      break;
+    case "css-function":
+      itemName = `<${itemName}()>`;
+      // not all functions have an entry in the syntax
+      if (valuespaces[itemName]) {
+        itemSyntax = valuespaces[itemName].value;
+      }
+      break;
+    case "css-at-rule":
+        itemSyntax = getAtRuleSyntax(itemName);
+        break;
+      case "css-at-rule-descriptor":
+      itemSyntax = getAtRuleDescriptorSyntax(itemName);
+      break;
+  }
+  return {
+    name: itemName,
+    syntax: itemSyntax
+  }
 }
 
 /**

--- a/kumascript/macros/CSSSyntax.ejs
+++ b/kumascript/macros/CSSSyntax.ejs
@@ -84,17 +84,13 @@ for (const spec of Object.values(parsedWebRef)) {
  * @param {string} itemType - this can only be "properties" or "atrules"
  */
 function getSpecsForItem(itemName, itemType) {
-  // 1) Get all specs which list this item
-  let specsForItem = [];
+  // Get all specs which list this item
+  const specsForItem = [];
   for (const [shortname, data] of Object.entries(parsedWebRef)) {
     const itemNames = Object.keys(data[itemType]);
     if (itemNames.includes(itemName)) {
       specsForItem.push(shortname);
     }
-  }
-  // 2) If we have more than one spec, filter out specs that end "-n" where n is a number
-  if (specsForItem.length > 1) {
-    specsForItem = specsForItem.filter( specName => !(/-\d+$/.test(specName)) );
   }
   return specsForItem;
 }
@@ -105,13 +101,17 @@ function getSpecsForItem(itemName, itemType) {
  * @param {string} propertyName - the name of the property
  */
  function getPropertySyntax(propertyName) {
-  // Get all specs which list this property
-  const specsForProp = getSpecsForItem(propertyName, "properties");
-  // If we have only one spec, return the syntax it lists
+  // 1) Get all specs which list this property
+  let specsForProp = getSpecsForItem(propertyName, "properties");
+  // 2) If we have more than one spec, filter out specs that end "-n" where n is a number
+  if (specsForProp.length > 1) {
+    specsForProp = specsForProp.filter( specName => !(/-\d+$/.test(specName)) );
+  }
+  // 3) If we have only one spec, return the syntax it lists
   if (specsForProp.length === 1) {
     return parsedWebRef[specsForProp[0]].properties[propertyName].value;
   }
-  // If we have > 1 spec, assume that:
+  // 4) If we have > 1 spec, assume that:
   // - one of them is the base spec, which defines `values`,
   // - the others define incremental additions as `newValues`
   let syntax = '';


### PR DESCRIPTION
## Summary

Support at-rules and at-rule descriptors in the formal syntax.

### Problem

When we switched to use webref for formal syntax, we dropped support for at-rules and at-rule descriptors. This restores it as promised in https://github.com/mdn/yari/pull/4656#issuecomment-1137467121.

### Solution

There are a few code changes here:
- the `getNameAndSyntax()` function is the entry point to the bit of this macro that interfaces with webref, and is basically a switch on the different page types. I've extended it to support the additional cases of `css-at-rule` and `css-at-rule-descriptor`
- I've added new functions, `getAtRuleSyntax()` and `getAtRuleDescriptorSyntax()`, to fetch the syntax for these things
- very minor refactoring of a bit of shared code out of `getPropertySyntax()` and into a new function `getSpecsForItem()`
- moved `getPropertySyntax()` so it lives alongside these other `getXYZSyntax()` functions, before `getNameAndSyntax()`

We need somehow to map at-rule descriptors onto their at-rule, which I'm doing here by assuming that at-rule descriptors always appear under their at-rule in the page hierarchy. This is a safe assumption now and we're not planning to break it AFAIK. If we did want to make this system independent of page hierarchy we could have a front matter key for at-rule descriptors, pointing to their at-rule.

## Screenshots

At-rule and at-rule descriptor pages now get syntax-highlighted.

### Before

@property:

<img width="803" alt="Screen Shot 2022-10-10 at 3 13 50 PM" src="https://user-images.githubusercontent.com/432915/194960330-dacc85b9-d3ed-4cc0-bf5f-ee654144663f.png">

@counter-style/pad:

<img width="806" alt="Screen Shot 2022-10-10 at 3 14 19 PM" src="https://user-images.githubusercontent.com/432915/194960369-52beb84a-b096-4c77-a021-9323f9363952.png">

### After

\@property:

<img width="795" alt="Screen Shot 2022-10-10 at 3 14 04 PM" src="https://user-images.githubusercontent.com/432915/194960438-3a9be247-c5fe-4203-9bcf-103a8c39173f.png">

\@counter-style/pad:

<img width="795" alt="Screen Shot 2022-10-10 at 3 14 30 PM" src="https://user-images.githubusercontent.com/432915/194960453-95f6b71b-b3d6-4586-8184-8be07453c74c.png">


## How did you test this change?

To test this:

1) check out this branch: https://github.com/wbamberg/content/tree/add-at-rule-descriptor-formal-syntax , which [updates all relevant at-rule and at-rule descriptor pages to use csssyntax](https://github.com/mdn/content/compare/main...wbamberg:content:add-at-rule-descriptor-formal-syntax),
2) point your CONTENT_ROOT at this branch
3) run yarn dev
4) visit the pages:

**at-rules:**
[/web/css/@viewport](http://localhost:3000/en-US/docs/web/css/@viewport)
[/web/css/@import](http://localhost:3000/en-US/docs/web/css/@import)
[/web/css/@supports](http://localhost:3000/en-US/docs/web/css/@supports)
[/web/css/@keyframes](http://localhost:3000/en-US/docs/web/css/@keyframes)
[/web/css/@document](http://localhost:3000/en-US/docs/web/css/@document)
[/web/css/@property](http://localhost:3000/en-US/docs/web/css/@property)
[/web/css/@color-profile](http://localhost:3000/en-US/docs/web/css/@color-profile)
[/web/css/@namespace](http://localhost:3000/en-US/docs/web/css/@namespace)
[/web/css/@scroll-timeline](http://localhost:3000/en-US/docs/web/css/@scroll-timeline)
[/web/css/@font-feature-values](http://localhost:3000/en-US/docs/web/css/@font-feature-values)
[/web/css/@layer](http://localhost:3000/en-US/docs/web/css/@layer)
[/web/css/@charset](http://localhost:3000/en-US/docs/web/css/@charset)
[/web/css/@page](http://localhost:3000/en-US/docs/web/css/@page)
[/web/css/@media](http://localhost:3000/en-US/docs/web/css/@media)
[/web/css/@font-face](http://localhost:3000/en-US/docs/web/css/@font-face)
[/web/css/@font-face](http://localhost:3000/en-US/docs/web/css/@counter-style)

**at-rule descriptors:**
[/web/css/@property/initial-value](http://localhost:3000/en-US/docs/web/css/@property/initial-value)
[/web/css/@property/inherits](http://localhost:3000/en-US/docs/web/css/@property/inherits)
[/web/css/@property/syntax](http://localhost:3000/en-US/docs/web/css/@property/syntax)
[/web/css/@page/size](http://localhost:3000/en-US/docs/web/css/@page/size)
[/web/css/@font-face/line-gap-override](http://localhost:3000/en-US/docs/web/css/@font-face/line-gap-override)
[/web/css/@font-face/size-adjust](http://localhost:3000/en-US/docs/web/css/@font-face/size-adjust)
[/web/css/@font-face/font-variation-settings](http://localhost:3000/en-US/docs/web/css/@font-face/font-variation-settings)
[/web/css/@font-face/font-stretch](http://localhost:3000/en-US/docs/web/css/@font-face/font-stretch)
[/web/css/@font-face/ascent-override](http://localhost:3000/en-US/docs/web/css/@font-face/ascent-override)
[/web/css/@font-face/descent-override](http://localhost:3000/en-US/docs/web/css/@font-face/descent-override)
[/web/css/@font-face/font-variant](http://localhost:3000/en-US/docs/web/css/@font-face/font-variant)
[/web/css/@font-face/unicode-range](http://localhost:3000/en-US/docs/web/css/@font-face/unicode-range)
[/web/css/@font-face/font-weight](http://localhost:3000/en-US/docs/web/css/@font-face/font-weight)
[/web/css/@font-face/font-display](http://localhost:3000/en-US/docs/web/css/@font-face/font-display)
[/web/css/@font-face/font-style](http://localhost:3000/en-US/docs/web/css/@font-face/font-style)
[/web/css/@font-face/font-family](http://localhost:3000/en-US/docs/web/css/@font-face/font-family)
[/web/css/@font-face/src](http://localhost:3000/en-US/docs/web/css/@font-face/src)
[/web/css/@counter-style/fallback](http://localhost:3000/en-US/docs/web/css/@counter-style/fallback)
[/web/css/@counter-style/prefix](http://localhost:3000/en-US/docs/web/css/@counter-style/prefix)
[/web/css/@counter-style/negative](http://localhost:3000/en-US/docs/web/css/@counter-style/negative)
[/web/css/@counter-style/suffix](http://localhost:3000/en-US/docs/web/css/@counter-style/suffix)
[/web/css/@counter-style/pad](http://localhost:3000/en-US/docs/web/css/@counter-style/pad)
[/web/css/@counter-style/system](http://localhost:3000/en-US/docs/web/css/@counter-style/system)
[/web/css/@counter-style/symbols](http://localhost:3000/en-US/docs/web/css/@counter-style/symbols)
[/web/css/@counter-style/additive-symbols](http://localhost:3000/en-US/docs/web/css/@counter-style/additive-symbols)
[/web/css/@counter-style/range](http://localhost:3000/en-US/docs/web/css/@counter-style/range)
[/web/css/@counter-style/speak-as](http://localhost:3000/en-US/docs/web/css/@counter-style/speak-as)

Note that in a few of these case I haven't updated the page to use csssyntax, but I don't think any of these are the macro's fault:

* [/web/css/@font-face/src](http://localhost:3000/en-US/docs/web/css/@font-face/src) - here [the spec says "see prose" where there should be syntax](https://github.com/w3c/webref/blob/0fe1d7a77e69fd88efc45173f42e94e022a71fa9/ed/css/css-fonts.json#L397). If this can't be fixed upstream we will need to hardcode it.
* A few cases are nonstandard/deprecated/removed, and should either hardcode the syntax or (more likely) delete the pages:
    * [/web/css/@viewport](http://localhost:3000/en-US/docs/web/css/@viewport)
    * [/web/css/@document](http://localhost:3000/en-US/docs/web/css/@document)
    * [/web/css/@scroll-timeline](http://localhost:3000/en-US/docs/web/css/@scroll-timeline)
    * [/web/css/@font-face/font-variant](http://localhost:3000/en-US/docs/web/css/@font-face/font-variant)
* [/web/css/@charset](http://localhost:3000/en-US/docs/web/css/@charset): formal syntax isn't listed in webref. I think this might be an upstream problem, but if we can't fix it there we will hardcode the syntax.

We can check for regressions by visiting some other pages, as below.

### CSS properties

http://localhost:3000/en-US/docs/Web/CSS/animation-duration
http://localhost:3000/en-US/docs/Web/CSS/background-clip#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/background#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/border-block-style#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/border-color#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/border-right#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/box-sizing#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/column-rule-color#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/color#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/clip-path#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/flex#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/filter#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/font-synthesis#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/font-variant#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/grid-auto-rows#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/grid-area#formal_syntax

### CSS functions

http://localhost:3000/en-US/docs/Web/css/cross-fade#formal_syntax
http://localhost:3000/en-US/docs/Web/css/sign#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/transform-function/translateY#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/min#formal_syntax

### CSS types

http://localhost:3000/en-US/docs/Web/CSS/alpha-value#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/angle-percentage#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/color_value#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/display-box#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/frequency-percentage#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/gradient#formal_syntax
http://localhost:3000/en-US/docs/Web/CSS/image#formal_syntax


