### PR TITLE
refactor(aws-lambda): convert to ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,12 @@ module.exports = {
       },
     },
     {
+      files: ["deployer/aws-lambda/**/*.js"],
+      parserOptions: {
+        sourceType: "module",
+      },
+    },
+    {
       files: ["ssr/**/*.js"],
       parserOptions: {
         sourceType: "module",

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -1,10 +1,10 @@
-const { VALID_LOCALES } = require("@yari-internal/constants");
-const fs = require("node:fs");
-const path = require("node:path");
+import { VALID_LOCALES } from "@yari-internal/constants";
+import fs from "node:fs";
+import path from "node:path";
+import dotenv from "dotenv";
 
 const dirname = __dirname;
 
-const dotenv = require("dotenv");
 const root = path.join(dirname, "..", "..", "..");
 dotenv.config({
   path: path.join(root, process.env.ENV_FILE || ".env"),

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -1,9 +1,10 @@
 import { VALID_LOCALES } from "@yari-internal/constants";
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import dotenv from "dotenv";
 
-const dirname = __dirname;
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const root = path.join(dirname, "..", "..", "..");
 dotenv.config({

--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 /* eslint-disable n/no-missing-import */
 import { resolveFundamental } from "@yari-internal/fundamental-redirects";
 import { getLocale } from "@yari-internal/locale-utils";
@@ -33,7 +34,8 @@ const LEGACY_URI_NEEDING_TRAILING_SLASH = new RegExp(
 
 const CONTENT_DEVELOPMENT_DOMAIN = ".content.dev.mdn.mozit.cloud";
 
-import REDIRECTS from "./redirects.json";
+const require = createRequire(import.meta.url);
+const REDIRECTS = require("./redirects.json");
 const REDIRECT_SUFFIXES = ["/index.json", "/bcd.json", ""];
 
 function redirect(location, { status = 302, cacheControlSeconds = 0 } = {}) {

--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -1,12 +1,12 @@
-/* eslint-disable n/no-missing-require */
-const { resolveFundamental } = require("@yari-internal/fundamental-redirects");
-const { getLocale } = require("@yari-internal/locale-utils");
-const {
+/* eslint-disable n/no-missing-import */
+import { resolveFundamental } from "@yari-internal/fundamental-redirects";
+import { getLocale } from "@yari-internal/locale-utils";
+import {
   decodePath,
   encodePath,
   slugToFolder,
-} = require("@yari-internal/slug-utils");
-const { VALID_LOCALES } = require("@yari-internal/constants");
+} from "@yari-internal/slug-utils";
+import { VALID_LOCALES } from "@yari-internal/constants";
 
 const THIRTY_DAYS = 3600 * 24 * 30;
 const NEEDS_LOCALE = /^\/(?:docs|search|settings|signin|signup|plus)(?:$|\/)/;
@@ -33,7 +33,7 @@ const LEGACY_URI_NEEDING_TRAILING_SLASH = new RegExp(
 
 const CONTENT_DEVELOPMENT_DOMAIN = ".content.dev.mdn.mozit.cloud";
 
-const REDIRECTS = require("./redirects.json");
+import REDIRECTS from "./redirects.json";
 const REDIRECT_SUFFIXES = ["/index.json", "/bcd.json", ""];
 
 function redirect(location, { status = 302, cacheControlSeconds = 0 } = {}) {
@@ -83,7 +83,7 @@ function redirect(location, { status = 302, cacheControlSeconds = 0 } = {}) {
   };
 }
 
-exports.handler = async (event) => {
+export async function handler(event) {
   /*
    * Modify the request before it's passed to the S3 origin.
    */
@@ -243,4 +243,4 @@ exports.handler = async (event) => {
     }
   }
   return request;
-};
+}

--- a/deployer/aws-lambda/content-origin-request/package.json
+++ b/deployer/aws-lambda/content-origin-request/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Defines the deployment package for this AWS Lambda function.",
   "license": "MPL-2.0",
+  "type": "module",
   "main": "index.js",
   "files": [
     "index.js",

--- a/deployer/aws-lambda/content-origin-request/package.json
+++ b/deployer/aws-lambda/content-origin-request/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "yarn install && node build.js",
-    "make-package": "yarn build && yarn install --production && zip -r -X function.zip . -i index.js 'redirects.json' 'node_modules/*'"
+    "make-package": "yarn build && yarn install --production && zip -r -X function.zip . -i index.js package.json 'redirects.json' 'node_modules/*'"
   },
   "dependencies": {
     "@yari-internal/constants": "file:../../../libs/constants",

--- a/deployer/aws-lambda/content-origin-response/index.js
+++ b/deployer/aws-lambda/content-origin-response/index.js
@@ -1,6 +1,6 @@
-const { CSP_VALUE } = require("@yari-internal/constants");
+import { CSP_VALUE } from "@yari-internal/constants";
 
-exports.handler = async (event) => {
+export async function handler(event) {
   /*
    * This Lambda@Edge function is designed to handle origin-response
    * events, so for example we can modify the response before it's
@@ -68,4 +68,4 @@ exports.handler = async (event) => {
   }
 
   return response;
-};
+}

--- a/deployer/aws-lambda/content-origin-response/package.json
+++ b/deployer/aws-lambda/content-origin-response/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Defines the deployment package for this AWS Lambda function.",
   "license": "MPL-2.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "make-package": "yarn install && zip -r -X function.zip . -i index.js 'node_modules/*'"

--- a/deployer/aws-lambda/content-origin-response/package.json
+++ b/deployer/aws-lambda/content-origin-response/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "make-package": "yarn install && zip -r -X function.zip . -i index.js 'node_modules/*'"
+    "make-package": "yarn install && zip -r -X function.zip . -i index.js package.json 'node_modules/*'"
   },
   "dependencies": {
     "@yari-internal/constants": "file:../../../libs/constants"

--- a/deployer/aws-lambda/mdn-stripe-price-ids/index.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/index.js
@@ -1,11 +1,11 @@
-const acceptLanguageParser = require("accept-language-parser");
+import acceptLanguageParser from "accept-language-parser";
 
-const stageLookup = require("./plans-stage-lookup.json");
-const prodLookup = require("./plans-prod-lookup.json");
+import stageLookup from "./plans-stage-lookup.json";
+import prodLookup from "./plans-prod-lookup.json";
 
 const STAGE_ENV = "stage";
 
-exports.handler = async (event) => {
+export async function handler(event) {
   const request = event.Records[0].cf.request;
   //This should fail if this header is not set.
   const ENV =
@@ -82,4 +82,4 @@ exports.handler = async (event) => {
   };
 
   return response;
-};
+}

--- a/deployer/aws-lambda/mdn-stripe-price-ids/index.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/index.js
@@ -1,7 +1,10 @@
+import { createRequire } from "node:module";
 import acceptLanguageParser from "accept-language-parser";
 
-import stageLookup from "./plans-stage-lookup.json";
-import prodLookup from "./plans-prod-lookup.json";
+const require = createRequire(import.meta.url);
+
+const stageLookup = require("./plans-stage-lookup.json");
+const prodLookup = require("./plans-prod-lookup.json");
 
 const STAGE_ENV = "stage";
 

--- a/deployer/aws-lambda/mdn-stripe-price-ids/package.json
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Provides Stripe price code + Currency for region",
   "license": "MPL-2.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "make-package": "yarn install && zip -r -X function.zip . -i index.js 'node_modules/*' 'plans-stage-lookup.json' 'plans-prod-lookup.json'",

--- a/deployer/aws-lambda/mdn-stripe-price-ids/package.json
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "make-package": "yarn install && zip -r -X function.zip . -i index.js 'node_modules/*' 'plans-stage-lookup.json' 'plans-prod-lookup.json'",
+    "make-package": "yarn install && zip -r -X function.zip . -i index.js package.json 'node_modules/*' 'plans-stage-lookup.json' 'plans-prod-lookup.json'",
     "test": "jest ./tests"
   },
   "dependencies": {

--- a/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
@@ -1,4 +1,4 @@
-const handler = require("../index");
+import { handler } from "../index.js";
 jest.mock("../plans-stage-lookup.json", () => {
   return require("./__mocks__/plans-stage-lookup-test.json");
 });
@@ -8,7 +8,7 @@ jest.mock("../plans-prod-lookup.json", () => {
 
 test("Returns Italian language with Euro price_id for Italian in Germany", async () => {
   const event = getEventForAcceptHeaderAndCountry("it;q=0.7,en;q=0.3", "DE");
-  const res = await handler.handler(event);
+  const res = await handler(event);
   const bodyJson = JSON.parse(res.body);
   const expectedPriceArray = [
     "ITALIAN_1",
@@ -28,7 +28,7 @@ test("(PROD) Returns Italian language with Euro price_id for Italian in Germany"
     "DE",
     "prod"
   );
-  const res = await handler.handler(event);
+  const res = await handler(event);
   const bodyJson = JSON.parse(res.body);
   const expectedPriceArray = [
     "PROD_ITALIAN_1",
@@ -45,7 +45,7 @@ test("(PROD) Returns Italian language with Euro price_id for Italian in Germany"
 test("Returns French language with CHF price_id for Swiss person in Switzerland", async () => {
   //French dialect in Switzerland
   const event = getEventForAcceptHeaderAndCountry("fr-CA;q=0.7,en;q=0.3", "CH");
-  const res = await handler.handler(event);
+  const res = await handler(event);
   const bodyJson = JSON.parse(res.body);
   const expectedPriceArray = [
     "SWISS_FRENCH_1",
@@ -62,7 +62,7 @@ test("Returns French language with CHF price_id for Swiss person in Switzerland"
 test("Returns English (default) language with USD price_id for German person in USA", async () => {
   //French dialect in Switzerland
   const event = getEventForAcceptHeaderAndCountry("de;q=1.0", "US");
-  const res = await handler.handler(event);
+  const res = await handler(event);
   const bodyJson = JSON.parse(res.body);
   const expectedPriceArray = [
     "USD_ENGLISH_1",
@@ -79,7 +79,7 @@ test("Returns English (default) language with USD price_id for German person in 
 test("Returns 404 for unsupported country", async () => {
   //British user in the Falklands
   const event = getEventForAcceptHeaderAndCountry("en-GB;q=1", "FK");
-  const res = await handler.handler(event);
+  const res = await handler(event);
   expect(res.status).toEqual(404);
 });
 

--- a/deployer/aws-lambda/tests/package.json
+++ b/deployer/aws-lambda/tests/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "description": "End-to-end test AWS Lambda functions",
   "license": "MPL-2.0",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "serve": "node-dev server.js",

--- a/deployer/aws-lambda/tests/package.json
+++ b/deployer/aws-lambda/tests/package.json
@@ -6,13 +6,14 @@
   "main": "index.js",
   "scripts": {
     "serve": "node-dev server.js",
-    "test-server": "jest"
+    "test-server": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "dependencies": {
     "@yari-internal/content-origin-request": "file:../content-origin-request",
     "@yari-internal/content-origin-response": "file:../content-origin-response"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "got": "11.8.5",
     "jest": "29.3.1",
     "kleur": "4.1.5",

--- a/deployer/aws-lambda/tests/server.js
+++ b/deployer/aws-lambda/tests/server.js
@@ -1,8 +1,8 @@
-const polka = require("polka");
-const kleur = require("kleur");
+import polka from "polka";
+import kleur from "kleur";
 
-const requestHandler = require("../content-origin-request").handler;
-const responseHandler = require("../content-origin-response").handler;
+import { handler as requestHandler } from "@yari-internal/content-origin-request";
+import { handler as responseHandler } from "@yari-internal/content-origin-response";
 
 const PORT = parseInt(process.env.PORT || "7000");
 
@@ -105,7 +105,7 @@ async function catchall(req, res) {
         } '${handle.body.trim()}'`
       );
     } else {
-      console.log(`${kleur.gree(handle.status)} '${handle.body.trim()}'`);
+      console.log(`${kleur.green(handle.status)} '${handle.body.trim()}'`);
     }
     res.statusCode = handle.status;
     res.end(handle.body || "");

--- a/deployer/aws-lambda/tests/server.test.js
+++ b/deployer/aws-lambda/tests/server.test.js
@@ -1,4 +1,4 @@
-const got = require("got");
+import got from "got";
 
 const BASE_URL = process.env.SERVER_BASE_URL || "http://localhost:7000";
 

--- a/deployer/aws-lambda/tests/yarn.lock
+++ b/deployer/aws-lambda/tests/yarn.lock
@@ -1267,7 +1267,14 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
-cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary


### Problem

Our lambdas are mostly independent from the rest of yari, which allows us to migrate them to ESM independently. Yet we haven't done so yet.

### Solution

Migrates them to ESM.

_Note_: AWS Lambda supports ESM [since January 2022](https://aws.amazon.com/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/), and we're currently using their Node.js 16.x runtime.

---

## Screenshots

n/a

---

## How did you test this change?

- [ ] Deploy to stage and test