### PR TITLE
style(lint-staged): run ESLint on *.ts files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
   "*": "prettier --ignore-unknown --write",
-  "*.{js,jsx,tsx}": "eslint --fix",
+  "*.{js,jsx,ts,tsx}": "eslint --fix",
   "*.{css,scss}": "stylelint --fix"
 }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We already run `eslint --fix` on staged parts of *.js, *.jsx and *.tsx files, but not yet on *.ts files.

### Solution

Add *.ts to the lint-staged config.

---

## Screenshots

n/a

---

## How did you test this change?

- Added an `import zlib from "zlib"` to a `*.ts` file.
- Verified that `yarn lint-staged` auto-fixes it to `import zlib from "node:zlib"`.