### PR TITLE
feat(quicksearch): boost exact matches

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -74,12 +74,11 @@ function useSearchIndex(): readonly [
     }
     const gather = async () => {
       const flex = data.map(
-        ({ title, url }, i) =>
-          [
-            i,
-            title.toLowerCase(),
-            url.split("/").pop().toLowerCase(),
-          ] as FlexItem
+        ({ title, url }, i): FlexItem => [
+          i,
+          title.toLowerCase(),
+          url.split("/").pop().toLowerCase(),
+        ]
       );
 
       setSearchIndex({

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -221,11 +221,12 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     // overlaying search results don't trigger a scroll.
     const limit = window.innerHeight < 850 ? 5 : 10;
 
+    const inputValueLC = inputValue.toLowerCase().trim();
     const q = splitQuery(inputValue);
     const indexResults = searchIndex.flex
       .filter(([_, title]) => q.every((q) => title.includes(q)))
       .map(([index, title, slugTail]) => {
-        const exact = Number(q.length === 1 && q[0] === slugTail);
+        const exact = Number([title, slugTail].includes(inputValueLC));
         return [exact, index];
       })
       .sort(([aExact], [bExact]) => bExact - aExact) // Boost exact matches.

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -77,7 +77,7 @@ function useSearchIndex(): readonly [
         ({ title, url }, i): FlexItem => [
           i,
           title.toLowerCase(),
-          url.split("/").pop().toLowerCase(),
+          (url.split("/").pop() as string).toLowerCase(),
         ]
       );
 

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -20,8 +20,7 @@ type Item = {
 };
 
 type SearchIndex = {
-  // [index, title, slugTail][]
-  flex: [number, string, string][];
+  flex: [index: number, title: string, slugTail: string][];
   items: null | Item[];
 };
 
@@ -223,14 +222,11 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
 
     const q = splitQuery(inputValue);
     const indexResults = searchIndex.flex
-      .reduce((results, item) => {
-        const [index, title, slugTail] = item;
-        if (q.every((q) => title.includes(q))) {
-          const exact = Number(q.length === 1 && q[0] === slugTail);
-          results.push([exact, index]);
-        }
-        return results;
-      }, [] as Array<[number, number]>)
+      .filter(([_, title]) => q.every((q) => title.includes(q)))
+      .map(([index, title, slugTail]) => {
+        const exact = Number(q.length === 1 && q[0] === slugTail);
+        return [exact, index];
+      })
       .sort(([aExact], [bExact]) => bExact - aExact) // Boost exact matches.
       .map(([_, i]) => i)
       .slice(0, limit);

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -19,8 +19,10 @@ type Item = {
   title: string;
 };
 
+type FlexItem = [index: number, title: string, slugTail: string];
+
 type SearchIndex = {
-  flex: [index: number, title: string, slugTail: string][];
+  flex: FlexItem[];
   items: null | Item[];
 };
 
@@ -73,11 +75,11 @@ function useSearchIndex(): readonly [
     const gather = async () => {
       const flex = data.map(
         ({ title, url }, i) =>
-          [i, title.toLowerCase(), url.split("/").pop().toLowerCase()] as [
-            number,
-            string,
-            string
-          ]
+          [
+            i,
+            title.toLowerCase(),
+            url.split("/").pop().toLowerCase(),
+          ] as FlexItem
       );
 
       setSearchIndex({


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/7047.

### Problem

Currently, some pages (e.g. [Element]() and [with](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with)) cannot be found via quicksearch, some pages cannot be found directly (e.g. [a](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a), [p](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p) or [head](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)), and pages like [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) or [GET](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET) don't appear at the top when searching specifically for them.

### Solution

Boost exact matches, where the query is identical to the title or the "slug tail" (last part of the slug). 

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

| Keyword | Before | After |
| --- | --- | --- |
| Element | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392944-ab84ce4f-eec0-42c2-b795-17c914dd7e3d.png"> | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392902-5a065990-a2aa-4426-9325-8122b889b45b.png"> |
| with | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209391940-514a60f3-ae39-43a5-bdd7-c437de59bc5c.png"> | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209391875-ff0f28bc-b581-42d0-b8b7-681f6524c6ec.png"> |
| a | <img width="642" alt="image" src="https://user-images.githubusercontent.com/495429/209431771-39ea0a7a-fcb6-40c5-8bd8-7df9729911b5.png"> | <img width="642" alt="image" src="https://user-images.githubusercontent.com/495429/209431793-1c8fce67-9913-4471-a8b6-e15d2f9be554.png"> |
| p | <img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432574-25bcacc0-c269-46c9-b187-8691d9993f41.png"> | <img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432585-1d7a8dc3-5801-4bf7-b2ff-0d606c7696cd.png"> |
| head | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392002-268b70d0-f34e-4b39-990d-b9a85ac55de3.png"> | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209391988-a9a646d4-90f5-436c-9557-cf273add38d1.png"> |
| object | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392039-4f26e2e1-df8a-4fa5-ad03-a7c327e6b4cd.png"> | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392064-d7665adc-792d-4bf7-b482-6a828f271c1a.png"> |
| get | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392143-de29bf4a-0301-4e58-94a1-c02d64f18eac.png"> | <img width="818" alt="image" src="https://user-images.githubusercontent.com/495429/209392155-3c3fbf83-b7a9-4949-88b4-3d5908ab9c32.png"> |

---

## How did you test this change?

Typed in the queries in the quicksearch locally on http://localhost:3000/en-US/docs/Web.