### PR TITLE
chore(footer): Point to CONTRIBUTING.md instead of README in footer

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -15,13 +15,13 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
-          Want to fix the problem yourself? See{" "}
+          Want to fix the problem yourself? See the{" "}
           <a
-            href="https://github.com/mdn/content/blob/main/README.md"
+            href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            our Contribution guide
+            MDN Web Docs contribution guide
           </a>
           .
         </li>

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -15,15 +15,15 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
-          Want to fix the problem yourself? See the{" "}
+          Want to fix the problem yourself? Learn{" "}
           <a
             href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            MDN Web Docs contribution guide
+            how to contribute
           </a>
-          .
+          !
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Minor change to point to our CONTRIBUTING.md instead of the README. 

Opening as draft pending team feedback.