### PR TITLE
ci(auto-merge): use dependabot/fetch-metadata + GitHub CLI

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
 
       - name: Squash and merge
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
         run: gh pr comment ${{ github.event.number }} --body "@dependabot squash and merge"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,10 +9,14 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+
     steps:
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      - uses: dependabot/fetch-metadata@v1
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
-          command: "squash and merge"
-          approve: false
-          target: minor
+
+      - name: Squash and merge
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
+        run: gh pr comment ${{ github.event.number }} --body "@dependabot squash and merge"


### PR DESCRIPTION
## Summary

Unblocks the failing auto-merge check by moving away from `ahmadnassri/action-dependabot-auto-merge`.

### Problem

The auto-merge check is currently failing, preventing us from having minor/patch dependency updates merged automatically.

### Solution

Replace `ahmadnassri/action-dependabot-auto-merge` by `dependabot/fetch-metadata` and GitHub CLI to automatically "squash and merge" minor/patch dependency updates.

---

## Screenshots

n/a

---

## How did you test this change?

_I'm not sure how to test this._