### PR TITLE
refactor(imports): always use `node:` protocol + add ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 const { readGitignoreFiles } = require("eslint-gitignore");
-const path = require("path");
+const path = require("node:path");
 
 const ignores = readGitignoreFiles({
   cwd: path.join(".git", "info"),
@@ -15,7 +15,7 @@ module.exports = {
     "jest/globals": true,
   },
   extends: ["eslint:recommended", "plugin:n/recommended"],
-  plugins: ["jest"],
+  plugins: ["jest", "unicorn"],
   globals: {
     Atomics: "readonly",
     SharedArrayBuffer: "readonly",
@@ -25,6 +25,7 @@ module.exports = {
   },
   rules: {
     "one-var": ["error", "never"],
+    "unicorn/prefer-node-protocol": "error",
   },
   reportUnusedDisableDirectives: true,
   overrides: [

--- a/build/check-images.ts
+++ b/build/check-images.ts
@@ -2,7 +2,7 @@
 // Or, something. Checking for flaws should be very different from checking
 // for images.
 
-import path from "path";
+import path from "node:path";
 
 import sizeOf from "image-size";
 

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import crypto from "crypto";
-import fs from "fs";
-import path from "path";
-import zlib from "zlib";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import zlib from "node:zlib";
 
 import chalk from "chalk";
 import cliProgress from "cli-progress";

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import fromMarkdown from "mdast-util-from-markdown";
 import visit from "unist-util-visit";

--- a/build/flaws/index.ts
+++ b/build/flaws/index.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import chalk from "chalk";
 import { RequestError } from "got";
 

--- a/build/git-history.ts
+++ b/build/git-history.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { execGit } from "../content";
 import { CONTENT_ROOT } from "../libs/env";

--- a/build/index.ts
+++ b/build/index.ts
@@ -1,6 +1,6 @@
 import { Doc } from "../libs/types";
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import chalk from "chalk";
 import {

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import frontmatter from "front-matter";
 import { fdir, PathsOutput } from "fdir";
 

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import * as cheerio from "cheerio";
 import got from "got";

--- a/content/document-paths.ts
+++ b/content/document-paths.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 
 import { fdir, PathsOutput } from "fdir";
 

--- a/content/document.test.ts
+++ b/content/document.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import * as Document from "./document";
 

--- a/content/document.ts
+++ b/content/document.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import util from "util";
+import fs from "node:fs";
+import path from "node:path";
+import util from "node:util";
 
 import fm from "front-matter";
 import yaml from "js-yaml";

--- a/content/githistories.ts
+++ b/content/githistories.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 // Module-level cache
 const gitHistoryMaps = new Map();

--- a/content/image.ts
+++ b/content/image.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import readChunk from "read-chunk";
 import imageType from "image-type";

--- a/content/popularities.ts
+++ b/content/popularities.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 const dirname = __dirname;
 

--- a/content/redirect.ts
+++ b/content/redirect.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { resolveFundamental } from "../libs/fundamental-redirects";
 import { decodePath, slugToFolder } from "../libs/slug-utils";

--- a/content/utils.ts
+++ b/content/utils.ts
@@ -1,5 +1,5 @@
-import path from "path";
-import childProcess from "child_process";
+import path from "node:path";
+import childProcess from "node:child_process";
 import LRU from "lru-cache";
 
 import { CONTENT_ROOT, CONTENT_TRANSLATED_ROOT } from "../libs/env";

--- a/content/wikihistories.ts
+++ b/content/wikihistories.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 // Module-level cache
 const wikiHistoryMaps = new Map();

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -1,6 +1,6 @@
 const { VALID_LOCALES } = require("@yari-internal/constants");
-const fs = require("fs");
-const path = require("path");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const dirname = __dirname;
 

--- a/filecheck/checker.ts
+++ b/filecheck/checker.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import { promisify } from "util";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
 
 import fse from "fs-extra";
 import tempy from "tempy";

--- a/filecheck/cli.ts
+++ b/filecheck/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import path from "path";
+import path from "node:path";
 
 import { program } from "@caporal/core";
 

--- a/kumascript/src/api/kuma.ts
+++ b/kumascript/src/api/kuma.ts
@@ -1,4 +1,4 @@
-import url from "url";
+import url from "node:url";
 import * as util from "./util";
 
 const kuma = {

--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import * as util from "./util";
 

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -23,8 +23,8 @@
  * template names to the name of the file that implements the
  * template (this is used by the /macros/ endpoint in server.js)
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import ejs from "ejs";
 
 const dirname = __dirname;

--- a/kumascript/tests/macros.test.ts
+++ b/kumascript/tests/macros.test.ts
@@ -1,7 +1,7 @@
 /**
  * Verify that all of the macros in ../macros/ compile without errors
  */
-import fs from "fs";
+import fs from "node:fs";
 import ejs from "ejs";
 import Templates from "../src/templates";
 const dirname = __dirname;

--- a/kumascript/tests/macros/Compat.test.ts
+++ b/kumascript/tests/macros/Compat.test.ts
@@ -1,7 +1,7 @@
 import { assert, itMacro, describeMacro, lintHTML } from "./utils";
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import jsdom from "jsdom";
 import extend from "extend";
 const dirname = __dirname;

--- a/kumascript/tests/macros/DefaultAPISidebar.test.ts
+++ b/kumascript/tests/macros/DefaultAPISidebar.test.ts
@@ -7,8 +7,8 @@ const dirname = __dirname;
 /**
  * Load all the fixtures.
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 const pagesFixturePath = path.resolve(
   dirname,
   "fixtures/defaultapisidebar/pages.json"

--- a/kumascript/tests/macros/HTTPSidebar.test.ts
+++ b/kumascript/tests/macros/HTTPSidebar.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import jsdom from "jsdom";
 import { Document } from "../../../content";
 import {

--- a/kumascript/tests/macros/ListGroups.test.ts
+++ b/kumascript/tests/macros/ListGroups.test.ts
@@ -7,8 +7,8 @@ const dirname = __dirname;
 /**
  * Load all the fixtures.
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 const groupDataFixturePath = path.resolve(
   dirname,
   "fixtures/listgroups/groupdata.json"

--- a/kumascript/tests/macros/apiref.test.ts
+++ b/kumascript/tests/macros/apiref.test.ts
@@ -7,8 +7,8 @@ const dirname = __dirname;
 /**
  * Load all the fixtures.
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 const subpagesFixturePath = path.resolve(
   dirname,
   "fixtures/apiref/subpages.json"

--- a/kumascript/tests/macros/page-api.test.ts
+++ b/kumascript/tests/macros/page-api.test.ts
@@ -2,8 +2,8 @@
 // tested its main functions. The features of that macro are now
 // part of ../../src/environment.js, but we're still testing them here.
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { Document } from "../../../content";
 import { assert, itMacro, describeMacro, beforeEachMacro } from "./utils";
 

--- a/kumascript/tests/macros/svginfo.test.ts
+++ b/kumascript/tests/macros/svginfo.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import cheerio from "cheerio";
 
 import { itMacro, describeMacro, beforeEachMacro } from "./utils";

--- a/kumascript/tests/render.test.ts
+++ b/kumascript/tests/render.test.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "node:fs";
 import Templates from "../src/templates";
 import { render } from "../src/render";
 import {

--- a/kumascript/tests/templates.test.ts
+++ b/kumascript/tests/templates.test.ts
@@ -1,6 +1,6 @@
 import EJS from "ejs";
 import Templates from "../src/templates";
-import path from "path";
+import path from "node:path";
 
 const dirname = __dirname;
 

--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { DEFAULT_LOCALE } from "../../../libs/constants";
 import { code } from "./code";
 import { asDefinitionList, isDefinitionList } from "./dl";

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "eslint-plugin-n": "^15.5.1",
     "eslint-plugin-react": "^7.31.11",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-unicorn": "^45.0.0",
     "eslint-webpack-plugin": "^3.2.0",
     "extend": "^3.0.2",
     "file-loader": "^6.2.0",

--- a/server/document.ts
+++ b/server/document.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import express, { Request } from "express";
 

--- a/server/fake-v1-api.ts
+++ b/server/fake-v1-api.ts
@@ -5,8 +5,8 @@
  * You can read more about it in the docs/proxying.md document.
  */
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import express from "express";
 

--- a/server/flaws.ts
+++ b/server/flaws.ts
@@ -1,8 +1,8 @@
 import { Doc } from "../libs/types/document";
 import { FlawFilters } from "./types";
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { fdir, PathsOutput } from "fdir";
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import crypto from "crypto";
-import fs from "fs";
-import path from "path";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
 
 import chalk from "chalk";
 import express from "express";

--- a/server/search-index.ts
+++ b/server/search-index.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { fdir, PathsOutput } from "fdir";
 import fm from "front-matter";

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 
 import express from "express";
 import compression from "compression";

--- a/server/translations.ts
+++ b/server/translations.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { fdir } from "fdir";
 

--- a/ssr/index.ts
+++ b/ssr/index.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 
 import dotenv from "dotenv";
 import React from "react";

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { renderToString } from "react-dom/server";
 
 import { DEFAULT_LOCALE } from "../libs/constants";

--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 
 const nodeExternals = require("webpack-node-externals");
 const webpack = require("webpack");

--- a/testing/tests/csp.test.ts
+++ b/testing/tests/csp.test.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import crypto from "crypto";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
 import { CSP_SCRIPT_SRC_VALUES } from "../../libs/constants";
 
 describe("Content-Security-Policy", () => {

--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -8,10 +8,10 @@
  * with any of the files there.
  */
 
-import fs from "fs";
+import fs from "node:fs";
 import fse from "fs-extra";
-import path from "path";
-import { execSync } from "child_process";
+import path from "node:path";
+import { execSync } from "node:child_process";
 
 import tempy from "tempy";
 

--- a/testing/tests/filecheck.test.ts
+++ b/testing/tests/filecheck.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import { checkFile } from "../../filecheck/checker";
 

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import cheerio from "cheerio";
 import sizeOf from "image-size";

--- a/testing/tests/offline-db.test.ts
+++ b/testing/tests/offline-db.test.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import path from "path";
-import crypto from "crypto";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
 
 test("db.ts should be identical (PWA vs. Client)", () => {
   function sha256sum(path) {

--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -3,7 +3,7 @@
  * process.env.BUILD_ALWAYS_ALLOW_ROBOTS.
  *
  */
-import fs from "fs";
+import fs from "node:fs";
 
 import { VALID_LOCALES } from "../libs/constants";
 import { ALWAYS_ALLOW_ROBOTS } from "../libs/env";

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -2,8 +2,8 @@
 import { isValidLocale } from "../libs/locale-utils";
 import type { Doc } from "../libs/types/document";
 
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import { fdir, PathsOutput } from "fdir";
 import frontmatter from "front-matter";
 import { program } from "@caporal/core";

--- a/tool/optimize-client-build.ts
+++ b/tool/optimize-client-build.ts
@@ -3,8 +3,8 @@
  * (react-scripts) can't do.
  *
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import cheerio from "cheerio";
 import md5File from "md5-file";

--- a/tool/popularities.ts
+++ b/tool/popularities.ts
@@ -9,7 +9,7 @@
  * dynamically on every single production build.
  *
  */
-import fs from "fs";
+import fs from "node:fs";
 
 import * as csv from "@fast-csv/parse";
 import got from "got";

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -1,6 +1,6 @@
-import fs from "fs";
-import crypto from "crypto";
-import path from "path";
+import fs from "node:fs";
+import crypto from "node:crypto";
+import path from "node:path";
 
 import chalk from "chalk";
 import fm from "front-matter";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3438,7 +3438,7 @@ buffer@^5.2.1, buffer@^5.5.0:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-builtin-modules@^3.1.0:
+builtin-modules@^3.1.0, builtin-modules@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
   integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
@@ -3723,6 +3723,11 @@ ci-info@^3.2.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.5.0.tgz#bfac2a29263de4c829d806b1ab478e35091e171f"
   integrity sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==
 
+ci-info@^3.6.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.7.0.tgz#6d01b3696c59915b6ce057e4aa4adfc2fa25f5ef"
+  integrity sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==
+
 cjs-module-lexer@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
@@ -3734,6 +3739,13 @@ clean-css@^5.2.2:
   integrity sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==
   dependencies:
     source-map "~0.6.0"
+
+clean-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-regexp/-/clean-regexp-1.0.0.tgz#8df7c7aae51fd36874e8f8d05b9180bc11a3fed7"
+  integrity sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -5192,6 +5204,28 @@ eslint-plugin-testing-library@^5.0.1:
   integrity sha512-QzOKgu4x8WmNq4LdbHb8lz5nBR+KX5kSg5VvIdr/5f1BvHx2IoO1B/tgDa5pD/ng2LsiQ0/HIH6gsUuxpbcrkQ==
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
+
+eslint-plugin-unicorn@^45.0.0:
+  version "45.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-45.0.0.tgz#a6650ff3000dc1a87cc2f6ac3a11edcde61712e2"
+  integrity sha512-iP8cMRxXKHonKioOhnCoCcqVhoqhAp6rB+nsoLjXFDxTHz3btWMAp8xwzjHA0B1K6YV/U/Yvqn1bUXZt8sJPuQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.19.1"
+    ci-info "^3.6.1"
+    clean-regexp "^1.0.0"
+    eslint-utils "^3.0.0"
+    esquery "^1.4.0"
+    indent-string "^4.0.0"
+    is-builtin-module "^3.2.0"
+    jsesc "3.0.2"
+    lodash "^4.17.21"
+    pluralize "^8.0.0"
+    read-pkg-up "^7.0.1"
+    regexp-tree "^0.1.24"
+    regjsparser "0.9.1"
+    safe-regex "^2.1.1"
+    semver "^7.3.8"
+    strip-indent "^3.0.0"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -6997,6 +7031,13 @@ is-buffer@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
 
+is-builtin-module@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-3.2.0.tgz#bb0310dfe881f144ca83f30100ceb10cf58835e0"
+  integrity sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==
+  dependencies:
+    builtin-modules "^3.3.0"
+
 is-callable@^1.1.4, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
@@ -7817,6 +7858,11 @@ jsdom@^20.0.0, jsdom@^20.0.3:
     whatwg-url "^11.0.0"
     ws "^8.11.0"
     xml-name-validator "^4.0.0"
+
+jsesc@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.0.2.tgz#bb8b09a6597ba426425f2e4a07245c3d00b9343e"
+  integrity sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -9441,6 +9487,11 @@ playwright-core@1.28.1:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
   integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
 pngquant-bin@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/pngquant-bin/-/pngquant-bin-6.0.1.tgz#2b5789ca219eeb4d8509ab1ae082092801b7f07e"
@@ -10476,6 +10527,11 @@ regex-parser@^2.2.11:
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
   integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
 
+regexp-tree@^0.1.24, regexp-tree@~0.1.1:
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.24.tgz#3d6fa238450a4d66e5bc9c4c14bb720e2196829d"
+  integrity sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -10507,7 +10563,7 @@ regjsgen@^0.7.1:
   resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.7.1.tgz#ee5ef30e18d3f09b7c369b76e7c2373ed25546f6"
   integrity sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==
 
-regjsparser@^0.9.1:
+regjsparser@0.9.1, regjsparser@^0.9.1:
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.9.1.tgz#272d05aa10c7c1f67095b1ff0addae8442fc5709"
   integrity sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==
@@ -10817,6 +10873,13 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
+
+safe-regex@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-2.1.1.tgz#f7128f00d056e2fe5c11e81a1324dd974aadced2"
+  integrity sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==
+  dependencies:
+    regexp-tree "~0.1.1"
 
 safe-stable-stringify@^2.3.1:
   version "2.4.1"


### PR DESCRIPTION
## Summary

Makes it clearer which imports are built-in modules and packages.

See also: https://2ality.com/2021/12/node-protocol-imports.html

### Problem

It is not always trivial whether an import comes from a built-in module or an installed package.

### Solution

Always use the `node:` protocol (prefix) for imports of Node.js built-in modules, and ensures this via the `unicorn/prefer-node-protocol` rule of `eslint-plugin-unicorn`.

---

## Screenshots

n/a

---

## How did you test this change?

Added the `node:` protocol by running `yarn eslint --fix`.
