### PR TITLE
chore(plus-menu): mark Updates as new

### DIFF
--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -46,7 +46,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Updates",
-        isNew: true,
+        isNew: Date.now() < 1675209600000, // new Date("2023-02-01 00:00:00Z").getTime()
         url: `/${locale}/plus/updates`,
       },
       {

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -46,6 +46,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Updates",
+        isNew: true,
         url: `/${locale}/plus/updates`,
       },
       {

--- a/client/src/ui/molecules/submenu/index.tsx
+++ b/client/src/ui/molecules/submenu/index.tsx
@@ -6,6 +6,7 @@ type SubmenuItem = {
   description?: string;
   extraClasses?: string | null;
   hasIcon?: boolean;
+  isNew?: boolean;
   iconClasses?: string;
   label?: string;
   subText?: string;
@@ -67,7 +68,15 @@ export const Submenu = ({
                     </span>
                   )}
                   <div className="submenu-content-container">
-                    <div className="submenu-item-heading">{item.label}</div>
+                    <div className="submenu-item-heading">
+                      {item.label}
+                      {item.isNew && (
+                        <>
+                          {" "}
+                          <span className="badge">New</span>
+                        </>
+                      )}
+                    </div>
                     {item.description && (
                       <p className="submenu-item-description">
                         {item.description}
@@ -84,7 +93,15 @@ export const Submenu = ({
                 <div key={key} className="submenu-item">
                   {item.hasIcon && <div className={item.iconClasses} />}
                   <div className="submenu-content-container">
-                    <div className="submenu-item-heading">{item.label}</div>
+                    <div className="submenu-item-heading">
+                      {item.label}
+                      {item.isNew && (
+                        <>
+                          {" "}
+                          <span className="badge">New</span>
+                        </>
+                      )}
+                    </div>
                     {item.description && (
                       <p className="submenu-item-description">
                         {item.description}


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Users have to open the MDN Plus menu und notice that there is a new entry "Updates".

### Solution

Highlight it with a "new" badge (until end of January 2023).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="975" alt="image" src="https://user-images.githubusercontent.com/495429/208435240-3ef8cc0f-d6ec-403a-9d16-cd74ddfd0e5e.png">

### After

<img width="975" alt="image" src="https://user-images.githubusercontent.com/495429/208435117-5e7ff9ef-8261-42d5-8f61-6fc50e0aaf7f.png">

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
