### PR TITLE
ci(auto-merge): use html_url, not [api] url

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.url }} --body "@dependabot squash and merge"
+        run: gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/mdn/yari/pull/7670.

### Problem

The `pull_request.url` contains the API url, so it cannot be used as a parameter of `gh pr comment`.

### Solution

Use `pull_request.html_url` instead.

---

## Screenshots

n/a

---

## How did you test this change?

🤞 
