### PR TITLE
fix(print): hide sidebar (+ banner)

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -63,7 +63,8 @@
     <link rel="canonical" href="https://developer.mozilla.org" />
     <style media="print">
       .mdn-cta-container,
-      .breadcrumbs-container,
+      .article-actions-container,
+      .main-menu-toggle,
       .document-toc-container,
       .on-github,
       .sidebar,

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -62,6 +62,7 @@
 
     <link rel="canonical" href="https://developer.mozilla.org" />
     <style media="print">
+      .mdn-cta-container,
       .breadcrumbs-container,
       .document-toc-container,
       .on-github,

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -65,7 +65,7 @@
       .breadcrumbs-container,
       .document-toc-container,
       .on-github,
-      nav.sidebar,
+      .sidebar,
       .top-navigation-main,
       .page-footer,
       ul.prev-next,


### PR DESCRIPTION
## Summary

Fixes #7767.

### Problem

In https://github.com/mdn/yari/pull/7400, we changed our `.sidebar` from `nav` to `aside`, but we used the specific `nav.sidebar` selector to hide the sidebar when printing.

### Solution

Update the print style to use the unspecific `.sidebar` selector.

---

## Screenshots

| Before | After |
|--------|------|
| <img width="469" alt="image" src="https://user-images.githubusercontent.com/495429/206499049-cf50dc4d-93e0-41e5-abf3-1c4dae1e4c44.png"> | <img width="469" alt="image" src="https://user-images.githubusercontent.com/495429/206498941-aff0aa0c-d952-4639-848e-9e0f85cd25e3.png"> |



---

## How did you test this change?

Ran `yarn dev` and checked out the print preview for http://localhost:5042/en-US/docs/Web locally, comparing it to the print preview of https://developer.mozilla.org/en-US/docs/Web.