### PR TITLE
Always use latest series version of spec when using series nightly URL

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -651,7 +651,9 @@ function _addSingleSpecialSection(
             specURL.startsWith(spec.url) ||
             specURL.startsWith(spec.nightly.url) ||
             spec.nightly.alternateUrls.some((s) => specURL.startsWith(s)) ||
-            specURL.startsWith(spec.series.nightlyUrl)
+            // When grabbing series nightly, make sure we're grabbing the latest spec version
+            (spec.shortname === spec.series.currentSpecification &&
+              specURL.startsWith(spec.series.nightlyUrl))
         );
         const specificationsData = {
           bcdSpecificationURL: specURL,


### PR DESCRIPTION
This PR fixes https://github.com/mdn/content/issues/22061 by adding some logic to ensure that when there is a match for the series nightly URL, it will always grab the latest version of the series.

Testing Method:
Navigated to http://localhost:3000/en-US/docs/Web/SVG/Attribute/orient and ensured that the specifications section shows "SVG 2" instead of "SVG 1.1 (Second Edition)".
