### PR TITLE
feat(kumascript): expose status on page object

### DIFF
--- a/kumascript/src/info.ts
+++ b/kumascript/src/info.ts
@@ -191,13 +191,14 @@ const info = {
       return this.getPageByURL(document);
     }
 
-    const { locale, slug, title, tags } = document.metadata;
+    const { locale, slug, title, status, tags } = document.metadata;
     const { rawBody, isMarkdown } = document;
     return {
       url: document.url,
       locale,
       slug,
       title,
+      status: status || [],
       tags: tags || [],
       pageType: document.metadata["page-type"],
       translations: [], // TODO Object.freeze(buildTranslationObjects(data)),


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes #7799.

### Problem

We're deprecating tags, e.g. by using the `status` instead, but ~~there is no equivalent helper `page.hasStatus()` like `page.hasTag()`~~ it is not yet available on the `page` object.

### Solution

Add the `status` to the `page` object.

---

## Screenshots

n/a

---

## How did you test this change?

~~Added `status: ['deprecated']` to `content/files/en-us/web/api/merchantvalidationevent/index.md`, updated `APIRef.ejs` to use `hasStatus` instead of `hasTag`, then ran `yarn dev` and opened http://localhost:3000/en-US/docs/Web/API/MerchantValidationEvent locally.~~