### PR TITLE
chore(tool/add-redirect): accept URLs with origin

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -277,7 +277,8 @@ program
   .argument("<to>", "To-URL")
   .action(
     tryOrExit(({ args, logger }: AddRedirectActionParameters) => {
-      const { from, to } = args;
+      const from = new URL(args.from).pathname;
+      const to = new URL(args.to).pathname;
       const locale = from.split("/")[1];
       Redirect.add(locale, [[from, to]]);
       logger.info(chalk.green(`Saved '${from}' → '${to}'`));


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes #4106.

### Problem

`yarn tool add-redirect` expects its arguments `from` and `to` to be absolute URLs without origin, (e.g. `/en-US/docs/...`) and providing a URL with origin (e.g. `https://developer.mozilla.org/en-US/docs/...`) does not work.

### Solution

Accept any URL and just use their `pathname`.

---

## Screenshots

<img width="878" alt="image" src="https://user-images.githubusercontent.com/495429/202022373-402d11b5-0148-41da-8bf8-ce3144c9cc63.png">

---

## How did you test this change?

Ran `yarn tool add-redirect https://developer.mozilla.org/en-US/docs/Foo https://developer.mozilla.org/en-US/docs/Bar`.
