### PR TITLE
Add constructor to JS sidebar

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -15,6 +15,7 @@ var jsl10n = web.getJSONData('L10n-JavaScript');
 
 var text = {
     'stdlib': mdn.getLocalString(jsl10n, 'stdlib'),
+    'Constructor': mdn.getLocalString(commonl10n, 'Constructor'),
     'Properties': mdn.getLocalString(commonl10n, 'Properties'),
     'Methods': mdn.getLocalString(commonl10n, 'Methods'),
     'Inheritance': mdn.getLocalString(commonl10n, 'Inheritance'),
@@ -93,6 +94,7 @@ if  (inheritance.indexOf("Object") > -1) {
 var result = {};
 result[mainObj] = {
     title: mainObj,
+    constructors: [],
     methods: [],
     properties: [],
     defaultOpened: true
@@ -100,6 +102,7 @@ result[mainObj] = {
 if  (inheritance.indexOf("Function") > -1) {
 result['iFunction'] = {
     title: 'Function',
+    constructors: [],
     methods: [],
     properties: [],
     defaultOpened: false
@@ -108,6 +111,7 @@ result['iFunction'] = {
 if  (inheritance.indexOf("Object") > -1) {
 result['iObject'] = {
     title: 'Object',
+    constructors: [],
     methods: [],
     properties: [],
     defaultOpened: false
@@ -140,6 +144,10 @@ function isMethodPage(page) {
     ].includes(page.pageType);
 }
 
+function isConstructorPage(page) {
+    return "javascript-constructor" === page.pageType;
+}
+
 for (var object in source) {
     pageList = source[object];
     if (object === "iObject") {
@@ -147,6 +155,9 @@ for (var object in source) {
         pageList = pageList.filter(page => isPrototypeMemberPage(page));
     }
     for (const page of pageList) {
+        if (isConstructorPage(page)) {
+            result[object].constructors.push(page);
+        }
         if (isPropertyPage(page)) {
             result[object].properties.push(page);
           }
@@ -230,6 +241,7 @@ function buildSublist(pages, title, opened) {
 
 
 var resultTitle;
+var resultConstructors;
 var resultProperties;
 var resultMethods;
 var resultOpen;
@@ -243,10 +255,11 @@ output += `<li><strong>${link}</strong></li>`;
 
 for (object in result) {
     len++;
-    resultTitle      = result[object].title || '';
-    resultProperties = result[object].properties || '';
-    resultMethods    = result[object].methods || '';
-    resultOpen       = result[object].defaultOpened || '';
+    resultTitle        = result[object].title || '';
+    resultConstructors = result[object].constructors || '';
+    resultProperties   = result[object].properties || '';
+    resultMethods      = result[object].methods || '';
+    resultOpen         = result[object].defaultOpened || '';
 
     if (len == 2) {
         output += '<li><strong>'+text['Inheritance']+'</strong></li>';
@@ -255,6 +268,9 @@ for (object in result) {
     const link = web.smartLink(`${slug_stdlib}/${resultTitle}`, null, `<code>${resultTitle}</code>`, null, slug_stdlib, "JSRef");
     output += `<li><strong>${link}</strong></li>`;
 
+    if (resultConstructors) {
+        output += buildSublist(resultConstructors, text['Constructor'], resultOpen);
+    }
     if (resultProperties.length > 0) {
         output += buildSublist(resultProperties, text['Properties'], resultOpen);
     }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This PR adds a link to the constructor page to the sidebar of JS objects and fixes #5942 

### Before
![image](https://user-images.githubusercontent.com/100634371/214664895-10697ef8-1a94-485e-ad39-084f15e6838e.png)

### After
![image](https://user-images.githubusercontent.com/100634371/214661131-cdc583a0-a914-4e42-a480-0a6e31dd0992.png)

Currently, a listed item contains an unnecessary `constructor` word, which is not ideal. I can make the name be generator based on the slug or I can simply `.title.replace(' constructor', '')`. I think it's better to remove the word `constructor` from the content repository though because that's how it's done in Web API pages.

- Currently, multiple constructors could be listed, even though in the content repository there is maximally one per object. This is consistent with web API code.
