### PR TITLE
fix(css): line-clamp on webkit showing black in gradient

### DIFF
--- a/client/src/ui/_mixins.scss
+++ b/client/src/ui/_mixins.scss
@@ -22,10 +22,11 @@
   position: relative;
 
   &::after {
-    background: linear-gradient(to right, transparent, $background-color 75%);
+    background: $background-color;
     content: "";
     display: block;
     height: calc(1em * $line-height);
+    mask-image: linear-gradient(to right, transparent, #000 75%);
     pointer-events: none;
     position: absolute;
     right: 0;
@@ -35,8 +36,8 @@
 
   &:dir(rtl) {
     &::after {
-      background: linear-gradient(to left, transparent, $background-color 75%);
       left: 0;
+      mask-image: linear-gradient(to left, transparent, #000 75%);
       right: initial;
     }
   }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Webkit shows a black band in the line-clamp gradient - this is actually correct according to the spec, as it defines `transparent` as "transparent black".

### Solution

Use a `mask-image` with the gradient in it instead, where we can use a gradient from transparent black to black for all background colours (turning a css variable transparent isn't yet a supported css feature).

Though I wonder if it's worth just going back to the `-webkit-line-clamp` property which we used before (and I didn't like). It's imperfect, but so is this approach. It's also far less code:

```scss
@mixin line-clamp($lines) {
  display: -webkit-box;
  -webkit-box-orient: vertical;
  -webkit-line-clamp: $lines;
  overflow: hidden;
}
```
---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![screenshot](https://user-images.githubusercontent.com/755354/201351497-1630fd33-7bb1-42b0-b6df-8cac2cfb873d.png)

### After

![screenshot](https://user-images.githubusercontent.com/755354/201351582-477abdfb-8daa-4bcf-9850-50b630a1d786.png)


---

## How did you test this change?

Tested across Firefox/Chromium/GNOME Web across dark/light themes on `http://localhost:3000/en-US/_homepage`.