### PR TITLE
chore(macros/CSSRef): add Combinator pages

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -764,6 +764,7 @@ const standardPages = pageList.filter(page => !hasTag(page, "Non-standard"));
 const groups = [];
 let properties = [];
 const selectors = [];
+const combinators = [];
 const pseudoClasses = [];
 const pseudoElements = [];
 const atRules = [];
@@ -780,6 +781,9 @@ for (const page of standardPages) {
       break;
     case "css-selector":
       selectors.push(page);
+      break;
+    case "css-combinator":
+      combinators.push(page);
       break;
     case "css-pseudo-class":
       pseudoClasses.push(page);
@@ -934,6 +938,7 @@ function buildSublist(pages, title) {
   <%-buildSublist(groups, 'Modules');%>
   <%-buildSublist(properties, 'Properties');%>
   <%-buildSublist(selectors, 'Selectors');%>
+  <%-buildSublist(combinators, 'Combinators');%>
   <%-buildSublist(pseudoClasses, 'Pseudo-classes');%>
   <%-buildSublist(pseudoElements, 'Pseudo-elements');%>
   <%-buildSublist(atRules, 'At-rules');%>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/7437 by adding combinators to the CSS sidebar.

### Problem

See https://github.com/mdn/yari/issues/7437.

### Solution

Adds combinators to CSS sidebar.

---

## Screenshots

### Before

![Screen Shot 2022-10-26 at 10 59 10 AM](https://user-images.githubusercontent.com/432915/198104760-a436bd8a-0eb3-42b7-9317-6285aa6a1d36.png)

### After

en-US:

![Screen Shot 2022-10-26 at 10 58 50 AM](https://user-images.githubusercontent.com/432915/198104830-84fd335a-79a0-498f-a17f-c66d66f3de45.png)

fr (Note that titles are not translated due to https://github.com/mdn/yari/issues/7438.):

![Screen Shot 2022-10-26 at 10 58 22 AM](https://user-images.githubusercontent.com/432915/198104873-dba0a25a-404f-4a58-8fa8-94fa642dcb71.png)

## How did you test this change?

Ran yarn dev, looked at some pages.
