### PR TITLE
Respect navigator.globalPrivacyControl in Mozilla.dntEnabled

### DIFF
--- a/tool/mozilla.dnthelper.min.js
+++ b/tool/mozilla.dnthelper.min.js
@@ -4,6 +4,9 @@ if (typeof Mozilla === "undefined") {
 }
 Mozilla.dntEnabled = function (dnt, ua) {
   "use strict";
+  if (navigator.globalPrivacyControl) {
+    return true;
+  }
   var dntStatus =
     dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
   var userAgent = ua || navigator.userAgent;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Update `Mozilla.dntEnabled` to respect `navigator.globalPrivacyControl`, which is an alternative way and/or replacement to `navigator.doNotTrack`.
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
MDN not querying this setting is probably an oversight, this PR just fixes this.
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution
Just query `navigator.globalPrivacyControl` as one of other possible indicators like `navigator.doNotTrack`. Note that `navigator.globalPrivacyControl` is a boolean unlike `navigator.doNotTrack`.
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?
Enabled this API by setting `privacy.globalprivacycontrol.enabled` and `privacy.globalprivacycontrol.functionality.enabled` to `true`, and observed that `navigator.globalPrivacyControl` became `true` and when I copied `Mozilla.dntEnabled` and ran in the console it returned `true` (given that before this change it returned `false`). Since Google Analytics appears to be unused on development builds, I'm not sure how to test this end-to-end and verify that Google Analytics does not get downloaded after this patch.
<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
