### PR TITLE
ci(pr-deployer): cache with specific python version

### DIFF
--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Python
+        id: setup-python
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -23,13 +23,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: deployer/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}-${{ steps.setup-python.outputs.python-version }}
 
       - name: Load cached .local
         uses: actions/cache@v3
         with:
           path: ~/.local
-          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}
+          key: dotlocal-${{ runner.os }}-${{ hashFiles('.github/workflows/pr-deployer.yml') }}-${{ steps.setup-python.outputs.python-version }}
 
       - name: Install Python poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
## Summary

When python version changed, the cache should not be used for the deployer. We just have the same problem in translated-content and content. See mdn/translated-content#6568 and mdn/translated-content#6804. But I forgot the check the usage in mdn/yari. We can see the same problem (as the listed workflow run):

- The old python version works well: https://github.com/mdn/yari/actions/runs/3645561868/jobs/6155813422#step:8:7
- The new python version would break this: https://github.com/mdn/yari/actions/runs/3645618869/jobs/6155917363#step:8:7

### Solution

Specific the cache key with python version. We have fix this problem in translated-content/content:

- mdn/translated-content#6569
- mdn/translated-content#6805

---

## Screenshots

N/A

## How did you test this change?

N/A
