### PR TITLE
Update Kumascript readme to only instruct deletion of wiki.languages() macro

### DIFF
--- a/docs/kumascript/README.md
+++ b/docs/kumascript/README.md
@@ -391,17 +391,8 @@ page:
 {{ wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", … }) }}
 ```
 
-To fix the problem, just delete the macro. Or, replace the curly braces on
-either side with HTML comments `<!-- -->` to preserve the information, like so:
-
-```html
-<!-- wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", ... }) -->
-```
-
-Because Kuma supports localization differently, these macros aren't actually
-needed any more. But, they've been left intact in case we need to revisit the
-relationships between localized pages. Unfortunately, it seems like migration
-has failed to convert some of them properly.
+To fix the problem, just delete the macro. Because Kuma supports localization
+differently, these macros aren't actually needed any more.
 
 ### Finding the Current Page Language
 


### PR DESCRIPTION
This PR updates `docs/kumascript/README.md` as a long line is causing the [markdownlint test to fail](https://github.com/mdn/yari/actions/runs/3890508426/jobs/6639698280) and is [affecting other pull requests](https://github.com/mdn/yari/pull/7623).  This PR updates the document to remove suggestion of commenting out `wiki.languages()` macros, and instead just remove them entirely as they are no longer needed (as far as I know).  See #7946 for an alternative solution.

Closes #7946.
