### PR TITLE
chore(env): reduce MAX_FILE_SIZE to 500 KiB

### DIFF
--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -116,7 +116,7 @@ function correctContentPathFromEnv(envVarName) {
 // ---------
 
 const MAX_FILE_SIZE = JSON.parse(
-  process.env.FILECHECK_MAX_FILE_SIZE || 1024 * 1024 * 100 // ~100MiB
+  process.env.FILECHECK_MAX_FILE_SIZE || 500 * 1000 // 500KiB
 );
 
 // ----------


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

As we start to accept audio/video/font files, we want to avoid that files are checked into content that are bigger than necessary.

Rationale: There is only one file attachment larger than this, but this is not an issue, as filecheck only checks modified files.

### Problem

Currently, the `MAX_FILE_SIZE` is at 100 MB, which is too high.

### Solution

Reduce it to the lowest reasonable value, i.e. 500 KB.

```console
% ufind files/ -type f -size +500k
files/en-us/_githistory.json
files/en-us/web/api/htmlimageelement/sizes/new-york-skyline-wide.jpg
files/en-us/web/api/web_animations_api/using_the_web_animations_api/growing-shrinking_article_optimized.gif
files/en-us/_redirects.txt
files/en-us/_wikihistory.json
```

---

## Screenshots

n/a

---

## How did you test this change?

n/a