### PR TITLE
fix(on-github): improve copy language

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -15,12 +15,13 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
+          Want to fix the problem yourself?{" "}
           <a
             href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Learn how to contribute.
+            Learn how to contribute
           </a>
         </li>
       </ul>
@@ -37,7 +38,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      View the source.
+      View the source on <b>GitHub</b>
     </a>
   );
 }
@@ -51,7 +52,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Edit the page.
+      Edit it on <b>GitHub</b>
     </a>
   );
 }
@@ -109,7 +110,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Report a content issue.
+      Report a problem with this content on <b>GitHub</b>
     </a>
   );
 }

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -15,15 +15,14 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
-          Want to fix the problem yourself? Learn{" "}
+          Want to fix the problem yourself?{" "}
           <a
             href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            how to contribute
+            Learn how to contribute
           </a>
-          !
         </li>
       </ul>
     </div>
@@ -39,7 +38,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Source on <b>GitHub</b>
+      View the source on <b>GitHub</b>
     </a>
   );
 }
@@ -53,7 +52,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Edit on <b>GitHub</b>
+      Edit it on <b>GitHub</b>
     </a>
   );
 }

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -6,22 +6,25 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       <h3>Found a problem with this page?</h3>
       <ul>
         <li>
-          <NewIssueOnGitHubLink doc={doc} />
+          Edit the page <EditOnGitHubLink doc={doc} />.
         </li>
         <li>
-          <EditOnGitHubLink doc={doc} />
+          Report the <NewIssueOnGitHubLink doc={doc} />.
         </li>
         <li>
-          <a
-            href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
-            title={`This will take you to our contribution guidelines on GitHub.`}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Learn how to contribute
-          </a>
+          View the source <SourceOnGitHubLink doc={doc} />.
         </li>
       </ul>
+      Want to get more involved? Learn{" "}
+      <a
+        href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
+        title={`This will take you to our contribution guidelines on GitHub.`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        how to contribute
+      </a>
+      .
     </div>
   );
 }
@@ -35,7 +38,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Fix the problem yourself
+      on Github
     </a>
   );
 }
@@ -93,7 +96,21 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Report the content issue
+      content issue
+    </a>
+  );
+}
+
+function SourceOnGitHubLink({ doc }: { doc: Doc }) {
+  const { github_url, folder } = doc.source;
+  return (
+    <a
+      href={`${github_url}?plain=1`}
+      title={`Folder: ${folder} (Opens in a new tab)`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      on GitHub
     </a>
   );
 }

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -3,7 +3,7 @@ import { Doc } from "../../../libs/types/document";
 export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
-      <h3>Found a problem with this page?</h3>
+      <h3>Found a content problem with this page?</h3>
       <ul>
         <li>
           Edit the page <EditOnGitHubLink doc={doc} />.

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -6,18 +6,15 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       <h3>Found a problem with this page?</h3>
       <ul>
         <li>
-          <EditOnGitHubLink doc={doc} />
-        </li>
-        <li>
-          <SourceOnGitHubLink doc={doc} />
-        </li>
-        <li>
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
-          Want to fix the problem yourself?{" "}
+          <EditOnGitHubLink doc={doc} />
+        </li>
+        <li>
           <a
             href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
+            title={`This will take you to our contribution guidelines on GitHub.`}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -29,30 +26,16 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
   );
 }
 
-function SourceOnGitHubLink({ doc }: { doc: Doc }) {
-  const { github_url, folder } = doc.source;
-  return (
-    <a
-      href={`${github_url}?plain=1`}
-      title={`Folder: ${folder} (Opens in a new tab)`}
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      View the source on <b>GitHub</b>
-    </a>
-  );
-}
-
 function EditOnGitHubLink({ doc }: { doc: Doc }) {
   const { github_url } = doc.source;
   return (
     <a
       href={github_url.replace("/blob/", "/edit/")}
-      title={`You're going to need to sign in to GitHub first (Opens in a new tab)`}
+      title={`This will take you to GitHub, where you'll need to sign in first.`}
       target="_blank"
       rel="noopener noreferrer"
     >
-      Edit it on <b>GitHub</b>
+      Fix the problem yourself
     </a>
   );
 }
@@ -106,11 +89,11 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <a
       href={url.href}
-      title="This will take you to GitHub to file a new issue"
+      title="This will take you to GitHub to file a new issue."
       target="_blank"
       rel="noopener noreferrer"
     >
-      Report a problem with this content on <b>GitHub</b>
+      Report the content issue
     </a>
   );
 }

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -15,13 +15,12 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
           <NewIssueOnGitHubLink doc={doc} />
         </li>
         <li>
-          Want to fix the problem yourself?{" "}
           <a
             href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Learn how to contribute
+            Learn how to contribute.
           </a>
         </li>
       </ul>
@@ -38,7 +37,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      View the source on <b>GitHub</b>
+      View the source.
     </a>
   );
 }
@@ -52,7 +51,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Edit it on <b>GitHub</b>
+      Edit the page.
     </a>
   );
 }
@@ -110,7 +109,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Report a problem with this content on <b>GitHub</b>
+      Report a content issue.
     </a>
   );
 }

--- a/client/src/document/organisms/metadata/index.tsx
+++ b/client/src/document/organisms/metadata/index.tsx
@@ -15,7 +15,7 @@ export function LastModified({ value, locale }) {
   };
   return (
     <>
-      <b>Last modified:</b>{" "}
+      This page was last modified on{" "}
       <time dateTime={value}>
         {date.toLocaleString(locale, dateStringOptions)}
       </time>
@@ -33,8 +33,8 @@ export function Metadata({ doc, locale }) {
       <div className="metadata-content-container">
         {doc.isActive && <OnGitHubLink doc={doc} />}
         <p className="last-modified-date">
-          <LastModified value={doc.modified} locale={locale} />, by{" "}
-          <Authors url={doc.mdn_url} />
+          <LastModified value={doc.modified} locale={locale} /> by{" "}
+          <Authors url={doc.mdn_url} />.
         </p>
       </div>
     </aside>

--- a/client/src/document/organisms/metadata/index.tsx
+++ b/client/src/document/organisms/metadata/index.tsx
@@ -24,7 +24,7 @@ export function LastModified({ value, locale }) {
 }
 
 export function Authors({ url }) {
-  return <a href={`${url}/contributors.txt`}>by MDN contributors</a>;
+  return <a href={`${url}/contributors.txt`}>MDN contributors</a>;
 }
 
 export function Metadata({ doc, locale }) {
@@ -33,7 +33,7 @@ export function Metadata({ doc, locale }) {
       <div className="metadata-content-container">
         {doc.isActive && <OnGitHubLink doc={doc} />}
         <p className="last-modified-date">
-          <LastModified value={doc.modified} locale={locale} />,{" "}
+          <LastModified value={doc.modified} locale={locale} />, by{" "}
           <Authors url={doc.mdn_url} />
         </p>
       </div>


### PR DESCRIPTION
A. Fixes part of https://github.com/mdn/yari/issues/7656
1.
`Edit on GitHub` is now `Edit it on GitHub`
`Source on GitHub` is now `View the source on GitHub`

2. a)
`Last modified: Sep 25, 2022,` [by MDN contributors](https://developer.mozilla.org/en-US/docs/Web/CSS/contributors.txt)
is now
`Last modified: Sep 25, 2022, by` [MDN contributors](https://developer.mozilla.org/en-US/docs/Web/CSS/contributors.txt)

B. Makes minor changes to "Learn..."
The link is now on the whole phrase and the exclamation is removed

==> With the above changes, the only thing remaining in https://github.com/mdn/yari/issues/7656 to be fixed will be `2. b)`

### Before
<img width="778" alt="Screen Shot 2022-12-13 at 8 51 30 PM" src="https://user-images.githubusercontent.com/23019147/207489172-d569d60a-8a12-4a83-aaee-1ba3bd728335.png">


### After
<img width="778" alt="Screen Shot 2022-12-13 at 8 51 45 PM" src="https://user-images.githubusercontent.com/23019147/207489178-4e996895-6797-4434-ad4b-e112acde73fa.png">

