### PR TITLE
fix(filecheck): run from repository root

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
     "dev": "yarn build:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",
-    "filecheck": "cd filecheck && ts-node cli.ts",
+    "filecheck": "ts-node filecheck/cli.ts",
     "m2h": "ts-node markdown/m2h/cli.ts",
     "md": "echo 'The HTML to Markdown conversion command has been moved to https://github.com/mdn/markdown!' && exit 1",
     "prepack": "yarn build:dist",


### PR DESCRIPTION
Otherwise `correctContentPathFromEnv()` in libs/env fails.

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Running `yarn filecheck` in the yari repo has been failing if a relative path (e.g. `../content`) was specified as `CONTENT_ROOT`:

```
% yarn filecheck
Debugger attached.
yarn run v1.22.19
$ cd filecheck && ts-node cli.ts
Debugger attached.
Error: ENOENT: no such file or directory, lstat '/Users/claas/github/mdn/yari/content/files'
    at Object.realpathSync (node:fs:2503:7)
    at correctContentPathFromEnv (/Users/claas/github/mdn/yari/libs/env/index.js:98:17)
    at Object.<anonymous> (/Users/claas/github/mdn/yari/libs/env/index.js:67:22)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Object.require.extensions.<computed> [as .js] (/Users/claas/github/mdn/yari/node_modules/ts-node/src/index.ts:1608:43)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/Users/claas/github/mdn/yari/content/files'
}
```

### Solution

Run the `filecheck` from the repository root directory, so that relative paths are resolved properly.

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn filecheck`.