### PR TITLE
feat(plus/updates): use dots in plus-menu to highlight feature until viewed

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -4,3 +4,7 @@ export { MDN_PLUS_TITLE, VALID_LOCALES } from "../../libs/constants";
 // Constants that are NOT used outside of the client.
 export const HEADER_NOTIFICATIONS_MENU_API_URL =
   "/api/v1/plus/notifications/?limit=1&unread=true";
+
+export enum FeatureId {
+  PLUS_UPDATES_V2 = "plus_updates_v2",
+}

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -94,10 +94,14 @@ export function useScrollToTop() {
 }
 
 export function useViewedState() {
+  const isServer = useIsServer();
   const key = (id: FeatureId) => `viewed.${id}`;
 
   return {
     isViewed: (id: FeatureId) => {
+      if (isServer) {
+        return false;
+      }
       try {
         return !!window?.localStorage?.getItem(key(id));
       } catch (e) {
@@ -106,6 +110,9 @@ export function useViewedState() {
       }
     },
     setViewed: (id: FeatureId) => {
+      if (isServer) {
+        return;
+      }
       try {
         window?.localStorage?.setItem(key(id), Date.now().toString());
       } catch (e) {

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { useLocation, useNavigationType, useParams } from "react-router-dom";
 import { DEFAULT_LOCALE } from "../../libs/constants";
 import { isValidLocale } from "../../libs/locale-utils";
+import { FeatureId } from "./constants";
 
 // This is a bit of a necessary hack!
 // The only reason this list is needed is because of the PageNotFound rendering.
@@ -90,4 +91,13 @@ export function useScrollToTop() {
   useEffect(() => {
     if (navigationType === "PUSH") document.documentElement.scrollTo(0, 0);
   }, [navigationType, location]);
+}
+
+export function useViewedState() {
+  const key = (id: FeatureId) => `viewed.${id}`;
+
+  return {
+    isViewed: (id: FeatureId) => !!localStorage?.getItem(key(id)),
+    setViewed: (id: FeatureId) => localStorage?.setItem(key(id), "1"),
+  };
 }

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -97,8 +97,8 @@ export function useViewedState() {
   const key = (id: FeatureId) => `viewed.${id}`;
 
   return {
-    isViewed: (id: FeatureId) => !!localStorage?.getItem(key(id)),
+    isViewed: (id: FeatureId) => !!window?.localStorage?.getItem(key(id)),
     setViewed: (id: FeatureId) =>
-      localStorage?.setItem(key(id), Date.now().toString()),
+      window?.localStorage?.setItem(key(id), Date.now().toString()),
   };
 }

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -98,6 +98,7 @@ export function useViewedState() {
 
   return {
     isViewed: (id: FeatureId) => !!localStorage?.getItem(key(id)),
-    setViewed: (id: FeatureId) => localStorage?.setItem(key(id), "1"),
+    setViewed: (id: FeatureId) =>
+      localStorage?.setItem(key(id), Date.now().toString()),
   };
 }

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -97,8 +97,20 @@ export function useViewedState() {
   const key = (id: FeatureId) => `viewed.${id}`;
 
   return {
-    isViewed: (id: FeatureId) => !!window?.localStorage?.getItem(key(id)),
-    setViewed: (id: FeatureId) =>
-      window?.localStorage?.setItem(key(id), Date.now().toString()),
+    isViewed: (id: FeatureId) => {
+      try {
+        return !!window?.localStorage?.getItem(key(id));
+      } catch (e) {
+        console.warn("Unable to read viewed state from localStorage", e);
+        return false;
+      }
+    },
+    setViewed: (id: FeatureId) => {
+      try {
+        window?.localStorage?.setItem(key(id), Date.now().toString());
+      } catch (e) {
+        console.warn("Unable to write viewed state to localStorage", e);
+      }
+    },
   };
 }

--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -2,10 +2,10 @@ import Container from "../../ui/atoms/container";
 
 import useSWR from "swr";
 import { DocMetadata } from "../../../../libs/types/document";
-import { MDN_PLUS_TITLE } from "../../constants";
+import { FeatureId, MDN_PLUS_TITLE } from "../../constants";
 import BrowserCompatibilityTable from "../../document/ingredients/browser-compatibility-table";
 import { browserToIconName } from "../../document/ingredients/browser-compatibility-table/headers";
-import { useLocale, useScrollToTop } from "../../hooks";
+import { useLocale, useScrollToTop, useViewedState } from "../../hooks";
 import { Button } from "../../ui/atoms/button";
 import { Icon } from "../../ui/atoms/icon";
 import { Loading } from "../../ui/atoms/loading";
@@ -21,7 +21,7 @@ import { useGleanClick } from "../../telemetry/glean-context";
 import { PLUS_UPDATES } from "../../telemetry/constants";
 import SearchFilter, { AnyFilter, AnySort } from "../search-filter";
 import { LoginBanner } from "./login-banner";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DataError } from "../common";
 
@@ -129,6 +129,9 @@ function UpdatesLayout() {
   const { data, error } = useUpdates();
   const gleanClick = useGleanClick();
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const { setViewed } = useViewedState();
+  useEffect(() => setViewed(FeatureId.PLUS_UPDATES_V2));
 
   const hasFilters = [...searchParams.keys()].some((key) => key !== "page");
 

--- a/client/src/ui/molecules/menu/index.scss
+++ b/client/src/ui/molecules/menu/index.scss
@@ -1,0 +1,13 @@
+.top-level-entry-container {
+  .top-level-entry-dot ~ .top-level-entry::after {
+    background: var(--text-primary-blue);
+    border: 1px solid var(--background-primary);
+    border-radius: 2rem;
+    content: "";
+    height: 0.5rem;
+    position: absolute;
+    right: 0;
+    top: 0.5rem;
+    width: 0.5rem;
+  }
+}

--- a/client/src/ui/molecules/menu/index.tsx
+++ b/client/src/ui/molecules/menu/index.tsx
@@ -1,5 +1,6 @@
 import InternalLink from "../../atoms/internal-link";
 import { MenuEntry, Submenu } from "../submenu";
+import "./index.scss";
 
 interface MenuProps {
   menu: MenuEntry;
@@ -11,8 +12,13 @@ export const Menu = ({ menu, isOpen, toggle }: MenuProps) => {
   const buttonId = `${menu.id}-button`;
   const submenuId = `${menu.id}-menu`;
 
+  const hasAnyDot = menu.items.some((item) => item.dot);
+
   return (
     <li key={menu.id} className="top-level-entry-container">
+      {hasAnyDot && (
+        <span className="visually-hidden top-level-entry-dot"></span>
+      )}
       <button
         type="button"
         id={buttonId}

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -46,7 +46,7 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Updates",
-        isNew: Date.now() < 1675209600000, // new Date("2023-02-01 00:00:00Z").getTime()
+        dot: Date.now() < 1675209600000 ? "New feature" : undefined, // new Date("2023-02-01 00:00:00Z").getTime()
         url: `/${locale}/plus/updates`,
       },
       {

--- a/client/src/ui/molecules/plus-menu/index.tsx
+++ b/client/src/ui/molecules/plus-menu/index.tsx
@@ -1,8 +1,10 @@
 import "./index.scss";
 import { usePlusUrl } from "../../../plus/utils";
 import { Menu } from "../menu";
-import { useIsServer, useLocale } from "../../../hooks";
+import { useIsServer, useLocale, useViewedState } from "../../../hooks";
 import { useUserData } from "../../../user-context";
+import { MenuEntry } from "../submenu";
+import { FeatureId } from "../../../constants";
 
 export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
   const plusUrl = usePlusUrl();
@@ -11,7 +13,9 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
   const userData = useUserData();
   const isAuthenticated = userData && userData.isAuthenticated;
 
-  const plusMenu = {
+  const { isViewed } = useViewedState();
+
+  const plusMenu: MenuEntry = {
     label: "MDN Plus",
     id: "mdn-plus",
     to: plusUrl,
@@ -46,7 +50,11 @@ export const PlusMenu = ({ visibleSubMenuId, toggleMenu }) => {
         hasIcon: true,
         iconClasses: "submenu-icon",
         label: "Updates",
-        dot: Date.now() < 1675209600000 ? "New feature" : undefined, // new Date("2023-02-01 00:00:00Z").getTime()
+        dot:
+          Date.now() < 1675209600000 && // new Date("2023-02-01 00:00:00Z").getTime()
+          !isViewed(FeatureId.PLUS_UPDATES_V2)
+            ? "New feature"
+            : undefined,
         url: `/${locale}/plus/updates`,
       },
       {

--- a/client/src/ui/molecules/submenu/index.tsx
+++ b/client/src/ui/molecules/submenu/index.tsx
@@ -1,6 +1,6 @@
 import "./index.scss";
 
-type SubmenuItem = {
+export type SubmenuItem = {
   component?: () => JSX.Element;
   description?: string;
   extraClasses?: string | null;

--- a/client/src/ui/molecules/submenu/index.tsx
+++ b/client/src/ui/molecules/submenu/index.tsx
@@ -1,12 +1,10 @@
 import "./index.scss";
-import React from "react";
 
 type SubmenuItem = {
   component?: () => JSX.Element;
   description?: string;
   extraClasses?: string | null;
   hasIcon?: boolean;
-  isNew?: boolean;
   iconClasses?: string;
   label?: string;
   subText?: string;
@@ -68,15 +66,7 @@ export const Submenu = ({
                     </span>
                   )}
                   <div className="submenu-content-container">
-                    <div className="submenu-item-heading">
-                      {item.label}
-                      {item.isNew && (
-                        <>
-                          {" "}
-                          <span className="badge">New</span>
-                        </>
-                      )}
-                    </div>
+                    <div className="submenu-item-heading">{item.label}</div>
                     {item.description && (
                       <p className="submenu-item-description">
                         {item.description}
@@ -93,15 +83,7 @@ export const Submenu = ({
                 <div key={key} className="submenu-item">
                   {item.hasIcon && <div className={item.iconClasses} />}
                   <div className="submenu-content-container">
-                    <div className="submenu-item-heading">
-                      {item.label}
-                      {item.isNew && (
-                        <>
-                          {" "}
-                          <span className="badge">New</span>
-                        </>
-                      )}
-                    </div>
+                    <div className="submenu-item-heading">{item.label}</div>
                     {item.description && (
                       <p className="submenu-item-description">
                         {item.description}


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Currently, we highlighted the new Updates feature only **inside** the MDN Plus menu (using a "New" badge), but this is barely noticeable for users intentionally opening that menu.

### Solution

Use the existing "dot" feature (used in the MDN Plus user menu for Notifications) and add a top-level "dot" if any submenu entry has a "dot". Also, use localStorage to remember whether the user has visited the Updates page and hide the "dot" then.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="806" alt="image" src="https://user-images.githubusercontent.com/495429/209355412-88cc9176-0767-477b-8abd-ce717b1c8d60.png">


### After

<img width="806" alt="image" src="https://user-images.githubusercontent.com/495429/209355225-0ef50d01-9959-4bb9-a4e3-e2b945009981.png">


---

## How did you test this change?

To test, visit any other page first, and run `localStorage.removeItem('viewed.plus_updates_v2')` in the browser console (if necessary) to bring back the dot.