### PR TITLE
fix(rendering): persist object for prose rendering

### DIFF
--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -1,17 +1,12 @@
+import { useMemo } from "react";
 import { DisplayH2, DisplayH3 } from "./utils";
 
 export function Prose({ section }: { section: any }) {
   const { id } = section;
-
-  const Content = () => (
-    <div
-      className="section-content"
-      dangerouslySetInnerHTML={{ __html: section.content }}
-    />
-  );
+  const html = useMemo(() => ({ __html: section.content }), [section.content]);
 
   if (!id) {
-    return <Content />;
+    return <div className="section-content" dangerouslySetInnerHTML={html} />;
   }
 
   const DisplayHx = section.isH3 ? DisplayH3 : DisplayH2;
@@ -23,7 +18,7 @@ export function Prose({ section }: { section: any }) {
         title={section.title}
         titleAsText={section.titleAsText}
       />
-      <Content />
+      <div className="section-content" dangerouslySetInnerHTML={html} />
     </section>
   );
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Stop re-rendering the `Prose` component.

### Problem

Among other issues we've seen that interactive examples get loaded multiple times (filter the network tab for `.html`).

### Solution

Remember the object we use in `Prose`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="828" alt="image" src="https://user-images.githubusercontent.com/3604775/203351257-b80a129d-3ae7-46d0-9682-cfc3e4c8e504.png">


### After

<img width="828" alt="image" src="https://user-images.githubusercontent.com/3604775/203351779-cb526c6e-d686-4575-a073-c013ca6b4c4b.png">

---

## How did you test this change?

http://localhost:5042/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat