### PR TITLE
fix(htmlattrxref macro): fix uri fragment for global attributes

### DIFF
--- a/kumascript/macros/htmlattrxref.ejs
+++ b/kumascript/macros/htmlattrxref.ejs
@@ -25,16 +25,16 @@ var text = ($2 && ($2!=undefined)) ? $2 : attrLC;
 let basePath;
 if ($1) {
     basePath = '/' + lang + '/docs/Web/HTML/Element/';
-    url = basePath + $1;
+    url = basePath + $1 + '#attr-' + attrLC;
 } else {
-    url = '/' + lang + '/docs/Web/HTML/' + globalAttrSlug;
+    url = '/' + lang + '/docs/Web/HTML/' + globalAttrSlug + '#' + attrLC;
 }
 
 if (!$3) {
   text = `<code>${text}</code>`;
 }
 
-const result = web.smartLink(`${url}#attr-${attrLC}`, null, text, $1, basePath);
+const result = web.smartLink(url, null, text, $1, basePath);
 
 %>
 <%- result %>


### PR DESCRIPTION
## Summary

Fixes #7349.

### Problem

The PR fixes the scroll position of links to global attributes. Currently the site is not loaded in the correct scroll position after clicking on a link to a global attribute, that was created by the htmlattrxref macro.


### Solution

Make the uri fragment generated by the htmlattrxref macro match the actual id on the global attributes page by removing the `attr-` prefix from the uri fragment.

---

### Before

![image](https://user-images.githubusercontent.com/5075175/196054467-cdabcb4e-4aa3-4261-8c44-2c32cae68895.png)

### After

![image](https://user-images.githubusercontent.com/5075175/196054510-f111237b-1c84-485d-9909-f878de88df8c.png)

---

## How did you test this change?

Since in local dev mode scroll position seems to be broken for all links containing uri fragments I had to test it by replacing 'localhost' with 'developer.mozilla.org' for the generated uri.
