### PR TITLE
enchance(build): write metadata.json with hashes and browser compat

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -246,15 +246,16 @@ async function buildDocuments(
     delete builtDocument.toc;
 
     const hash = crypto.createHash("sha256").update(docString).digest("hex");
-    const metadata: DocMetadata = { ...builtDocument, hash };
+    const builtMetadata: DocMetadata = { ...builtDocument, hash };
+
     fs.writeFileSync(
       path.join(outPath, "metadata.json"),
-      JSON.stringify(metadata)
+      JSON.stringify(builtMetadata)
     );
-    if (metadata[document.metadata.locale]) {
-      metadata[document.metadata.locale].push(metadata);
+    if (builtMetadata[document.metadata.locale]) {
+      builtMetadata[document.metadata.locale].push(builtMetadata);
     } else {
-      metadata[document.metadata.locale] = [metadata];
+      builtMetadata[document.metadata.locale] = [builtMetadata];
     }
 
     if (!options.noProgressbar) {

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -241,21 +241,23 @@ async function buildDocuments(
       searchIndex.add(document);
     }
 
-    delete builtDocument.body;
-    delete builtDocument.sidebarHTML;
-    delete builtDocument.toc;
-
     const hash = crypto.createHash("sha256").update(docString).digest("hex");
-    const builtMetadata: DocMetadata = { ...builtDocument, hash };
+    const {
+      body: _,
+      toc: __,
+      sidebarHTML: ___,
+      ...builtMetadata
+    } = builtDocument;
+    builtMetadata.hash = hash;
 
     fs.writeFileSync(
       path.join(outPath, "metadata.json"),
       JSON.stringify(builtMetadata)
     );
-    if (builtMetadata[document.metadata.locale]) {
-      builtMetadata[document.metadata.locale].push(builtMetadata);
+    if (metadata[document.metadata.locale]) {
+      metadata[document.metadata.locale].push(builtMetadata);
     } else {
-      builtMetadata[document.metadata.locale] = [builtMetadata];
+      metadata[document.metadata.locale] = [builtMetadata];
     }
 
     if (!options.noProgressbar) {

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -16,7 +16,7 @@ import { VALID_LOCALES } from "../libs/constants";
 import { renderHTML } from "../ssr/dist/main";
 import options from "./build-options";
 import { buildDocument, BuiltDocument, renderContributorsTxt } from ".";
-import { Flaws } from "../libs/types";
+import { DocMetadata, Flaws } from "../libs/types";
 import * as bcd from "@mdn/browser-compat-data/types";
 import SearchIndex from "./search-index";
 import { BUILD_OUT_ROOT } from "../libs/env";
@@ -246,7 +246,7 @@ async function buildDocuments(
     delete builtDocument.toc;
 
     const hash = crypto.createHash("sha256").update(docString).digest("hex");
-    const metadata = { ...builtDocument, hash };
+    const metadata: DocMetadata = { ...builtDocument, hash };
     fs.writeFileSync(
       path.join(outPath, "metadata.json"),
       JSON.stringify(metadata)

--- a/build/index.ts
+++ b/build/index.ts
@@ -474,6 +474,7 @@ export async function buildDocument(
   doc.mdn_url = document.url;
   doc.locale = metadata.locale as string;
   doc.native = LANGUAGES.get(doc.locale.toLowerCase())?.native;
+  doc.browserCompat = metadata["browser-compat"];
 
   // If the document contains <math> HTML, it will set `doc.hasMathML=true`.
   // The client (<Document/> component) needs to know this for loading polyfills.

--- a/build/index.ts
+++ b/build/index.ts
@@ -474,7 +474,11 @@ export async function buildDocument(
   doc.mdn_url = document.url;
   doc.locale = metadata.locale as string;
   doc.native = LANGUAGES.get(doc.locale.toLowerCase())?.native;
-  doc.browserCompat = metadata["browser-compat"];
+  const browserCompat = metadata["browser-compat"];
+  doc.browserCompat =
+    browserCompat && Array.isArray(browserCompat)
+      ? browserCompat
+      : [browserCompat];
 
   // If the document contains <math> HTML, it will set `doc.hasMathML=true`.
   // The client (<Document/> component) needs to know this for loading polyfills.

--- a/build/index.ts
+++ b/build/index.ts
@@ -476,9 +476,8 @@ export async function buildDocument(
   doc.native = LANGUAGES.get(doc.locale.toLowerCase())?.native;
   const browserCompat = metadata["browser-compat"];
   doc.browserCompat =
-    browserCompat && Array.isArray(browserCompat)
-      ? browserCompat
-      : [browserCompat];
+    browserCompat &&
+    (Array.isArray(browserCompat) ? browserCompat : [browserCompat]);
 
   // If the document contains <math> HTML, it will set `doc.hasMathML=true`.
   // The client (<Document/> component) needs to know this for loading polyfills.

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -132,16 +132,13 @@ export type Toc = {
   sub?: boolean;
 };
 
-export interface Doc {
+export interface DocMetadata {
   title: string;
   locale: string;
   native: string;
   pageTitle: string;
   mdn_url: string;
   related_content: any[];
-  sidebarHTML: string;
-  toc: Toc[];
-  body: Section[];
   modified: string;
   flaws: Flaws;
   other_translations?: Translation[];
@@ -158,6 +155,13 @@ export interface Doc {
   popularity?: number;
   noIndexing?: boolean;
   browserCompat?: string[];
+  hash?: string;
+}
+
+export interface Doc extends DocMetadata {
+  sidebarHTML: string;
+  toc: Toc[];
+  body: Section[];
 }
 
 export interface DocFrontmatter {

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -157,6 +157,7 @@ export interface Doc {
   // Used for search.
   popularity?: number;
   noIndexing?: boolean;
+  browserCompat?: string[];
 }
 
 export interface DocFrontmatter {

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -151,8 +151,7 @@ export interface DocMetadata {
   hasMathML?: boolean;
   isMarkdown: boolean;
   summary: string;
-  // Used for search.
-  popularity?: number;
+  popularity?: number; // Used for search.
   noIndexing?: boolean;
   browserCompat?: string[];
   hash?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -316,14 +316,12 @@ app.get("/*", async (req, res, ...args) => {
     res.json({ doc: document });
   } else if (isMetadata) {
     const docString = JSON.stringify({ doc: document });
-    delete document.body;
-    delete document.sidebarHTML;
-    delete document.toc;
 
     const hash = crypto.createHash("sha256").update(docString).digest("hex");
-    const metadata = { ...document, hash };
+    const { body: _, toc: __, sidebarHTML: ___, ...builtMetadata } = document;
+    builtMetadata.hash = hash;
 
-    res.json(metadata);
+    res.json(builtMetadata);
   } else if (isJSONRequest) {
     // TODO: what's this for?
     res.json({ doc: document });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 
@@ -242,6 +243,8 @@ app.get("/*", async (req, res, ...args) => {
   let lookupURL = decodeURI(req.path);
   let extraSuffix = "";
   let bcdDataURL = "";
+  let isMetadata = false;
+  let isDocument = false;
   const bcdDataURLRegex = /\/(bcd-\d+|bcd)\.json$/;
 
   if (req.path.endsWith("index.json")) {
@@ -251,7 +254,12 @@ app.get("/*", async (req, res, ...args) => {
     // and that won't be found in getRedirectUrl() since that doesn't
     // index things with the '/index.json' suffix. So we need to
     // temporarily remove it and remember to but it back when we're done.
+    isDocument = true;
     extraSuffix = "/index.json";
+    lookupURL = lookupURL.replace(extraSuffix, "");
+  } else if (req.path.endsWith("metadata.json")) {
+    isMetadata = true;
+    extraSuffix = "/metadata.json";
     lookupURL = lookupURL.replace(extraSuffix, "");
   } else if (bcdDataURLRegex.test(req.path)) {
     bcdDataURL = req.path;
@@ -304,7 +312,20 @@ app.get("/*", async (req, res, ...args) => {
     );
   }
 
-  if (isJSONRequest) {
+  if (isDocument) {
+    res.json({ doc: document });
+  } else if (isMetadata) {
+    const docString = JSON.stringify({ doc: document });
+    delete document.body;
+    delete document.sidebarHTML;
+    delete document.toc;
+
+    const hash = crypto.createHash("sha256").update(docString).digest("hex");
+    const metadata = { ...document, hash };
+
+    res.json(metadata);
+  } else if (isJSONRequest) {
+    // TODO: what's this for?
     res.json({ doc: document });
   } else {
     res.header("Content-Security-Policy", CSP_VALUE);


### PR DESCRIPTION
## Summary

Adds a `metadata.json` per locale. This contains the sha256sum of all `index.json`s, too. This will be used to sync metadata with rumba in the future.