### PR TITLE
fix(ssr): avoid null in <title> on 404 pages

### DIFF
--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -166,7 +166,9 @@ export default function render(
   const hydrationData: HydrationData = {};
   const translations: string[] = [];
   if (pageNotFound) {
-    escapedPageTitle = `🤷🏽‍♀️ Page not found | ${escapedPageTitle}`;
+    escapedPageTitle = `🤷🏽‍♀️ Page not found | ${
+      escapedPageTitle || "MDN Web Docs"
+    }`;
     hydrationData.pageNotFound = true;
   } else if (hyData) {
     hydrationData.hyData = hyData;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes the `<title>` on 404 pages like https://developer.mozilla.org/fr/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example.

### Problem

The `<title>` is `<title>🤷🏽‍♀️ Page not found | null</title>`, when it should be `<title>🤷🏽‍♀️ Page not found | MDN Web Docs</title>`.

### Solution

Provide a fallback value for the section part of the title.

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:5042/fr/docs/Web/JavaScript/Guide/Obsolete_Pages/The_Employee_Example locally and verified that the `<title>` no longer contains `null`.