### PR TITLE
fix(macros/WebAssemblySidebar): remove link to deleted page

### DIFF
--- a/kumascript/macros/WebAssemblySidebar.ejs
+++ b/kumascript/macros/WebAssemblySidebar.ejs
@@ -13,7 +13,6 @@ var text = mdn.localStringMap({
       'Text_format' : 'Understanding WebAssembly text format',
       'Text_format_to_wasm' : 'Converting WebAssembly text format to wasm',
       'Loading_and_running' : 'Loading and running WebAssembly code',
-      'Caching_modules' : 'Caching compiled WebAssembly modules',
       'Exported_functions' : 'Exported WebAssembly functions',
     'JavaScript_interface' : 'JavaScript interface'
   },
@@ -27,7 +26,6 @@ var text = mdn.localStringMap({
       'Text_format' : "Comprendre le format texte WebAssembly",
       'Text_format_to_wasm' : "Convertir du format texte WebAssembly en wasm",
       'Loading_and_running' : "Chargement et exécution de code WebAssembly",
-      'Caching_modules' : "Mise en cache des modules WebAssembly compilés",
       'Exported_functions' : "Fonctions WebAssembly exportées",
     'JavaScript_interface' : "JavaScript interface"
   },
@@ -41,7 +39,6 @@ var text = mdn.localStringMap({
       'Text_format' : 'Описание текстового формата WebAssembly',
       'Text_format_to_wasm' : 'Перевод из текстового формата WebAssembly в wasm',
       'Loading_and_running' : 'Загрузка и запуск кода WebAssembly',
-      'Caching_modules' : 'Кеширование скомпилированных модулей WebAssembly',
       'Exported_functions' : 'Экспортируемые функции WebAssembly',
     'JavaScript_interface' : 'JavaScript interface'
   }
@@ -63,7 +60,6 @@ var text = mdn.localStringMap({
         <li><a href="<%=baseURL%>/Understanding_the_text_format"><%=text['Text_format']%></a></li>
         <li><a href="<%=baseURL%>/Text_format_to_wasm"><%=text['Text_format_to_wasm']%></a></li>
         <li><a href="<%=baseURL%>/Loading_and_running"><%=text['Loading_and_running']%></a></li>
-        <li><a href="<%=baseURL%>/Caching_modules"><%=text['Caching_modules']%></a></li>
         <li><a href="<%=baseURL%>/Exported_functions"><%=text['Exported_functions']%></a></li>
       </ol>
     </details>

--- a/kumascript/tests/macros/WebAssemblySidebar.test.ts
+++ b/kumascript/tests/macros/WebAssemblySidebar.test.ts
@@ -16,7 +16,6 @@ const expected = `\
         <li><a href="/en-US/docs/WebAssembly/Understanding_the_text_format">Understanding WebAssembly text format</a></li>
         <li><a href="/en-US/docs/WebAssembly/Text_format_to_wasm">Converting WebAssembly text format to wasm</a></li>
         <li><a href="/en-US/docs/WebAssembly/Loading_and_running">Loading and running WebAssembly code</a></li>
-        <li><a href="/en-US/docs/WebAssembly/Caching_modules">Caching compiled WebAssembly modules</a></li>
         <li><a href="/en-US/docs/WebAssembly/Exported_functions">Exported WebAssembly functions</a></li>
       </ol>
     </details>


### PR DESCRIPTION
## Summary
Remove caching modules.

Fixes #7807.

### Problem
It’s been removed.
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution
Remove it from yari.
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
