### PR TITLE
fix(plus/updates): sort update events by path

### DIFF
--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -229,7 +229,7 @@ function GroupComponent({ group }: { group: Group }) {
   const allEvents = [
     ...events.added.map((e) => ({ status: "added", ...e })),
     ...events.removed.map((e) => ({ status: "removed", ...e })),
-  ] as EventWithStatus[];
+  ].sort((a, b) => a.path.localeCompare(b.path)) as EventWithStatus[];
 
   return metadata ? (
     <div className="group">

--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -25,6 +25,9 @@ import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DataError } from "../common";
 
+type EventWithStatus = Event & { status: Status };
+type Status = "added" | "removed";
+
 const CATEGORY_TO_NAME = {
   api: "Web APIs",
   css: "CSS",
@@ -222,14 +225,11 @@ function GroupComponent({ group }: { group: Group }) {
     icon: browserToIconName(browser),
     title: `${name} ${version}`,
   };
-  // {
-  //   icon: "star",
-  //   title: "Subfeatures added",
-  // }
-  // {
-  //   icon: "add",
-  //   title: "Added missing compatibility data",
-  // }
+
+  const allEvents = [
+    ...events.added.map((e) => ({ status: "added", ...e })),
+    ...events.removed.map((e) => ({ status: "removed", ...e })),
+  ] as EventWithStatus[];
 
   return metadata ? (
     <div className="group">
@@ -245,17 +245,14 @@ function GroupComponent({ group }: { group: Group }) {
           })}
         </time>
       </header>
-      {collapseEvents(events.added).map((event) => (
-        <EventComponent key={event.path} event={event} status={"added"} />
-      ))}
-      {collapseEvents(events.removed).map((event) => (
-        <EventComponent key={event.path} event={event} status={"removed"} />
+      {collapseEvents(allEvents).map((event) => (
+        <EventComponent key={event.path} event={event} status={event.status} />
       ))}
     </div>
   ) : null;
 }
 
-function collapseEvents(events: Event[]): Event[] {
+function collapseEvents<T extends { path: string }>(events: T[]): T[] {
   return events.filter(
     (event) =>
       events.findIndex(
@@ -264,13 +261,7 @@ function collapseEvents(events: Event[]): Event[] {
   );
 }
 
-function EventComponent({
-  event,
-  status,
-}: {
-  event: Event;
-  status: "added" | "removed";
-}) {
+function EventComponent({ event, status }: { event: Event; status: Status }) {
   const [isOpen, setIsOpen] = useState(false);
   const [category, ...displayPath] = event.path.split(".");
   const engines = event.compat.engines;
@@ -315,7 +306,7 @@ function EventComponent({
   );
 }
 
-function EventStatus({ status }: { status: "added" | "removed" }) {
+function EventStatus({ status }: { status: Status }) {
   return <span className={`badge status-${status}`}>{status}</span>;
 }
 


### PR DESCRIPTION
## Summary

### Problem

Currently, we show the Updates loosely ordered by category, but not at all by path:
<img width="830" alt="image" src="https://user-images.githubusercontent.com/495429/209342467-943e518b-51e7-4de6-8333-157bce0b7f24.png">
<img width="830" alt="image" src="https://user-images.githubusercontent.com/495429/209342500-d6637d96-7667-4ef5-9929-9e2c6c573872.png">


### Solution

Order the Updates by path, which implies ordering them by category (which is the first path element).

---

## Screenshots


### Before

<img width="830" alt="image" src="https://user-images.githubusercontent.com/495429/209342720-ef20eca4-6da6-4207-813f-260e9b1f26d1.png">

### After

<img width="830" alt="image" src="https://user-images.githubusercontent.com/495429/209342824-7267eb66-c7cd-4f5a-b27a-ad36172f563d.png">

---

## How did you test this change?

Opened http://localhost:3000/en-US/plus/updates locally.