### PR TITLE
Deprecate {{gecko}} macro

### DIFF
--- a/kumascript/macros/gecko.ejs
+++ b/kumascript/macros/gecko.ejs
@@ -1,1 +1,7 @@
+<%
+// Throw a MacroDeprecatedError flaw
+// Can be removed when its usage translated-content is down to 0
+mdn.deprecated();
+%>
+
 <span title="<%= await template("geckoRelease", [$0]) %>">Gecko <%=$0%></span>


### PR DESCRIPTION
This PR marks the `{{gecko}}` macro as deprecated.  This macro is not used in any English content, and there are only 103 instances in translated content left.
