### PR TITLE
fix(macros/CSSInfo): use page-type instead of tags

### DIFF
--- a/kumascript/macros/CSSInfo.ejs
+++ b/kumascript/macros/CSSInfo.ejs
@@ -38,10 +38,9 @@ async function createLink(apiName, area, linkName) {
     let url = "/" + locale + "/docs/Web/" + (area || "CSS") + "/" + apiName;
     let thisPage = await localWiki.getPage(url);
 
-    if (currentPage.hasTag(thisPage, "CSS Function")) {
+    if (thisPage.pageType === "css-function") {
         formattedLinkName += "()";
-    } else if (currentPage.hasTag(thisPage, "CSS Data Type") ||
-        currentPage.hasTag(thisPage, "Element")) {
+    } else if (thisPage.pageType === "css-type" || thisPage.pageType === "svg-element") {
         formattedLinkName = "&lt;" + formattedLinkName + "&gt;";
     }
 


### PR DESCRIPTION
Following on from https://github.com/mdn/content/pull/22829, this PR updates [CSSInfo.ejs](https://github.com/mdn/yari/blob/main/kumascript/macros/CSSInfo.ejs) to use page types instead of tags.

CSSInfo uses tags for a rather esoteric thing. In mdn/data, [strings can embed KumaScript xref macros](https://github.com/mdn/data/blob/ce9c8377b57428d26d0c99942761554a93064088/l10n/css.json#L419). Because, as CSSInfo says, [KS macros can't call other KS macros from within functions](https://github.com/mdn/yari/blob/b5de80980950cbe5dd857f92a2bdeb7b193c834d/kumascript/macros/CSSInfo.ejs#L29)*, [CSSInfo reimplements some version of these xref macros](https://github.com/mdn/yari/blob/b5de80980950cbe5dd857f92a2bdeb7b193c834d/kumascript/macros/CSSInfo.ejs#L36-L50).

In the course of this it uses tags to decide whether to put `< >`around elements and data types, and `()` after CSS functions. As far as elements are concerned it seems that [only SVG elements are in play here](https://github.com/mdn/yari/blob/b5de80980950cbe5dd857f92a2bdeb7b193c834d/kumascript/macros/CSSInfo.ejs#L73-L90).

So I've replaced these usages with the relevant CSS and SVG page types.

Aside is that CSSInfo is a very complicated macro and is our last significant dependency on mdn/data, and some day we ought to replace it with something that slurps webref and is a lot more maintainable. But that isn't for today.

### Testing

Since SVG page types only just got merged, you'll need a fresh copy of /content to test this.

Some interesting pages to test:

http://localhost:3000/en-US/docs/Web/CSS/line-height-step#formal_definition
- Uses `{{cssxref(\"length\")}}`: cssxref to a CSS data type

http://localhost:3000/en-US/docs/Web/CSS/column-rule-width#formal_definition
- Uses `{{cssxref(\"column-rule-style\")}}`: cssxref to a CSS property

http://localhost:3000/en-US/docs/Web/CSS/transition#formal_definition
- Uses `{cssxref(\"::before\")}}`: cssxref to a CSS pseudo-element

http://localhost:3000/en-US/docs/Web/CSS/background-image#formal_definition
- Uses `{{cssxref(\"url\")}}`: cssxref to a CSS function

http://localhost:3000/en-US/docs/Web/CSS/image-orientation#formal_definition
- Uses `{{xref_cssangle}}`: this one doesn't even exist as a KS macro. Did it used to? Not sure. Anyway it works in this branch.

http://localhost:3000/en-US/docs/Web/CSS/mask-type#formal_definition
- Uses `{{SVGElement(\"mask\")}}`: SVGElement to an SVG element

http://localhost:3000/en-US/docs/Web/CSS/backdrop-filter#formal_definition
- Uses `{{SVGElement(\"defs\")}}`: SVGElement to an SVG element - but note in this case that the page has bad tags, so it's not getting the `<>` in production, but is getting them in this branch because the page types are right.

http://localhost:3000/en-US/docs/Web/CSS/-moz-orient#formal_definition
- Uses `{{HTMLElement(\"progress\")}}`, HTMLElement to an HTML element: the HTMLElement xref isn't supported in CSSInfo, so this one broken in both production and this branch. It is the only such page I could find though, and definitely not worth fixing in this PR.

*************************

\* or maybe they can now, idk, that bug is 9 years old and KS has been rewritten since
