### PR TITLE
fix(on-github): match issue template whose filename is in lowercase

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -98,7 +98,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
   sp.set(
     "template",
     locale !== "en-US"
-      ? `page-report-${locale.toLocaleLowerCase()}.yml`
+      ? `page-report-${locale.toLowerCase()}.yml`
       : "page-report.yml"
   );
   sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -97,7 +97,9 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       : "/mdn/content/issues/new";
   sp.set(
     "template",
-    locale !== "en-US" ? `page-report-${locale.toLocaleLowerCase()}.yml` : "page-report.yml"
+    locale !== "en-US"
+      ? `page-report-${locale.toLocaleLowerCase()}.yml`
+      : "page-report.yml"
   );
   sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -97,7 +97,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       : "/mdn/content/issues/new";
   sp.set(
     "template",
-    locale !== "en-US" ? `page-report-${locale}.yml` : "page-report.yml"
+    locale !== "en-US" ? `page-report-${locale.toLocaleLowerCase()}.yml` : "page-report.yml"
   );
   sp.set("mdn-url", `https://developer.mozilla.org${doc.mdn_url}`);
   sp.set("metadata", fillMetadata(METADATA_TEMPLATE, doc));


### PR DESCRIPTION
## Summary

This issue is originally reported by @iwanderer in [translated-content](https://github.com/mdn/translated-content/issues/10633#issuecomment-1350635809). And I found that the issue template file's name is in lowercase. We should match with that. For we used to use `lowercase` in other folder <https://github.com/mdn/translated-content/tree/main/docs>, <https://github.com/mdn/translated-content/tree/main/files>.

match issue template whose filename is in lowercase

Affect: `pt-BR`, `zh-CN`, `zh-TW`.
