### PR TITLE
Revert "fix(ssr): escape colon in <title>"

### DIFF
--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -23,8 +23,7 @@ function htmlEscape(s) {
     .replace(/"/gim, "&quot;")
     .replace(/</gim, "&lt;")
     .replace(/>/gim, "&gt;")
-    .replace(/'/gim, "&apos;")
-    .replace(/:/gim, "&colon;");
+    .replace(/'/gim, "&apos;");
 }
 
 function getHrefLang(locale, otherLocales) {


### PR DESCRIPTION
Reverts mdn/yari#7166.

This caused more problems than it solved.

See for example: https://duckduckgo.com/?t=ffab&q=mdn+wheel+event&ia=web

<img width="763" alt="image" src="https://user-images.githubusercontent.com/495429/204814332-3c27b5e8-d913-4dcc-915d-9568efa23c78.png">

When in fact, the title is `Element: wheel event` (HTML: `<title>Element&colon; wheel event - Web APIs | MDN</title>`). 🤷 