### PR TITLE
Add Svelte to syntax highlighting

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -1,5 +1,6 @@
 import Prism from "prismjs";
 import loadLanguages from "prismjs/components/index";
+import "prism-svelte";
 
 const lazy = (creator) => {
   let res;
@@ -42,6 +43,7 @@ const loadAllLanguages = lazy(() => {
     "regex",
     "rust",
     "scss",
+    "svelte",
     "sql",
     "toml",
     "tsx",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "mdn-data": "^2.0.30",
     "open": "^8.4.0",
     "open-editor": "^3.0.0",
+    "prism-svelte": "^0.5.0",
     "prismjs": "^1.29.0",
     "react-modal": "^3.16.1",
     "read-chunk": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10541,6 +10541,11 @@ pretty-format@^29.4.1:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+prism-svelte@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/prism-svelte/-/prism-svelte-0.5.0.tgz#c4aeffeaddb179cfef213aab91ee785b66d22992"
+  integrity sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==
+
 prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"


### PR DESCRIPTION
This PR adds Svelte's component syntax to the syntax highlighting language list.  Prism doesn't handle the language, so a third-party plugin is used to add support.

Note: this depends on ESM conversion because `prism-svelte` is an ESM-only package.
