### PR TITLE
Add error when `CONTENT_ROOT` is missing

### DIFF
--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -42,6 +42,7 @@ jobs:
           # The following env vars is what we do in npm-publish.yml
           # Each variable set is documented there.
 
+          ENV_FILE: testing/.env
           REACT_APP_CRUD_MODE: true
           REACT_APP_DISABLE_AUTH: true
           CONTENT_ROOT: testing/content/files

--- a/content/document-paths.ts
+++ b/content/document-paths.ts
@@ -85,6 +85,9 @@ function childrenForPath(
 }
 
 function initAllDocumentsPathsTree(): Tree {
+  if (!CONTENT_ROOT) {
+    throw new Error("Environmental variable CONTENT_ROOT has not been set");
+  }
   // When running a production build we can afford to look up all files upfront.
   if (process.env.NODE_ENV === "production") {
     return {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Currently when somebody just pulls the project and runs `yarn build`, the following error is shown:

![image](https://user-images.githubusercontent.com/100634371/215847956-621eb202-cb34-44e9-8fc1-73f00ffcd34b.png)

It's because `.env-dist` needs to be copied to `.env`, as mentioned in `README` file. I have changed the error to:

![image](https://user-images.githubusercontent.com/100634371/215848260-40311c2c-c402-4cf5-b7e7-174ed2673e92.png)

It's a minor thing, but it can make starting to work on YARI a little bit easier.