### PR TITLE
chore(sidebar): add common questions overview menu

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -274,6 +274,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Part 7: Deploying to production',
     'Further_resources': 'Further resources',
     'Common_questions': 'Common questions',
+      'Common_questions_overview': 'Common questions overview',
       'HTML_questions': 'HTML questions',
       'CSS_questions': 'CSS questions',
       'JavaScript_questions': 'JavaScript questions',
@@ -530,6 +531,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Tutorial Rápido Parte 7: Implantando em produção',
     'Further_resources': 'Mais recursos',
     'Common_questions': 'Questões gerais',
+      'Common_questions_overview': 'Visão geral sobre Questões gerais',
       'HTML_questions': 'Questões sobre HTML',
       'CSS_questions': 'Questões sobre CSS',
       'JavaScript_questions': 'Questões sobre JavaScript',
@@ -794,6 +796,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Part 7: Deploying to to production',
     'Further_resources': 'Дальнейшее чтение',
     'Common_questions': 'Общие вопросы',
+      'Common_questions_overview': 'Общие вопросы',
       'HTML_questions': 'Вопросы по HTML',
       'CSS_questions': 'Вопросы по CSS',
       'JavaScript_questions': 'Вопросы по JavaScript',
@@ -1058,6 +1061,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express 教程 7： 部署至生产环境',
     'Further_resources': '更多资源',
     'Common_questions': '常见问题',
+      'Common_questions_overview': '常见问题概述',
       'HTML_questions': 'HTML 问题',
       'CSS_questions': 'CSS 问题',
       'Web_mechanics': 'Web 是如何运作的',
@@ -1319,6 +1323,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express 教學 7: 佈署到正式環境',
     'Further_resources': '更多資源',
     'Common_questions': '常見問題',
+      'Common_questions_overview': '常見問題概述',
       'HTML_questions': 'HTML 問題',
       'CSS_questions': 'CSS 問題',
       'Web_mechanics': 'Web 的運作方式',
@@ -1606,6 +1611,7 @@ var text = mdn.localStringMap({
         'Express_Tutorial_Part_7_Deploying_to_production' : 'Express Tutorial Part 7: Deploying to production',
     'Further_resources': 'Further resources',
     'Common_questions': 'Common questions',
+      'Common_questions_overview': '一般的な質問',
       'HTML_questions': 'HTML questions',
       'CSS_questions': 'CSS questions',
       'JavaScript_questions': 'JavaScript questions',
@@ -2068,6 +2074,7 @@ var text = mdn.localStringMap({
     <details <%=currentPageIsUnder('Common_questions')%>>
         <summary><%=text['Common_questions']%></summary>
         <ol>
+          <li><a href="<%=baseURL%>Common_questions"><%=text['Common_questions_overview']%></a></li>
           <li><a href="<%=baseURL%>HTML/Howto"><%=text['HTML_questions']%></a></li>
           <li><a href="<%=baseURL%>CSS/Howto"><%=text['CSS_questions']%></a></li>
           <li><a href="<%=baseURL%>JavaScript/Howto"><%=text['JavaScript_questions']%></a></li>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

There is no link to [Common questions](https://developer.mozilla.org/en-US/docs/Learn/Common_questions) in the Learn Sidebar.

### Problem

A link to the page of common questions is missing

### Solution

Add links for the Common question overview to existing sidebar.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![before](https://user-images.githubusercontent.com/6697081/196101213-c12b2355-c30b-4927-b591-3ce3b984fd4c.png)

### After

![after](https://user-images.githubusercontent.com/6697081/196101244-4b54e381-b555-4026-91ea-517ff90e9fa6.png)