### PR TITLE
MP-128: validate collections forms when submitting with return key

### DIFF
--- a/client/src/plus/collections/collection.tsx
+++ b/client/src/plus/collections/collection.tsx
@@ -233,13 +233,6 @@ function ItemEdit({
     setShow(false);
   };
 
-  const enterHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      saveHandler(e);
-    }
-  };
-
   return (
     <MDNModal
       isOpen={show}
@@ -270,7 +263,6 @@ function ItemEdit({
               name="title"
               value={formItem.title}
               onChange={changeHandler}
-              onKeyDown={enterHandler}
               autoComplete="off"
               type="text"
               required={true}
@@ -284,7 +276,6 @@ function ItemEdit({
               name="notes"
               value={formItem.notes}
               onChange={changeHandler}
-              onKeyDown={enterHandler}
               autoComplete="off"
               type="text"
               disabled={isPending}

--- a/client/src/plus/collections/new-edit-collection-modal.tsx
+++ b/client/src/plus/collections/new-edit-collection-modal.tsx
@@ -72,13 +72,6 @@ export default function NewEditCollectionModal({
     setShow(false);
   };
 
-  const enterHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      saveHandler(e);
-    }
-  };
-
   return (
     <MDNModal
       isOpen={show}
@@ -140,7 +133,6 @@ export default function NewEditCollectionModal({
                   name="name"
                   value={collection.name}
                   onChange={changeHandler}
-                  onKeyDown={enterHandler}
                   autoComplete="off"
                   type="text"
                   required={true}
@@ -154,7 +146,6 @@ export default function NewEditCollectionModal({
                   name="description"
                   value={collection.description}
                   onChange={changeHandler}
-                  onKeyDown={enterHandler}
                   autoComplete="off"
                   type="text"
                   disabled={isPending}

--- a/client/src/ui/organisms/article-actions/bookmark-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/bookmark-menu/index.tsx
@@ -132,13 +132,6 @@ export default function BookmarkV2Menu({ doc }: { doc: Doc }) {
     setShow(false);
   };
 
-  const enterHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      saveHandler(e);
-    }
-  };
-
   const deleteHandler = async (e: React.MouseEvent) => {
     e.preventDefault();
     if (!collections || isPending) return;
@@ -202,7 +195,11 @@ export default function BookmarkV2Menu({ doc }: { doc: Doc }) {
             }`}
             role="menu"
           >
-            <button onClick={cancelHandler} className="header mobile-only">
+            <button
+              onClick={cancelHandler}
+              type="button"
+              className="header mobile-only"
+            >
               <span className="header-inner">
                 <Icon name="chevron" />
                 {savedItems?.length ? "Edit Item" : "Add to Collection"}
@@ -265,7 +262,7 @@ export default function BookmarkV2Menu({ doc }: { doc: Doc }) {
                 autoComplete="off"
                 type="text"
                 onChange={changeHandler}
-                onKeyDown={enterHandler}
+                required={true}
                 disabled={isPending}
               />
             </div>
@@ -278,7 +275,6 @@ export default function BookmarkV2Menu({ doc }: { doc: Doc }) {
                 autoComplete="off"
                 value={formItem.notes}
                 onChange={changeHandler}
-                onKeyDown={enterHandler}
                 disabled={isPending}
               />
             </div>


### PR DESCRIPTION
this was causing the name/title field to not be validated as required,
and so showing an api error

also add `required` to item name in bookmark dropdown