### PR TITLE
Use page types, not tags, for CSS sidebar

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -761,13 +761,42 @@ const rtlLocales = ['ar', 'he', 'fa'];
 const pageList = await page.subpagesExpand('/en-US/docs/Web/CSS');
 const standardPages = pageList.filter(page => !hasTag(page, "Non-standard"));
 
-const groups = standardPages.filter(page => hasTag(page, "Overview"));
-const properties = standardPages.filter(page => hasTag(page, "CSS Property")).sort((a, b) => a.title.localeCompare(b.title));
-const selectors = standardPages.filter(page => (hasTag(page, "Selector") && !hasTag(page, "Pseudo-element") && !hasTag(page, "Pseudo-class")));
-const pseudoClasses = standardPages.filter(page => hasTag(page, "Pseudo-class"));
-const pseudoElements = standardPages.filter(page => hasTag(page, "Pseudo-element"));
-const atRules = standardPages.filter(page => hasTag(page, "At-rule"));
-const types = standardPages.filter(page => hasTag(page, "CSS Data Type"));
+const groups = [];
+let properties = [];
+const selectors = [];
+const pseudoClasses = [];
+const pseudoElements = [];
+const atRules = [];
+const types = [];
+
+for (const page of standardPages) {
+  switch(page.pageType) {
+    case "css-module":
+      groups.push(page);
+      break;
+    case "css-shorthand-property":
+    case "css-property":
+      properties.push(page);
+      break;
+    case "css-selector":
+      selectors.push(page);
+      break;
+    case "css-pseudo-class":
+      pseudoClasses.push(page);
+      break;
+    case "css-pseudo-element":
+      pseudoElements.push(page);
+      break;
+    case "css-at-rule":
+      atRules.push(page);
+      break;
+    case "css-type":
+      types.push(page);
+      break;
+  }
+}
+
+properties = properties.sort((a, b) => a.title.localeCompare(b.title));
 
 const badges = {
   ExperimentalBadge : await template("ExperimentalBadge"),


### PR DESCRIPTION
## Summary

This PR updates the CSSRef.ejs macro, which builds the CSS sidebar, to use the `page-type` key to classify pages, instead of tags.

### Problem

Tags are an unreliable way to classify pages and their semantics is often unclear. For example, https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions and https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Types are tagged as "CSS Data Type" pages, which is understandable because they are about CSS types. But they aren't reference docs pages for individual CSS types, which means it's incorrect for them to show up in the sidebar as part of such a list:

<img width="254" alt="Screen Shot 2022-10-12 at 3 58 13 PM" src="https://user-images.githubusercontent.com/432915/195462912-d5b3cb39-c676-4179-8273-81b46f572b09.png">

### Solution

Use page types instead of tags to group pages.

I changed the code to use a switch instead of a collection of `filter` calls, as the logic seemed clearer that way (there's one item, and we're doing something different for each value it can take).

## Screenshots

The same as before, only with fewer errors from incorrect tags.

## How did you test this change?

- ran `yarn dev`
- opened some CSS pages and looked at the sidebar