### PR TITLE
fix(macros/JSRef): use page type instead of tags

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -115,7 +115,6 @@ result['iObject'] = {
 }
 
 var pageList;
-var isObj;
 
 function isPrototypeMemberPage(page) {
     return [
@@ -143,13 +142,11 @@ function isMethodPage(page) {
 
 for (var object in source) {
     pageList = source[object];
-    if (object == "iObject") {
-        isObj = true;
+    if (object === "iObject") {
+        // For objects, we're only interested in prototype members.
+        pageList = pageList.filter(page => isPrototypeMemberPage(page));
     }
     for (const page of pageList) {
-        if (isObj && !isPrototypeMemberPage(page)) {
-            continue;
-        }
         if (isPropertyPage(page)) {
             result[object].properties.push(page);
           }

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -116,7 +116,30 @@ result['iObject'] = {
 
 var pageList;
 var isObj;
-var includeme;
+
+function isPrototypeMemberPage(page) {
+    return [
+        "javascript-instance-accessor-property",
+        "javascript-instance-data-property",
+        "javascript-instance-method",
+    ].includes(page.pageType);
+}
+
+function isPropertyPage(page) {
+    return [
+        "javascript-static-accessor-property",
+        "javascript-static-data-property",
+        "javascript-instance-accessor-property",
+        "javascript-instance-data-property",
+    ].includes(page.pageType);
+}
+
+function isMethodPage(page) {
+    return [
+        "javascript-static-method",
+        "javascript-instance-method",
+    ].includes(page.pageType);
+}
 
 for (var object in source) {
     pageList = source[object];
@@ -124,17 +147,15 @@ for (var object in source) {
         isObj = true;
     }
     for (aPage in pageList) {
-        if (isObj) {
-            includeme = containsTag(pageList[aPage], "prototype");
-        } else {
-            includeme = true;
+        if (isObj && !isPrototypeMemberPage(aPage)) {
+            continue;
         }
-        if (containsTag(pageList[aPage], 'Property') && includeme) {
+        if (isPropertyPage(aPage)) {
             result[object].properties.push(pageList[aPage]);
-        }
-        if (containsTag(pageList[aPage], 'Method') && includeme) {
+          }
+          if (isMethodPage(aPage)) {
             result[object].methods.push(pageList[aPage]);
-        }
+          }
     }
 }
 

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -146,15 +146,15 @@ for (var object in source) {
     if (object == "iObject") {
         isObj = true;
     }
-    for (aPage in pageList) {
-        if (isObj && !isPrototypeMemberPage(aPage)) {
+    for (const page of pageList) {
+        if (isObj && !isPrototypeMemberPage(page)) {
             continue;
         }
-        if (isPropertyPage(aPage)) {
-            result[object].properties.push(pageList[aPage]);
+        if (isPropertyPage(page)) {
+            result[object].properties.push(page);
           }
-          if (isMethodPage(aPage)) {
-            result[object].methods.push(pageList[aPage]);
+          if (isMethodPage(page)) {
+            result[object].methods.push(page);
           }
     }
 }

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -153,9 +153,9 @@ for (var object in source) {
         if (isPropertyPage(page)) {
             result[object].properties.push(page);
           }
-          if (isMethodPage(page)) {
+        if (isMethodPage(page)) {
             result[object].methods.push(page);
-          }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Use page types instead of tags in JSRef.

## Problem / solution

The [JSRef.ejs](https://github.com/mdn/yari/blob/main/kumascript/macros/JSRef.ejs) macro builds the sidebar that appears on "JS object" pages, like the page for [`Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) and its children.

It uses tags to divide up members into properties and methods, and also to exclude non-prototype properties of objects that the current object inherits from (for example, although `Array` inherits from `Object`, it does not inherit [`freeze()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze) from it.

Now we have [page types for JS](https://github.com/mdn/content/issues/16156), we can replace this usage of tags with page types, and that's what this PR does.

Note that with page types we could also split members between static and instance: this PR doesn't do that in the interests of keeping things minimal, but it could be a follow-up.

Also note that this macro still uses tags for Experimental, Non-standard, Deprecated, and Obsolete. This is is a separate problem which will have its own solution.

## How did you test this change?

Ran yarn dev, loaded some pages, examined the sidebar, including the "Inheritance" section. Checked that this branch has the same sidebar as production.

http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl



