### PR TITLE
fix(bcd): Allow check for __compat on objects that don't inherit from Object

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -36,8 +36,7 @@ function findFirstCompatDepth(identifier: BCD.Identifier) {
 
   while (entries.length) {
     const [path, value] = entries.shift() as [string, BCD.Identifier];
-
-    if (value.hasOwnProperty("__compat")) {
+    if (value.__compat) {
       // Following entries have at least this depth.
       return path.split(".").length;
     }


### PR DESCRIPTION
## Summary

Fixes #7466

### Problem

See https://stackoverflow.com/questions/53978067/hasownproperty-is-not-a-function-in-node-js/53978289#53978289.

### Solution

Use the simpler value.__compat

---

## How did you test this change?

Tested on dev site
