### PR TITLE
chore(syntax-highlight): accept `-nolint` suffix for all syntax languages

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -60,9 +60,6 @@ const loadAllLanguages = lazy(() => {
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   // ["idl", "webidl"],  // block list
-  ["css-nolint", "css"],
-  ["html-nolint", "html"],
-  ["js-nolint", "js"],
   ["sh", "shell"],
 ]);
 
@@ -95,7 +92,7 @@ export function syntaxHighlight($, doc) {
     if (!match) {
       return;
     }
-    const name = ALIASES.get(match[1]) || match[1];
+    const name = match[1].replace("-nolint", "");
     if (IGNORE.has(name)) {
       // Seems to exist a couple of these in our docs. Just bail.
       return;

--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -92,7 +92,10 @@ export function syntaxHighlight($, doc) {
     if (!match) {
       return;
     }
-    const name = match[1].replace("-nolint", "");
+    let name = match[1].replace("-nolint", "");
+    if (ALIASES.has(name)) {
+      name = ALIASES.get(name);
+    }
     if (IGNORE.has(name)) {
       // Seems to exist a couple of these in our docs. Just bail.
       return;


### PR DESCRIPTION
This PR updates the syntax highlighting so that any language we have loaded may be appended with the `-nolint` suffix, instead of having to manually add them in for each language.
