### PR TITLE
fix(filecheck): check path using path.sep

### DIFF
--- a/filecheck/checker.ts
+++ b/filecheck/checker.ts
@@ -257,9 +257,11 @@ export async function checkFile(
 }
 
 function canCheckFile(filePath: string) {
+  const filePathParts = filePath.split(path.sep);
+
   return (
-    /\/files\//.test(filePath) &&
-    !/\/node_modules\//.test(filePath) &&
+    filePathParts.includes("files") &&
+    !filePathParts.includes("node_modules") &&
     !/\.(DS_Store|html|json|md|txt|yml)$/i.test(filePath)
   );
 }


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Relates to https://github.com/mdn/content/pull/22914#issuecomment-1347697650.

### Problem

Windows paths never include `/files/`, just `\files\`, so the filecheck was just ignoring all files on Windows.

### Solution

Change the check to split the paths using `path.sep` instead of a RegExp with a OS-specific path separator.

---

## Screenshots

n/a

---

## How did you test this change?

Tested on a Windows machine.