### PR TITLE
fix(offline): when actually offline article pages error out

### DIFF
--- a/client/pwa/src/fetch-interceptors.ts
+++ b/client/pwa/src/fetch-interceptors.ts
@@ -59,14 +59,20 @@ class DefaultApiInterceptor implements FetchInterceptor {
     try {
       return await fetch(req);
     } catch (err: any) {
-      return new Response(jsonBlob({ error: "offline" }));
+      return new Response(jsonBlob({ error: "offline" }), {
+        status: 418,
+        statusText: "You're offline",
+      });
     }
   }
   async onPost(req: Request): Promise<Response> {
     try {
       return await fetch(req);
     } catch (err) {
-      return new Response(jsonBlob({ error: "offline" }));
+      return new Response(jsonBlob({ error: "offline" }), {
+        status: 418,
+        statusText: "You're offline",
+      });
     }
   }
 }


### PR DESCRIPTION
any 5xx error code seemed unsuitable, as it's not originating from the
server, whereas 418 is a nice easter egg, and should allow us to easily
catch these errors in future if we want to handle them specially

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When truly offline, the serviceworker replaces api responses with `{ "error": "offline" }`, but was "responding" with a 200 ok. This makes our type checking break down, hence the error: `T.map is not a function`.

### Solution

Add an error code in the "response".

---

## How did you test this change?

Deployed to stage, on the next branch: https://github.com/mdn/yari/commit/bf4b40aee8290b23838ffeaed95c7bfc545aba56
