### PR TITLE
chore(workflows/pr-commit-signatures): use GitHub CLI + tee

### DIFF
--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
       - name: Fetch commits
-        run: curl -s "${{ github.event.pull_request._links.commits.href }}" > commits.json
+        run: curl -s "${{ github.event.pull_request._links.commits.href }}" | tee commits.json
 
       - name: Filter unverified commits
-        run: jq '[.[].commit | select(.verification.verified == false)]' < commits.json > unverified-commits.json
+        run: jq '[.[].commit | select(.verification.verified == false)]' < commits.json | tee unverified-commits.json
 
       - name: List unverified commits
         run: jq '.[] | [{message, tree, author, committer, verification}]' < unverified-commits.json

--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -9,7 +9,9 @@ jobs:
 
     steps:
       - name: Fetch commits
-        run: curl -s "${{ github.event.pull_request._links.commits.href }}" | tee commits.json
+        run: gh api "${{ github.event.pull_request._links.commits.href }}" | tee commits.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Filter unverified commits
         run: jq '[.[].commit | select(.verification.verified == false)]' < commits.json | tee unverified-commits.json


### PR DESCRIPTION
## Summary

### Problem

The commit-signatures workflow sometimes fails for unknown reasons, and we don't know why.

### Solution

Pipe some intermediate results to `tee` so that we can see what we get from the GitHub API and what our filtered result looks like.

---

## Screenshots

n/a

---

## How did you test this change?

I will look at the run in this PR.