### PR TITLE
fix(client/config): migrate to setupMiddlewares option

### DIFF
--- a/client/config/webpackDevServer.config.js
+++ b/client/config/webpackDevServer.config.js
@@ -99,27 +99,32 @@ module.exports = function (proxy, allowedHost) {
     },
     // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
     proxy,
-    onBeforeSetupMiddleware(devServer) {
-      // Keep `evalSourceMapMiddleware`
-      // middlewares before `redirectServedPath` otherwise will not have any effect
-      // This lets us fetch source contents from webpack for the error overlay
-      devServer.app.use(evalSourceMapMiddleware(devServer));
+    setupMiddlewares(middlewares, devServer) {
+      middlewares.unshift(
+        // Keep `evalSourceMapMiddleware`
+        // middlewares before `redirectServedPath` otherwise will not have any effect
+        // This lets us fetch source contents from webpack for the error overlay
+        evalSourceMapMiddleware(devServer)
+      );
 
       if (fs.existsSync(paths.proxySetup)) {
         // This registers user provided middleware for proxy reasons
         require(paths.proxySetup)(devServer.app);
       }
-    },
-    onAfterSetupMiddleware(devServer) {
-      // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
-      devServer.app.use(redirectServedPath(paths.publicUrlOrPath));
 
-      // This service worker file is effectively a 'no-op' that will reset any
-      // previous service worker registered for the same host:port combination.
-      // We do this in development to avoid hitting the production cache if
-      // it used the same host and port.
-      // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-      devServer.app.use(noopServiceWorkerMiddleware(paths.publicUrlOrPath));
+      middlewares.push(
+        // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
+        redirectServedPath(paths.publicUrlOrPath),
+
+        // This service worker file is effectively a 'no-op' that will reset any
+        // previous service worker registered for the same host:port combination.
+        // We do this in development to avoid hitting the production cache if
+        // it used the same host and port.
+        // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
+        noopServiceWorkerMiddleware(paths.publicUrlOrPath)
+      );
+
+      return middlewares;
     },
   };
 };


### PR DESCRIPTION
## Summary

Fixes the following warnings when running `yarn dev` (or `yarn start`):

```
12:27:29 PM web.1       |  (node:5123) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
12:27:29 PM web.1       |  (Use `node --trace-deprecation ...` to show where the warning was created)
12:27:29 PM web.1       |  (node:5123) [DEP_WEBPACK_DEV_SERVER_ON_BEFORE_SETUP_MIDDLEWARE] DeprecationWarning: 'onBeforeSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
```

### Problem

The webpack devserver config options `onBeforeSetupMiddleware` and `onAfterSetupMiddleware` have been deprecated in favor of `setupMiddleware`, but we're still using the deprecated options in our client/config (which resulted from ejecting `react-scripts`).

### Solution

Migrate to the `setupMiddleware` option ~~(and remove a proxy feature that we haven't been using)~~.

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn dev` (no more warnings), and verified that http://localhost:3000/ is still working as expected.
