### PR TITLE
Move Jest configuration to separate file

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,12 @@
+{
+  "preset": "ts-jest",
+  "testPathIgnorePatterns": ["headless*", "developing.spec.ts"],
+  "transform": {
+    "\\.tsx?$": [
+      "ts-jest",
+      {
+        "babelConfig": true
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -48,21 +48,6 @@
     "tool": "ts-node tool/cli.ts",
     "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
-  "jest": {
-    "preset": "ts-jest",
-    "testPathIgnorePatterns": [
-      "headless*",
-      "developing.spec.ts"
-    ],
-    "transform": {
-      "\\.tsx?$": [
-        "ts-jest",
-        {
-          "babelConfig": true
-        }
-      ]
-    }
-  },
   "resolutions": {
     "lodash": ">=4.17.15"
   },


### PR DESCRIPTION
This PR takes the Jest configuration out of `package.json` and moves it to its own file.  This will help reduce merge conflicts and keep all configuration for packages out of `package.json`.
