### PR TITLE
feat(sidebar): scroll to the current page

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -9,10 +9,6 @@
     display: none;
   }
 
-  .sidebar-content {
-    overflow: scroll;
-  }
-
   // apply drawer styles only to the sizes that need them.
   @media screen and (max-width: #{$screen-md - 1}) {
     height: 100vh;

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -100,7 +100,6 @@
     hyphens: auto;
     padding: 0.25rem;
     padding-left: 0.5rem;
-    scroll-margin-top: 30vh;
     width: 100%;
   }
 

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -9,6 +9,10 @@
     display: none;
   }
 
+  .sidebar-content {
+    overflow: scroll;
+  }
+
   // apply drawer styles only to the sizes that need them.
   @media screen and (max-width: #{$screen-md - 1}) {
     height: 100vh;
@@ -96,6 +100,7 @@
     hyphens: auto;
     padding: 0.25rem;
     padding-left: 0.5rem;
+    scroll-margin-top: 30vh;
     width: 100%;
   }
 

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -29,8 +29,13 @@ export function SidebarContainer({ doc, children }) {
   }, [isSidebarOpen]);
 
   useEffect(() => {
-    const currentSidebarItem = document.querySelector(".sidebar-content em");
-    currentSidebarItem?.scrollIntoView();
+    const sidebar = document.querySelector(".sidebar");
+    const currentSidebarItem = sidebar?.querySelector("em");
+    if (sidebar && currentSidebarItem) {
+      sidebar.scrollTo({
+        top: currentSidebarItem.offsetTop - window.innerHeight / 3,
+      });
+    }
   }, [isSidebarOpen]);
 
   return (

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -65,7 +65,6 @@ export function RenderSideBar({ doc }) {
           <>
             <h4 className="sidebar-heading">Related Topics</h4>
             <div
-              className="sidebar-content"
               dangerouslySetInnerHTML={{
                 __html: `${doc.sidebarHTML}`,
               }}

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -31,7 +31,7 @@ export function SidebarContainer({ doc, children }) {
   useEffect(() => {
     const currentSidebarItem = document.querySelector(".sidebar-content em");
     currentSidebarItem?.scrollIntoView();
-  }, []);
+  }, [isSidebarOpen]);
 
   return (
     <>

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -32,9 +32,11 @@ export function SidebarContainer({ doc, children }) {
     const sidebar = document.querySelector("#sidebar-quicklinks");
     const currentSidebarItem = sidebar?.querySelector("em");
     if (sidebar && currentSidebarItem) {
-      [sidebar, sidebar.querySelector(".sidebar-inner")].forEach(n => n?.scrollTo({
-        top: currentSidebarItem.offsetTop - window.innerHeight / 3,
-      }));
+      [sidebar, sidebar.querySelector(".sidebar-inner")].forEach((n) =>
+        n?.scrollTo({
+          top: currentSidebarItem.offsetTop - window.innerHeight / 3,
+        })
+      );
     }
   }, []);
 

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -28,6 +28,11 @@ export function SidebarContainer({ doc, children }) {
     }
   }, [isSidebarOpen]);
 
+  useEffect(() => {
+    const currentSidebarItem = document.querySelector(".sidebar-content em");
+    currentSidebarItem?.scrollIntoView();
+  }, []);
+
   return (
     <>
       <nav id="sidebar-quicklinks" className={classes}>
@@ -55,6 +60,7 @@ export function RenderSideBar({ doc }) {
           <>
             <h4 className="sidebar-heading">Related Topics</h4>
             <div
+              className="sidebar-content"
               dangerouslySetInnerHTML={{
                 __html: `${doc.sidebarHTML}`,
               }}

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -29,14 +29,14 @@ export function SidebarContainer({ doc, children }) {
   }, [isSidebarOpen]);
 
   useEffect(() => {
-    const sidebar = document.querySelector(".sidebar");
+    const sidebar = document.querySelector("#sidebar-quicklinks");
     const currentSidebarItem = sidebar?.querySelector("em");
     if (sidebar && currentSidebarItem) {
-      sidebar.scrollTo({
+      [sidebar, sidebar.querySelector(".sidebar-inner")].forEach(n => n?.scrollTo({
         top: currentSidebarItem.offsetTop - window.innerHeight / 3,
-      });
+      }));
     }
-  }, [isSidebarOpen]);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary

Make the sidebar scroll to the entry for the currently open page

### Problem

Although the sidebar is manually scrollable, it doesn't auto-scroll to show the entry you are currently on.

### Solution

I don't entirely know what I'm doing here so I may be off in the weeds, but I thought it was worth a go, since this would be a great feature to have.

I've just added a bit of React code to scroll the current item into view when the page loads...I think.

It doesn't quite work because the main content area scrolls a bit too. I think somehow the sidebar isn't accounting for the header, and that is making it happen? Would love some help with that.

## Screenshots

### Before

![sidebar-scroll-before](https://user-images.githubusercontent.com/432915/198498570-d7853b72-95c9-4b0d-856e-46ba443fdf80.gif)

### After

![sidebar-scroll-after](https://user-images.githubusercontent.com/432915/198498593-f11532dd-fd8c-42d3-af02-d1180660bb29.gif)


## How did you test this change?

...ran yarn dev, loaded some pages...