### PR TITLE
fix(filecheck): use current working directory

### DIFF
--- a/filecheck/cli.ts
+++ b/filecheck/cli.ts
@@ -21,7 +21,7 @@ program
   .version("0.0.0")
   .option("--cwd <path>", "Explicit current-working-directory", {
     validator: program.STRING,
-    default: path.join(process.cwd(), ".."),
+    default: process.cwd(),
   })
   .option(
     "--max-compression-difference-percentage <amount>",


### PR DESCRIPTION
## Summary

Previously, the filecheck was run from the filecheck directory (`cd filecheck && ts-node filecheck.ts`), which caused issues, because `node_modules` couldn't be resolved, so this CLI option was born as a workaround.

Recently, this changed and the filecheck is run directly from the repository root, so the workaround is outdated and even prevents us from running filecheck from yari.

This means mdn/content will no longer need to override the working directory (`--cwd=.`), but for now we need to keep the option for backward-compatibility.

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
