### PR TITLE
fix(build): sync broken-links flaw with web.smartLink()

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -61,8 +61,6 @@ function mutateLink(
     $element.attr("href", suggestion);
   } else if (enUSFallback) {
     $element.attr("href", enUSFallback);
-    // This functionality here should match what we do inside
-    // the `web.smartLink()` function in kumascript rendering.
     $element.append(` <small>(${DEFAULT_LOCALE})<small>`);
     $element.addClass("only-in-en-us");
     $element.attr("title", "Currently only available in English (US)");

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -63,7 +63,7 @@ function mutateLink(
     $element.attr("href", enUSFallback);
     // This functionality here should match what we do inside
     // the `web.smartLink()` function in kumascript rendering.
-    $element.text(`${$element.text()} (${DEFAULT_LOCALE})`);
+    $element.append(` <small>(${DEFAULT_LOCALE})<small>`);
     $element.addClass("only-in-en-us");
     $element.attr("title", "Currently only available in English (US)");
   } else {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5269 by syncing the fallback-link behavior of the broken-links flaw with `web.smartLink()`.

### Problem

Yari automatically replaces links to missing translated pages to their English counter-part, adding a "(en-US)" inside the link, but this was discarding formatting of the link text.

### Solution

Sync the implementation of the broken-link flaw that does this for inline links, with the implementation of `web.smartLink()` which is used by macros and already did this correctly.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="730" alt="image" src="https://user-images.githubusercontent.com/495429/197862145-61e371f7-8038-4313-83e7-96e820c5d971.png">


### After

<img width="730" alt="image" src="https://user-images.githubusercontent.com/495429/197862202-3af5fec5-f614-412e-9763-ab7734216a3a.png">

---

## How did you test this change?

Locally added a missing inline-link in the Spanish locale [here](http://localhost:3000/es/docs/Web/JavaScript/Reference/Global_Objects#propiedades_de_valor).
