### PR TITLE
fix(build): fix broken parents for constructor

### DIFF
--- a/build/document-utils.ts
+++ b/build/document-utils.ts
@@ -1,13 +1,7 @@
 import { Document } from "../content";
 
-/**
- * Temporary fix for long titles in breadcrumbs
- * @see https://github.com/mdn/yari-private/issues/612
- * @param {String} title : the title of the document
- * @returns transformed title or original title as a string
- */
-function transformTitle(title) {
-  const transformStrings = {
+const TRANSFORM_STRINGS = new Map(
+  Object.entries({
     "Web technology for developers": "References",
     "Learn web development": "Guides",
     "HTML: HyperText Markup Language": "HTML",
@@ -18,8 +12,15 @@ function transformTitle(title) {
     "Structuring the web with HTML": "HTML",
     "Learn to style HTML using CSS": "CSS",
     "Web forms — Working with user data": "Forms",
-  };
-
+  })
+);
+/**
+ * Temporary fix for long titles in breadcrumbs
+ * @see https://github.com/mdn/yari-private/issues/612
+ * @param {String} title : the title of the document
+ * @returns transformed title or original title as a string
+ */
+function transformTitle(title) {
   // if the title contains a string like `<input>: The Input (Form Input) element`,
   // return only the `<input>` portion of the title
   if (/<\w+>/g.test(title)) {
@@ -29,7 +30,7 @@ function transformTitle(title) {
   // if the above did not match, see if it is one of the strings in the
   // transformStrings object and return the relevant replacement or
   // the unmodified title string
-  return transformStrings[title] || title;
+  return TRANSFORM_STRINGS.get(title) || title;
 }
 
 /**


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

The parents of Web/JavaScript/Reference/Classes/constructor are broken. The last element is missing the title. This is because we use an Object as a Map and looking up `contructor` breaks it.

### Problem

We use an Object from random look ups.

### Solution

Use a Map.