### PR TITLE
fix(plus): remove always-displayed scrollbars on article action dropdowns

### DIFF
--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -18,7 +18,7 @@
   .article-actions-submenu {
     --gutter-padding: 1rem;
     display: none;
-    overflow: scroll;
+    overflow: auto;
 
     &.show {
       background: var(--background-primary);


### PR DESCRIPTION
in Chromium Linux, before:

![Screenshot from 2022-11-02 17-38-48](https://user-images.githubusercontent.com/755354/199563188-bb98f597-a82b-4888-9415-f83ab15ffecb.png)

after:

![Screenshot from 2022-11-02 17-39-07](https://user-images.githubusercontent.com/755354/199563218-c9d9e2f2-f69c-4a2b-bd3c-925787d7f9f7.png)
