### PR TITLE
chore(plus/updates): add metrics for expand/collapse/pagination

### DIFF
--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -81,7 +81,7 @@ export default function Updates() {
               current={currentPage}
               last={data.last}
               onChange={(page, oldPage) =>
-                gleanClick(`${PLUS_UPDATES.PAGINATION}: ${oldPage} -> ${page}`)
+                gleanClick(`${PLUS_UPDATES.PAGE_CHANGE}: ${oldPage} -> ${page}`)
               }
             />
           </>

--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -1,6 +1,6 @@
 import Container from "../../ui/atoms/container";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useSWR from "swr";
 import { DocMetadata } from "../../../../libs/types/document";
@@ -42,11 +42,6 @@ export default function Updates() {
   const { data } = useUpdates(currentPage);
   const gleanClick = useGleanClick();
 
-  useEffect(
-    () => gleanClick(`${PLUS_UPDATES.PAGE}: ${currentPage}`),
-    [gleanClick, currentPage]
-  );
-
   return (
     <div className="updates">
       <header className="plus-header-mandala">
@@ -82,7 +77,13 @@ export default function Updates() {
                 group={group}
               />
             ))}
-            <Paginator current={currentPage} last={data.last} />
+            <Paginator
+              current={currentPage}
+              last={data.last}
+              onChange={(page, oldPage) =>
+                gleanClick(`${PLUS_UPDATES.PAGINATION}: ${oldPage} -> ${page}`)
+              }
+            />
           </>
         ) : (
           <Loading />

--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -155,8 +155,8 @@ function EventComponent({ event, status }: { event: Event; status: string }) {
         if (target instanceof HTMLDetailsElement) {
           setIsOpen(target.open);
           const source = target.open
-            ? PLUS_UPDATES.TOGGLE_EVENT.OPEN
-            : PLUS_UPDATES.TOGGLE_EVENT.CLOSE;
+            ? PLUS_UPDATES.EVENT_EXPAND
+            : PLUS_UPDATES.EVENT_COLLAPSE;
           gleanClick(source);
         }
       }}

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -25,7 +25,7 @@ export const TOGGLE_PLUS_OFFLINE_DISABLED = "toggle_plus_offline_disabled";
 export const TOGGLE_PLUS_OFFLINE_ENABLED = "toggle_plus_offline_enabled";
 
 export const PLUS_UPDATES = Object.freeze({
-  PAGE: "plus_updates_page",
+  PAGINATION: "plus_updates_pagination",
   TOGGLE_EVENT: Object.freeze({
     OPEN: "plus_updates_toggle_event_open",
     CLOSE: "plus_updates_toggle_event_close",

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -23,3 +23,11 @@ export const TOP_NAV_ALREADY_SUBSCRIBER = "top_nav_already_subscriber";
 export const TOP_NAV_GET_MDN_PLUS = "top_nav_get_mdn_plus";
 export const TOGGLE_PLUS_OFFLINE_DISABLED = "toggle_plus_offline_disabled";
 export const TOGGLE_PLUS_OFFLINE_ENABLED = "toggle_plus_offline_enabled";
+
+export const PLUS_UPDATES = Object.freeze({
+  PAGE: "plus_updates_page",
+  TOGGLE_EVENT: Object.freeze({
+    OPEN: "plus_updates_toggle_event_open",
+    CLOSE: "plus_updates_toggle_event_close",
+  }),
+});

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -25,9 +25,7 @@ export const TOGGLE_PLUS_OFFLINE_DISABLED = "toggle_plus_offline_disabled";
 export const TOGGLE_PLUS_OFFLINE_ENABLED = "toggle_plus_offline_enabled";
 
 export const PLUS_UPDATES = Object.freeze({
+  EVENT_COLLAPSE: "plus_updates_event_collapse",
+  EVENT_EXPAND: "plus_updates_event_expand",
   PAGINATION: "plus_updates_pagination",
-  TOGGLE_EVENT: Object.freeze({
-    OPEN: "plus_updates_toggle_event_open",
-    CLOSE: "plus_updates_toggle_event_close",
-  }),
 });

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -27,5 +27,5 @@ export const TOGGLE_PLUS_OFFLINE_ENABLED = "toggle_plus_offline_enabled";
 export const PLUS_UPDATES = Object.freeze({
   EVENT_COLLAPSE: "plus_updates_event_collapse",
   EVENT_EXPAND: "plus_updates_event_expand",
-  PAGINATION: "plus_updates_pagination",
+  PAGE_CHANGE: "plus_updates_page_change",
 });

--- a/client/src/ui/molecules/paginator/index.tsx
+++ b/client/src/ui/molecules/paginator/index.tsx
@@ -1,8 +1,14 @@
 import { Link } from "react-router-dom";
 import { range } from "../../../utils";
 
-function PageLink({ page }: { page: number }) {
-  return <Link to={`?page=${page}`}>{page}</Link>;
+function PageLink({
+  page,
+  children,
+}: {
+  page: number;
+  children?: React.ReactNode;
+}) {
+  return <Link to={`?page=${page}`}>{children || page}</Link>;
 }
 
 export function Paginator({
@@ -24,7 +30,7 @@ export function Paginator({
 
   return (
     <div className="pagination">
-      {current > 0 && <Link to={`?page=${current - 1}`}>{"<"} Previous</Link>}
+      {current > 0 && <PageLink page={current - 1}>{"<"} Previous</PageLink>}
       {left.map((page) => (
         <PageLink key={page} page={page} />
       ))}
@@ -42,7 +48,7 @@ export function Paginator({
       {right.map((page) => (
         <PageLink key={page} page={page} />
       ))}
-      {current < last && <Link to={`?page=${current + 1}`}>Next {">"}</Link>}
+      {current < last && <PageLink page={current + 1}>Next {">"}</PageLink>}
     </div>
   );
 }

--- a/client/src/ui/molecules/paginator/index.tsx
+++ b/client/src/ui/molecules/paginator/index.tsx
@@ -4,11 +4,17 @@ import { range } from "../../../utils";
 function PageLink({
   page,
   children,
+  onClick,
 }: {
   page: number;
   children?: React.ReactNode;
+  onClick?: (page: number) => unknown;
 }) {
-  return <Link to={`?page=${page}`}>{children || page}</Link>;
+  return (
+    <Link to={`?page=${page}`} onClick={() => onClick && onClick(page)}>
+      {children || page}
+    </Link>
+  );
 }
 
 export function Paginator({
@@ -16,11 +22,13 @@ export function Paginator({
   last,
   endPadding = 2,
   middlePadding = 2,
+  onChange,
 }: {
   current: number;
   last: number;
   endPadding?: number;
   middlePadding?: number;
+  onChange?: (page: number, oldPage: number) => unknown;
 }) {
   const middleFirst = Math.max(current - middlePadding, 0);
   const middleLast = Math.min(middleFirst + middlePadding * 2 + 1, last + 1);
@@ -28,27 +36,37 @@ export function Paginator({
   const middle = range(middleFirst, middleLast);
   const right = range(Math.max(last + 1 - endPadding, middleLast), last + 1);
 
+  const onClick = (page: number) => onChange && onChange(page, current);
+
   return (
     <div className="pagination">
-      {current > 0 && <PageLink page={current - 1}>{"<"} Previous</PageLink>}
+      {current > 0 && (
+        <PageLink page={current - 1} onClick={onClick}>
+          {"<"} Previous
+        </PageLink>
+      )}
       {left.map((page) => (
-        <PageLink key={page} page={page} />
+        <PageLink key={page} page={page} onClick={onClick} />
       ))}
       {Boolean(left.length) && left[left.length - 1] + 1 !== middle[0] && "…"}
       {middle.map((page) =>
         current === page ? (
           <span key={page}>{page}</span>
         ) : (
-          <PageLink key={page} page={page} />
+          <PageLink key={page} page={page} onClick={onClick} />
         )
       )}
       {Boolean(right.length) &&
         middle[middle.length - 1] + 1 !== right[0] &&
         "…"}
       {right.map((page) => (
-        <PageLink key={page} page={page} />
+        <PageLink key={page} page={page} onClick={onClick} />
       ))}
-      {current < last && <PageLink page={current + 1}>Next {">"}</PageLink>}
+      {current < last && (
+        <PageLink page={current + 1} onClick={onClick}>
+          Next {">"}
+        </PageLink>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Resolves [MP-205](https://mozilla-hub.atlassian.net/browse/MP-205).

### Problem

We landed a new feature (https://github.com/mdn/yari/pull/7814), but we don't have metrics yet to understand how it's being used.

### Solution

Add three metrics:

1. Click event when a feature support event is expanded.
2. Click event when a feature support event is collapsed.
3. Click event when ~~a specific page (0, 1, 2, …) is opened~~ switching from one page (e.g. 0) to another (e.g. 1).

---

## Screenshots

n/a

---

## How did you test this change?

Added `REACT_APP_GLEAN_DEBUG=true`, reran `yarn dev` and verified that the events show up in the console.