### PR TITLE
fix(client): reduce pre/code font-size

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -420,7 +420,7 @@ code,
 .code-example {
   border-radius: var(--elem-radius);
   font-family: var(--font-code);
-  font-size: var(--type-base-font-size-rem);
+  font-size: var(--type-smaller-font-size);
 }
 
 code {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/5875.

### Problem

Our layout prevents us from fitting 80 characters into one line of a code block.

### Solution

Reduce the font-size.

_Note_: Before https://github.com/mdn/yari/pull/7131, code blocks were already using a smaller default font in Chrome, 

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/495429/204252712-470715b5-b4c2-4977-befc-f2037719dd1c.png">

### After

<img width="1422" alt="image" src="https://user-images.githubusercontent.com/495429/204252644-c2429b43-9234-4ea1-9a32-454a64299720.png">

---

## How did you test this change?

Ran `yarn dev`, then opened http://localhost:3000/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters#basic_example locally and compared it to https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Counter_Styles/Using_CSS_counters#basic_example.