### PR TITLE
Deprecate Service Worker sidebar

### DIFF
--- a/kumascript/macros/ServiceWorkerSidebar.ejs
+++ b/kumascript/macros/ServiceWorkerSidebar.ejs
@@ -1,4 +1,9 @@
 <%
+
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated();
+
 var currentSection = $0;
 var locale = env.locale;
 


### PR DESCRIPTION
The Service Worker API has its own dedicated sidebar, implemented using the [ServiceWorkerSidebar.ejs](https://github.com/mdn/yari/compare/main...wbamberg:deprecate-sw-sidebar?expand=1#diff-88d7716c52b0d8196b92ac5158533aac6fe2251c9002dcaa8fc9af277409062f) macro.

There's no special reason it needs to do this, and in https://github.com/mdn/content/pull/22469 I replaced it in en-US with the standard `{{DefaultAPISidebar}}` macro.

If we can do the same for translated content we can delete this sidebar.