### PR TITLE
ci(auto-merge): use pull_request.url for comment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
-        run: gh pr comment ${{ github.event.number }} --body "@dependabot squash and merge"
+        run: gh pr comment ${{ github.event.pull_request.url }} --body "@dependabot squash and merge"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/mdn/yari/pull/7662 and https://github.com/mdn/yari/pull/7663.

### Problem

The auto-merge workflow fails, because we don't `actions/checkout` the repository and so the `gh pr comment` call doesn't know the repository to post the PR comment in.

### Solution

Use the fully-qualified PR url, as `gh pr comment` also accepts that.

---

## Screenshots

n/a

---

## How did you test this change?

Time will tell.
