### PR TITLE
fix(lambda): use single set of bcd api jsons across all dev builds

### DIFF
--- a/deployer/aws-lambda/content-origin-request/index.js
+++ b/deployer/aws-lambda/content-origin-request/index.js
@@ -1,5 +1,5 @@
 import { createRequire } from "node:module";
-/* eslint-disable n/no-missing-import */
+
 import { resolveFundamental } from "@yari-internal/fundamental-redirects";
 import { getLocale } from "@yari-internal/locale-utils";
 import {
@@ -241,9 +241,13 @@ export async function handler(event) {
     // considered a "custom" origin because we're using S3 as a website.
     request.headers.host[0].value = request.origin.custom.domainName;
     // Conditionally rewrite the path (prefix) of the origin.
-    if (host.endsWith(CONTENT_DEVELOPMENT_DOMAIN)) {
+    if (
+      host.endsWith(CONTENT_DEVELOPMENT_DOMAIN) &&
+      !decodedUri.startsWith("/bcd/")
+    ) {
       // When reviewing PR's, each PR gets its own subdomain, and
-      // all of its content is prefixed with that subdomain in S3.
+      // all of its content is prefixed with that subdomain in S3,
+      // apart from the bcd data
       request.origin.custom.path = `/${host.split(".")[0]}`;
     } else {
       request.origin.custom.path = "/main";


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

https://github.com/mdn/yari/issues/8056

### Problem

Dev builds (which run on content/translated-content PRs to preview the changes) have no bcd tables.

### Solution

This makes the lambda route to a single set of bcd files, so we don't have to upload them for every differently-named dev build (of which most of them are).

I still need to author the PR on the bcd-utils side to add an action for dev build.

---

## How did you test this change?

I haven't :yolo: