### PR TITLE
Add Handlebars to syntax highlighting

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -27,6 +27,7 @@ const loadAllLanguages = lazy(() => {
     "diff",
     "django",
     "glsl",
+    "handlebars",
     "http",
     "ignore",
     "ini",


### PR DESCRIPTION
This PR adds Handlebars as a language for syntax highlighting.  We have a few instances of Handlebars in our documents already.
