### PR TITLE
support undefined doc in article actions, improve mobile overlay logic

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -117,8 +117,10 @@ body {
   color: var(--text-primary);
   scrollbar-color: var(--scrollbar-color) var(--scrollbar-bg);
 
-  &.full-screen-overlay {
-    overflow: hidden;
+  &.mobile-overlay-active {
+    @media screen and (max-width: $screen-md) {
+      overflow: hidden;
+    }
   }
 }
 

--- a/client/src/banners/banner.scss
+++ b/client/src/banners/banner.scss
@@ -1,3 +1,5 @@
+@use "./../ui/vars" as *;
+
 .mdn-cta-container {
   align-items: center;
   background-color: #212121;
@@ -57,6 +59,8 @@
   }
 }
 
-body.full-screen-overlay .mdn-cta-container {
-  display: none;
+body.mobile-overlay-active .mdn-cta-container {
+  @media screen and (max-width: $screen-md) {
+    display: none;
+  }
 }

--- a/client/src/plus/collections/collection.tsx
+++ b/client/src/plus/collections/collection.tsx
@@ -231,14 +231,12 @@ function ItemComponent({
         <h2>
           <Link to={item.url}>{camelWrap(item.title)}</Link>
         </h2>
-        {doc && (
-          <ArticleActions
-            doc={doc}
-            showTranslations={false}
-            item={"collection_id" in item ? item : undefined}
-            scopedMutator={mutate}
-          />
-        )}
+        <ArticleActions
+          doc={doc}
+          showTranslations={false}
+          item={"collection_id" in item ? item : undefined}
+          scopedMutator={mutate}
+        />
       </header>
       <div className="breadcrumbs">{breadcrumbs.join(" > ")}</div>
       {doc && (

--- a/client/src/ui/organisms/article-actions/index.tsx
+++ b/client/src/ui/organisms/article-actions/index.tsx
@@ -10,8 +10,8 @@ import { Doc, DocMetadata } from "../../../../../libs/types/document";
 import "./index.scss";
 
 import BookmarkMenu from "./bookmark-menu";
-import { useUIStatus } from "../../../ui-context";
-import { useState } from "react";
+import { Overlay, useUIStatus } from "../../../ui-context";
+import { useEffect, useState } from "react";
 import { KeyedMutator } from "swr";
 import { Item } from "../../../plus/collections/api";
 
@@ -21,7 +21,7 @@ export const ArticleActions = ({
   item,
   scopedMutator,
 }: {
-  doc: Doc | DocMetadata;
+  doc?: Doc | DocMetadata;
   showTranslations?: boolean;
   item?: Item;
   scopedMutator?: KeyedMutator<Item[][]>;
@@ -29,15 +29,19 @@ export const ArticleActions = ({
   const [showArticleActionsMenu, setShowArticleActionsMenu] = useState(false);
   const userData = useUserData();
   const isServer = useIsServer();
-  const { fullScreenOverlay, setFullScreenOverlay } = useUIStatus();
+  const { toggleMobileOverlay } = useUIStatus();
   const isAuthenticated = userData && userData.isAuthenticated;
-  const translations = doc.other_translations || [];
-  const { native } = doc;
+  const translations = doc?.other_translations || [];
+  const native = doc?.native;
 
   function toggleArticleActionsMenu() {
     setShowArticleActionsMenu(!showArticleActionsMenu);
-    setFullScreenOverlay(!fullScreenOverlay);
   }
+
+  useEffect(
+    () => toggleMobileOverlay(Overlay.ArticleActions, showArticleActionsMenu),
+    [showArticleActionsMenu, toggleMobileOverlay]
+  );
 
   // @TODO we will need the following when including the language drop-down
   // const translations = doc.other_translations || [];
@@ -77,17 +81,20 @@ export const ArticleActions = ({
                   />
                 </li>
               )}
-              {showTranslations && translations && !!translations.length && (
-                <li className="article-actions-entry">
-                  <LanguageMenu
-                    onClose={() =>
-                      showArticleActionsMenu && toggleArticleActionsMenu()
-                    }
-                    translations={translations}
-                    native={native}
-                  />
-                </li>
-              )}
+              {showTranslations &&
+                translations &&
+                !!translations.length &&
+                native && (
+                  <li className="article-actions-entry">
+                    <LanguageMenu
+                      onClose={() =>
+                        showArticleActionsMenu && toggleArticleActionsMenu()
+                      }
+                      translations={translations}
+                      native={native}
+                    />
+                  </li>
+                )}
             </>
           </ul>
         </div>


### PR DESCRIPTION
this means the watch/bookmark buttons load immediately in collections,
and stop being disabled once the metadata loads in

the new overlay logic isn't immediately useful, but will be used in
the updates work, where we have watch/bookmark buttons outside of the
article actions component

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Dependency of https://mozilla-hub.atlassian.net/browse/MP-175

### Problem

Watch/Bookmark menu buttons require a doc to be rendered, making things a bit "jumpy" and giving no indication that the functionality will become available (which will especially be a problem in the updates work).

Current overlay full screen overlay logic is very inflexible, it doesn't support having multiple overlays with independent show/hide logic, this is a requirement in updates as we render the watch/bookmark menu buttons outside the article actions component.

### Solution

Make `doc` an optional argument to watch and bookmark menus, and article actions by extension. This was a relatively simple change in article actions/watch, however the bookmark menu required splitting the dropdown into a separate component, as the logic became unnecessarily complex to handle an undefined doc.

Track a set of mobile overlays, instead of a single boolean, allowing components which render as a mobile overlay to record when they themselves are open or closed, and let the UIContext to then determine whether any overlays are showing.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before


https://user-images.githubusercontent.com/755354/205302181-c1e48672-bcad-47c5-b78f-9a2726041384.mp4



### After


https://user-images.githubusercontent.com/755354/205302205-90497659-b40d-497c-a459-170fb105af23.mp4



---

## How did you test this change?

Opened/closed menus across screen sizes. Reloaded the page a lot.
