### PR TITLE
chore(macros): delete {{IncludeSubnav}} macro

### DIFF
--- a/content/translation.ts
+++ b/content/translation.ts
@@ -53,7 +53,6 @@ const IMPORTANT_MACROS = new Map(
     "GamesSidebar",
     "HTMLSidebar",
     "HTTPSidebar",
-    "IncludeSubnav",
     "JsSidebar",
     "LearnSidebar",
     "MDNSidebar",

--- a/kumascript/index.ts
+++ b/kumascript/index.ts
@@ -16,7 +16,7 @@ import { SourceCodeError } from "./src/errors";
 import * as cheerio from "cheerio";
 
 const DEPENDENCY_LOOP_INTRO =
-  'The following documents form a circular dependency when rendering (via the "page" and/or "IncludeSubnav" macros):';
+  'The following documents form a circular dependency when rendering (via the "page" macros):';
 
 export const renderCache = new LRU<string, unknown>({ max: 2000 });
 

--- a/kumascript/macros/IncludeSubnav.ejs
+++ b/kumascript/macros/IncludeSubnav.ejs
@@ -1,8 +1,0 @@
-<%
-// The IncludeSubnav macro is considered deprecated.
-// As of today, Feb 2021, no content in the en-US repo uses it.
-// The few translated-content files that were using it were buggy and
-// we decided it wasn't worth even trying to recover that because no
-// content should be using it anyway.
-mdn.deprecated();
-%>


### PR DESCRIPTION
## Summary

The `{{IncludeSubnav}}` macro has been [removed from translated-content](https://github.com/mdn/translated-content/pull/10577). So it's time to remove it from yari. See: https://github.com/mdn/translated-content/search?q=IncludeSubnav

![image](https://user-images.githubusercontent.com/15844309/207803355-9cf8cf74-4eb9-4e20-827b-dbec9e8cc258.png)
