### PR TITLE
fix(macros/SubpagesWithSummaries): remove junk and important tag handling

### DIFF
--- a/kumascript/macros/SubpagesWithSummaries.ejs
+++ b/kumascript/macros/SubpagesWithSummaries.ejs
@@ -23,31 +23,15 @@ if ($0 && ($0 != undefined)) {
 var numTerms = termList.length;
 
 if (numTerms) {
-    var importantList = [];
-    var regularList = [];
-
     // Alphabetize the list
-
     termList.sort(pageSorter);
-
-    // Now move the important items to the top; these are items tagged "Important".
-
-    for (var i=0; i<numTerms; i++) {
-        if (page.hasTag(termList[i], "Important")) {
-            importantList.push(termList[i]);
-        } else {
-            regularList.push(termList[i]);
-        }
-    }
-
-    termList = importantList.concat(regularList);
 
     html += "<dl>";
 
     for (var i=0; i<numTerms; i++) {
         var aPage = termList[i];
 
-        if (!page.hasTag(aPage, "junk") && (aPage.title != "Index")) {
+        if (aPage.title != "Index") {
             var title = aPage.title;
             var summary = aPage.summary().replace(/<img[^>]*>/g," ");
             var url = aPage.url;


### PR DESCRIPTION
I'm trying to remove some of the places we use tags in KS macros, to enable us to remove tags from content (cc @hamishwillee ).

This PR removes the use of "Junk" and "Important" from the [SubpagesWithSummaries.ejs](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs) macro.

That macro uses these tags to:
- exclude pages tagged "Junk"
- list pages tagged "Important" first

This never really caught on. We have zero pages tagged "Important" in mdn/content, and only two pages tagged "Junk":
https://developer.mozilla.org/en-US/docs/web/css/tutorials 
https://developer.mozilla.org/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls 

I don't think either of these pages are currently in scope for this macro, and we should not have a "Junk" tag - if a page is junk we should delete it or fix it.

This macro is called directly by some pages and indirectly by others, via the [LandingPageListSubpages](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs) macro. Neither of these are very widely used:

```
$ rg -i "\{\{SubpagesWithSummaries"
files/en-us/web/accessibility/aria/roles/index.md
150:{{SubpagesWithSummaries}}

files/en-us/web/accessibility/aria/attributes/index.md
118:{{SubpagesWithSummaries}}

files/en-us/web/exslt/exsl/index.md
14:{{SubpagesWithSummaries}}

files/en-us/web/exslt/str/index.md
14:{{SubpagesWithSummaries}}

files/en-us/web/exslt/set/index.md
14:{{SubpagesWithSummaries}}

files/en-us/web/exslt/index.md
11:{{SubpagesWithSummaries}}

files/en-us/web/exslt/math/index.md
14:{{SubpagesWithSummaries}}

files/en-us/web/exslt/regexp/index.md
14:{{SubpagesWithSummaries}}

files/en-us/web/webdriver/commands/index.md
16:{{SubpagesWithSummaries}}
```


```
$ rg -i "\{\{LandingPageListSubpages"
files/en-us/mozilla/firefox/index.md
63:{{LandingPageListSubpages}}

files/en-us/mozilla/index.md
17:{{LandingPageListSubpages}}

files/en-us/web/performance/index.md
30:{{LandingPageListSubpages}}

files/en-us/web/api/webrtc_api/high-level_guide/index.md
19:{{LandingPageListSubpages}}

files/en-us/web/api/web_audio_api/index.md
196:{{LandingPageListSubpages}}

files/en-us/web/xml/index.md
15:{{LandingPageListSubpages}}

files/en-us/web/guide/performance/index.md
28:{{LandingPageListSubpages}}

files/en-us/mozilla/add-ons/webextensions/api/index.md
63:{{LandingPageListSubpages}}

files/en-us/mdn/contribute/index.md
151:{{LandingPageListSubPages()}}

files/en-us/mdn/contribute/processes/index.md
14:{{LandingPageListSubPages()}}

files/en-us/mdn/writing_guidelines/howto/index.md
16:{{LandingPageListSubpages}}

files/en-us/mdn/writing_guidelines/page_structures/index.md
15:{{LandingPageListSubPages()}}
```

## Testing

I've tested content pages that use one of the two macros, and they look the same as in production. Examples:

SubpagesWithSummaries:
http://localhost:3000/en-US/docs/Web/Accessibility/ARIA/Roles
http://localhost:3000/en-US/docs/Web/WebDriver/Commands
http://localhost:3000/en-US/docs/Web/EXSLT/exsl
http://localhost:3000/en-US/docs/Web/Performance

LandingPageListSubpages:
http://localhost:3000/en-US/docs/Web/Performance#key_performance_guides
http://localhost:3000/en-US/docs/Web/API/Web_Audio_API#guides_and_tutorials
http://localhost:3000/en-US/docs/MDN/Contribute#other_useful_pages
http://localhost:3000/en-US/docs/mozilla/add-ons/webextensions/api/#javascript_api_listing