### PR TITLE
docs(README): fix broken "Production Build" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Yari
 
 ![Testing](https://github.com/mdn/yari/workflows/Testing%20Yari/badge.svg)
-![Production Build](https://github.com/mdn/yari/workflows/Production%20Build/badge.svg)
+![Prod Build](https://github.com/mdn/yari/workflows/Prod%20Build/badge.svg)
 
 ## Quickstart
 


### PR DESCRIPTION
## Summary

Fixes #7944

### Problem

The "Production Build" badge in README is broken, which is caused by a workflow renaming from "Production Build" to "Prod Build" in commit 09568d0.

### Solution

Replace "Production Build" with "Prod Build".

PS 1: Should I use workflow file name (e.g., `prod-build.yml`) instead of workflow name (e.g., `Prod Build`) in badge svg urls? Because only workflow file name is documented in corresponding [GitHub Docs page](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name).

PS 2: Though out of the scope of current PR, do badges of other two builds ("Dev Build" and "Stage Build") need to added to README?

---

### Before

![image](https://user-images.githubusercontent.com/6376638/211732764-d8713885-4dd1-49b2-ac3e-ab19769ce8fd.png)

### After

Visit my fork https://github.com/muzimuzhi/yari/tree/readme-badge#yari
![image](https://user-images.githubusercontent.com/6376638/211733282-36b4dc07-0703-40a2-9d52-0267378abde5.png)

---

## How did you test this change?

Visit https://github.com/muzimuzhi/yari/tree/readme-badge#yari and check the "Prod Build" badge is shown as expected.