### PR TITLE
chore(deps-dev): add @types/fs-extra 9.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@svgr/webpack": "^6.5.1",
     "@swc/core": "^1.3.21",
     "@testing-library/react": "^13.4.0",
+    "@types/fs-extra": "^9.0.13",
     "@types/hast": "^2.3.4",
     "@types/imagemin": "^8.0.0",
     "@types/jest": "^29.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,6 +2093,13 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@^9.0.13":
+  version "9.0.13"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
+  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Adds the missing `@types/fs-extra` package.

### Problem

We're using `fs-extra`, but it doesn't come with TypeScript declarations.

### Solution

Add the `@types` package.

---

## Screenshots

n/a

---

## How did you test this change?

👉 Checks.
