### PR TITLE
chore(macros/HTMLSidebar): add "Content categories" / "Constraint validation"

### DIFF
--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -45,10 +45,12 @@ var text = mdn.localStringMap({
     'Attributes': 'Attributes',
     'Input_types': '<code>&lt;input&gt;</code> types',
     'Guides': 'Guides:',
+      'Content_categories': 'Content categories',
       'Allowing_cross-origin_images_and_canvas': 'Allowing cross-origin use of images and canvas',
       'Block-level_elements': 'Block-level elements',
       'Inline_elements': 'Inline elements',
       'Date_and_time_formats': 'Date and time formats used in HTML',
+      'Constraint_validation': 'Constraint validation',
       'Microdata': 'Microdata',
       'Microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': 'Quirks Mode and Standards Mode',
@@ -87,6 +89,7 @@ var text = mdn.localStringMap({
     'Attributes': 'Attributs',
     'Input_types': 'Types <code>&lt;input&gt;</code>',
     'Guides': 'Guides:',
+      'Content_categories': 'Catégories de contenu',
       'Allowing_cross-origin_images_and_canvas': 'Autoriser les images et canevas provenant d\'autres origines',
       'Block-level_elements': 'Éléments de bloc',
       'Inline_elements': 'Éléments en ligne',
@@ -132,6 +135,8 @@ var text = mdn.localStringMap({
     'Index': '前ページの索引',
     'Contribute': '協力',
     'The_MDN_project': 'MDN プロジェクト',
+    'Content_categories': 'コンテンツカテゴリー',
+    'Constraint_validation': '制約検証',
   },
   'pt-BR': {
     'Tutorials': 'Tutoriais:',
@@ -166,6 +171,7 @@ var text = mdn.localStringMap({
     'Attributes': 'Atributos',
     'Input_types': 'Tipos de <code>&lt;input&gt;</code>',
     'Guides': 'Guides:',
+      'Content_categories': 'Categorias de conteúdo',
       'Allowing_cross-origin_images_and_canvas': 'CORS habilitar imagens',
       'Block-level_elements': 'Elementos block-level',
       'Inline_elements': 'Elementos inline',
@@ -208,10 +214,12 @@ var text = mdn.localStringMap({
     'Attributes': 'Aтрибуты',
     'Input_types': 'Типы <code>&lt;input&gt;</code>',
     'Guides': 'Путеводитель:',
+      'Content_categories': 'Категории контента',
       'Allowing_cross-origin_images_and_canvas': 'Разрешение использования изображений из разных источников и canvas',
       'Block-level_elements': 'Блочные элементы',
       'Inline_elements': 'Строчные элементы',
       'Date_and_time_formats': 'Date and time formats used in HTML',
+      'Constraint_validation': 'Валидация ограничений',
       'Microdata': 'Microdata',
       'microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': 'Режим совместимости (Quirks Mode) и стандартный режим (Standards Mode)',
@@ -250,10 +258,12 @@ var text = mdn.localStringMap({
     'Attributes': '属性',
     'Input_types': '<code>&lt;input&gt;</code> types',
     'Guides': '指南：',
+      'Content_categories': '内容分类',
       'Allowing_cross-origin_images_and_canvas': '启用了 CORS 的图片',
       'Block-level_elements': '块级元素',
       'Inline_elements': '行内元素',
       'Date_and_time_formats': 'HTML 中使用的日期与时间格式',
+      'Constraint_validation': '约束验证',
       'Microdata': 'Microdata',
       'microformats': 'Microformats',
       'Quirks_Mode_and_Standards_Mode': '怪异模式和标准模式',
@@ -351,10 +361,12 @@ var text = mdn.localStringMap({
   <li><strong><%=text['Guides']%></strong></li>
   <li>
     <ol>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Content_categories"><%=text["Content_categories"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
+      <li><a href="/<%=locale%>/docs/Web/HTML/Constraint_validation"><%=text["Constraint_validation"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
       <li><a href="/<%=locale%>/docs/Web/HTML/Viewport_meta_tag"><%=text["Viewport_meta_tag"]%></a></li>


### PR DESCRIPTION
Related to https://github.com/mdn/content/pull/22730

The two guide pages have been moved to `Web/HTML/` hierarchy. These pages are not part of the HTMLSidebar.
The PR adds them to the sidebar macro.

@wbamberg let me know if the pages are in right order in the sidebar list.