### PR TITLE
fix(tables): wrap in figure.table-container, not div.table-scroll

### DIFF
--- a/build/wrap-tables.ts
+++ b/build/wrap-tables.ts
@@ -1,7 +1,7 @@
 // Wraps tables in a scrollable div to avoid overlapping with the TOC sidebar.
 // Before: <table>...</table>
-// After: <div class="table-scroll"><table>...</table></div>
+// After: <div class="table-container"><table>...</table></div>
 export function wrapTables($) {
-  const div = $('<div class="table-scroll"></div>');
+  const div = $('<div class="table-container"></div>');
   $("table").wrap(div);
 }

--- a/build/wrap-tables.ts
+++ b/build/wrap-tables.ts
@@ -1,7 +1,7 @@
-// Wraps tables in a scrollable div to avoid overlapping with the TOC sidebar.
+// Wraps tables in a scrollable figure to avoid overlapping with the TOC sidebar.
 // Before: <table>...</table>
-// After: <div class="table-container"><table>...</table></div>
+// After: <figure class="table-container"><table>...</table></figure>
 export function wrapTables($) {
-  const div = $('<div class="table-container"></div>');
-  $("table").wrap(div);
+  const figure = $('<figure class="table-container"></figure>');
+  $("table").wrap(figure);
 }

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop-md.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop-md.scss
@@ -1,5 +1,5 @@
 @media screen and (min-width: $screen-md) {
-  .table-scroll {
+  .table-container {
     width: calc(100% + 6rem);
   }
 

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
@@ -1,10 +1,10 @@
 @media screen and (min-width: $screen-xl) {
-  .table-scroll {
+  .table-container {
     margin: 0;
     width: 100%;
   }
 
-  .table-scroll-inner {
+  .table-container-inner {
     padding: 0;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop.scss
@@ -32,13 +32,13 @@
     }
   }
 
-  .table-scroll {
+  .table-container {
     margin: 0 -3rem;
     overflow: auto;
     width: 100vw;
   }
 
-  .table-scroll-inner {
+  .table-container-inner {
     min-width: max-content;
     padding: 0 3rem;
     position: relative;

--- a/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
@@ -25,7 +25,7 @@
     }
   }
 
-  .table-scroll {
+  .table-container {
     overflow-x: auto;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -171,8 +171,8 @@ export default function BrowserCompatibilityTable({
         >
           Report problems with this compatibility data on GitHub
         </a>
-        <div className="table-container">
-          <div className="table-container-inner">
+        <figure className="table-container">
+          <figure className="table-container-inner">
             <table key="bc-table" className="bc-table bc-table-web">
               <Headers {...{ platforms, browsers }} />
               <tbody>
@@ -183,8 +183,8 @@ export default function BrowserCompatibilityTable({
                 />
               </tbody>
             </table>
-          </div>
-        </div>
+          </figure>
+        </figure>
         <Legend compat={data} name={name} />
 
         {/* https://github.com/mdn/yari/issues/1191 */}

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -171,8 +171,8 @@ export default function BrowserCompatibilityTable({
         >
           Report problems with this compatibility data on GitHub
         </a>
-        <div className="table-scroll">
-          <div className="table-scroll-inner">
+        <div className="table-container">
+          <div className="table-container-inner">
             <table key="bc-table" className="bc-table bc-table-web">
               <Headers {...{ platforms, browsers }} />
               <tbody>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/5358 by wrapping tables in a `<figure>` with a CSS class doesn't contain the keyword `scroll`.

### Problem

Firefox Reader View was not showing our tables, which were wrapped in a `div.table-scroll` to make them horizontally scrollable (when overflowing, especially for long tables and on mobile).

### Solution

Wrap them in a `figure.table-container` instead.

---

## Screenshots

### Before

(https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)
<img width="728" alt="image" src="https://user-images.githubusercontent.com/495429/201975550-eb59cef9-4051-4f9d-b4ba-5723aa98074f.png">


### After


<img width="728" alt="image" src="https://user-images.githubusercontent.com/495429/201975638-874102b2-5fa0-4351-b15f-b6db99c6c025.png">

---

## How did you test this change?

Opened http://localhost:5042/en-US/docs/Web/HTTP/Headers/WWW-Authenticate locally in Firefox Reader Mode.

**Note**: Firefox Reader Mode is not available on http://localhost:3000/, because it parses the site without JavaScript (i.e. requires SSR, which is only available on port 5042).