### PR TITLE
Deduplicate JS sidebar entries

### DIFF
--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -61,7 +61,6 @@ var text = mdn.localStringMap({
     'Enumerability':'Enumerability and ownership of properties',
     'Data_types': 'Data types and data structures',
     'Iteration_protocols': 'Iteration protocols',
-    'Transitioning_to_strict_mode': 'Transitioning to strict mode',
     'Template_strings': 'Template literals',
     'Trailing_commas': 'Trailing commas',
     'Deprecated_features': 'Deprecated features',
@@ -117,7 +116,6 @@ var text = mdn.localStringMap({
     'Enumerability':'Перечисляемость и принадлежность свойств',
     'Data_types': 'Типы и структуры данных',
     'Iteration_protocols': 'Протоколы перебора',
-    'Transitioning_to_strict_mode': 'Переход в строгий режим',
     'Template_strings': 'Шаблонные строки',
     'Trailing_commas': 'Висящие запятые',
     'Deprecated_features': 'Устаревшие возможности',
@@ -173,7 +171,6 @@ var text = mdn.localStringMap({
     'Enumerability': 'Rattachement des propriétés',
     'Data_types': 'Types et structures de données',
     'Iteration_protocols': 'Protocoles d\'itération',
-    'Transitioning_to_strict_mode': 'Passer au mode strict',
     'Template_strings': 'Gabarits de chaînes de caractères',
     'Trailing_commas': 'Virgules finales',
     'Deprecated_features': 'Fonctionnalités dépréciées',
@@ -229,7 +226,6 @@ var text = mdn.localStringMap({
     'Enumerability':'属性的可枚举性和所有权',
     'Data_types': '数据类型和数据解构',
     'Iteration_protocols': '迭代协议',
-    'Transitioning_to_strict_mode': '切换到严格模式',
     'Template_strings': '模板字符串',
     'Trailing_commas': '尾后逗号',
     'Deprecated_features': '已废弃的特性',
@@ -285,7 +281,6 @@ var text = mdn.localStringMap({
     'Enumerability': 'プロパティの列挙可能性と所有権',
     'Data_types': 'データ型とデータ構造',
     'Iteration_protocols': '反復処理プロトコル',
-    'Transitioning_to_strict_mode': 'strict モードへの移行',
     'Template_strings': 'テンプレート文字列',
     'Trailing_commas': '末尾のカンマ',
     'Deprecated_features': '廃止予定の機能',
@@ -341,7 +336,6 @@ var text = mdn.localStringMap({
     'Enumerability':'Enumerabilidade e domínio de propriedades',
     'Data_types': 'Tipos de dados e estruturas de dados',
     'Iteration_protocols': 'Protocolos de iteração',
-    'Transitioning_to_strict_mode': 'Migrando para o "strict mode"',
     'Template_strings': 'Template literals',
     'Trailing_commas': 'Trailing commas',
     'Deprecated_features': 'Funcionalidades depreciadas',
@@ -396,6 +390,7 @@ var text = mdn.localStringMap({
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Language_overview"><%=text['Language_overview']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Data_structures"><%=text['Data_structures']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Equality_comparisons_and_sameness"><%=text['Equality']%></a></li>
+        <li><a href="/<%=locale%>/docs/Web/JavaScript/Enumerability_and_ownership_of_properties"><%=text['Enumerability']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Closures"><%=text['Closures']%></a></li>
       </ol>
     </details>
@@ -405,7 +400,6 @@ var text = mdn.localStringMap({
       <summary><%=text['Advanced']%></summary>
       <ol>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Inheritance_and_the_prototype_chain"><%=text['Inheritance']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Strict_mode"><%=text['Strict_mode']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Typed_arrays"><%=text['Typed_arrays']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Memory_Management"><%=text['Memory_Management']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/EventLoop"><%=text['Event_Loop']%></a></li>
@@ -455,11 +449,8 @@ var text = mdn.localStringMap({
       <ol>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/JavaScript_technologies_overview"><%=text['Overview']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Lexical_grammar"><%=text['Lexical_grammar']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Data_structures"><%=text['Data_structures']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Enumerability_and_ownership_of_properties"><%=text['Enumerability']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Iteration_protocols"><%=text['Iteration_protocols']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Strict_mode"><%=text['Strict_mode']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode"><%=text['Transitioning_to_strict_mode']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Template_literals"><%=text['Template_strings']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Trailing_commas"><%=text['Trailing_commas']%></a></li>
         <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features"><%=text['Deprecated_features']%></a></li>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

There are some entries that are duplicated between the "Tutorials" and "References" sections, which IMO is unnecessary. I figured it's best to keep the "References" part strictly to those pages with `/Reference/` in its slug.

Also removed an entry that points to a nonexistent page (`Transitioning_to_strict_mode` has been merged into `Strict_mode`).

cc @mdn/yari-content-javascript 