### PR TITLE
fix(filecheck): allow to compress if the file is larger than MAX_FILE_SIZE

### DIFF
--- a/filecheck/checker.ts
+++ b/filecheck/checker.ts
@@ -19,7 +19,7 @@ import {
   MAX_COMPRESSION_DIFFERENCE_PERCENTAGE,
 } from "../libs/constants";
 
-function formatSize(bytes) {
+function formatSize(bytes: number): string {
   if (bytes > 1024 * 1024) {
     return `${(bytes / 1024.0 / 1024.0).toFixed(1)}MB`;
   }
@@ -33,7 +33,10 @@ interface CheckerOptions {
   saveCompression?: boolean;
 }
 
-export async function checkFile(filePath, options: CheckerOptions = {}) {
+export async function checkFile(
+  filePath: string,
+  options: CheckerOptions = {}
+) {
   // Check that the filename is always lowercase.
   if (path.basename(filePath) !== path.basename(filePath).toLowerCase()) {
     throw new Error(
@@ -46,12 +49,9 @@ export async function checkFile(filePath, options: CheckerOptions = {}) {
   if (!stat.size) {
     throw new Error(`${filePath} is 0 bytes`);
   }
-  if (stat.size > MAX_FILE_SIZE) {
-    const formatted =
-      stat.size > 1024 * 1024
-        ? `${(stat.size / 1024.0 / 1024).toFixed(1)}MB`
-        : `${(stat.size / 1024.0).toFixed(1)}KB`;
-    const formattedMax = `${(MAX_FILE_SIZE / 1024.0 / 1024).toFixed(1)}MB`;
+  const formattedMax = `${(MAX_FILE_SIZE / 1024.0 / 1024).toFixed(1)}MB`;
+  if (!options.saveCompression && stat.size > MAX_FILE_SIZE) {
+    const formatted = formatSize(stat.size);
     throw new Error(
       `${filePath} is too large (${formatted} > ${formattedMax})`
     );
@@ -168,6 +168,13 @@ export async function checkFile(filePath, options: CheckerOptions = {}) {
     const sizeAfter = fs.statSync(compressed.destinationPath).size;
     const reductionPercentage = 100 - (100 * sizeAfter) / sizeBefore;
 
+    if (sizeAfter > MAX_FILE_SIZE) {
+      const formattedAfter = formatSize(sizeAfter);
+      throw new Error(
+        `${filePath} is too large, even after compressing to ${formattedAfter} (still larger than ${formattedMax}).`
+      );
+    }
+
     if (reductionPercentage > MAX_COMPRESSION_DIFFERENCE_PERCENTAGE) {
       if (options.saveCompression) {
         console.log(
@@ -205,6 +212,6 @@ export async function checkFile(filePath, options: CheckerOptions = {}) {
   }
 }
 
-export async function runChecker(files, options: CheckerOptions) {
+export async function runChecker(files: string[], options: CheckerOptions) {
   return Promise.all(files.map((f) => checkFile(f, options)));
 }

--- a/filecheck/checker.ts
+++ b/filecheck/checker.ts
@@ -168,7 +168,8 @@ export async function checkFile(
     const sizeAfter = fs.statSync(compressed.destinationPath).size;
     const reductionPercentage = 100 - (100 * sizeAfter) / sizeBefore;
 
-    if (sizeAfter > MAX_FILE_SIZE) {
+    // this check should only be done if we want to save the compressed file
+    if (options.saveCompression && sizeAfter > MAX_FILE_SIZE) {
       const formattedAfter = formatSize(sizeAfter);
       throw new Error(
         `${filePath} is too large, even after compressing to ${formattedAfter} (still larger than ${formattedMax}).`

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@swc/core": "^1.3.21",
     "@testing-library/react": "^13.4.0",
     "@types/hast": "^2.3.4",
+    "@types/imagemin": "^8.0.0",
     "@types/jest": "^29.2.3",
     "@types/mdast": "^3.0.10",
     "@types/node": "^16.18.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,6 +2132,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/imagemin@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.npmmirror.com/@types/imagemin/-/imagemin-8.0.0.tgz#bf5bbe1feff3b112c7e0de06d024712ad261e033"
+  integrity sha512-B9X2CUeDv/uUeY9CqkzSTfmsLkeJP6PkmXlh4lODBbf9SwpmNuLS30WzUOi863dgsjY3zt3gY5q2F+UdifRi1A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"


### PR DESCRIPTION
## Summary

Fixes: #7731.

### Problem

It also fails for "too large" images when running with `--save-compression`, even if the images would be smaller than the MAX_FILE_SIZE after compression.

### Solution

Skip file size check first if running with `--save-compressio` first. We could check whether the file could be compressed to a suitable size.

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15844309/205426906-81d1df0a-a2e8-4371-ba99-c72332374668.png)

### After

![image](https://user-images.githubusercontent.com/15844309/205426835-ab1f6461-5460-4964-9e7d-8da5f40cb12d.png)

---

## How did you test this change?

Download `https://raw.githubusercontent.com/mdn/translated-content/ce835e1d0357297fc3f93f0cb7de2b7ff74bdfc9/files/ko/learn/getting_started_with_the_web/what_will_your_website_look_like/screenshot_from_2014-11-04_15-09-21.png` and test locally.
