### PR TITLE
fix(client/hooks): sendBeacon can be undefined

### DIFF
--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -139,26 +139,35 @@ export function usePing() {
   const user = useUserData();
 
   React.useEffect(() => {
-    const nextPing = new Date(localStorage.getItem("next-ping") || 0);
-    if (isOnline && user?.isAuthenticated && nextPing < new Date()) {
-      const params = new URLSearchParams();
+    try {
+      const nextPing = new Date(localStorage.getItem("next-ping") || 0);
+      if (
+        navigator.sendBeacon &&
+        isOnline &&
+        user?.isAuthenticated &&
+        nextPing < new Date()
+      ) {
+        const params = new URLSearchParams();
 
-      // fetch offline settings from local storage as its
-      // values are very inconsistent in the user context
-      const offlineSettings = JSON.parse(
-        localStorage.getItem(OFFLINE_SETTINGS_KEY) || "{}"
-      );
-      if (offlineSettings?.offline) params.set("offline", "true");
+        // fetch offline settings from local storage as its
+        // values are very inconsistent in the user context
+        const offlineSettings = JSON.parse(
+          localStorage.getItem(OFFLINE_SETTINGS_KEY) || "{}"
+        );
+        if (offlineSettings?.offline) params.set("offline", "true");
 
-      navigator.sendBeacon("/api/v1/ping", params);
+        navigator.sendBeacon("/api/v1/ping", params);
 
-      const newNextPing = new Date();
-      newNextPing.setUTCDate(newNextPing.getUTCDate() + 1);
-      newNextPing.setUTCHours(0);
-      newNextPing.setUTCMinutes(0);
-      newNextPing.setUTCSeconds(0);
-      newNextPing.setUTCMilliseconds(0);
-      localStorage.setItem("next-ping", newNextPing.toISOString());
+        const newNextPing = new Date();
+        newNextPing.setUTCDate(newNextPing.getUTCDate() + 1);
+        newNextPing.setUTCHours(0);
+        newNextPing.setUTCMinutes(0);
+        newNextPing.setUTCSeconds(0);
+        newNextPing.setUTCMilliseconds(0);
+        localStorage.setItem("next-ping", newNextPing.toISOString());
+      }
+    } catch (e) {
+      console.error(e);
     }
   }, [isOnline, user]);
 }

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -167,7 +167,7 @@ export function usePing() {
         localStorage.setItem("next-ping", newNextPing.toISOString());
       }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to send ping", e);
     }
   }, [isOnline, user]);
 }


### PR DESCRIPTION
wrap whole block in try/catch for extra safety

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

https://github.com/mdn/yari/issues/7969

### Problem

`navigator.sendBeacon` can be undefined - babel doesn't handle this, apparently

### Solution

conditionally call `navigator.sendBeacon`, also wrap the entire hook in a try/catch for extra safety

---

## How did you test this change?

Disabled `beacon.enabled` in `about:config`, observed the error, made the changes, observed no error.

Note: you need to be logged in, and `next-ping` in localstorage needs to be cleared before each page reload when testing, otherwise the problematic code won't be executed.
