### PR TITLE
fix(quicksearch): click pings for quicksearch

### DIFF
--- a/testing/tests/headless.search.spec.ts
+++ b/testing/tests/headless.search.spec.ts
@@ -33,7 +33,7 @@ test.describe("Autocomplete search", () => {
     await page.waitForLoadState("networkidle");
     expect(await page.innerText("h1")).toBe("<foo>: A test tag");
     // Should have been redirected too...
-    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo?qs=foo"));
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
   });
 
   test("find nothing by title search", async ({ page }) => {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Improve quick search debugging.

### Problem

Adding the query parameter was leaking into online search. It also breaks caching.

### Solution

Use a click ping

---

