### PR TITLE
refactor(content): split Document.findAll().iter{Paths,Docs}()

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -150,9 +150,7 @@ async function buildDocuments(
     progressBar.start(documents.count);
   }
 
-  for (const documentPath of documents.iter({
-    pathOnly: true,
-  }) as Iterable<string>) {
+  for (const documentPath of documents.iterPaths()) {
     const result = await buildDocumentInteractive(documentPath, interactive);
 
     const isSkippedDocumentBuild = (result): result is SkippedDocumentBuild =>

--- a/content/document.test.ts
+++ b/content/document.test.ts
@@ -5,12 +5,12 @@ import * as Document from "./document";
 
 describe("Document.findAll()", () => {
   it("should always return files that exist", () => {
-    const filePaths = [...Document.findAll().iter({ pathOnly: true })];
+    const filePaths = [...Document.findAll().iterPaths()];
     expect(filePaths.every((value) => fs.existsSync(value))).toBeTruthy();
   });
 
   it("all files should be either index.html or index.md", () => {
-    const filePaths = [...Document.findAll().iter({ pathOnly: true })];
+    const filePaths = [...Document.findAll().iterPaths()];
     expect(
       filePaths.every(
         (value) => value.endsWith("index.html") || value.endsWith("index.md")
@@ -19,12 +19,10 @@ describe("Document.findAll()", () => {
   });
 
   it("searching by specific file", () => {
-    const filePaths = [...Document.findAll().iter({ pathOnly: true })];
+    const filePaths = [...Document.findAll().iterPaths()];
     const randomFile = filePaths[Math.floor(Math.random() * filePaths.length)];
     const specificFilePaths = [
-      ...Document.findAll({ files: new Set([randomFile]) }).iter({
-        pathOnly: true,
-      }),
+      ...Document.findAll({ files: new Set([randomFile]) }).iterPaths(),
     ];
     expect(specificFilePaths).toHaveLength(1);
     expect(specificFilePaths[0]).toBe(randomFile);
@@ -32,9 +30,7 @@ describe("Document.findAll()", () => {
 
   it("searching by specific locales", () => {
     const specificFilePaths = [
-      ...Document.findAll({ locales: new Map([["fr", true]]) }).iter({
-        pathOnly: true,
-      }),
+      ...Document.findAll({ locales: new Map([["fr", true]]) }).iterPaths(),
     ];
     expect(
       specificFilePaths.every((filePath) =>
@@ -45,9 +41,7 @@ describe("Document.findAll()", () => {
 
   it("searching by specific folders", () => {
     const specificFilePaths = [
-      ...Document.findAll({ folderSearch: "/foo/" }).iter({
-        pathOnly: true,
-      }),
+      ...Document.findAll({ folderSearch: "/foo/" }).iterPaths(),
     ];
     expect(
       specificFilePaths.every((filePath) =>

--- a/content/document.ts
+++ b/content/document.ts
@@ -514,9 +514,14 @@ export function findAll({
   }
   return {
     count: filePaths.length,
-    *iter({ pathOnly = false } = {}) {
+    *iterPaths() {
       for (const filePath of filePaths) {
-        yield pathOnly ? filePath : read(filePath);
+        yield filePath;
+      }
+    },
+    *iterDocs() {
+      for (const filePath of filePaths) {
+        yield read(filePath);
       }
     },
   };

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -11,7 +11,7 @@ const LANGUAGES = new Map(
 const TRANSLATIONS_OF = new Map();
 
 function gatherTranslations() {
-  const iter = Document.findAll().iter();
+  const iter = Document.findAll().iterDocs();
   for (const {
     metadata: { slug, locale, title },
   } of iter) {

--- a/markdown/m2h/cli.ts
+++ b/markdown/m2h/cli.ts
@@ -51,7 +51,7 @@ program
         folderSearch: args.folder,
         locales: buildLocaleMap(options.locale),
       });
-      for (const doc of all.iter()) {
+      for (const doc of all.iterDocs()) {
         if (!doc.isMarkdown) {
           continue;
         }

--- a/server/translations.ts
+++ b/server/translations.ts
@@ -86,7 +86,7 @@ function findDocuments({ locale }) {
   }
   const cache = _foundDocumentsCache.get(locale);
 
-  for (const filePath of documentsFound.iter({ pathOnly: true })) {
+  for (const filePath of documentsFound.iterPaths()) {
     const mtime = fs.statSync(filePath).mtime;
 
     if (!cache.has(filePath) || cache.get(filePath).mtime < mtime) {
@@ -278,7 +278,7 @@ function gatherL10NstatsSection({
   });
 
   const translatedFolderNames = new Set();
-  for (const filePath of foundTranslations.iter({ pathOnly: true })) {
+  for (const filePath of foundTranslations.iterPaths()) {
     const asFolder = path.relative(
       CONTENT_TRANSLATED_ROOT,
       path.dirname(filePath)
@@ -300,7 +300,7 @@ function gatherL10NstatsSection({
     folderSearch: folderSearchDefaultLocale,
   });
 
-  for (const filePath of foundDefaultLocale.iter({ pathOnly: true })) {
+  for (const filePath of foundDefaultLocale.iterPaths()) {
     const asFolder = path.relative(CONTENT_ROOT, path.dirname(filePath));
     const asFolderWithoutLocale = asFolder
       .split(path.sep)
@@ -417,7 +417,7 @@ function buildL10nDashboard({ locale, section }) {
     ...Document.findAll({
       locales: new Map([[DEFAULT_LOCALE.toLowerCase(), true]]),
       folderSearch: DEFAULT_LOCALE.toLowerCase() + sectionDirPath.toLowerCase(),
-    }).iter({ pathOnly: false }),
+    }).iterDocs(),
   ];
 
   const subSectionsStartingWith = defaultLocaleDocs

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -692,7 +692,7 @@ program
       const allDocs = Document.findAll({
         locales: new Map([[locale.toLowerCase(), true]]),
       });
-      for (const document of allDocs.iter()) {
+      for (const document of allDocs.iterDocs()) {
         if (fileTypes.includes(document.isMarkdown ? "md" : "html")) {
           await buildDocument(document, {
             fixFlaws: true,
@@ -760,7 +760,7 @@ program
       }
       // Build up a map of translations by their `translation_of`
       const map = new Map();
-      for (const document of documents.iter()) {
+      for (const document of documents.iterDocs()) {
         if (!document.isTranslated) continue;
         const { translation_of, locale } = document.metadata;
         if (!map.has(translation_of)) {
@@ -1013,7 +1013,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
       let countSkipped = 0;
       let countModified = 0;
       let countNoChange = 0;
-      for (const document of documents.iter()) {
+      for (const document of documents.iterDocs()) {
         countTotal++;
         console.group(`${document.fileInfo.path}:`);
         const originalRawBody = document.rawBody;


### PR DESCRIPTION
## Summary

Splits up the `iter({ pathOnly})` method returned by `Document.findAll()` into two methods `iterPaths()` and `iterDocs()`.

### Problem

`iter()` currently returns `string`s or `Doc`s depending on the value of `pathOnly`, which makes it unnecessarily hard for TypeScript to infer the return type.

### Solution

Split it up into `iterPaths()` returning `string`s and `iterDocs()` returning `Doc`s.

---

## Screenshots

n/a

---

## How did you test this change?

-