### PR TITLE
Fix BCD rendering when added is "true" and removed is truthy

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -151,7 +151,7 @@ const CellText = React.memo(
         status = { isSupported: "unknown" };
         break;
       case true:
-        status = { isSupported: "yes" };
+        status = { isSupported: removed ? "no" : "yes" };
         break;
       case false:
         status = { isSupported: "no" };


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/mdn/browser-compat-data/issues/18139.  During #5679, some logic was accidentally removed that handles the case for when `version_added` is `true` and `version_removed` is truthy.  This adds such logic back in.