### PR TITLE
Deprecate WebRTCSidebar

### DIFF
--- a/kumascript/macros/WebRTCSidebar.ejs
+++ b/kumascript/macros/WebRTCSidebar.ejs
@@ -1,4 +1,9 @@
 <%
+
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated();
+
 var currentSection = $0;
 var locale = env.locale;
 


### PR DESCRIPTION
Current mission is to remove custom sidebars from the Web/API docs, so everyone can use the standard ones. This will make life easier if we ever want to do anything about sidebars in the future.

https://github.com/mdn/content/pull/22486 removed all references to the custom WebRTCSidebar, and this PR deprecates it.

There's more information about this sidebar at https://discourse.mozilla.org/t/defaultapisidebar-apiref-and-groupdata/40210/24.