### PR TITLE
chore(pr-companion): minor formatting fix for PR comment timestamp resolution

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -73,7 +73,8 @@ def analyze_pr(build_directory: Path, config):
             for comment in github_issue.get_comments():
                 if comment.user.login == "github-actions[bot]":
                     if hidden_comment_regex.search(comment.body):
-                        combined_comment += f"\n\n*(this comment was updated {datetime.datetime.utcnow()})*"
+                        now = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+                        combined_comment += f"\n\n*(comment last updated: {now})*"
                         comment.edit(body=combined_comment)
                         print(f"Updating existing comment ({comment})")
                         break


### PR DESCRIPTION
## Summary

Changing the formatting of the PR companion comment to be more readable.

### Problem

We don't need microsecond-resolution for the "comment last modified" value.

### Solution

Use `.strftime("%Y-%m-%d %H:%M:%S")` to format `datetime` value to be second-level resolution.

```
Current date and time:
2022-11-29 09:59:37.118367
2022-11-29 09:59:37
```

