### PR TITLE
fix(csp): remove polyfill.io from script-src

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -64,7 +64,6 @@ const CSP_SCRIPT_SRC_VALUES = [
   "'self'",
 
   "www.google-analytics.com/analytics.js",
-  "polyfill.io/v3/polyfill.min.js",
 
   "assets.codepen.io",
   "production-assets.codepen.io",


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/mdn/yari/pull/7689.

### Problem

We removed the Polyfill and the CSP entry for the inline script, but not the CSP entry for the polyfill itself.

### Solution

Also remove the CSP entry for the polyfill.

---

## Screenshots

n/a

---

## How did you test this change?

n/a