### PR TITLE
Remove obsolete tag from APIRef

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -156,7 +156,6 @@ var badges = {
   ExperimentalBadge : await template("ExperimentalBadge"),
   NonStandardBadge : await template("NonStandardBadge"),
   DeprecatedBadge : await template("DeprecatedBadge"),
-  ObsoleteBadge : await template("ObsoleteBadge"),
 }
 
 function buildSublist(pages, title) {
@@ -206,11 +205,6 @@ function buildSublist(pages, title) {
         pageBadges += badges.DeprecatedBadge;
     }
 
-    if (hasTag(aPage, 'Obsolete')) {
-        pageBadges += badges.ObsoleteBadge;
-        result += '<s class="obsoleteElement">';
-    }
-
     if (rtlLocales.indexOf(locale) != -1) {
         result += '<bdi>';
     }
@@ -223,10 +217,6 @@ function buildSublist(pages, title) {
 
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
-    }
-
-    if (hasTag(aPage, 'Obsolete')) {
-        result += '</s>';
     }
 
     result += '</li>';


### PR DESCRIPTION
## Summary

This removes the addition of badges to sidebars if an API page has the tag "Obsolete". 
- Obsolete was replaced by Deprecated across the docs some years ago (at least 3 or 4, maybe more).
- No pages in the whole of MDN use the Obsolete tag.

This fell out of work doing for https://github.com/mdn/mdn/issues/262

### Problem

Good to clean up unused code.

### Solution

Simply removes the code that adds the obsolete tagging.

## How did you test this change?

Added Obsolete tag to a page, viewed that it had black bin icon. Removed code in yari - observed that the page changed to remove the icon.
