### PR TITLE
chore(kumascript): log macro failures

### DIFF
--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -115,11 +115,16 @@ export default class Templates {
         );
       }
     }
-    const rendered = await ejs.renderFile(path, args, {
-      async: true,
-      cache: process.env.NODE_ENV === "production",
-    });
-    return rendered.trim();
+    try {
+      const rendered = await ejs.renderFile(path, args, {
+        async: true,
+        cache: process.env.NODE_ENV === "production",
+      });
+      return rendered.trim();
+    } catch (error) {
+      console.error(`${name} macro failed:`, error);
+      throw error;
+    }
   }
 
   getTemplateMap() {


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Our kumascript macros sometimes fail under certain circumstances (e.g. https://github.com/mdn/yari/issues/4670), but there is no indication as to why they failed. This makes it almost impossible for users to report them, and hard for developers to investigate them.

### Solution

Catch errors when rendering macros, and print them to the console.

---

## Screenshots

<img width="694" alt="image" src="https://user-images.githubusercontent.com/495429/202731333-48687650-fd84-4cb0-940b-638101fbce4a.png">

---

## How did you test this change?

Introduced a syntax error into `kumascript/src/api/web.ts` (`web.smartLink()`), and visited http://localhost:3000/en-US/docs/Web/API/Window#deprecated_methods locally.
