### PR TITLE
fix(plus): render collection filter correct

### DIFF
--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -118,33 +118,34 @@ export default function Updates() {
 }
 
 const useFilters = (canFilter: boolean) => {
-  const filters = useRef(FILTERS);
+  const [filters, setFilters] = useState(FILTERS);
   const { data, isLoading, error } = useCollections();
   useEffect(() => {
     if (!isLoading && data?.length && !error) {
-      let updated: AnyFilter[] = filters.current.map((val) => {
-        if (val.key === "collections") {
-          return {
-            ...val,
-            options: data
-              ?.filter((collection) => collection.article_count > 0)
-              .map((info) => {
-                const label =
-                  info.name === "Default" ? "Saved Articles" : info.name;
-                return {
-                  label,
-                  value: info.id,
-                };
-              }),
-          };
-        } else {
-          return val;
-        }
-      });
-      filters.current = updated;
+      setFilters((old) =>
+        old.map((val) => {
+          if (val.key === "collections") {
+            return {
+              ...val,
+              options: data
+                ?.filter((collection) => collection.article_count > 0)
+                .map((info) => {
+                  const label =
+                    info.name === "Default" ? "Saved Articles" : info.name;
+                  return {
+                    label,
+                    value: info.id,
+                  };
+                }),
+            };
+          } else {
+            return val;
+          }
+        })
+      );
     }
-  }, [isLoading, canFilter, filters, data, error]);
-  return filters.current;
+  }, [isLoading, canFilter, data, error]);
+  return filters;
 };
 
 function UpdatesLayout() {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

The collection filter was only loading after refocusing.