### PR TITLE
enhance(bcd): add release date label to timeline

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -240,7 +240,7 @@ const CellText = React.memo(
               : ""}
           </span>
         </div>
-        <CellIcons support={support} timeline={timeline} />
+        <CellIcons support={support} />
       </div>
     );
   }
@@ -257,13 +257,7 @@ function Icon({ name }: { name: string }) {
   );
 }
 
-function CellIcons({
-  support,
-  timeline,
-}: {
-  support: BCD.SupportStatement | undefined;
-  timeline?: boolean;
-}) {
+function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
   const supportItem = getCurrentSupport(support);
   if (!supportItem) {
     return null;
@@ -271,9 +265,7 @@ function CellIcons({
 
   const icons = [
     supportItem.prefix && <Icon key="prefix" name="prefix" />,
-    !timeline && hasNoteworthyNotes(supportItem) && (
-      <Icon key="footnote" name="footnote" />
-    ),
+    hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
     supportItem.alternative_name && <Icon key="altname" name="altname" />,
     supportItem.flags && <Icon key="disabled" name="disabled" />,
     hasMore(support) && <Icon key="more" name="more" />,

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -206,7 +206,11 @@ const CellText = React.memo(
     }
 
     return (
-      <div className="bcd-cell-text-wrapper">
+      <div
+        className={
+          timeline ? "bcd-timeline-cell-text-wrapper" : "bcd-cell-text-wrapper"
+        }
+      >
         <div className="bcd-cell-icons">
           <span className="icon-wrap">
             <abbr
@@ -225,13 +229,18 @@ const CellText = React.memo(
           <span
             className="bc-version-label"
             title={
-              browserReleaseDate ? `Released ${browserReleaseDate}` : undefined
+              browserReleaseDate && !timeline
+                ? `Released ${browserReleaseDate}`
+                : undefined
             }
           >
             {label}
+            {browserReleaseDate && timeline
+              ? ` (Released ${browserReleaseDate})`
+              : ""}
           </span>
         </div>
-        <CellIcons support={support} />
+        <CellIcons support={support} timeline={timeline} />
       </div>
     );
   }
@@ -248,7 +257,13 @@ function Icon({ name }: { name: string }) {
   );
 }
 
-function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
+function CellIcons({
+  support,
+  timeline,
+}: {
+  support: BCD.SupportStatement | undefined;
+  timeline?: boolean;
+}) {
   const supportItem = getCurrentSupport(support);
   if (!supportItem) {
     return null;
@@ -256,7 +271,9 @@ function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
 
   const icons = [
     supportItem.prefix && <Icon key="prefix" name="prefix" />,
-    hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
+    !timeline && hasNoteworthyNotes(supportItem) && (
+      <Icon key="footnote" name="footnote" />
+    ),
     supportItem.alternative_name && <Icon key="altname" name="altname" />,
     supportItem.flags && <Icon key="disabled" name="disabled" />,
     hasMore(support) && <Icon key="more" name="more" />,

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -398,6 +398,12 @@ dl.bc-notes-list {
   }
 }
 
+.bcd-timeline-cell-text-wrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+}
+
 .bcd-cell-text-copy {
   color: var(--text-primary);
   display: flex;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This PR adds `(Release YEAR-MONTH-DAY)` text in the Browser Compatibility Data timeline, instead of placing it in the title.
Fixes #6812
Fixes #7603 

Additionally, I have removed `See implementation notes` icon from the timeline. It took up space and it didn't really make sense to keep it there, considering that the user has already clicked to see those notes.
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Before
![image](https://user-images.githubusercontent.com/100634371/214370333-3d0313da-cf62-4f0f-9ab9-a76d15ca69d6.png)

<!-- Replace this line with your screenshot (or video). -->

### After
![image](https://user-images.githubusercontent.com/100634371/214370463-cb1e0c4e-8422-4f0b-85fc-29bb741c54ea.png)

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
I checked [yield](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield) and [mask-image](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-image)