### PR TITLE
fix(bcd): Fix version range in production

### DIFF
--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -14,7 +14,7 @@ import web from "../kumascript/src/api/web";
 interface SimpleSupportStatementWithReleaseDate
   extends bcd.SimpleSupportStatement {
   release_date?: string;
-  version_supported_last?: string;
+  version_last?: string;
 }
 
 type SectionsAndFlaws = [Section[], string[]];
@@ -465,23 +465,15 @@ function _addSingleSpecialSection(
           : [originalInfo];
 
         for (const infoEntry of infos) {
-          const added =
-            typeof infoEntry.version_added === "string" &&
-            infoEntry.version_added.startsWith("≤")
-              ? infoEntry.version_added.slice(1)
-              : infoEntry.version_added;
-          const removed =
-            typeof infoEntry.version_removed === "string" &&
-            infoEntry.version_removed.startsWith("≤")
-              ? infoEntry.version_removed.slice(1)
-              : infoEntry.version_removed;
+          const added = _normalizeVersion(infoEntry.version_added);
+          const removed = _normalizeVersion(infoEntry.version_removed);
           if (browserReleaseData.has(browser)) {
             if (browserReleaseData.get(browser).has(added)) {
               infoEntry.release_date = browserReleaseData
                 .get(browser)
                 .get(added).release_date;
               if (typeof removed === "string") {
-                infoEntry.version_supported_last = _getPreviousVersion(
+                infoEntry.version_last = _getPreviousVersion(
                   removed,
                   browsers[browser]
                 );
@@ -533,6 +525,12 @@ function _addSingleSpecialSection(
     }
 
     return version;
+  }
+
+  function _normalizeVersion(version: bcd.VersionValue): bcd.VersionValue {
+    return typeof version === "string" && version.startsWith("≤")
+      ? version.slice(1)
+      : version;
   }
 
   function _getFirstVersion(support: bcd.SimpleSupportStatement): string {

--- a/build/document-extractor.ts
+++ b/build/document-extractor.ts
@@ -14,7 +14,7 @@ import web from "../kumascript/src/api/web";
 interface SimpleSupportStatementWithReleaseDate
   extends bcd.SimpleSupportStatement {
   release_date?: string;
-  version_last?: string;
+  version_last?: bcd.VersionValue;
 }
 
 type SectionsAndFlaws = [Section[], string[]];
@@ -472,12 +472,10 @@ function _addSingleSpecialSection(
               infoEntry.release_date = browserReleaseData
                 .get(browser)
                 .get(added).release_date;
-              if (typeof removed === "string") {
-                infoEntry.version_last = _getPreviousVersion(
-                  removed,
-                  browsers[browser]
-                );
-              }
+              infoEntry.version_last = _getPreviousVersion(
+                removed,
+                browsers[browser]
+              );
             }
           }
         }
@@ -511,10 +509,10 @@ function _addSingleSpecialSection(
   }
 
   function _getPreviousVersion(
-    version: string,
+    version: bcd.VersionValue,
     browser: bcd.BrowserStatement
-  ): string {
-    if (browser) {
+  ): bcd.VersionValue {
+    if (browser && typeof version === "string") {
       const browserVersions = Object.keys(browser["releases"]).sort(
         _compareVersions
       );

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -4,7 +4,6 @@ import { BrowserInfoContext } from "./browser-info";
 import {
   asList,
   getCurrentSupport,
-  getPreviousVersion,
   hasMore,
   hasNoteworthyNotes,
   isFullySupportedWithoutLimitation,
@@ -136,10 +135,7 @@ const CellText = React.memo(
     const currentSupport = getCurrentSupport(support);
 
     const added = currentSupport?.version_added ?? null;
-    const removed = getPreviousVersion(
-      currentSupport?.version_removed ?? null,
-      browser
-    );
+    const lastSupport = currentSupport?.version_supported_last ?? null;
 
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
     const supportClassName = getSupportClassName(support, browser);
@@ -155,7 +151,7 @@ const CellText = React.memo(
         status = { isSupported: "unknown" };
         break;
       case true:
-        status = { isSupported: removed ? "no" : "yes" };
+        status = { isSupported: lastSupport ? "no" : "yes" };
         break;
       case false:
         status = { isSupported: "no" };
@@ -166,7 +162,7 @@ const CellText = React.memo(
       default:
         status = {
           isSupported: supportClassName,
-          label: versionLabelFromSupport(added, removed, browser),
+          label: versionLabelFromSupport(added, lastSupport, browser),
         };
         break;
     }

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -135,7 +135,7 @@ const CellText = React.memo(
     const currentSupport = getCurrentSupport(support);
 
     const added = currentSupport?.version_added ?? null;
-    const lastSupport = currentSupport?.version_supported_last ?? null;
+    const lastVersion = currentSupport?.version_last ?? null;
 
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
     const supportClassName = getSupportClassName(support, browser);
@@ -151,7 +151,7 @@ const CellText = React.memo(
         status = { isSupported: "unknown" };
         break;
       case true:
-        status = { isSupported: lastSupport ? "no" : "yes" };
+        status = { isSupported: lastVersion ? "no" : "yes" };
         break;
       case false:
         status = { isSupported: "no" };
@@ -162,7 +162,7 @@ const CellText = React.memo(
       default:
         status = {
           isSupported: supportClassName,
-          label: versionLabelFromSupport(added, lastSupport, browser),
+          label: versionLabelFromSupport(added, lastVersion, browser),
         };
         break;
     }

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -7,8 +7,8 @@ interface SimpleSupportStatementExtended extends BCD.SimpleSupportStatement {
   // as opposed to just "true" and if the version release date is known.
   release_date?: string;
   // The version before the version_removed if the *version* removed is known,
-  // as opposed to just "true".
-  version_last?: string;
+  // as opposed to just "true". Otherwise the version_removed.
+  version_last?: BCD.VersionValue;
 }
 
 export type SupportStatementExtended =

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -8,7 +8,7 @@ interface SimpleSupportStatementExtended extends BCD.SimpleSupportStatement {
   release_date?: string;
   // The version before the version_removed if the *version* removed is known,
   // as opposed to just "true".
-  version_supported_last?: string;
+  version_last?: string;
 }
 
 export type SupportStatementExtended =

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -1,5 +1,3 @@
-import { compareVersions } from "compare-versions";
-
 import type BCD from "@mdn/browser-compat-data/types";
 
 // Extended for the fields, beyond the bcd types, that are extra-added
@@ -8,6 +6,9 @@ interface SimpleSupportStatementExtended extends BCD.SimpleSupportStatement {
   // Known for some support statements where the browser *version* is known,
   // as opposed to just "true" and if the version release date is known.
   release_date?: string;
+  // The version before the version_removed if the *version* removed is known,
+  // as opposed to just "true".
+  version_supported_last?: string;
 }
 
 export type SupportStatementExtended =
@@ -192,21 +193,4 @@ export function getCurrentSupport(
 
   // Default (likely never reached)
   return getFirst(support);
-}
-
-export function getPreviousVersion(
-  version: BCD.VersionValue,
-  browser: BCD.BrowserStatement
-): BCD.VersionValue {
-  if (browser && typeof version === "string") {
-    const browserVersions = Object.keys(browser["releases"]).sort(
-      compareVersions
-    );
-    const currentVersionIndex = browserVersions.indexOf(version);
-    if (currentVersionIndex > 0) {
-      return browserVersions[currentVersionIndex - 1];
-    }
-  }
-
-  return version;
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.12",
     "cli-progress": "^3.11.2",
-    "compare-versions": "^5.0.1",
     "compression": "^1.7.4",
     "cookie": "^0.5.0",
     "cookie-parser": "^1.4.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3947,11 +3947,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-compare-versions@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.1.tgz#14c6008436d994c3787aba38d4087fabe858555e"
-  integrity sha512-v8Au3l0b+Nwkp4G142JcgJFh1/TUhdxut7wzD1Nq1dyp5oa3tXaqb03EXOAB6jS4gMlalkjAUPZBMiAfKUixHQ==
-
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/6667 on prod

### Problem

See https://github.com/mdn/yari/pull/7589#issuecomment-1318433195

### Solution

Put `version_last` (version before version_removed when version_removed is a string) in BCD info in document-extractor. Then show it in BCD version range.

---

## Screenshots

No difference compared to https://github.com/mdn/yari/pull/7589

---

## How did you test this change?

`yarn build`
