### PR TITLE
enhance(quicksearch): add a qs paramater

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -15,6 +15,10 @@ import { getCollectionItems } from "./plus/collections-quicksearch";
 const PRELOAD_WAIT_MS = 500;
 const SHOW_INDEXING_AFTER_MS = 500;
 
+function qsURL(url, input) {
+  return `${url}?qs=${input}`;
+}
+
 type Item = {
   url: string;
   title: string;
@@ -283,7 +287,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     defaultHighlightedIndex: 0,
     onSelectedItemChange: ({ type, selectedItem }) => {
       if (type !== useCombobox.stateChangeTypes.InputBlur && selectedItem) {
-        navigate(selectedItem.url);
+        navigate(qsURL(selectedItem.url, inputValue));
         onChangeInputValue("");
         reset();
         toggleMenu();
@@ -403,7 +407,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
                 })}
               >
                 <a
-                  href={item.url}
+                  href={qsURL(item.url, inputValue)}
                   onClick={(event: React.MouseEvent) => {
                     if (event.ctrlKey || event.metaKey) {
                       // Open in new tab, don't navigate current tab.

--- a/testing/tests/headless.search.spec.ts
+++ b/testing/tests/headless.search.spec.ts
@@ -33,7 +33,7 @@ test.describe("Autocomplete search", () => {
     await page.waitForLoadState("networkidle");
     expect(await page.innerText("h1")).toBe("<foo>: A test tag");
     // Should have been redirected too...
-    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo?qs=foo"));
   });
 
   test("find nothing by title search", async ({ page }) => {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

We cannot debug where people come from if using quick search, now we can.

### Problem

We cannot debug where people come from if using quick search.

### Solution

Add the input used as parameter.

---

