### PR TITLE
chore(bug-report): replace "Paste" with "Attach"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,3 @@
-
 name: "\U0001F41E Bug report"
 description: Report a frontend bug on MDN Web Docs.
 labels:
@@ -109,8 +108,6 @@ body:
       label: Screenshot
       description: Please always add a screenshot or (even better) a screen recording to help us understand the problem.
       placeholder: Attach screenshot or screen recording here.
-    validations:
-      required: false
   - type: textarea
     attributes:
       label: Anything else?

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -107,7 +107,9 @@ body:
     attributes:
       label: Screenshot
       description: Please always add a screenshot or (even better) a screen recording to help us understand the problem.
-      placeholder: Paste screenshot or screen recording here.
+      placeholder: Attach screenshot or screen recording here.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: Anything else?

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
----
+
 name: "\U0001F41E Bug report"
 description: Report a frontend bug on MDN Web Docs.
 labels:
@@ -110,7 +110,7 @@ body:
       description: Please always add a screenshot or (even better) a screen recording to help us understand the problem.
       placeholder: Attach screenshot or screen recording here.
     validations:
-      required: true
+      required: false
   - type: textarea
     attributes:
       label: Anything else?

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,4 @@
+---
 name: "\U0001F41E Bug report"
 description: Report a frontend bug on MDN Web Docs.
 labels:


### PR DESCRIPTION
I replace 'Paste' with 'Attach' word as it sounds good in code line 110 and add validations 'true' in code line 111

<!--
  Thanks for taking the time to submit a pull request (PR)!
 

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
I make two changes:
1. I change word 'paste' with 'attach' in code line 110 as that section is for screenshot.
2. I add validations in code line 111 and required as true in code line 112 as it mentioned there 
'Please always add a screenshot or (even better) a screen recording to help us understand the problem.' in description
<!--
  Please reference the issue you're solving here.
  Example: Change code line 110, and add code line 111, code line 112
-->

### Problem
Screenshot is not a required option till now and 'paste' doesn't look good for a screenshot.
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->
It make screenshot compulsory to attach and word 'attach' looks good to read.
### Solution

by adding validations and required as either true or false according to the issue found.
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->
---
My PR will make it compulsory to add a screenshot and makes the to understand problem more clear.


---
