### PR TITLE
fix(macros/HTMLSidebar): replace Documentation section by Guides section

### DIFF
--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -294,8 +294,11 @@ var text = mdn.localStringMap({
 
             for (const attr of attributes) {
               const name = attr.slug.split('/').pop();
+              const url = attr.url.replace('en-US', locale);
+              const subPath = `/${locale}/docs/Web/HTML/Attributes`;
+              const link = web.smartLink(url, null, name, subPath, null);
           %>
-              <li><a href="/en-US/docs/Web/HTML/Attributes/<%-name%>"><%-name%></a></li>
+              <li><%-link%></li>
           <%
             }
           %>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -43,7 +43,7 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML elements',
     'Global_attributes': 'Global attributes',
     'Input_types': '<code>&lt;input&gt;</code> types',
-    'Guides': 'Guides',
+    'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'Allowing cross-origin use of images and canvas',
       'Block-level_elements': 'Block-level elements',
       'Inline_elements': 'Inline elements',
@@ -84,7 +84,7 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'Éléments HTML',
     'Global_attributes': 'Attributs universels',
     'Input_types': 'Types <code>&lt;input&gt;</code>',
-    'Guides': 'Guides',
+    'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'Autoriser les images et canevas provenant d\'autres origines',
       'Block-level_elements': 'Éléments de bloc',
       'Inline_elements': 'Éléments en ligne',
@@ -125,7 +125,7 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'Elementos HTML',
     'Global_attributes': 'Atributos globais',
     'Input_types': 'Tipos de <code>&lt;input&gt;</code>',
-    'Guides': 'Guides',
+    'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'CORS habilitar imagens',
       'Block-level_elements': 'Elementos block-level',
       'Inline_elements': 'Elementos inline',
@@ -166,7 +166,7 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML элементы',
     'Global_attributes': 'Глобальные атрибуты',
     'Input_types': 'Типы <code>&lt;input&gt;</code>',
-    'Guides': 'путеводитель',
+    'Guides': 'Путеводитель:',
       'Allowing_cross-origin_images_and_canvas': 'Разрешение использования изображений из разных источников и canvas',
       'Block-level_elements': 'Блочные элементы',
       'Inline_elements': 'Строчные элементы',
@@ -207,7 +207,7 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML 元素',
     'Global_attributes': '全局属性',
     'Input_types': '<code>&lt;input&gt;</code> types',
-    'Guides': '指南',
+    'Guides': '指南：',
       'Allowing_cross-origin_images_and_canvas': '启用了 CORS 的图片',
       'Block-level_elements': '块级元素',
       'Inline_elements': '行内元素',
@@ -285,20 +285,18 @@ var text = mdn.localStringMap({
       <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Element/input'])%>
     </details>
   </li>
-  <li class="toggle">
-    <details <%=state('Guides')%>>
-      <summary><%-text['Guides']%></summary>
-      <ol>
-        <li><a href="/<%=locale%>/docs/Web/HTML/CORS_enabled_image"><%=text["Allowing_cross-origin_images_and_canvas"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Viewport_meta_tag"><%=text["Viewport_meta_tag"]%></a></li>
-      </ol>
-    </details>
+  <li><strong><%=text['Guides']%></strong></li>
+  <li>
+    <ol>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Viewport_meta_tag"><%=text["Viewport_meta_tag"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/CORS_enabled_image"><%=text["Allowing_cross-origin_images_and_canvas"]%></a></li>
+    </ol>
   </li>
  </ol>
 </section>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -287,7 +287,19 @@ var text = mdn.localStringMap({
   <li class="toggle">
     <details <%=state('Attributes')%>>
       <summary><%=text['Attributes']%></summary>
-        <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Attributes'])%>
+        <ol>
+          <%
+            const attributesRoot = await wiki.getPage("/en-US/docs/Web/HTML/Attributes");
+            const attributes = attributesRoot.subpages;
+
+            for (const attr of attributes) {
+              const name = attr.slug.split('/').pop();
+          %>
+              <li><a href="/en-US/docs/Web/HTML/Attributes/<%-name%>"><%-name%></a></li>
+          <%
+            }
+          %>
+        </ol>
     </details>
   </li>
   <li class="toggle">

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -42,6 +42,7 @@ var text = mdn.localStringMap({
     'Reference': 'References:',
     'HTML_Elements': 'HTML elements',
     'Global_attributes': 'Global attributes',
+    'Attributes': 'Attributes',
     'Input_types': '<code>&lt;input&gt;</code> types',
     'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'Allowing cross-origin use of images and canvas',
@@ -83,6 +84,7 @@ var text = mdn.localStringMap({
     'Reference': 'Références\xa0:',
     'HTML_Elements': 'Éléments HTML',
     'Global_attributes': 'Attributs universels',
+    'Attributes': 'Attributs',
     'Input_types': 'Types <code>&lt;input&gt;</code>',
     'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'Autoriser les images et canevas provenant d\'autres origines',
@@ -124,6 +126,7 @@ var text = mdn.localStringMap({
     'Reference': 'Referências:',
     'HTML_Elements': 'Elementos HTML',
     'Global_attributes': 'Atributos globais',
+    'Attributes': 'Atributos',
     'Input_types': 'Tipos de <code>&lt;input&gt;</code>',
     'Guides': 'Guides:',
       'Allowing_cross-origin_images_and_canvas': 'CORS habilitar imagens',
@@ -165,6 +168,7 @@ var text = mdn.localStringMap({
     'Reference': 'Справочники:',
     'HTML_Elements': 'HTML элементы',
     'Global_attributes': 'Глобальные атрибуты',
+    'Attributes': 'Aтрибуты',
     'Input_types': 'Типы <code>&lt;input&gt;</code>',
     'Guides': 'Путеводитель:',
       'Allowing_cross-origin_images_and_canvas': 'Разрешение использования изображений из разных источников и canvas',
@@ -206,6 +210,7 @@ var text = mdn.localStringMap({
     'Reference': '参考：',
     'HTML_Elements': 'HTML 元素',
     'Global_attributes': '全局属性',
+    'Attributes': '属性',
     'Input_types': '<code>&lt;input&gt;</code> types',
     'Guides': '指南：',
       'Allowing_cross-origin_images_and_canvas': '启用了 CORS 的图片',
@@ -277,6 +282,12 @@ var text = mdn.localStringMap({
     <details <%=state('Global_attributes')%>>
       <summary><%=text['Global_attributes']%></summary>
       <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Global_attributes'])%>
+    </details>
+  </li>
+  <li class="toggle">
+    <details <%=state('Attributes')%>>
+      <summary><%=text['Attributes']%></summary>
+        <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Attributes'])%>
     </details>
   </li>
   <li class="toggle">

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -43,11 +43,15 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML elements',
     'Global_attributes': 'Global attributes',
     'Input_types': '<code>&lt;input&gt;</code> types',
-    'Documentation': 'Documentation:',
-    'Useful_lists': 'Useful lists',
-    'Index': 'All pages index',
-    'Contribute': 'Contribute',
-    'The_MDN_project': 'The MDN project',
+    'Guides': 'Guides',
+      'Allowing_cross-origin_images_and_canvas': 'Allowing cross-origin use of images and canvas',
+      'Block-level_elements': 'Block-level elements',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
+      'Inline_elements': 'Inline elements',
+      'Microdata': 'Microdata',
+      'Microformats': 'Microformats',
+      'Quirks_Mode_and_Standards_Mode': 'Quirks Mode and Standards Mode',
+      'Viewport_meta_tag': 'Viewport meta tag',
   },
   'fr': {
     'Tutorials': 'Tutoriels\xa0:',
@@ -80,11 +84,15 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'Éléments HTML',
     'Global_attributes': 'Attributs universels',
     'Input_types': 'Types <code>&lt;input&gt;</code>',
-    'Documentation': 'Documentation\xa0:',
-    'Useful_lists': 'Listes utiles',
-    'Index': 'Index de toutes les pages',
-    'Contribute': 'Contribuer',
-    'The_MDN_project': 'Le projet MDN',
+    'Guides': 'Guides',
+      'Allowing_cross-origin_images_and_canvas': 'Autoriser les images et canevas provenant d\'autres origines',
+      'Block-level_elements': 'Éléments de bloc',
+      'Date_and_time_formats': 'Formats de date et d\'heure utilisés en HTML',
+      'Inline_elements': 'Éléments en ligne',
+      'Microdata': 'Microdonnées',
+      'microformats': 'Microformats',
+      'Quirks_Mode_and_Standards_Mode': 'Mode quirks et mode standard',
+      'Viewport_meta_tag': 'Utilisation de la balise meta viewport pour contrôler la mise en page sur mobile',
   },
   'pt-BR': {
     'Tutorials': 'Tutoriais:',
@@ -117,11 +125,15 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'Elementos HTML',
     'Global_attributes': 'Atributos globais',
     'Input_types': 'Tipos de <code>&lt;input&gt;</code>',
-    'Documentation': 'Documentação:',
-    'Useful_lists': 'Listas úteis',
-    'Index': 'Índice para todas as páginas',
-    'Contribute': 'Contribua!',
-    'The_MDN_project': 'O projeto MDN',
+    'Guides': 'Guides',
+      'Allowing_cross-origin_images_and_canvas': 'CORS habilitar imagens',
+      'Block-level_elements': 'Elementos block-level',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
+      'Inline_elements': 'Elementos inline',
+      'Microdata': 'Microdata',
+      'microformats': 'Microformatos',
+      'Quirks_Mode_and_Standards_Mode': 'Quirks Mode e Standards Mode',
+      'Viewport_meta_tag': 'Viewport meta tag',
   },
   'ru': {
     'Tutorials': 'Уроки:',
@@ -154,11 +166,15 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML элементы',
     'Global_attributes': 'Глобальные атрибуты',
     'Input_types': 'Типы <code>&lt;input&gt;</code>',
-    'Documentation': 'Документация:',
-    'Useful_lists': 'Полезные списки',
-    'Index': 'Индекс всех страниц',
-    'Contribute': 'Внести вклад',
-    'The_MDN_project': 'Проект MDN',
+    'Guides': 'путеводитель',
+      'Allowing_cross-origin_images_and_canvas': 'Разрешение использования изображений из разных источников и canvas',
+      'Block-level_elements': 'Блочные элементы',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
+      'Inline_elements': 'Строчные элементы',
+      'Microdata': 'Microdata',
+      'microformats': 'Microformats',
+      'Quirks_Mode_and_Standards_Mode': 'Режим совместимости (Quirks Mode) и стандартный режим (Standards Mode)',
+      'Viewport_meta_tag': 'Viewport meta tag',
   },
   'zh-CN': {
     'Tutorials': '教程',
@@ -191,11 +207,15 @@ var text = mdn.localStringMap({
     'HTML_Elements': 'HTML 元素',
     'Global_attributes': '全局属性',
     'Input_types': '<code>&lt;input&gt;</code> types',
-    'Documentation': '文档：',
-    'Useful_lists': '附表',
-    'Index': 'HTML 文档索引',
-    'Contribute': '贡献',
-    'The_MDN_project': 'MDN 项目',
+    'Guides': '指南',
+      'Allowing_cross-origin_images_and_canvas': '启用了 CORS 的图片',
+      'Block-level_elements': '块级元素',
+      'Date_and_time_formats': 'HTML 中使用的日期与时间格式',
+      'Inline_elements': '行内元素',
+      'Microdata': 'Microdata',
+      'microformats': 'Microformats',
+      'Quirks_Mode_and_Standards_Mode': '怪异模式和标准模式',
+      'Viewport_meta_tag': 'Viewport meta tag',
   },
 });
 %>
@@ -265,20 +285,18 @@ var text = mdn.localStringMap({
       <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/HTML/Element/input'])%>
     </details>
   </li>
-  <li><strong><a href="/<%=locale%>/docs/MDN"><%=text['Documentation']%></a></strong></li>
   <li class="toggle">
-    <details <%=state('Useful_lists')%>>
-      <summary><%=text['Useful_lists']%></summary>
+    <details <%=state('Guides')%>>
+      <summary><%-text['Guides']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Index"><%=text['Index']%></a></li>
-      </ol>
-    </details>
-  </li>
-  <li class="toggle">
-    <details <%=state('Contribute')%>>
-      <summary><%=text['Contribute']%></summary>
-      <ol>
-        <li><a href="/<%=locale%>/docs/MDN"><%=text['The_MDN_project']%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/CORS_enabled_image"><%=text["Allowing_cross-origin_images_and_canvas"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Viewport_meta_tag"><%=text["Viewport_meta_tag"]%></a></li>
       </ol>
     </details>
   </li>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -46,8 +46,8 @@ var text = mdn.localStringMap({
     'Guides': 'Guides',
       'Allowing_cross-origin_images_and_canvas': 'Allowing cross-origin use of images and canvas',
       'Block-level_elements': 'Block-level elements',
-      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Inline_elements': 'Inline elements',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Microdata': 'Microdata',
       'Microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': 'Quirks Mode and Standards Mode',
@@ -87,8 +87,8 @@ var text = mdn.localStringMap({
     'Guides': 'Guides',
       'Allowing_cross-origin_images_and_canvas': 'Autoriser les images et canevas provenant d\'autres origines',
       'Block-level_elements': 'Éléments de bloc',
-      'Date_and_time_formats': 'Formats de date et d\'heure utilisés en HTML',
       'Inline_elements': 'Éléments en ligne',
+      'Date_and_time_formats': 'Formats de date et d\'heure utilisés en HTML',
       'Microdata': 'Microdonnées',
       'microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': 'Mode quirks et mode standard',
@@ -128,8 +128,8 @@ var text = mdn.localStringMap({
     'Guides': 'Guides',
       'Allowing_cross-origin_images_and_canvas': 'CORS habilitar imagens',
       'Block-level_elements': 'Elementos block-level',
-      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Inline_elements': 'Elementos inline',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Microdata': 'Microdata',
       'microformats': 'Microformatos',
       'Quirks_Mode_and_Standards_Mode': 'Quirks Mode e Standards Mode',
@@ -169,8 +169,8 @@ var text = mdn.localStringMap({
     'Guides': 'путеводитель',
       'Allowing_cross-origin_images_and_canvas': 'Разрешение использования изображений из разных источников и canvas',
       'Block-level_elements': 'Блочные элементы',
-      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Inline_elements': 'Строчные элементы',
+      'Date_and_time_formats': 'Date and time formats used in HTML',
       'Microdata': 'Microdata',
       'microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': 'Режим совместимости (Quirks Mode) и стандартный режим (Standards Mode)',
@@ -210,8 +210,8 @@ var text = mdn.localStringMap({
     'Guides': '指南',
       'Allowing_cross-origin_images_and_canvas': '启用了 CORS 的图片',
       'Block-level_elements': '块级元素',
-      'Date_and_time_formats': 'HTML 中使用的日期与时间格式',
       'Inline_elements': '行内元素',
+      'Date_and_time_formats': 'HTML 中使用的日期与时间格式',
       'Microdata': 'Microdata',
       'microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': '怪异模式和标准模式',
@@ -291,8 +291,8 @@ var text = mdn.localStringMap({
       <ol>
         <li><a href="/<%=locale%>/docs/Web/HTML/CORS_enabled_image"><%=text["Allowing_cross-origin_images_and_canvas"]%></a></li>
         <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
         <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
         <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
         <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
         <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>

--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -47,6 +47,11 @@ const web = {
     return out.join("");
   },
 
+  // Creates a hyperlink for given document location(href).
+  // e.g /en-US/docs/Web/HTML/Attributes
+  //
+  // For translated content, if the document doesn't exist
+  // then hyperlink to corresponding en-US document is returned.
   smartLink(href, title, content, subpath, basepath, ignoreFlawMacro = null) {
     let flaw;
     let flawAttribute = "";


### PR DESCRIPTION
## Summary

Addresses https://github.com/mdn/content/pull/21617#issuecomment-1286240392

The PR:
- removes "Documentation" section
- adds a new "Guides" section to include miscellaneous pages under `mdn/content/files/en-us/web/html` directory
- adds localized text for links in the new "Guides" section, iff the page has been translated

### Problem

There are two sidebar macros for HTML pages at the moment: `HTMLSidebar` and `HTMLRef`. And some pages are not included in any of the macros. Also, `HTMLRef` macro doesn't add extra content compared to `HTMLSidebar`.

### Solution

Make `HTMLSidebar` complete and use it everywhere. Then deprecate `HTMLRef` macro.

## Screenshots

### Before

https://web.archive.org/web/20221019094528/https://developer.mozilla.org/en-US/docs/Web/HTML

### After

![HTMLSidebar](https://user-images.githubusercontent.com/87750369/197164595-0cad8e36-7426-4de2-bde0-bcefb9bdc12b.png)

## How did you test this change?

In local dev environment.

/cc @teoli2003 , @wbamberg , @caugner 