### PR TITLE
fix(footer): update Creative Common license link

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -225,7 +225,7 @@ export function Footer() {
             <br />
             Portions of this content are ©1998–{new Date().getFullYear()} by
             individual mozilla.org contributors. Content available under{" "}
-            <a href="/docs/MDN/Writing_guidelines/Attrib_copyright_license">
+            <a href={`/${locale}/docs/MDN/Writing_guidelines/Attrib_copyright_license`}>
               a Creative Commons license
             </a>
             .

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -225,7 +225,7 @@ export function Footer() {
             <br />
             Portions of this content are ©1998–{new Date().getFullYear()} by
             individual mozilla.org contributors. Content available under{" "}
-            <a href="/docs/MDN/About#Copyrights_and_licenses">
+            <a href="/docs/MDN/Writing_guidelines/Attrib_copyright_license">
               a Creative Commons license
             </a>
             .

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -225,7 +225,9 @@ export function Footer() {
             <br />
             Portions of this content are ©1998–{new Date().getFullYear()} by
             individual mozilla.org contributors. Content available under{" "}
-            <a href={`/${locale}/docs/MDN/Writing_guidelines/Attrib_copyright_license`}>
+            <a
+              href={`/${locale}/docs/MDN/Writing_guidelines/Attrib_copyright_license`}
+            >
               a Creative Commons license
             </a>
             .


### PR DESCRIPTION
The link links to the wrong page that does not contain information about the Creative Commons license. I make a correction by changing href attribute to /docs/MDN/Writing_guidelines/Attribu_copyright_license now the link redirects us to https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license.

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Changing the URL link of the creative commons license as the link attached with it didn't provide information about the creative commons license.

Fixes #6036.

### Problem
The link is not linked to the creative commons license it is linked to the page that describes rules for writing guidelines.
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->
This makes visitors easy to find the creative commons licenses page and helps them to know more about it without navigating other pages.
### Solution
Changing the link in href attribute to /docs/MDN/Writing_guidelines/Attrib_copyright_license
