### PR TITLE
fix(quicksearch): split query before dot

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -244,7 +244,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     // overlaying search results don't trigger a scroll.
     const limit = window.innerHeight < 850 ? 5 : 10;
 
-    const q: string[] = splitQuery(inputValue);
+    const q = splitQuery(inputValue);
     const indexResults: number[] = searchIndex.flex
       .filter(([_, title]) => q.every((q) => title.includes(q)))
       .map(([i]) => i)

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -38,6 +38,14 @@ function quicksearchPing(input) {
   return `quick-search: ${input}`;
 }
 
+function splitQuery(term: string): string[] {
+  return term
+    .trim()
+    .toLowerCase()
+    .replace(".", " .") // Allows to find `Map.prototype.get()` via `Map.get`.
+    .split(/[ ,]+/);
+}
+
 function useSearchIndex(): readonly [
   null | SearchIndex,
   null | Error,
@@ -112,7 +120,7 @@ function useSearchIndex(): readonly [
 
 function HighlightMatch({ title, q }: { title: string; q: string }) {
   // Split on highlight term and include term into parts, ignore case.
-  const words = q.trim().toLowerCase().split(/[ ,]+/);
+  const words = splitQuery(q);
   // $& means the whole matched string
   const regexWords = words.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
   const regex = regexWords.map((word) => `(${word})`).join("|");
@@ -236,10 +244,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     // overlaying search results don't trigger a scroll.
     const limit = window.innerHeight < 850 ? 5 : 10;
 
-    const q: string[] = inputValue
-      .toLowerCase()
-      .split(" ")
-      .map((s) => s.trim());
+    const q: string[] = splitQuery(inputValue);
     const indexResults: number[] = searchIndex.flex
       .filter(([_, title]) => q.every((q) => title.includes(q)))
       .map(([i]) => i)


### PR DESCRIPTION
## Summary

Allows to find the `Map.prototype.get()` page by searching for "map.get".

Fixes https://github.com/mdn/yari/issues/7859.

### Problem

Currently, we split the quicksearch query at space only, which means "map.get" is treated as a single word, and therefore won't find the `Map.prototype.get()` page.

### Solution

Preprocess the query so that "map.get" is treated like "map .get", resulting in two words "map" and ".get".

---

## Screenshots

### Before

<img width="806" alt="image" src="https://user-images.githubusercontent.com/495429/209375582-04f0cf17-0c8f-4b31-8e89-27d88988cbd4.png">

### After

<img width="806" alt="image" src="https://user-images.githubusercontent.com/495429/209375520-6306300e-cff8-4d0d-951c-616df6d0141f.png">

---

## How did you test this change?

Typed "map.get" into the quicksearch on any page at http://localhost:3000/.