### PR TITLE
fix(pwa): don't start the service worker if offline is disabled

### DIFF
--- a/client/pwa/src/db.ts
+++ b/client/pwa/src/db.ts
@@ -8,7 +8,6 @@ import Dexie from "dexie";
 export enum SwType {
   PreferOnline = "PreferOnline",
   PreferOffline = "PreferOffline",
-  ApiOnly = "ApiOnly",
 }
 
 export interface PlusSettings {

--- a/client/src/plus/collections-quicksearch.ts
+++ b/client/src/plus/collections-quicksearch.ts
@@ -43,7 +43,7 @@ function setCollectionItemsUpdatedDate(updated: Date) {
 export async function getCollectionItems(
   remoteUpdated?: null | Date
 ): Promise<CollectionItem[]> {
-  remoteUpdated && fetchAllCollectionsItems(remoteUpdated);
+  remoteUpdated && (await fetchAllCollectionsItems(remoteUpdated));
   if (collectionItems) {
     return collectionItems;
   }

--- a/client/src/plus/collections-quicksearch.ts
+++ b/client/src/plus/collections-quicksearch.ts
@@ -1,6 +1,8 @@
 const COLLECTION_ITEMS_KEY = "collection-items";
 const COLLECTION_ITEMS_UPDATED_DATE_KEY = "collection-items-updated-date";
 
+let collectionItems: CollectionItem[] | null = null;
+
 type CollectionItem = {
   id: number;
   title: string;
@@ -38,22 +40,27 @@ function setCollectionItemsUpdatedDate(updated: Date) {
   }
 }
 
-export function getCollectionItems(): CollectionItem[] {
+export async function getCollectionItems(
+  remoteUpdated?: null | Date
+): Promise<CollectionItem[]> {
+  remoteUpdated && fetchAllCollectionsItems(remoteUpdated);
+  if (collectionItems) {
+    return collectionItems;
+  }
+
   let collectionItemString;
   try {
     collectionItemString = window?.localStorage?.getItem(COLLECTION_ITEMS_KEY);
   } catch (err) {
     console.warn("Unable to read collection items from localStorage", err);
   }
-  return JSON.parse(collectionItemString || "[]");
+  collectionItems = JSON.parse(collectionItemString || "[]");
+  return collectionItems || [];
 }
 
 function setCollectionItems(items: CollectionItem[]) {
   try {
     window?.localStorage?.setItem(COLLECTION_ITEMS_KEY, JSON.stringify(items));
-    if (Number.isFinite(window?.mdnWorker?.mutationCounter)) {
-      window.mdnWorker.mutationCounter++;
-    }
   } catch (err) {
     console.warn("Unable to write collection items to localStorage", err);
   }
@@ -66,31 +73,6 @@ export async function fetchAllCollectionsItems(remoteUpdated: null | Date) {
     const { items = [] } = await res.json();
     setCollectionItems(items);
     setCollectionItemsUpdatedDate(remoteUpdated || new Date());
+    collectionItems = items;
   }
-}
-
-export function addCollectionItem({ id, title, url }: CollectionItem) {
-  const items = getCollectionItems();
-  items.push({
-    id,
-    title,
-    url,
-  });
-  setCollectionItems(items);
-}
-
-export function updateCollectionItem({ id, title }: CollectionItem) {
-  const items = getCollectionItems();
-  const index = items.findIndex((item) => item.id === id);
-  items[index].title = title;
-  setCollectionItems(items);
-}
-
-export function removeCollectionItem({ id }: CollectionItem) {
-  const items = getCollectionItems();
-  const index = items.findIndex((item) => item.id === id);
-  if (index >= 0) {
-    items.splice(index, 1);
-  }
-  setCollectionItems(items);
 }

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -92,7 +92,12 @@ function useSearchIndex(): readonly [
       });
     };
     gather();
-  }, [shouldInitialize, data, user?.settings?.colInSearch]);
+  }, [
+    shouldInitialize,
+    data,
+    user?.settings?.colInSearch,
+    user?.settings?.collectionLastModified,
+  ]);
 
   return useMemo(
     () => [searchIndex, error || null, () => setShouldInitialize(true)],

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -65,7 +65,9 @@ function useSearchIndex(): readonly [
     const gather = async () => {
       const collection: Item[] = [];
       if (user?.settings?.colInSearch) {
-        const all = getCollectionItems();
+        const all = await getCollectionItems(
+          user?.settings?.collectionLastModified
+        );
         collection.push(
           ...all.map((item) => {
             return { ...item, collection: true };
@@ -90,12 +92,7 @@ function useSearchIndex(): readonly [
       });
     };
     gather();
-  }, [
-    shouldInitialize,
-    data,
-    user?.settings?.colInSearch,
-    user?.mdnWorker?.mutationCounter,
-  ]);
+  }, [shouldInitialize, data, user?.settings?.colInSearch]);
 
   return useMemo(
     () => [searchIndex, error || null, () => setShouldInitialize(true)],

--- a/client/src/settings/db.ts
+++ b/client/src/settings/db.ts
@@ -8,7 +8,6 @@ import Dexie from "dexie";
 export enum SwType {
   PreferOnline = "PreferOnline",
   PreferOffline = "PreferOffline",
-  ApiOnly = "ApiOnly",
 }
 
 export interface PlusSettings {

--- a/client/src/settings/mdn-worker.tsx
+++ b/client/src/settings/mdn-worker.tsx
@@ -58,7 +58,7 @@ export class MDNWorker {
   }
 
   swName(type: SwType | null | undefined = null) {
-    return `/service-worker.js?type=${type ?? SwType.PreferOffline}`;
+    return `/service-worker.js?type=${type ?? SwType.PreferOnline}`;
   }
 
   registerMessageHandler() {
@@ -112,7 +112,7 @@ export class MDNWorker {
   }
 
   async setOfflineSettings(
-    settingsData: OfflineSettingsData
+    settingsData: Partial<OfflineSettingsData>
   ): Promise<OfflineSettingsData> {
     const current = this.offlineSettings();
 
@@ -146,13 +146,8 @@ export class MDNWorker {
       this.autoUpdate();
     }
 
-    const settings = { ...current, ...settingsData };
-    try {
-      window.localStorage.setItem("MDNSettings", JSON.stringify(settings));
-    } catch (err) {
-      console.warn("Unable to write settings to localStorage", err);
-    }
-    this.settings = new OfflineSettingsData(settings);
+    this.settings = new OfflineSettingsData({ ...current, ...settingsData });
+    this.settings.write();
     return this.settings;
   }
 

--- a/client/src/settings/mdn-worker.tsx
+++ b/client/src/settings/mdn-worker.tsx
@@ -1,30 +1,17 @@
+import { OfflineSettingsData } from "../user-context";
 import { getContentStatus, SwType, offlineDb } from "./db";
 
-export class SettingsData {
-  offline?: boolean;
-  preferOnline?: boolean;
-  autoUpdates?: boolean;
-
-  constructor() {
-    this.offline = false;
-    this.preferOnline = false;
-    this.autoUpdates = false;
-  }
-}
-
 export class MDNWorker {
-  settings: SettingsData;
+  settings: OfflineSettingsData;
   registered: boolean;
   timeout?: ReturnType<typeof setTimeout> | null;
   keepAlive: ReturnType<typeof setInterval> | null;
-  mutationCounter: number;
 
   constructor() {
     this.settings = this.offlineSettings();
     this.registered = false;
     this.timeout = null;
     this.keepAlive = null;
-    this.mutationCounter = 0;
 
     if (this.settings.autoUpdates) {
       this.autoUpdate();
@@ -34,7 +21,7 @@ export class MDNWorker {
         this.settings.preferOnline ? SwType.PreferOnline : SwType.PreferOffline
       );
     } else {
-      this.enableServiceWorker(SwType.ApiOnly);
+      this.disableServiceWorker();
     }
   }
 
@@ -50,9 +37,6 @@ export class MDNWorker {
 
   messageHandler(event) {
     switch (event.data.type) {
-      case "mutate":
-        this.mutationCounter++;
-        break;
       case "pong":
         console.log("pong");
         break;
@@ -74,7 +58,7 @@ export class MDNWorker {
   }
 
   swName(type: SwType | null | undefined = null) {
-    return `/service-worker.js?type=${type ?? SwType.ApiOnly}`;
+    return `/service-worker.js?type=${type ?? SwType.PreferOffline}`;
   }
 
   registerMessageHandler() {
@@ -123,20 +107,13 @@ export class MDNWorker {
     return await getContentStatus();
   }
 
-  offlineSettings(): SettingsData {
-    let settingsData: SettingsData | null = null;
-    try {
-      settingsData = JSON.parse(
-        window.localStorage.getItem("MDNSettings") || "null"
-      );
-    } catch (err) {
-      console.warn("Unable to read settings from localStorage", err);
-    }
-
-    return settingsData ?? new SettingsData();
+  offlineSettings(): OfflineSettingsData {
+    return OfflineSettingsData.read();
   }
 
-  async setOfflineSettings(settingsData: SettingsData): Promise<SettingsData> {
+  async setOfflineSettings(
+    settingsData: OfflineSettingsData
+  ): Promise<OfflineSettingsData> {
     const current = this.offlineSettings();
 
     if (!current.offline && settingsData.offline) {
@@ -157,7 +134,6 @@ export class MDNWorker {
     }
     if (current.offline && settingsData.offline === false) {
       await this.disableServiceWorker();
-      await this.enableServiceWorker(SwType.ApiOnly);
     }
 
     if (settingsData.autoUpdates === false && this.timeout) {
@@ -176,12 +152,12 @@ export class MDNWorker {
     } catch (err) {
       console.warn("Unable to write settings to localStorage", err);
     }
-    this.settings = settings;
-    return settings;
+    this.settings = new OfflineSettingsData(settings);
+    return this.settings;
   }
 
   async clearOfflineSettings() {
-    await this.setOfflineSettings(new SettingsData());
+    await this.setOfflineSettings(new OfflineSettingsData());
   }
 
   async clear() {

--- a/client/src/settings/offline-settings.tsx
+++ b/client/src/settings/offline-settings.tsx
@@ -1,5 +1,5 @@
 import { Switch } from "../ui/atoms/switch";
-import { SettingsData, getMDNWorker } from "./mdn-worker";
+import { getMDNWorker } from "./mdn-worker";
 import useInterval from "@use-it/interval";
 
 import { useEffect, useRef, useState } from "react";
@@ -8,7 +8,7 @@ import ClearButton from "./clear";
 import { Spinner } from "../ui/atoms/spinner";
 import { MDN_PLUS_TITLE } from "../constants";
 import { ContentStatus, ContentStatusPhase } from "./db";
-import { useUserData } from "../user-context";
+import { OfflineSettingsData, useUserData } from "../user-context";
 import { useLocale } from "../hooks";
 import {
   TOGGLE_PLUS_OFFLINE_DISABLED,
@@ -58,7 +58,7 @@ function Settings() {
   const [saving, setSaving] = useState<boolean>(true);
 
   const [estimate, setEstimate] = useState<StorageEstimate | null>(null);
-  const [settings, setSettings] = useState<SettingsData>();
+  const [settings, setSettings] = useState<OfflineSettingsData>();
   // Workaround to avoid "Error: Too many re-renders." (https://github.com/mdn/yari/pull/5744).
   const updateTriggered = useRef(false);
   const gleanClick = useGleanClick();
@@ -98,7 +98,7 @@ function Settings() {
     }
   }, [status?.phase]);
 
-  const updateSettings = async (change: SettingsData) => {
+  const updateSettings = async (change: OfflineSettingsData) => {
     setSaving(true);
     const mdnWorker = getMDNWorker();
     let newSettings = await mdnWorker.setOfflineSettings(change);

--- a/client/src/settings/offline-settings.tsx
+++ b/client/src/settings/offline-settings.tsx
@@ -98,7 +98,7 @@ function Settings() {
     }
   }, [status?.phase]);
 
-  const updateSettings = async (change: OfflineSettingsData) => {
+  const updateSettings = async (change: Partial<OfflineSettingsData>) => {
     setSaving(true);
     const mdnWorker = getMDNWorker();
     let newSettings = await mdnWorker.setOfflineSettings(change);

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -3,7 +3,6 @@ import useSWR from "swr";
 
 import { DISABLE_AUTH, DEFAULT_GEO_COUNTRY } from "./env";
 import { fetchAllCollectionsItems } from "./plus/collections-quicksearch";
-import { MDNWorker } from "./settings/mdn-worker";
 
 export enum SubscriptionType {
   MDN_CORE = "core",
@@ -37,7 +36,7 @@ export class OfflineSettingsData {
     let settingsData: OfflineSettingsData | undefined;
     try {
       settingsData = JSON.parse(
-        window.localStorage.getItem("MDNSettings") || "null"
+        window.localStorage.getItem("MDNSettings") || "{}"
       );
     } catch (err) {
       console.warn("Unable to read settings from localStorage", err);
@@ -137,10 +136,10 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
       }
       const data = await response.json();
       const collectionLastModified =
-        data.settings?.collections_last_modified_time;
-      const settings: UserPlusSettings | null = data.settings
+        data?.settings?.collections_last_modified_time;
+      const settings: UserPlusSettings | null = data?.settings
         ? {
-            colInSearch: data.settings.col_in_search || false,
+            colInSearch: data?.settings?.col_in_search || false,
             collectionLastModified:
               (collectionLastModified && new Date(collectionLastModified)) ||
               null,

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -44,6 +44,14 @@ export class OfflineSettingsData {
 
     return new OfflineSettingsData(settingsData);
   }
+
+  write() {
+    try {
+      window.localStorage.setItem("MDNSettings", JSON.stringify(this));
+    } catch (err) {
+      console.warn("Unable to write settings to localStorage", err);
+    }
+  }
 }
 
 export type UserData = {

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -18,9 +18,9 @@ export type UserPlusSettings = {
 };
 
 export class OfflineSettingsData {
-  offline?: boolean;
-  preferOnline?: boolean;
-  autoUpdates?: boolean;
+  offline: boolean;
+  preferOnline: boolean;
+  autoUpdates: boolean;
 
   constructor({
     offline = false,


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

The service worker runs for all logged in users. Let's run it only for users which have MDN offline enabled.

### Problem

We need the service only for MDN Offline these days. But we run it for all logged in users and it sometimes causes random request failures.

### Solution

- disable the service worker if MDN Offline is disabled
- refactor after removing code

---

