### PR TITLE
Make spec-urls an override for browser-compat

### DIFF
--- a/build/extract-specifications.ts
+++ b/build/extract-specifications.ts
@@ -71,7 +71,8 @@ export function extractSpecifications(
     }
   }
 
-  if (query) {
+  // Look for spec URLS in BCD only if specURLsString is not set
+  if (query && !specURLsString) {
     for (const feature of query.split(",").map((id) => id.trim())) {
       const { data } = packageBCD(feature);
       // If 'data' is non-null, we have data for one or more BCD features


### PR DESCRIPTION
## Summary

Changes Yari to ignore specs from BCD if the `spec-urls` front matter key is set.

Fixes https://github.com/mdn/content/issues/23618.

### Problem

When authors include both a `browser-compat` key that contains spec URLs, and an explicit `spec-urls` key, then the platform renders URLs from both sources. But in this case it should only render the URLs from the `spec-urls` key. 

I think there are only 2 pages in which this condition applies:

https://developer.mozilla.org/en-US/docs/web/api/web_midi_api
https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/set/keys

So in these cases the tables include 2 sets of URLs, one set from`browser-compat` and one set from `spec-urls`. I think in both these it would be better for the table to include only the URLs from `spec-urls`: that is, to make `spec-urls` an override for the URLs in BCD.

* for https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/set/keys, the issue is that this is an alias for `Set.values()`, and apparently the BCD only contains data for `Set.values()`. So the page is forced to contain a query for `Set.values()`, but then this would give the wrong spec URL, so we have a `spec-urls` key listing the spec for `Set.keys()`. The result is that both specs get listed, but it would I think be better only to list the spec for `Set.keys()`, since that's the page we are on.
* https://developer.mozilla.org/en-US/docs/web/api/web_midi_api is an API overview page. Usually these pages map to specifications, and the spec URL would ideally be just a link to the spec. Sometimes people want to include BCD for API overview pages, and the problem then is that BCD doesn't directly represent compat for Web APIs, only for the interfaces and other concrete features that comprise them. So then people include BCD for these concrete features, and then they get extra duplicate spec URLs from those BCD queries. That's why https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API#specifications contains duplicate entries. It would be better for https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API#specifications to include a single entry.

### Solution

Only look for BCD-derived spec URLs if `spec-data` is not set.

## Screenshots

Only 2 pages are affected by this change.

### Before

https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API#specifications:

<img width="820" alt="Screen Shot 2023-01-23 at 5 12 36 PM" src="https://user-images.githubusercontent.com/432915/214192800-1707c180-f481-4a73-9938-42cce9ff56de.png">

https://developer.mozilla.org/en-US/docs/web/javascript/reference/global_objects/set/keys#specifications:

<img width="798" alt="Screen Shot 2023-01-23 at 5 13 13 PM" src="https://user-images.githubusercontent.com/432915/214192849-11b7895c-7ad5-4a14-b776-1d7ecde30cb5.png">


### After

http://localhost:3000/en-US/docs/Web/API/Web_MIDI_API#specifications:

<img width="806" alt="Screen Shot 2023-01-23 at 5 16 08 PM" src="https://user-images.githubusercontent.com/432915/214193164-e1c62ec7-bc82-48c7-ad21-906ee26120d2.png">

http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/keys:

<img width="803" alt="Screen Shot 2023-01-23 at 5 17 10 PM" src="https://user-images.githubusercontent.com/432915/214193249-5dbef9cc-fe25-46bb-87bf-a6e344a5d9ac.png">


## How did you test this change?

Ran yarn dev, looked at:
- pages that have only browser-compat: http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete#specifications
- pages that have only spec-urls: http://localhost:3000/en-US/docs/Web/API/IndexedDB_API#specifications
- pages that have both: http://localhost:3000/en-US/docs/Web/API/Web_MIDI_API#specifications
