### PR TITLE
fix(bcd): show previous version in range when feature was removed

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -4,6 +4,7 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getCurrentSupport,
+  getPreviousVersion,
   hasMore,
   hasNoteworthyNotes,
   isFullySupportedWithoutLimitation,
@@ -135,7 +136,10 @@ const CellText = React.memo(
     const currentSupport = getCurrentSupport(support);
 
     const added = currentSupport?.version_added ?? null;
-    const removed = currentSupport?.version_removed ?? null;
+    const removed = getPreviousVersion(
+      currentSupport?.version_removed ?? null,
+      browser
+    );
 
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
     const supportClassName = getSupportClassName(support, browser);

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -191,3 +191,20 @@ export function getCurrentSupport(
   // Default (likely never reached)
   return getFirst(support);
 }
+
+export function getPreviousVersion(
+  version: BCD.VersionValue | string | undefined,
+  browser: BCD.BrowserStatement
+): BCD.VersionValue | string | undefined {
+  if (browser && typeof version === "string") {
+    const browserVersions = Object.keys(browser["releases"]).sort(
+      (a, b) => Number(a) - Number(b)
+    );
+    const currentVersionIndex = browserVersions.indexOf(version);
+    if (currentVersionIndex && currentVersionIndex > 0) {
+      return browserVersions[currentVersionIndex - 1];
+    }
+  }
+
+  return version;
+}

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -1,3 +1,5 @@
+import { compareVersions } from "compare-versions";
+
 import type BCD from "@mdn/browser-compat-data/types";
 
 // Extended for the fields, beyond the bcd types, that are extra-added
@@ -198,7 +200,7 @@ export function getPreviousVersion(
 ): BCD.VersionValue | string | undefined {
   if (browser && typeof version === "string") {
     const browserVersions = Object.keys(browser["releases"]).sort(
-      (a, b) => Number(a) - Number(b)
+      compareVersions
     );
     const currentVersionIndex = browserVersions.indexOf(version);
     if (currentVersionIndex && currentVersionIndex > 0) {

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -195,15 +195,15 @@ export function getCurrentSupport(
 }
 
 export function getPreviousVersion(
-  version: BCD.VersionValue | string | undefined,
+  version: BCD.VersionValue,
   browser: BCD.BrowserStatement
-): BCD.VersionValue | string | undefined {
+): BCD.VersionValue {
   if (browser && typeof version === "string") {
     const browserVersions = Object.keys(browser["releases"]).sort(
       compareVersions
     );
     const currentVersionIndex = browserVersions.indexOf(version);
-    if (currentVersionIndex && currentVersionIndex > 0) {
+    if (currentVersionIndex > 0) {
       return browserVersions[currentVersionIndex - 1];
     }
   }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.12",
     "cli-progress": "^3.11.2",
+    "compare-versions": "^5.0.1",
     "compression": "^1.7.4",
     "cookie": "^0.5.0",
     "cookie-parser": "^1.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3971,6 +3971,11 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
+compare-versions@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.1.tgz#14c6008436d994c3787aba38d4087fabe858555e"
+  integrity sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==
+
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"


### PR DESCRIPTION
## Summary

Fixes #6667

### Problem

The version range showed the version where support was removed as well, which was confusing.

### Solution

Get version before that version using a helper function, and show that version number instead.

---

## Screenshots

### Before

https://developer.mozilla.org/en-US/docs/Web/API/DocumentType#browser_compatibility

![Screenshot from 2022-11-16 11-59-04](https://user-images.githubusercontent.com/29206584/202244847-4a5cc0e6-0639-467a-9bfb-299277145cdf.png)

### After

http://localhost:3000/en-US/docs/Web/API/DocumentType#browser_compatibility

![Screenshot from 2022-11-16 11-50-41](https://user-images.githubusercontent.com/29206584/202243642-1f354d5e-a04c-4299-a615-56e73a519fbb.png)

