### PR TITLE
chore(plus-menu): add Updates link

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -42,6 +42,13 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
           ]
         : []),
       {
+        description: "All browser compatibility updates at a glance",
+        hasIcon: true,
+        iconClasses: "submenu-icon",
+        label: "Updates",
+        url: `/${locale}/plus/updates`,
+      },
+      {
         description: "Learn how to use MDN Plus",
         hasIcon: true,
         iconClasses: "submenu-icon",


### PR DESCRIPTION
## Summary

Part of [MP-186](https://mozilla-hub.atlassian.net/browse/MP-186).

### Problem

We added a new feature in https://github.com/mdn/yari/pull/7814, but it's not yet linked anywhere.

### Solution

Add it to the "MDN Plus" menu.

---

## Screenshots

### Unauthenticated guests

| Before | After |
| --- | --- |
| <img width="1437" alt="image" src="https://user-images.githubusercontent.com/495429/208420235-379ce45e-2e7e-4c5a-b891-b0da0a4f46ee.png"> | <img width="1437" alt="image" src="https://user-images.githubusercontent.com/495429/208420362-43c9931f-55ff-4555-9851-cfcca88a4dea.png"> |

### Logged in users

| Before | After |
| --- | --- |
| <img width="1437" alt="image" src="https://user-images.githubusercontent.com/495429/208420144-b0baa16c-3582-4254-872b-c82c60106817.png"> | <img width="1437" alt="image" src="https://user-images.githubusercontent.com/495429/208419981-1c0b207d-5ee4-415e-9127-50e309a261f4.png"> |


---

## How did you test this change?

Ran `yarn dev`, visited http://localhost:3000/en-US/plus/updates and checked out the menu.