### PR TITLE
chore(macros): delete {{web.link}} macro

### DIFF
--- a/kumascript/macros/web.link.ejs
+++ b/kumascript/macros/web.link.ejs
@@ -1,7 +1,0 @@
-<%
-// Throw a MacroDeprecatedError flaw
-// Condition for removal: no more use in translated-content (May 2022: 1668 occurrences)
-// 0 occurrences left in en-US
-mdn.deprecated();
-%>
-<%-web.link($0, $1, $2, $3)%>


### PR DESCRIPTION
## Summary

The {{web.link}} macro has been deprecated. And now, this macro has been removed from mdn/translated-content. I've run the command below to verify it:

```bash
rg -i '\{\{\s*web\.link' | wc -l
```

![image](https://user-images.githubusercontent.com/15844309/202830159-08cbff50-8744-457a-8281-e51c29c14a96.png)

There is no {{web.link}} macro left in content and translated-content. It's time to remove it.

---

## How did you test this change?

Verified by using `rg`.
