### PR TITLE
ci(glean-probe-scraper): run on PR + main pushes only

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -1,6 +1,11 @@
----
 name: Glean probe-scraper
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   glean-probe-scraper:
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/mdn/yari/pull/7652.

### Problem

https://github.com/mdn/yari/pull/7652 added a "Glean probe-scraper" workflow, but it runs twice on PRs from non-fork mdn/yari branches: Once for the `push` event and once for the `pull_request` event.

### Solution

Only run the workflow for pushes to the default branch (`main`) and for PRs.

_Note_: This is the same behavior as our "Testing" workflow:

https://github.com/mdn/yari/blob/d8b827cc72bd4f035787d41c228c28f26e2193d6/.github/workflows/testing.yml#L6-L10

---

## Screenshots

n/a

---

## How did you test this change?

The workflow only ran once for this PR, as intended.