### PR TITLE
fix(plus): textarea grow broken when zoomed out

### DIFF
--- a/client/src/ui/atoms/form/expanding-textarea.tsx
+++ b/client/src/ui/atoms/form/expanding-textarea.tsx
@@ -10,8 +10,8 @@ export default function ExpandingTextarea(
 
   const resizeCallback = useCallback(
     (node: HTMLTextAreaElement) => {
-      if (value && node && node.scrollHeight + 2 > node.clientHeight) {
-        node.style.height = `${node.scrollHeight + 2}px`;
+      if (value && node && node.scrollHeight > node.clientHeight) {
+        node.style.height = `${node.scrollHeight}px`;
       }
     },
     [value]

--- a/client/src/ui/atoms/form/expanding-textarea.tsx
+++ b/client/src/ui/atoms/form/expanding-textarea.tsx
@@ -11,7 +11,7 @@ export default function ExpandingTextarea(
   const resizeCallback = useCallback(
     (node: HTMLTextAreaElement) => {
       if (value && node && node.scrollHeight > node.clientHeight) {
-        node.style.height = `${node.scrollHeight}px`;
+        node.style.height = `${node.scrollHeight + 2}px`;
       }
     },
     [value]


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fix text area growing when zoomed out.

### Problem

When zooming out the textarea in the add collection item menu was growing while entering whitespaces.

### Solution

Remove the 2px for borders in the update logic.

---

