### PR TITLE
Expand all collapsible sidebar sections, not just the closest

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -47,7 +47,7 @@ export function extractSidebar($: cheerio.CheerioAPI, doc: Partial<Doc>) {
 
   // Open menu and highlight current page.
   search.find(`a[href='${doc.mdn_url}']`).each((_i, el) => {
-    $(el).closest("details").prop("open", true);
+    $(el).parents("details").prop("open", true);
     $(el).attr("aria-current", "page");
     // Highlight, unless it already is highlighted (e.g. heading).
     if ($(el).find("em,strong").length === 0) {


### PR DESCRIPTION

## Summary

Expand all sidebar sections, not just the closest.

### Problem

If a sidebar has collapsible sections, we expand the one containing the link to the current page. But we only expand the closest one, so if the sidebar has nested collapsible sections, then the current-page link is still not visible.

I don't know if we have nested collapsible sections in any sidebars at the moment, but https://github.com/mdn/yari/pull/7441 proposes a sidebar design that has some.

### Solution

Use [`parents()`](https://api.jquery.com/parents/) instead of [`closest()`](https://api.jquery.com/closest/) to find elements to expand.


