### PR TITLE
chore(macros/APIRef): separate static and instance members

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -36,10 +36,10 @@ if (group) {
 var commonl10n = web.getJSONData("L10n-Common");
 
 var text = {
-    'Static methods': mdn.getLocalString(commonl10n, 'Static_methods'),
     'Static properties': mdn.getLocalString(commonl10n, 'Static_properties'),
-    'Instance methods': mdn.getLocalString(commonl10n, 'Instance_methods'),
     'Instance properties': mdn.getLocalString(commonl10n, 'Instance_properties'),
+    'Static methods': mdn.getLocalString(commonl10n, 'Static_methods'),
+    'Instance methods': mdn.getLocalString(commonl10n, 'Instance_methods'),
     'Constructor': mdn.getLocalString(commonl10n, 'Constructor'),
     'Inheritance': mdn.getLocalString(commonl10n, 'Inheritance'),
     'Implemented_by': mdn.getLocalString(commonl10n, 'Implemented_by'),
@@ -68,8 +68,8 @@ if (group && webAPIGroups[0][group]) {
 }
 
 var staticProperties = [];
-var staticMethods = [];
 var instanceProperties = [];
+var staticMethods = [];
 var instanceMethods = [];
 var ctors = [];
 var events = [];
@@ -83,11 +83,11 @@ function collect(pageList) {
       case "web-api-static-property":
         staticProperties.push(aPage);
         break;
-      case "web-api-static-method":
-        staticMethods.push(aPage);
-        break;
       case "web-api-instance-property":
         instanceProperties.push(aPage);
+        break;
+      case "web-api-static-method":
+        staticMethods.push(aPage);
         break;
       case "web-api-instance-method":
         instanceMethods.push(aPage);
@@ -121,8 +121,8 @@ function APISort(a, b) {
 }
 
 staticProperties.sort(APISort);
-staticMethods.sort(APISort);
 instanceProperties.sort(APISort);
+staticMethods.sort(APISort);
 instanceMethods.sort(APISort);
 ctors.sort(APISort);
 events.sort(APISort);
@@ -264,11 +264,11 @@ if (ctors.length > 0) {
 if (staticProperties.length > 0) {
   output += buildSublist(staticProperties, text['Static properties']);
 }
-if (staticMethods.length > 0) {
-  output += buildSublist(staticMethods, text['Static methods']);
-}
 if (instanceProperties.length > 0) {
   output += buildSublist(instanceProperties, text['Instance properties']);
+}
+if (staticMethods.length > 0) {
+  output += buildSublist(staticMethods, text['Static methods']);
 }
 if (instanceMethods.length > 0) {
   output += buildSublist(instanceMethods, text['Instance methods']);

--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -36,8 +36,10 @@ if (group) {
 var commonl10n = web.getJSONData("L10n-Common");
 
 var text = {
-    'Methods': mdn.getLocalString(commonl10n, 'Methods'),
-    'Properties': mdn.getLocalString(commonl10n, 'Properties'),
+    'Static methods': mdn.getLocalString(commonl10n, 'Static_methods'),
+    'Static properties': mdn.getLocalString(commonl10n, 'Static_properties'),
+    'Instance methods': mdn.getLocalString(commonl10n, 'Instance_methods'),
+    'Instance properties': mdn.getLocalString(commonl10n, 'Instance_properties'),
     'Constructor': mdn.getLocalString(commonl10n, 'Constructor'),
     'Inheritance': mdn.getLocalString(commonl10n, 'Inheritance'),
     'Implemented_by': mdn.getLocalString(commonl10n, 'Implemented_by'),
@@ -46,7 +48,6 @@ var text = {
     'title': mdn.getLocalString(commonl10n, 'TranslationCTA'),
     'Events': mdn.getLocalString(commonl10n, 'Events'),
 };
-
 
 // Collect all the things
 var mainIFPages = await page.subpagesExpand('/en-US/docs/Web/API/' + mainIF);
@@ -66,8 +67,10 @@ if (group && webAPIGroups[0][group]) {
   related.sort();
 }
 
-var properties = [];
-var methods = [];
+var staticProperties = [];
+var staticMethods = [];
+var instanceProperties = [];
+var instanceMethods = [];
 var ctors = [];
 var events = [];
 var inheritedIF = [];
@@ -78,12 +81,16 @@ function collect(pageList) {
     var aPage = pageList[i];
     switch(aPage.pageType) {
       case "web-api-static-property":
-      case "web-api-instance-property":
-        properties.push(aPage);
+        staticProperties.push(aPage);
         break;
       case "web-api-static-method":
+        staticMethods.push(aPage);
+        break;
+      case "web-api-instance-property":
+        instanceProperties.push(aPage);
+        break;
       case "web-api-instance-method":
-        methods.push(aPage);
+        instanceMethods.push(aPage);
         break;
       case "web-api-constructor":
         ctors.push(aPage);
@@ -113,8 +120,10 @@ function APISort(a, b) {
   return a.toLowerCase().localeCompare(b.toLowerCase());
 }
 
-properties.sort(APISort);
-methods.sort(APISort);
+staticProperties.sort(APISort);
+staticMethods.sort(APISort);
+instanceProperties.sort(APISort);
+instanceMethods.sort(APISort);
 ctors.sort(APISort);
 events.sort(APISort);
 
@@ -252,12 +261,17 @@ output += `<li><strong>${web.smartLink(APIHref + '/' + mainIF, null, `<code>${ma
 if (ctors.length > 0) {
   output += buildSublist(ctors, text['Constructor']);
 }
-
-if (properties.length > 0) {
-  output += buildSublist(properties, text['Properties']);
+if (staticProperties.length > 0) {
+  output += buildSublist(staticProperties, text['Static properties']);
 }
-if (methods.length > 0) {
-  output += buildSublist(methods, text['Methods']);
+if (staticMethods.length > 0) {
+  output += buildSublist(staticMethods, text['Static methods']);
+}
+if (instanceProperties.length > 0) {
+  output += buildSublist(instanceProperties, text['Instance properties']);
+}
+if (instanceMethods.length > 0) {
+  output += buildSublist(instanceMethods, text['Instance methods']);
 }
 if (events.length > 0) {
   output += buildSublist(events, text['Events']);

--- a/kumascript/tests/macros/apiref.test.ts
+++ b/kumascript/tests/macros/apiref.test.ts
@@ -60,51 +60,81 @@ const expectedMainIfLink = {
   },
 };
 
-const expectedProperties = {
+const expectedStaticProperties = {
   "en-US": [
     {
       badges: [],
-      text: "MyTestProperty1",
-      target: "/en-US/docs/Web/API/TestInterface/TestProperty1",
+      text: "MyTestStaticProperty1",
+      target: "/en-US/docs/Web/API/TestInterface/TestStaticProperty1",
       title:
-        "The MyTestProperty1 property of the TestInterface interface has no badges.",
+        "The TestStaticProperty1 property of the TestInterface interface has no badges.",
     },
   ],
   fr: [
     {
       badges: [],
-      text: "MyTestProperty1",
-      target: "/fr/docs/Web/API/TestInterface/TestProperty1",
+      text: "MyTestStaticProperty1",
+      target: "/fr/docs/Web/API/TestInterface/TestStaticProperty1",
       title:
-        "The MyTestProperty1 property of the TestInterface interface has no badges.",
+        "The TestStaticProperty1 property of the TestInterface interface has no badges.",
     },
   ],
   ja: [
     {
       badges: [],
-      text: "MyTestProperty1",
-      target: "/ja/docs/Web/API/TestInterface/TestProperty1",
+      text: "MyTestStaticProperty1",
+      target: "/ja/docs/Web/API/TestInterface/TestStaticProperty1",
       title:
-        "The MyTestProperty1 property of the TestInterface interface has no badges (ja translation).",
+        "The TestStaticProperty1 property of the TestInterface interface has no badges (ja translation).",
     },
   ],
 };
 
-const expectedMethods = {
+const expectedInstanceProperties = {
+  "en-US": [
+    {
+      badges: [],
+      text: "MyTestInstanceProperty1",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestInstanceProperty1",
+      title:
+        "The MyTestInstanceProperty1 property of the TestInterface interface has no badges.",
+    },
+  ],
+  fr: [
+    {
+      badges: [],
+      text: "MyTestInstanceProperty1",
+      target: "/fr/docs/Web/API/TestInterface/MyTestInstanceProperty1",
+      title:
+        "The MyTestInstanceProperty1 property of the TestInterface interface has no badges.",
+    },
+  ],
+  ja: [
+    {
+      badges: [],
+      text: "MyTestInstanceProperty1",
+      target: "/ja/docs/Web/API/TestInterface/MyTestInstanceProperty1",
+      title:
+        "The MyTestInstanceProperty1 property of the TestInterface interface has no badges (ja translation).",
+    },
+  ],
+};
+
+const expectedStaticMethods = {
   "en-US": [
     {
       badges: ["icon-experimental"],
-      text: "MyTestMethod1",
-      target: "/en-US/docs/Web/API/TestInterface/TestMethod1",
+      text: "MyTestStaticMethod1",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod1",
       title:
-        "The MyTestMethod1 property of the TestInterface interface is experimental.",
+        "The MyTestStaticMethod1 property of the TestInterface interface is experimental.",
     },
     {
       badges: ["icon-deprecated", "icon-nonstandard"],
-      text: "MyTestMethod2",
-      target: "/en-US/docs/Web/API/TestInterface/TestMethod2",
+      text: "MyTestStaticMethod2",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod2",
       title:
-        "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
+        "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
       badges: [
@@ -113,26 +143,26 @@ const expectedMethods = {
         "icon-nonstandard",
         "obsolete",
       ],
-      text: "MyTestMethod3",
-      target: "/en-US/docs/Web/API/TestInterface/TestMethod3",
+      text: "MyTestStaticMethod3",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
-        "The MyTestMethod3 property of the TestInterface interface has all the badges.",
+        "The MyTestStaticMethod3 property of the TestInterface interface has all the badges.",
     },
   ],
   fr: [
     {
       badges: ["icon-experimental"],
-      text: "MyTestMethod1",
-      target: "/fr/docs/Web/API/TestInterface/TestMethod1",
+      text: "MyTestStaticMethod1",
+      target: "/fr/docs/Web/API/TestInterface/MyTestStaticMethod1",
       title:
-        "The MyTestMethod1 property of the TestInterface interface is experimental.",
+        "The MyTestStaticMethod1 property of the TestInterface interface is experimental.",
     },
     {
       badges: ["icon-deprecated", "icon-nonstandard"],
-      text: "MyTestMethod2",
-      target: "/fr/docs/Web/API/TestInterface/TestMethod2",
+      text: "MyTestStaticMethod2",
+      target: "/fr/docs/Web/API/TestInterface/MyTestStaticMethod2",
       title:
-        "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard.",
+        "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
       badges: [
@@ -141,26 +171,26 @@ const expectedMethods = {
         "icon-nonstandard",
         "obsolete",
       ],
-      text: "MyTestMethod3",
-      target: "/fr/docs/Web/API/TestInterface/TestMethod3",
+      text: "MyTestStaticMethod3",
+      target: "/fr/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
-        "The MyTestMethod3 property of the TestInterface interface has all the badges.",
+        "The MyTestStaticMethod3 property of the TestInterface interface has all the badges.",
     },
   ],
   ja: [
     {
       badges: ["icon-experimental"],
-      text: "MyTestMethod1",
-      target: "/ja/docs/Web/API/TestInterface/TestMethod1",
+      text: "MyTestStaticMethod1",
+      target: "/ja/docs/Web/API/TestInterface/MyTestStaticMethod1",
       title:
-        "The MyTestMethod1 property of the TestInterface interface is experimental (ja translation).",
+        "The MyTestStaticMethod1 property of the TestInterface interface is experimental (ja translation).",
     },
     {
       badges: ["icon-deprecated", "icon-nonstandard"],
-      text: "MyTestMethod2",
-      target: "/ja/docs/Web/API/TestInterface/TestMethod2",
+      text: "MyTestStaticMethod2",
+      target: "/ja/docs/Web/API/TestInterface/MyTestStaticMethod2",
       title:
-        "The MyTestMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
+        "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
     },
     {
       badges: [
@@ -169,10 +199,97 @@ const expectedMethods = {
         "icon-nonstandard",
         "obsolete",
       ],
-      text: "MyTestMethod3",
-      target: "/ja/docs/Web/API/TestInterface/TestMethod3",
+      text: "MyTestStaticMethod3",
+      target: "/ja/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
-        "The MyTestMethod3 property of the TestInterface interface has all the badges (ja translation).",
+        "The MyTestStaticMethod3 property of the TestInterface interface has all the badges (ja translation).",
+    },
+  ],
+};
+
+const expectedInstanceMethods = {
+  "en-US": [
+    {
+      badges: ["icon-experimental"],
+      text: "MyTestInstanceMethod1",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod1",
+      title:
+        "The MyTestInstanceMethod1 property of the TestInterface interface is experimental.",
+    },
+    {
+      badges: ["icon-deprecated", "icon-nonstandard"],
+      text: "MyTestInstanceMethod2",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod2",
+      title:
+        "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard.",
+    },
+    {
+      badges: [
+        "icon-experimental",
+        "icon-deprecated",
+        "icon-nonstandard",
+        "obsolete",
+      ],
+      text: "MyTestInstanceMethod3",
+      target: "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod3",
+      title:
+        "The MyTestInstanceMethod3 property of the TestInterface interface has all the badges.",
+    },
+  ],
+  fr: [
+    {
+      badges: ["icon-experimental"],
+      text: "MyTestInstanceMethod1",
+      target: "/fr/docs/Web/API/TestInterface/MyTestInstanceMethod1",
+      title:
+        "The MyTestInstanceMethod1 property of the TestInterface interface is experimental.",
+    },
+    {
+      badges: ["icon-deprecated", "icon-nonstandard"],
+      text: "MyTestInstanceMethod2",
+      target: "/fr/docs/Web/API/TestInterface/MyTestInstanceMethod2",
+      title:
+        "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard.",
+    },
+    {
+      badges: [
+        "icon-experimental",
+        "icon-deprecated",
+        "icon-nonstandard",
+        "obsolete",
+      ],
+      text: "MyTestInstanceMethod3",
+      target: "/fr/docs/Web/API/TestInterface/MyTestInstanceMethod3",
+      title:
+        "The MyTestInstanceMethod3 property of the TestInterface interface has all the badges.",
+    },
+  ],
+  ja: [
+    {
+      badges: ["icon-experimental"],
+      text: "MyTestInstanceMethod1",
+      target: "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod1",
+      title:
+        "The MyTestInstanceMethod1 property of the TestInterface interface is experimental (ja translation).",
+    },
+    {
+      badges: ["icon-deprecated", "icon-nonstandard"],
+      text: "MyTestInstanceMethod2",
+      target: "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod2",
+      title:
+        "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
+    },
+    {
+      badges: [
+        "icon-experimental",
+        "icon-deprecated",
+        "icon-nonstandard",
+        "obsolete",
+      ],
+      text: "MyTestInstanceMethod3",
+      target: "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod3",
+      title:
+        "The MyTestInstanceMethod3 property of the TestInterface interface has all the badges (ja translation).",
     },
   ],
 };
@@ -289,8 +406,10 @@ const expectedImplemented = [
 const expectedBasic = {
   mainIfLink: expectedMainIfLink.withoutGroupData,
   details: {
-    properties: expectedProperties,
-    methods: expectedMethods,
+    staticProperties: expectedStaticProperties,
+    staticMethods: expectedStaticMethods,
+    instanceProperties: expectedInstanceProperties,
+    instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
   },
 };
@@ -298,8 +417,10 @@ const expectedBasic = {
 const expectedWithGroupData = {
   mainIfLink: expectedMainIfLink.withGroupData,
   details: {
-    properties: expectedProperties,
-    methods: expectedMethods,
+    staticProperties: expectedStaticProperties,
+    staticMethods: expectedStaticMethods,
+    instanceProperties: expectedInstanceProperties,
+    instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
     related: expectedRelated,
   },
@@ -308,8 +429,10 @@ const expectedWithGroupData = {
 const expectedWithInterfaceData = {
   mainIfLink: expectedMainIfLink.withoutGroupData,
   details: {
-    properties: expectedProperties,
-    methods: expectedMethods,
+    staticProperties: expectedStaticProperties,
+    staticMethods: expectedStaticMethods,
+    instanceProperties: expectedInstanceProperties,
+    instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
     inherited: expectedInherited,
     implemented: expectedImplemented,
@@ -431,27 +554,58 @@ function checkResult(html, config) {
   const details = dom.querySelectorAll("ol>li>details");
   expect(details.length).toEqual(Object.keys(config.expected.details).length);
 
-  // Test the properties sublist
-  const expectedPropertySummary = commonl10nFixture.Properties[config.locale];
-  const expectedPropertyItems =
-    config.expected.details.properties[config.locale];
-  const properties = details[0];
+  // Test the static properties sublist
+  const expectedStaticPropertySummary =
+    commonl10nFixture.Static_properties[config.locale];
+  const expectedStaticPropertyItems =
+    config.expected.details.staticProperties[config.locale];
+  const staticProperties = details[0];
   checkItemList(
-    expectedPropertySummary,
-    expectedPropertyItems,
-    properties,
+    expectedStaticPropertySummary,
+    expectedStaticPropertyItems,
+    staticProperties,
     config,
     checkInterfaceItem
   );
 
-  // Test the methods sublist
-  const expectedMethodSummary = commonl10nFixture.Methods[config.locale];
-  const expectedMethodItems = config.expected.details.methods[config.locale];
-  const methods = details[1];
+  // Test the static methods sublist
+  const expectedStaticMethodSummary =
+    commonl10nFixture.Static_methods[config.locale];
+  const expectedStaticMethodItems =
+    config.expected.details.staticMethods[config.locale];
+  const staticMethods = details[1];
   checkItemList(
-    expectedMethodSummary,
-    expectedMethodItems,
-    methods,
+    expectedStaticMethodSummary,
+    expectedStaticMethodItems,
+    staticMethods,
+    config,
+    checkInterfaceItem
+  );
+
+  // Test the instance properties sublist
+  const expectedInstancePropertySummary =
+    commonl10nFixture.Instance_properties[config.locale];
+  const expectedInstancePropertyItems =
+    config.expected.details.instanceProperties[config.locale];
+  const instanceProperties = details[2];
+  checkItemList(
+    expectedInstancePropertySummary,
+    expectedInstancePropertyItems,
+    instanceProperties,
+    config,
+    checkInterfaceItem
+  );
+
+  // Test the instance methods sublist
+  const expectedInstanceMethodSummary =
+    commonl10nFixture.Instance_methods[config.locale];
+  const expectedInstanceMethodItems =
+    config.expected.details.instanceMethods[config.locale];
+  const instanceMethods = details[3];
+  checkItemList(
+    expectedInstanceMethodSummary,
+    expectedInstanceMethodItems,
+    instanceMethods,
     config,
     checkInterfaceItem
   );
@@ -459,7 +613,7 @@ function checkResult(html, config) {
   // Test the events sublist
   const expectedEventSummary = commonl10nFixture.Events[config.locale];
   const expectedEventItems = config.expected.details.events[config.locale];
-  const events = details[2];
+  const events = details[4];
   checkItemList(
     expectedEventSummary,
     expectedEventItems,
@@ -474,7 +628,7 @@ function checkResult(html, config) {
     const expectedInheritedSummary =
       commonl10nFixture.Inheritance[config.locale];
     const expectedInheritedItems = config.expected.details.inherited;
-    const inherited = details[3];
+    const inherited = details[5];
     checkItemList(
       expectedInheritedSummary,
       expectedInheritedItems,
@@ -490,7 +644,7 @@ function checkResult(html, config) {
     const expectedImplementedSummary =
       commonl10nFixture.Implemented_by[config.locale];
     const expectedImplementedItems = config.expected.details.implemented;
-    const implemented = details[4];
+    const implemented = details[6];
     checkItemList(
       expectedImplementedSummary,
       expectedImplementedItems,
@@ -507,7 +661,7 @@ function checkResult(html, config) {
       config.locale
     ].replace("$1", config.argument);
     const expectedRelatedItems = config.expected.details.related;
-    const related = details[3];
+    const related = details[5];
     checkItemList(
       expectedRelatedSummary,
       expectedRelatedItems,
@@ -570,8 +724,8 @@ describeMacro("APIRef", function () {
 
   // Test with current page as a subpage
   testMacro({
-    name: "slug: 'Web/API/TestInterface/TestMethod1'; no InterfaceData entries; no argument",
-    currentSlug: "Web/API/TestInterface/TestMethod1",
+    name: "slug: 'Web/API/TestInterface/TestStaticMethod1'; no InterfaceData entries; no argument",
+    currentSlug: "Web/API/TestInterface/TestStaticMethod1",
     argument: null,
     interfaceData: interfaceDataNoEntriesFixture,
     expected: expectedBasic,

--- a/kumascript/tests/macros/apiref.test.ts
+++ b/kumascript/tests/macros/apiref.test.ts
@@ -407,8 +407,8 @@ const expectedBasic = {
   mainIfLink: expectedMainIfLink.withoutGroupData,
   details: {
     staticProperties: expectedStaticProperties,
-    staticMethods: expectedStaticMethods,
     instanceProperties: expectedInstanceProperties,
+    staticMethods: expectedStaticMethods,
     instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
   },
@@ -418,8 +418,8 @@ const expectedWithGroupData = {
   mainIfLink: expectedMainIfLink.withGroupData,
   details: {
     staticProperties: expectedStaticProperties,
-    staticMethods: expectedStaticMethods,
     instanceProperties: expectedInstanceProperties,
+    staticMethods: expectedStaticMethods,
     instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
     related: expectedRelated,
@@ -430,8 +430,8 @@ const expectedWithInterfaceData = {
   mainIfLink: expectedMainIfLink.withoutGroupData,
   details: {
     staticProperties: expectedStaticProperties,
-    staticMethods: expectedStaticMethods,
     instanceProperties: expectedInstanceProperties,
+    staticMethods: expectedStaticMethods,
     instanceMethods: expectedInstanceMethods,
     events: expectedEvents,
     inherited: expectedInherited,
@@ -568,30 +568,30 @@ function checkResult(html, config) {
     checkInterfaceItem
   );
 
-  // Test the static methods sublist
-  const expectedStaticMethodSummary =
-    commonl10nFixture.Static_methods[config.locale];
-  const expectedStaticMethodItems =
-    config.expected.details.staticMethods[config.locale];
-  const staticMethods = details[1];
-  checkItemList(
-    expectedStaticMethodSummary,
-    expectedStaticMethodItems,
-    staticMethods,
-    config,
-    checkInterfaceItem
-  );
-
   // Test the instance properties sublist
   const expectedInstancePropertySummary =
     commonl10nFixture.Instance_properties[config.locale];
   const expectedInstancePropertyItems =
     config.expected.details.instanceProperties[config.locale];
-  const instanceProperties = details[2];
+  const instanceProperties = details[1];
   checkItemList(
     expectedInstancePropertySummary,
     expectedInstancePropertyItems,
     instanceProperties,
+    config,
+    checkInterfaceItem
+  );
+
+  // Test the static methods sublist
+  const expectedStaticMethodSummary =
+    commonl10nFixture.Static_methods[config.locale];
+  const expectedStaticMethodItems =
+    config.expected.details.staticMethods[config.locale];
+  const staticMethods = details[2];
+  checkItemList(
+    expectedStaticMethodSummary,
+    expectedStaticMethodItems,
+    staticMethods,
     config,
     checkInterfaceItem
   );

--- a/kumascript/tests/macros/fixtures/apiref/commonl10n.json
+++ b/kumascript/tests/macros/fixtures/apiref/commonl10n.json
@@ -13,6 +13,34 @@
     "es": "Propiedades"
   },
 
+  "Static_methods": {
+    "en-US": "Static methods",
+    "fr": "Méthodes",
+    "ja": "メソッド",
+    "es": "Métodos"
+  },
+
+  "Static_properties": {
+    "en-US": "Static properties",
+    "fr": "Propriétés",
+    "ja": "プロパティ",
+    "es": "Propiedades"
+  },
+
+  "Instance_methods": {
+    "en-US": "Instance methods",
+    "fr": "Méthodes",
+    "ja": "メソッド",
+    "es": "Métodos"
+  },
+
+  "Instance_properties": {
+    "en-US": "Instance properties",
+    "fr": "Propriétés",
+    "ja": "プロパティ",
+    "es": "Propiedades"
+  },
+
   "Constructor": {
     "en-US": "Constructor",
     "fr": "Constructeur",

--- a/kumascript/tests/macros/fixtures/apiref/subpages.json
+++ b/kumascript/tests/macros/fixtures/apiref/subpages.json
@@ -1,21 +1,97 @@
 [
   {
     "tags": [],
+    "pageType": "web-api-static-property",
+    "locale": "en-US",
+    "translations": [
+      {
+        "title": "MyTestStaticProperty1",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestStaticProperty1",
+        "tags": [],
+        "summary": "The <code><strong>MyTestStaticProperty1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
+        "locale": "ja"
+      }
+    ],
+    "summary": "The <code><strong>MyTestStaticProperty1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
+    "slug": "Web/API/TestInterface/MyTestStaticProperty1",
+    "title": "TestInterface.MyTestStaticProperty1",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestStaticProperty1"
+  },
+
+  {
+    "tags": [],
     "pageType": "web-api-instance-property",
     "locale": "en-US",
     "translations": [
       {
-        "title": "MyTestProperty1",
-        "url": "/ja/docs/Web/API/TestInterface/TestProperty1",
+        "title": "MyTestInstanceProperty1",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestInstanceProperty1",
         "tags": [],
-        "summary": "The <code><strong>MyTestProperty1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
+        "summary": "The <code><strong>MyTestInstanceProperty1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges (ja translation).",
         "locale": "ja"
       }
     ],
-    "summary": "The <code><strong>MyTestProperty1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
-    "slug": "Web/API/TestInterface/TestProperty1",
-    "title": "TestInterface.MyTestProperty1",
-    "url": "/en-US/docs/Web/API/TestInterface/TestProperty1"
+    "summary": "The <code><strong>MyTestInstanceProperty1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has no badges.",
+    "slug": "Web/API/TestInterface/MyTestInstanceProperty1",
+    "title": "TestInterface.MyTestInstanceProperty1",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestInstanceProperty1"
+  },
+
+  {
+    "tags": ["Experimental"],
+    "pageType": "web-api-static-method",
+    "locale": "en-US",
+    "translations": [
+      {
+        "title": "MyTestStaticMethod1",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestStaticMethod1",
+        "tags": [],
+        "summary": "The <code><strong>MyTestStaticMethod1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental (ja translation).",
+        "locale": "ja"
+      }
+    ],
+    "summary": "The <code><strong>MyTestStaticMethod1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental.",
+    "slug": "Web/API/TestInterface/MyTestStaticMethod1",
+    "title": "MyTestStaticMethod1",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod1"
+  },
+
+  {
+    "tags": ["Deprecated", "Non-standard"],
+    "pageType": "web-api-static-method",
+    "locale": "en-US",
+    "translations": [
+      {
+        "title": "MyTestStaticMethod2",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestStaticMethod2",
+        "tags": [],
+        "summary": "The <code><strong>MyTestStaticMethod2</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard (ja translation).",
+        "locale": "ja"
+      }
+    ],
+    "summary": "The <code><strong>MyTestStaticMethod2</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard.",
+    "slug": "Web/API/TestInterface/MyTestStaticMethod2",
+    "title": "MyTestStaticMethod2",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod2"
+  },
+
+  {
+    "tags": ["Deprecated", "Non-standard", "Obsolete", "Experimental"],
+    "pageType": "web-api-static-method",
+    "locale": "en-US",
+    "translations": [
+      {
+        "title": "MyTestStaticMethod3",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestStaticMethod3",
+        "tags": [],
+        "summary": "The <code><strong>MyTestStaticMethod3</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges (ja translation).",
+        "locale": "ja"
+      }
+    ],
+    "summary": "The <code><strong>MyTestStaticMethod3</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges.",
+    "slug": "Web/API/TestInterface/MyTestStaticMethod3",
+    "title": "MyTestStaticMethod3",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod3"
   },
 
   {
@@ -24,17 +100,17 @@
     "locale": "en-US",
     "translations": [
       {
-        "title": "MyTestMethod1",
-        "url": "/ja/docs/Web/API/TestInterface/TestMethod1",
+        "title": "MyTestInstanceMethod1",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod1",
         "tags": [],
-        "summary": "The <code><strong>MyTestMethod1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental (ja translation).",
+        "summary": "The <code><strong>MyTestInstanceMethod1</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental (ja translation).",
         "locale": "ja"
       }
     ],
-    "summary": "The <code><strong>MyTestMethod1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental.",
-    "slug": "Web/API/TestInterface/TestMethod1",
-    "title": "MyTestMethod1",
-    "url": "/en-US/docs/Web/API/TestInterface/TestMethod1"
+    "summary": "The <code><strong>MyTestInstanceMethod1</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is experimental.",
+    "slug": "Web/API/TestInterface/MyTestInstanceMethod1",
+    "title": "MyTestInstanceMethod1",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod1"
   },
 
   {
@@ -43,17 +119,17 @@
     "locale": "en-US",
     "translations": [
       {
-        "title": "MyTestMethod2",
-        "url": "/ja/docs/Web/API/TestInterface/TestMethod2",
+        "title": "MyTestInstanceMethod2",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod2",
         "tags": [],
-        "summary": "The <code><strong>MyTestMethod2</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard (ja translation).",
+        "summary": "The <code><strong>MyTestInstanceMethod2</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard (ja translation).",
         "locale": "ja"
       }
     ],
-    "summary": "The <code><strong>MyTestMethod2</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard.",
-    "slug": "Web/API/TestInterface/TestMethod2",
-    "title": "MyTestMethod2",
-    "url": "/en-US/docs/Web/API/TestInterface/TestMethod2"
+    "summary": "The <code><strong>MyTestInstanceMethod2</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface is deprecated and non-standard.",
+    "slug": "Web/API/TestInterface/MyTestInstanceMethod2",
+    "title": "MyTestInstanceMethod2",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod2"
   },
 
   {
@@ -62,17 +138,17 @@
     "locale": "en-US",
     "translations": [
       {
-        "title": "MyTestMethod3",
-        "url": "/ja/docs/Web/API/TestInterface/TestMethod3",
+        "title": "MyTestInstanceMethod3",
+        "url": "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod3",
         "tags": [],
-        "summary": "The <code><strong>MyTestMethod3</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges (ja translation).",
+        "summary": "The <code><strong>MyTestInstanceMethod3</strong></code> property of the <a href=\"/ja/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges (ja translation).",
         "locale": "ja"
       }
     ],
-    "summary": "The <code><strong>MyTestMethod3</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges.",
-    "slug": "Web/API/TestInterface/TestMethod3",
-    "title": "MyTestMethod3",
-    "url": "/en-US/docs/Web/API/TestInterface/TestMethod3"
+    "summary": "The <code><strong>MyTestInstanceMethod3</strong></code> property of the <a href=\"/en-US/docs/Web/API/TestInterface\" title=\"TestInterface summary stuff\"><code>TestInterface</code></a> interface has all the badges.",
+    "slug": "Web/API/TestInterface/MyTestInstanceMethod3",
+    "title": "MyTestInstanceMethod3",
+    "url": "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod3"
   },
 
   {


### PR DESCRIPTION
## Summary

In the APIRef sidebar, have separate lists for static and instance properties and methods.

### Problem

Currently the APIRef sidebar lists just "Properties" and "Methods", combining instance and static members and not distinguishing them.

### Solution

This PR uses page types to build separate lists for instance and static members, as @Elchi3 suggested in https://github.com/mdn/yari/pull/7223#pullrequestreview-1129982474.

This is in line with the recent work @hamishwillee  has been doing in https://github.com/mdn/content/pull/21353 and so on, and contributes to https://github.com/openwebdocs/project/issues/104 .

This PR has a dependency on the l10 strings in https://github.com/mdn/content/blob/main/files/jsondata/L10n-Common.json. I've added strings for en-US in https://github.com/wbamberg/content/tree/l10-static-instance, so you can try this PR out. @SphinxKnight , if we want to go ahead with this can you notify the relevant people in the l10n community? Maybe they could add translations to that branch. I'm setting this PR to draft in the meantime.

- the macro code change: https://github.com/mdn/yari/pull/7335/commits/73db3e7e3ea2fde25bbd26a77a0fedddc2533300 is super simple and clear
- the unit test updates: https://github.com/mdn/yari/pull/7335/commits/ad265292e138337373a7fd28ea0975c834711418 are a lot more complicated

## Screenshots

### Before

https://developer.mozilla.org/en-US/docs/Web/API/IDBKeyRange

<img width="293" alt="Screen Shot 2022-10-12 at 9 40 26 AM" src="https://user-images.githubusercontent.com/432915/195400420-76545983-9c5f-4008-9529-d1e06792782f.png">

### After

http://localhost:3000/en-US/docs/Web/API/IDBKeyRange

<img width="292" alt="Screen Shot 2022-10-12 at 9 40 16 AM" src="https://user-images.githubusercontent.com/432915/195400608-34c19593-f631-42c9-bc9b-ff7a608c7052.png">

## How did you test this change?

- check out this branch
- check out https://github.com/wbamberg/content/tree/l10-static-instance, and set is as CONTENT_ROOT
- run yarn dev
- open some Web/API pages