### PR TITLE
chore(macros): deprecate WebGLSidebar

### DIFF
--- a/kumascript/macros/WebGLSidebar.ejs
+++ b/kumascript/macros/WebGLSidebar.ejs
@@ -1,4 +1,9 @@
 <%
+
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated();
+
 var currentSection = $0;
 var locale = env.locale;
 


### PR DESCRIPTION
This PR deprecates the last custom sidebar macro in Web/API 🎉 

https://github.com/mdn/content/pull/22782 removed all references to the custom WebGLSidebar macro from en-US, and this PR deprecates it.

There's more information about this sidebar at https://discourse.mozilla.org/t/defaultapisidebar-apiref-and-groupdata/40210/24.