### PR TITLE
chore(client): remove Array.flat/ES6 polyfill

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -24,16 +24,6 @@
       title="MDN Web Docs"
     />
 
-    <script>
-      // Only include the polyfill for browsers that seem to not have
-      // certain JS features. E.g. Firefox 58.
-      if (!Array.prototype.flat || !Array.prototype.includes) {
-        document.write(
-          '<script src="https://polyfill.io/v3/polyfill.min.js?features=Array.prototype.flat%2Ces6"><\/script>'
-        );
-      }
-    </script>
-
     <title>MDN Web Docs</title>
     <meta name="SSR_DATA" />
     <meta

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -78,10 +78,7 @@ const CSP_SCRIPT_SRC_VALUES = [
    * previous hash to avoid issues shortly after cache invalidation.
    */
 
-  // 1. Polyfill.
-  "'sha256-JEt9Nmc3BP88wxuTZm9aKNu87vEgGmKW1zzy/vb1KPs='",
-
-  // 2. Theme switching.
+  // 1. Theme switching.
   // - Previous hash (to avoid cache invalidation issues):
   "'sha256-GA8+DpFnqAM/vwERTpb5zyLUaN5KnOhctfTsqWfhaUA='",
   // - Current hash:

--- a/testing/tests/csp.test.ts
+++ b/testing/tests/csp.test.ts
@@ -24,7 +24,7 @@ describe("Content-Security-Policy", () => {
 
     // If this assertion fails, an inline script was added to client/public/index.html`.
     // Please consider merging it with the other inline script, or increment this number.
-    expect(inlineScriptContents).toHaveLength(2);
+    expect(inlineScriptContents).toHaveLength(1);
 
     const inlineScriptCspValues = inlineScriptContents.map(cspValueOf);
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Removes the polyfill for [Array.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat#browser_compatibility) (see [caniuse](https://caniuse.com/mdn-javascript_builtins_array_flat)) and ES6 (see [caniuse](https://caniuse.com/es6)), originally introduced in https://github.com/mdn/yari/pull/2387, as those features now have wide support.

### Problem

We have this polyfill, but we don't need it anymore.

### Solution

Remove the polyfill.

---

## Screenshots

n/a

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
