### PR TITLE
Simplify imports/calls for JSDOM

### DIFF
--- a/kumascript/tests/macros/Compat.test.ts
+++ b/kumascript/tests/macros/Compat.test.ts
@@ -2,12 +2,10 @@ import { assert, itMacro, describeMacro, lintHTML } from "./utils";
 
 import fs from "node:fs";
 import path from "node:path";
-import jsdom from "jsdom";
+import { JSDOM } from "jsdom";
 import extend from "extend";
 const dirname = __dirname;
 const fixture_dir = path.resolve(dirname, "fixtures/compat");
-
-const { JSDOM } = jsdom;
 
 let fixtureCompatData = {};
 fs.readdirSync(fixture_dir).forEach(function (fn) {

--- a/kumascript/tests/macros/HTTPSidebar.test.ts
+++ b/kumascript/tests/macros/HTTPSidebar.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import jsdom from "jsdom";
+import { JSDOM } from "jsdom";
 import { Document } from "../../../content";
 import {
   assert,
@@ -79,7 +79,7 @@ describeMacro("HTTPSidebar", function () {
     macro.ctx.env.locale = "en-US";
     return macro.call().then(function (result) {
       expect(lintHTML(result)).toBeFalsy();
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "en-US");
     });
   });
@@ -88,7 +88,7 @@ describeMacro("HTTPSidebar", function () {
     macro.ctx.env.locale = "es";
     return macro.call().then(function (result) {
       expect(lintHTML(result)).toBeFalsy();
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "es");
     });
   });

--- a/kumascript/tests/macros/firefoxsidebar.test.ts
+++ b/kumascript/tests/macros/firefoxsidebar.test.ts
@@ -1,5 +1,5 @@
 import { assert, itMacro, describeMacro } from "./utils";
-import jsdom from "jsdom";
+import { JSDOM } from "jsdom";
 
 const locales = {
   "en-US": {
@@ -19,7 +19,7 @@ describeMacro("FirefoxSidebar", function () {
   itMacro("Creates a sidebar object for en-US", function (macro) {
     macro.ctx.env.locale = "en-US";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "en-US");
     });
   });
@@ -27,7 +27,7 @@ describeMacro("FirefoxSidebar", function () {
   itMacro("Creates a sidebar object for fr", function (macro) {
     macro.ctx.env.locale = "fr";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "fr");
     });
   });

--- a/kumascript/tests/macros/gamessidebar.test.ts
+++ b/kumascript/tests/macros/gamessidebar.test.ts
@@ -1,5 +1,5 @@
 import { assert, itMacro, describeMacro } from "./utils";
-import jsdom from "jsdom";
+import { JSDOM } from "jsdom";
 
 const locales = {
   "en-US": {
@@ -19,7 +19,7 @@ describeMacro("GamesSidebar", function () {
   itMacro("Creates a sidebar object for en-US", function (macro) {
     macro.ctx.env.locale = "en-US";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "en-US");
     });
   });
@@ -27,7 +27,7 @@ describeMacro("GamesSidebar", function () {
   itMacro("Creates a sidebar object for ja", function (macro) {
     macro.ctx.env.locale = "ja";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "ja");
     });
   });

--- a/kumascript/tests/macros/mdnsidebar.test.ts
+++ b/kumascript/tests/macros/mdnsidebar.test.ts
@@ -1,5 +1,5 @@
 import { assert, itMacro, describeMacro } from "./utils";
-import jsdom from "jsdom";
+import { JSDOM } from "jsdom";
 
 const locales = {
   "en-US": {
@@ -19,7 +19,7 @@ describeMacro("MDNSidebar", function () {
   itMacro("Creates a sidebar object for en-US", function (macro) {
     macro.ctx.env.locale = "en-US";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "en-US");
     });
   });
@@ -27,7 +27,7 @@ describeMacro("MDNSidebar", function () {
   itMacro("Creates a sidebar object for fr", function (macro) {
     macro.ctx.env.locale = "fr";
     return macro.call().then(function (result) {
-      const dom = jsdom.JSDOM.fragment(result);
+      const dom = JSDOM.fragment(result);
       checkSidebarDom(dom, "fr");
     });
   });


### PR DESCRIPTION
This PR simplifies the imports and calls for the `jsdom` package, simply importing the `JSDOM` export rather than calling `jsdom.JSDOM` everywhere.
