### PR TITLE
fix(lint): run check:tsc with 2 processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:ssr": "cd ssr && webpack --mode=production",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
-    "check:tsc": "find . -mindepth 2 -name 'tsconfig.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -P $(nproc) -0 bash -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
+    "check:tsc": "find . -mindepth 2 -name 'tsconfig.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -P 2 -0 bash -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
     "dev": "yarn build:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",
     "filecheck": "ts-node filecheck/cli.ts",


### PR DESCRIPTION
Avoids `nproc`, which might not be available.

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Avoids `nproc`, which might not be available in the developer environment.

Supersedes https://github.com/mdn/yari/pull/8088.

### Problem

https://github.com/mdn/yari/pull/8083 added parallelization for check:tsc, but it uses nproc, which isn't always available (as reported by @NiedziolkaMichal).

### Solution

Just run with 2 processes, which doesn't seem to be slower than 4 or even 8 processes.

---

## Screenshots

n/a

---

## How did you test this change?

- Ran `yarn check:tsc` with different hard-coded process counts.
