### PR TITLE
fix(useViewedState): assume isViewed on SSR

### DIFF
--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -100,7 +100,8 @@ export function useViewedState() {
   return {
     isViewed: (id: FeatureId) => {
       if (isServer) {
-        return false;
+        // Avoids the dot from popping up quickly on each load.
+        return true;
       }
       try {
         return !!window?.localStorage?.getItem(key(id));


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The "unviewed feature" dot pops up quickly on each load, even after the feature was viewed, because we assumed `isViewed = true` on SSR.

### Solution

Inverse it, so that `isViewed = false` on SSR.
---

## Screenshots

n/a

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
