### PR TITLE
fix(mathml): add missing comma in the @font-face declaration of the S…

### DIFF
--- a/client/src/document/mathml-polyfill/mathml-font.scss
+++ b/client/src/document/mathml-polyfill/mathml-font.scss
@@ -1,8 +1,8 @@
 @font-face {
   font-family: "STIXTwoMath-Regular";
   font-weight: normal;
-  src: local("STIXTwoMath-Regular") url("./font/STIXTwoMath-Regular.woff2")
-    format("woff2");
+  src: local("STIXTwoMath-Regular"),
+    url("./font/STIXTwoMath-Regular.woff2") format("woff2");
 }
 
 math {


### PR DESCRIPTION
## Summary

Fix the `@font-face` rule for loading STIX Two Math, see #7967

### Problem

The invalid CSS syntax make the pages fail to use local fonts (if installed on the system) or load the Web font (otherwise).

### Solution

Add missing comma.

---

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/567455/212461980-715eeb03-4da7-463c-a692-89af9c44d58d.png)

### After
![after](https://user-images.githubusercontent.com/567455/212461985-6772153c-4069-4bfb-878f-e4e4ea2bd36a.png)

## How did you test this change?

I reproduced the steps described in #7967 with a local yari copy, verifying that:
- If STIX Two Math is installed on my system, the "All fonts on page" panel indicates "System".
- Otherwise, the "All fonts on page" panel indicates "http://localhost:3000/static/media/STIXTwoMath-Regular.a6dd783b1df04c61b10a.woff2"
