### PR TITLE
Update ignored files lists

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,7 @@
 *.min.js
 client/build/
 dist/
+ssr/dist/
 libs/
 client/public/service-worker.js
 client/public/

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ yarn-error.log*
 /server/*.js.map
 /ssr/dist/
 /ssr/*.js
+!/ssr/webpack.config.js
 /ssr/*.js.map
 /tool/*.js
 /tool/*.js.map

--- a/.prettierignore
+++ b/.prettierignore
@@ -28,3 +28,4 @@ _githistory.json
 /ssr/mozilla.dnthelper.min.js
 /mdn/content
 popularities.json
+/client/public/service-worker.js


### PR DESCRIPTION
This PR updates the ESLint, Prettier and Git ignore lists to perform the following:

1) Ignore built files in the SSR folder
2) Ignore formatting a generated file (`/client/public/service-worker.js`)
3) Don't ignore SSR's Webpack configuration file (accidentally ignored while attempting to ignore TypeScript build output)
