### PR TITLE
fix: require optional dependencies conditionally

### DIFF
--- a/content/utils.ts
+++ b/content/utils.ts
@@ -1,8 +1,6 @@
 import path from "path";
 import childProcess from "child_process";
-
 import LRU from "lru-cache";
-import prettier from "prettier";
 
 import { CONTENT_ROOT, CONTENT_TRANSLATED_ROOT } from "../libs/env";
 import { slugToFolder as _slugToFolder } from "../libs/slug-utils";
@@ -107,7 +105,8 @@ export function execGit(args, opts: { cwd?: string } = {}, root = null) {
 export function toPrettyJSON(value) {
   const json = JSON.stringify(value, null, 2) + "\n";
   try {
-    return prettier.format(json, { parser: "json" });
+    // eslint-disable-next-line n/no-unpublished-require
+    return require("prettier").format(json, { parser: "json" });
   } catch (e) {
     return json;
   }

--- a/server/dev.ts
+++ b/server/dev.ts
@@ -1,11 +1,13 @@
-import webpack from "webpack";
-import webpackDevMiddleware from "webpack-dev-middleware";
-import webpackHotMiddleware from "webpack-hot-middleware";
-import { WebpackConfiguration } from "webpack-dev-server";
+import type { WebpackConfiguration } from "webpack-dev-server";
 
 export const devMiddlewares = [];
 
 if (process.env.NODE_ENV === "development") {
+  /* eslint-disable n/no-unpublished-require */
+  const webpack = require("webpack");
+  const webpackDevMiddleware = require("webpack-dev-middleware");
+  const webpackHotMiddleware = require("webpack-hot-middleware");
+
   const webpackConfig: WebpackConfiguration = {
     entry: {
       app: [


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Should fix the failing check when bumping yari in mdn/content https://github.com/mdn/content/pull/22218.

### Problem

https://github.com/mdn/yari/pull/7430 changed the way we import dependencies by moving from `require` to `import`, and `import` statements cannot be imported _conditionally_, because they must appear at the top of the file. However, when `import`ing (or `require`ing) an optional dependency (e.g. a `devDepencency`) _unconditionally_, this will cause an error.

Specifically, we `require` prettier and webpack, which are available when developing yari, but not when using yari as part of mdn/content.

PS: ESLint actually complains about this via the `n/no-unpublished-import` rule, but we don't currently run ESLint on TypeScript until https://github.com/mdn/yari/pull/7454 lands and that PR has that rule disabled.

### Solution

When using (dev) dependencies, use a conditional `require` instead of `import`.

PS: Migrating to ESM would allow us to use `await import("webpack")` instead, but we're not there yet.

---

## Screenshots

n/a

---

## How did you test this change?

Relying on tests.
