### PR TITLE
chore(deployer): ignore /bcd when deploying and add /bcd to lambda

### DIFF
--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -234,6 +234,7 @@ export async function handler(event) {
       // non-ascii symbols and sanitize symbols like ":".
       request.uri = encodePath(slugToFolder(decodedUri));
     }
+
     // Rewrite the HOST header to match the S3 bucket website domain.
     // This is required only because we're using S3 as a website, which
     // we need in order to do redirects from S3. NOTE: The origin is

--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -225,11 +225,15 @@ export async function handler(event) {
     request.origin.custom &&
     request.origin.custom.domainName.includes("s3")
   ) {
-    // Rewrite the URI to match the keys in S3.
-    // NOTE: The incoming URI should remain URI-encoded. However, it
-    // must be passed to slugToFolder as decoded version to lowercase
-    // non-ascii symbols and sanitize symbols like ":".
-    request.uri = encodePath(slugToFolder(decodedUri));
+    // If this is bcd request we must not change the uri as they are
+    // case sensitive.
+    if (!decodedUri.startsWith("/bcd/")) {
+      // Rewrite the URI to match the keys in S3.
+      // NOTE: The incoming URI should remain URI-encoded. However, it
+      // must be passed to slugToFolder as decoded version to lowercase
+      // non-ascii symbols and sanitize symbols like ":".
+      request.uri = encodePath(slugToFolder(decodedUri));
+    }
     // Rewrite the HOST header to match the S3 bucket website domain.
     // This is required only because we're using S3 as a website, which
     // we need in order to do redirects from S3. NOTE: The origin is

--- a/deployer/src/deployer/constants.py
+++ b/deployer/src/deployer/constants.py
@@ -51,4 +51,4 @@ DEFAULT_REPO = config("GITHUB_REPOSITORY", default=None)
 DEFAULT_GITHUB_TOKEN = config("GITHUB_TOKEN", default=None)
 
 # Object prefixes that are managed manually and must not be pruned.
-MANUAL_PREFIXES = ["opendesign", "_whatsdeployed"]
+MANUAL_PREFIXES = ["bcd", "opendesign", "_whatsdeployed"]


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

We'll serve data for bcd from a new static API.

### Problem

1. The deployer removes bcd data on each deployment as it lives next to the content.
2. The lambda transforms the uri into lower case and this breaks the bcd queries (there exists `api.crypto` and `api.Crypto`.

### Solution

1. Add an exception to the deployer.
2. Don't lowercase uris starting with `/bcd/`

---

## How did you test this change?

Manual deployment to stage: https://github.com/mdn/yari/actions/runs/3686702028
