### PR TITLE
fix(code): move font-family to pre/code/.code-example 

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -419,12 +419,12 @@ pre,
 code,
 .code-example {
   border-radius: var(--elem-radius);
+  font-family: var(--font-code);
   font-size: var(--type-base-font-size-rem);
 }
 
 code {
   background: var(--code-background-inline);
-  font-family: var(--font-code);
   padding: 0.125rem 0.25rem;
   width: fit-content;
 }


### PR DESCRIPTION
## Summary

Resolves an issue with Safari, which computed a font-size of 13px for the `<pre>` block and 19.69px for the `<code>` block.

Fixes https://github.com/mdn/yari/issues/7695.

### Problem

Safari calculated a wrong font-size for code blocks, causing them to appear much bigger than in Chrome/Firefox. The reason was that we applied a `font-size` to `pre/code/.code-example`, but the `font-family` only to `code`.

### Solution

Apply the `font-family` to `pre/code/.code-example`, not just `code`.

---

## Screenshots

(Safari)

### Before

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/495429/204558602-64208231-945b-4601-8642-9732c2bc7120.png">

### After

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/495429/204558674-6c003e09-a41b-4338-967d-6993ce77becd.png">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/docs/Web/API/PerformanceResourceTiming/nextHopProtocol#examples and https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/nextHopProtocol#examples in Safari to compare.