### PR TITLE
ci(auto-merge): specify name/id

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,7 +11,9 @@ jobs:
     if: github.actor == 'dependabot[bot]'
 
     steps:
-      - uses: dependabot/fetch-metadata@v1
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1
         with:
           github-token: ${{ secrets.AUTOMERGE_TOKEN }}
 


### PR DESCRIPTION


## Summary

Fixes a nit in https://github.com/mdn/yari/pull/7662.

### Problem

If a workflow step is not given an id, the following steps cannot reference its outputs via this id. Accordingly, the "squash and merge" step would _always_ be skipped ([example](https://github.com/mdn/yari/actions/runs/3543062427/jobs/5949177965)).

### Solution

Specify an id.

---

## Screenshots

n/a

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
