### PR TITLE
Add django to list of Prism.js languages

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -25,6 +25,7 @@ const loadAllLanguages = lazy(() => {
     "cpp",
     "cs",
     "diff",
+    "django",
     "glsl",
     "http",
     "ignore",


### PR DESCRIPTION
This PR adds `django` as an available syntax highlighting language in response to https://github.com/mdn/content/pull/24048#discussion_r1093126283.
