### PR TITLE
fix(plus/updates): check that user != null

### DIFF
--- a/client/src/plus/updates/api.ts
+++ b/client/src/plus/updates/api.ts
@@ -76,10 +76,13 @@ function composeUrl({
 }
 
 export function useUpdates() {
-  const { isAuthenticated } = useUserData();
+  const user = useUserData();
   const [searchParams] = useSearchParams();
 
-  const url = composeUrl({ isAuthenticated, searchParams });
+  const url = composeUrl({
+    isAuthenticated: user && user.isAuthenticated,
+    searchParams,
+  });
 
   return useSWR(
     url,


### PR DESCRIPTION
## Summary

Fixes an issue where the Updates page is blank for new unauthenticated users whose `whoami` request doesn't return quick enough.

### Problem

`useUserData()` can return `null`, but TypeScript doesn't want to accept that, which prompted me to use its return value as if it's never null.

### Solution

Check that `user` is not null before using its properties.

---

## Screenshots

n/a

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
