### PR TITLE
chore(deps): replace browser-specs with web-specs

### DIFF
--- a/build/extract-specifications.ts
+++ b/build/extract-specifications.ts
@@ -1,7 +1,7 @@
 import { packageBCD } from "./resolve-bcd";
 import * as bcd from "@mdn/browser-compat-data/types";
 import { Specification } from "../libs/types/document";
-import specs from "browser-specs";
+import specs from "web-specs";
 import web from "../kumascript/src/api/web";
 
 export function extractSpecifications(
@@ -91,7 +91,7 @@ export function extractSpecifications(
   specURLs = [...new Set(specURLs)];
 
   // Use BCD specURLs to look up more specification data
-  // from the browser-specs package
+  // from the web-specs package
   const specifications = specURLs
     .map((specURL) => {
       const spec = specs.find(

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@webref/css": "^5.4.4",
     "accept-language-parser": "^1.5.0",
     "async": "^3.2.4",
-    "browser-specs": "^3.43.0",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.12",
     "cli-progress": "^3.11.2",
@@ -116,7 +115,8 @@
     "tempy": "^1.0.1",
     "unified": "^9.2.1",
     "unist-builder": "^2.0.3",
-    "unist-util-visit": "^2.0.3"
+    "unist-util-visit": "^2.0.3",
+    "web-specs": "^2.46.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3507,12 +3507,17 @@ braces@^3.0.2, braces@~3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
-browser-specs@^3.43.0:
-  version "3.43.0"
-  resolved "https://registry.yarnpkg.com/browser-specs/-/browser-specs-3.43.0.tgz#3d09bc2c99bc4a70a7e758512ceb8bbd31b8817e"
-  integrity sha512-d0iojN/iKDsGMdP8iP9L+iNfqjm8kz+YiEYCg7fEGUunsEIC8W0orB09AKXAv1n9et/jM3qzXWLghPOCmrhkJQ==
+browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.18.1, browserslist@^4.20.3, browserslist@^4.21.3, browserslist@^4.21.4:
+  version "4.21.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.4.tgz#e7496bbc67b9e39dd0f98565feccdcb0d4ff6987"
+  integrity sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==
+  dependencies:
+    caniuse-lite "^1.0.30001400"
+    electron-to-chromium "^1.4.251"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.9"
 
-browserslist@^4.0.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^4.18.1, browserslist@^4.20.3, browserslist@^4.21.3, browserslist@^4.21.4, browserslist@^4.21.5:
+browserslist@^4.21.5:
   version "4.21.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.5.tgz#75c5dae60063ee641f977e00edd3cfb2fb7af6a7"
   integrity sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==
@@ -3689,6 +3694,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001426, caniuse-lite@^1.0.30001449:
   version "1.0.30001449"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
   integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
+
+caniuse-lite@^1.0.30001400:
+  version "1.0.30001450"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz#022225b91200589196b814b51b1bbe45144cf74f"
+  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -5021,7 +5031,7 @@ ejs@^3.1.5, ejs@^3.1.6, ejs@^3.1.8:
   dependencies:
     jake "^10.8.5"
 
-electron-to-chromium@^1.4.284:
+electron-to-chromium@^1.4.251, electron-to-chromium@^1.4.284:
   version "1.4.284"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
@@ -9228,7 +9238,7 @@ node-notifier@^8.0.1:
     uuid "^8.3.0"
     which "^2.0.2"
 
-node-releases@^2.0.8:
+node-releases@^2.0.6, node-releases@^2.0.8:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.9.tgz#fe66405285382b0c4ac6bcfbfbe7e8a510650b4d"
   integrity sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA==
@@ -12903,7 +12913,7 @@ upath@^1.2.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-update-browserslist-db@^1.0.10:
+update-browserslist-db@^1.0.10, update-browserslist-db@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz#0f54b876545726f17d00cd9a2561e6dade943ff3"
   integrity sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==
@@ -13127,6 +13137,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-specs@^2.46.0:
+  version "2.46.0"
+  resolved "https://registry.yarnpkg.com/web-specs/-/web-specs-2.46.0.tgz#db10a0bba2546a434cb45356512bf1d5440c591a"
+  integrity sha512-JLNjCl1778GLCTmsJefPlVpLkF1FowITbw3Ql9hyc2FtfeVWMvZwsU0BNw8aN5JMk9PzklRpxgoiRY91UN/BhA==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Summary

Replace the "browser-specs" package with "web-specs". 

### Problem

browser-specs doesn't contain all specs that we are interested in. web-specs does.

### Solution

"web-specs is a small super-set of browser-specs and it should be a drop-in replacement for MDN"
See https://github.com/w3c/browser-specs/pull/817#issuecomment-1377207689 for more details.

commands used:
yarn add web-specs
yarn remove browser-specs

## How did you test this change?

There should be no difference other than that a few more specification tables will render. For example, Do Not Track is not in browser-specs as of 3.38 anymore so the spec table on https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack will soon stop working. With web-specs the table will continue to render fine.

## Related

BCD will make this change in https://github.com/mdn/browser-compat-data/pull/18615 