### PR TITLE
fix(rendering): don't render everything twice

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -150,11 +150,12 @@ export async function buildSPAs(options) {
         { prefix: "about", pageTitle: "About MDN" },
         { prefix: "community", pageTitle: "Contribute to MDN" },
       ];
+      const urlLocale = VALID_LOCALES.get(locale) || locale;
       for (const { prefix, pageTitle, noIndexing } of SPAs) {
-        const url = `/${locale}/${prefix}`;
+        const url = `/${urlLocale}/${prefix}`;
         const context = {
           pageTitle,
-          locale: VALID_LOCALES.get(locale) || locale,
+          locale: urlLocale,
           noIndexing,
         };
 

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -109,8 +109,8 @@ export async function buildSPAs(options) {
     if (!root) {
       continue;
     }
-    for (const locale of fs.readdirSync(root)) {
-      if (!fs.statSync(path.join(root, locale)).isDirectory()) {
+    for (const pathLocale of fs.readdirSync(root)) {
+      if (!fs.statSync(path.join(root, pathLocale)).isDirectory()) {
         continue;
       }
 
@@ -150,17 +150,17 @@ export async function buildSPAs(options) {
         { prefix: "about", pageTitle: "About MDN" },
         { prefix: "community", pageTitle: "Contribute to MDN" },
       ];
-      const urlLocale = VALID_LOCALES.get(locale) || locale;
+      const locale = VALID_LOCALES.get(pathLocale) || pathLocale;
       for (const { prefix, pageTitle, noIndexing } of SPAs) {
-        const url = `/${urlLocale}/${prefix}`;
+        const url = `/${locale}/${prefix}`;
         const context = {
           pageTitle,
-          locale: urlLocale,
+          locale,
           noIndexing,
         };
 
         const html = renderHTML(url, context);
-        const outPath = path.join(BUILD_OUT_ROOT, locale, prefix);
+        const outPath = path.join(BUILD_OUT_ROOT, pathLocale, prefix);
         fs.mkdirSync(outPath, { recursive: true });
         const filePath = path.join(outPath, "index.html");
         fs.writeFileSync(filePath, html);

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -57,6 +57,17 @@ function Layout({ pageType, children }) {
   );
 }
 
+function LazyStandardLayout(props: {
+  extraClasses?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <React.Suspense>
+      <StandardLayout {...props}></StandardLayout>
+    </React.Suspense>
+  );
+}
+
 function StandardLayout({
   extraClasses,
   children,
@@ -111,14 +122,14 @@ export function App(appProps) {
   // is true. So you have to have `isServer && CRUD_MODE` at the same time.
   const homePage =
     !isServer && CRUD_MODE ? (
-      <Layout pageType="standard-page">
+      <LazyStandardLayout>
         <WritersHomepage />
-      </Layout>
+      </LazyStandardLayout>
     ) : (
       <PageOrPageNotFound pageNotFound={pageNotFound}>
-        <Layout pageType="standard-page">
+        <StandardLayout>
           <Homepage {...appProps} />
-        </Layout>
+        </StandardLayout>
       </PageOrPageNotFound>
     );
 
@@ -140,17 +151,17 @@ export function App(appProps) {
                 <Route
                   path="/_flaws"
                   element={
-                    <StandardLayout>
+                    <LazyStandardLayout>
                       <AllFlaws />
-                    </StandardLayout>
+                    </LazyStandardLayout>
                   }
                 />
                 <Route
                   path="/_translations/*"
                   element={
-                    <StandardLayout>
+                    <LazyStandardLayout>
                       <Translations />
-                    </StandardLayout>
+                    </LazyStandardLayout>
                   }
                 />
 
@@ -189,9 +200,9 @@ export function App(appProps) {
                 <Route
                   path="/_sitemap/*"
                   element={
-                    <StandardLayout>
+                    <LazyStandardLayout>
                       <Sitemap />
-                    </StandardLayout>
+                    </LazyStandardLayout>
                   }
                 />
               </>

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -12,8 +12,6 @@ import { A11yNav } from "./ui/molecules/a11y-nav";
 import { Footer } from "./ui/organisms/footer";
 import { TopNavigation } from "./ui/organisms/top-navigation";
 import { SiteSearch } from "./site-search";
-import { Loading } from "./ui/atoms/loading";
-import { MainContentContainer } from "./ui/atoms/page-content";
 import { PageNotFound } from "./page-not-found";
 import { Plus } from "./plus";
 import { About } from "./about";
@@ -81,18 +79,6 @@ function PageOrPageNotFound({ pageNotFound, children }) {
     </StandardLayout>
   ) : (
     children
-  );
-}
-
-function LoadingFallback({ message }: { message?: string }) {
-  return (
-    <StandardLayout>
-      <MainContentContainer standalone={true}>
-        {/* This extra minHeight is just so that the footer doesn't flicker
-          in and out as the fallback appears. */}
-        <Loading minHeight={800} message={message || "Loading…"} />
-      </MainContentContainer>
-    </StandardLayout>
   );
 }
 

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -276,13 +276,5 @@ export function App(appProps) {
       />
     </Routes>
   );
-  /* This might look a bit odd but it's actually quite handy.
-   * This way, when rendering client-side, we wrap all the routes in
-   * <React.Suspense> but in server-side rendering that goes away.
-   */
-  return isServer ? (
-    routes
-  ) : (
-    <React.Suspense fallback={<LoadingFallback />}>{routes}</React.Suspense>
-  );
+  return routes;
 }

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -22,6 +22,8 @@ import { useIsServer } from "./hooks";
 
 import { Banner } from "./banners";
 import { useGleanPage } from "./telemetry/glean-context";
+import { MainContentContainer } from "./ui/atoms/page-content";
+import { Loading } from "./ui/atoms/loading";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
@@ -57,12 +59,24 @@ function Layout({ pageType, children }) {
   );
 }
 
+function LoadingFallback({ message }: { message?: string }) {
+  return (
+    <StandardLayout>
+      <MainContentContainer standalone={true}>
+        {/* This extra minHeight is just so that the footer doesn't flicker
+        in and out as the fallback appears. */}
+        <Loading minHeight={800} message={message || "Loading…"} />
+      </MainContentContainer>
+    </StandardLayout>
+  );
+}
+
 function LazyStandardLayout(props: {
   extraClasses?: string;
   children: React.ReactNode;
 }) {
   return (
-    <React.Suspense>
+    <React.Suspense fallback={<LoadingFallback />}>
       <StandardLayout {...props}></StandardLayout>
     </React.Suspense>
   );


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fix double rendering for SSR pages.

### Problem

We render the document again when we hdyrate. This can be observed by looking at the network panel. Assets get loaded twice.

### Solution

Stop lazy loading the routes.

