### PR TITLE
fix(content): allow whitespace above content folder

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -242,14 +242,14 @@ export const read = memoize((folderOrFilePath: string, ...roots: string[]) => {
     locale = extractLocale(folder);
   }
 
-  if (filePath.includes(" ")) {
+  if (folder.includes(" ")) {
     throw new Error(
       `Folder contains whitespace which is not allowed (${util.inspect(
         filePath
       )})`
     );
   }
-  if (filePath.includes("\u200b")) {
+  if (folder.includes("\u200b")) {
     throw new Error(
       `Folder contains zero width whitespace which is not allowed (${filePath})`
     );


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->
Fixes #7986.

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

yari errors when run under file hierarchies containing space characters.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Check for spaces only in the portion of the path corresponding to the actual content folder, not its parent directories.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

Manual testing, by running `yarn dev` in such file hierarchies before and after the change, and with and without content folders containing spaces.
