### PR TITLE
fix(search) improve loading/error message

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -355,7 +355,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     if (searchIndexError) {
       return (
         <div className="searchindex-error result-item">
-          <span>Error initializing search index</span>
+          <span>Failed to load search index!</span>
         </div>
       );
     }
@@ -363,7 +363,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     if (!searchIndex) {
       return showIndexing ? (
         <div className="indexing-warning result-item">
-          <em>Initializing index</em>
+          <em>Loading search index...</em>
         </div>
       ) : null;
     }

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -354,13 +354,15 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
 
     if (searchIndexError) {
       return (
-        <div className="searchindex-error">Error initializing search index</div>
+        <div className="searchindex-error result-item">
+          <span>Error initializing search index</span>
+        </div>
       );
     }
 
     if (!searchIndex) {
       return showIndexing ? (
-        <div className="indexing-warning">
+        <div className="indexing-warning result-item">
           <em>Initializing index</em>
         </div>
       ) : null;

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -159,7 +159,7 @@
         }
       }
 
-      a {
+      > * {
         display: block;
         padding: 0.5rem;
       }


### PR DESCRIPTION
## Summary

### Problem

The search loading/error messages are not properly styled, and the messages themselves are rather technical.

### Solution

Use the same style as result items (and "Not seeing what you're search for" item), and rephrase the messages.

---

## Screenshots

### Before

<img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432330-1eb01a8b-8de7-4b2f-8132-94975fd77725.png">
<img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432351-91e2df8c-9214-4952-9e65-0727a05236c9.png">


### After

<img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432415-11b3883c-e481-4983-b5cc-9e3fed43b5f2.png">
<img width="546" alt="image" src="https://user-images.githubusercontent.com/495429/209432400-66cd092f-1621-42df-b217-f021fb26aad2.png">


---

## How did you test this change?

- Edited `if (searchIndexError)` and `if (!searchIndex)` in `search.tsx` to be temporarily `if (true)` to enforce showing the corresponding message.
- Ran `yarn dev`, then opened http://localhost:3000/en-US/docs/Web/HTML locally and typed in "test" into the quicksearch.