### PR TITLE
Update Kumascript readme to reduce line length

### DIFF
--- a/docs/kumascript/README.md
+++ b/docs/kumascript/README.md
@@ -388,14 +388,14 @@ If you edit the page, you'll probably see a macro like this at the bottom of the
 page:
 
 ```plain
-{{ wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", … }) }}
+{{ wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學", … }) }}
 ```
 
 To fix the problem, just delete the macro. Or, replace the curly braces on
 either side with HTML comments `<!-- -->` to preserve the information, like so:
 
 ```html
-<!-- wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", ... }) -->
+<!-- wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學", ... }) -->
 ```
 
 Because Kuma supports localization differently, these macros aren't actually


### PR DESCRIPTION
This PR updates `docs/kumascript/README.md` and trims down the line length of line 398, which is causing the [markdownlint test to fail](https://github.com/mdn/yari/actions/runs/3890508426/jobs/6639698280) and is [affecting other pull requests](https://github.com/mdn/yari/pull/7623).  See #7947 for an alternative solution.

Closes #7947.