### PR TITLE
fix(links): keep page-not-created styles on visited links

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -586,6 +586,7 @@ a.page-not-created {
 
   &:link,
   &:hover,
+  &:visited,
   &:not([href]),
   &:focus {
     color: var(--icon-critical);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes #7735 

### Problem

Links to pages that haven't been created yet lose their styles when the target page is `:visited`.

### Solution

Persist the `a.page-not-created` styles for `:visited` links

---

## Screenshots

### Before

https://user-images.githubusercontent.com/35560568/205434915-7313b360-49f6-470f-8976-e24caee2e593.mov

### After

https://user-images.githubusercontent.com/35560568/205434904-878cf04e-812c-4377-8ac4-00dd008445df.mov

<!--
  Only changed the user interface. Commenting out.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
