### PR TITLE
Deprecate ARIARole macro

### DIFF
--- a/kumascript/macros/ARIARole.ejs
+++ b/kumascript/macros/ARIARole.ejs
@@ -4,6 +4,10 @@
 //
 //  $0 - role
 
+// Throw a MacroDeprecatedError flaw
+// Macro to be removed when no more used in mdn/translated-content
+mdn.deprecated()
+
 var link = 'https://w3c.github.io/aria/#' + $0;
 %>
 <code><a href="<%=link%>" class="external"><%=$0%></a></code>

--- a/kumascript/macros/ARIARole.ejs
+++ b/kumascript/macros/ARIARole.ejs
@@ -5,7 +5,7 @@
 //  $0 - role
 
 // Throw a MacroDeprecatedError flaw
-// This macro can be removed when no more used in mdn/translated-content
+// Can be removed when no more used in mdn/translated-content
 mdn.deprecated()
 
 var link = 'https://w3c.github.io/aria/#' + $0;

--- a/kumascript/macros/ARIARole.ejs
+++ b/kumascript/macros/ARIARole.ejs
@@ -5,7 +5,7 @@
 //  $0 - role
 
 // Throw a MacroDeprecatedError flaw
-// Macro to be removed when no more used in mdn/translated-content
+// This macro can be removed when no more used in mdn/translated-content
 mdn.deprecated()
 
 var link = 'https://w3c.github.io/aria/#' + $0;


### PR DESCRIPTION
@estelle removed the last occurrences in mdn/content. We can mark it as deprecated.