### PR TITLE
chore(macros/LearnSidebar): translate Client-side_tooling_overview in Japanese

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1520,7 +1520,7 @@ var text = mdn.localStringMap({
         'Git_and_GitHub_overview' : 'Git and GitHub overview',
       'Client-side_web_development_tools' : 'クライアントサイドウェブ開発ツール',
         'Client-side_web_development_tools_index' : 'クライアントサイドウェブ開発ツールの理解',
-        'Client-side_tooling_overview' : 'Client-side tooling overview',
+        'Client-side_tooling_overview' : 'クライアントサイドツールの概要',
         'Command_line_crash_course' : 'Command line crash course',
         'Package_management_basics' : 'Package management basics',
         'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',


### PR DESCRIPTION
## Summary

@schalkneethling @caugner 
cc @hmatrjp @potappo 
- [Client-side tooling overview の翻訳 #651 ](https://github.com/mozilla-japan/translation/issues/651)  のPRです。
- [ feat(translate): Client-side tooling overview の翻訳 #9442 ](https://github.com/mdn/translated-content/pull/9442)

### Problem
still en-us only

### Solution

tranlate japanese for LearnSidebar.ejs


### Before

still en-us only

### After

add tranlate japanese for LearnSidebar.ejs


