### PR TITLE
fix(live-sample): inject MathML font/polyfill

### DIFF
--- a/kumascript/src/api/util.ts
+++ b/kumascript/src/api/util.ts
@@ -282,8 +282,9 @@ export class HTMLTool {
 
   extractLiveSampleObject(iframeID) {
     const sectionID = iframeID.substr("frame_".length);
+    let result;
     if (hasHeading(this.$, sectionID)) {
-      const result = Object.create(null);
+      result = Object.create(null);
       const sample = this.getSection(sectionID);
       // We have to wrap the collection of elements from the section
       // we've just acquired because we're going to search among all
@@ -307,19 +308,19 @@ export class HTMLTool {
           `unable to find any live code samples for "${sectionID}" within ${this.pathDescription}`
         );
       }
-      return result;
     } else {
       // We're here because we can't find the sectionID, so instead we're going
       // to find the live-sample iframe by its id (iframeID, NOT sectionID), and
       // then collect the closest blocks of code for the live sample.
-      const result = collectClosestCode(findSectionStart(this.$, iframeID));
+      result = collectClosestCode(findSectionStart(this.$, iframeID));
       if (!result) {
         throw new KumascriptError(
           `unable to find any live code samples for "${sectionID}" within ${this.pathDescription}`
         );
       }
-      return result;
     }
+    result.hasMathML = /<math\b/i.test(result.html);
+    return result;
   }
 
   html() {

--- a/kumascript/src/live-sample.ts
+++ b/kumascript/src/live-sample.ts
@@ -48,6 +48,10 @@ const LIVE_SAMPLE_HTML = `
         </style>
         <% } %>
         <title><%= sampleTitle %></title>
+        <% if (hasMathML) { %>
+          <link rel="stylesheet" href="https://fred-wang.github.io/MathFonts/STIX/mathfonts.css" />
+          <script src="https://fred-wang.github.io/mathml.css/mspace.js"></script>
+        <% } %>
     </head>
     <body>
         <% if (html) { %>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

MathML is only supported by Firefox and Safari, so we load both a font and a polyfill for pages that use MathML _directly_. However, this does not apply to live samples.

For example, 

### Solution

Inject font and polyfill into live samples that use MathML.

---

## Screenshots

### Before

<img width="779" alt="image" src="https://user-images.githubusercontent.com/495429/202761000-e9af2a75-42f2-4bc9-b12b-a93980659912.png">

### After

<img width="779" alt="image" src="https://user-images.githubusercontent.com/495429/202797112-dd934ac8-851b-4e3f-b04c-aa8e8db7dd24.png">

---

## How did you test this change?

Opened this live sample in Chrome:
- https://developer.mozilla.org/en-US/docs/Learn/MathML/First_steps/Getting_started#the_display_attribute
- http://localhost:5042/en-US/docs/Learn/MathML/First_steps/Getting_started#the_display_attribute