### PR TITLE
fix(Button): pass through ARIA attrs

### DIFF
--- a/client/src/plus/collections/index.tsx
+++ b/client/src/plus/collections/index.tsx
@@ -163,9 +163,9 @@ function CollectionCard({ collection }: { collection: Collection }) {
             <Button
               type="action"
               icon="ellipses"
-              ariaControls="collection-dropdown"
-              ariaHasPopup="menu"
-              ariaExpanded={showDropdown || undefined}
+              aria-controls="collection-dropdown"
+              aria-haspopup="menu"
+              aria-expanded={showDropdown || undefined}
               onClickHandler={() => {
                 setShowDropdown(!showDropdown);
               }}

--- a/client/src/plus/icon-card/index.tsx
+++ b/client/src/plus/icon-card/index.tsx
@@ -50,9 +50,9 @@ export default function WatchedCardListItem({
             <Button
               type="action"
               icon="ellipses"
-              ariaControls="watch-card-dropdown"
-              ariaHasPopup={"menu"}
-              ariaExpanded={show || undefined}
+              aria-controls="watch-card-dropdown"
+              aria-haspopup={"menu"}
+              aria-expanded={show || undefined}
               onClickHandler={() => {
                 setShow(!show);
               }}

--- a/client/src/plus/search-filter/index.tsx
+++ b/client/src/plus/search-filter/index.tsx
@@ -212,9 +212,9 @@ export default function SearchFilter({
         >
           <Button
             type="select"
-            ariaControls={filterMenu.id}
-            ariaHasPopup={"menu"}
-            ariaExpanded={openFilter === filterMenu.key}
+            aria-controls={filterMenu.id}
+            aria-haspopup={"menu"}
+            aria-expanded={openFilter === filterMenu.key}
             extraClasses={`${
               searchParams.get(filterMenu.key) ? "active" : ""
             } ${isDisabled ? "inactive" : ""}`}
@@ -259,9 +259,9 @@ export default function SearchFilter({
         >
           <Button
             type="select"
-            ariaControls={sortMenu.id}
-            ariaHasPopup={"menu"}
-            ariaExpanded={isSortingOpen || undefined}
+            aria-controls={sortMenu.id}
+            aria-haspopup={"menu"}
+            aria-expanded={isSortingOpen || undefined}
             extraClasses={`${searchParams.get("sort") ? "active" : ""} ${
               isDisabled ? "inactive" : ""
             }`}

--- a/client/src/ui/atoms/button/index.tsx
+++ b/client/src/ui/atoms/button/index.tsx
@@ -5,10 +5,6 @@ import InternalLink from "../internal-link";
 import "./index.scss";
 
 type ButtonProps = {
-  ariaControls?: string;
-  ariaExpanded?: boolean;
-  ariaHasPopup?: "true" | "false" | "menu" | "dialog" | "listbox";
-  ariaLabel?: string;
   title?: string;
 
   type?: "primary" | "secondary" | "action" | "select" | "link";
@@ -40,10 +36,6 @@ type ButtonProps = {
 };
 
 export const Button = ({
-  ariaControls,
-  ariaExpanded,
-  ariaHasPopup,
-  ariaLabel,
   title,
   name,
   type = "primary",
@@ -61,6 +53,7 @@ export const Button = ({
   state,
   value,
   children,
+  ...dashedProps
 }: ButtonProps) => {
   let buttonClasses = "button";
   [type, size, state].forEach((attr) => {
@@ -96,8 +89,8 @@ export const Button = ({
           id={id}
           onClick={onClickHandler}
           onFocus={onFocusHandler}
-          aria-label={ariaLabel}
           title={title}
+          {...dashedProps}
         >
           <span className="button-wrap">{renderContent()}</span>
         </a>
@@ -111,8 +104,8 @@ export const Button = ({
         id={id}
         onClick={onClickHandler}
         onFocus={onFocusHandler}
-        aria-label={ariaLabel}
         title={title}
+        {...dashedProps}
       >
         <span className="button-wrap">{renderContent()}</span>
       </InternalLink>
@@ -120,10 +113,6 @@ export const Button = ({
   }
   return (
     <button
-      aria-controls={ariaControls}
-      aria-expanded={ariaExpanded}
-      aria-haspopup={ariaHasPopup}
-      aria-label={ariaLabel}
       title={title}
       disabled={isDisabled}
       id={id}
@@ -133,6 +122,7 @@ export const Button = ({
       onFocus={onFocusHandler}
       value={value}
       name={name}
+      {...dashedProps}
     >
       <span className="button-wrap">{renderContent()}</span>
     </button>

--- a/client/src/ui/atoms/button/index.tsx
+++ b/client/src/ui/atoms/button/index.tsx
@@ -53,7 +53,7 @@ export const Button = ({
   state,
   value,
   children,
-  ...dashedProps
+  ...passthroughAttrs
 }: ButtonProps) => {
   let buttonClasses = "button";
   [type, size, state].forEach((attr) => {
@@ -90,7 +90,7 @@ export const Button = ({
           onClick={onClickHandler}
           onFocus={onFocusHandler}
           title={title}
-          {...dashedProps}
+          {...passthroughAttrs}
         >
           <span className="button-wrap">{renderContent()}</span>
         </a>
@@ -105,7 +105,7 @@ export const Button = ({
         onClick={onClickHandler}
         onFocus={onFocusHandler}
         title={title}
-        {...dashedProps}
+        {...passthroughAttrs}
       >
         <span className="button-wrap">{renderContent()}</span>
       </InternalLink>
@@ -122,7 +122,7 @@ export const Button = ({
       onFocus={onFocusHandler}
       value={value}
       name={name}
-      {...dashedProps}
+      {...passthroughAttrs}
     >
       <span className="button-wrap">{renderContent()}</span>
     </button>

--- a/client/src/ui/molecules/theme-switcher/index.tsx
+++ b/client/src/ui/molecules/theme-switcher/index.tsx
@@ -67,8 +67,8 @@ export const ThemeSwitcher = () => {
     >
       <Button
         type="action"
-        ariaHasPopup={"menu"}
-        ariaExpanded={isOpen || undefined}
+        aria-haspopup={"menu"}
+        aria-expanded={isOpen || undefined}
         icon={`theme-${activeTheme}`}
         extraClasses="theme-switcher-menu small"
         onClickHandler={() => {

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -79,9 +79,9 @@ export const UserMenu = () => {
         type="action"
         id={`${userMenuItems.id}-button`}
         extraClasses="top-level-entry menu-toggle user-menu-toggle"
-        ariaControls={userMenuItems.id}
-        ariaHasPopup="menu"
-        ariaExpanded={isOpen || undefined}
+        aria-controls={userMenuItems.id}
+        aria-haspopup="menu"
+        aria-expanded={isOpen || undefined}
         onClickHandler={() => {
           setIsOpen(!isOpen);
         }}

--- a/client/src/ui/organisms/article-actions-container/index.tsx
+++ b/client/src/ui/organisms/article-actions-container/index.tsx
@@ -26,7 +26,9 @@ export const ArticleActionsContainer = ({
           extraClasses="sidebar-button"
           icon="sidebar"
           type="action"
-          aria-label="Expand sidebar"
+          aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+          aria-expanded={isSidebarOpen}
+          aria-controls="sidebar-quicklinks"
           onClickHandler={() => setIsSidebarOpen(!isSidebarOpen)}
         />
 

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -104,8 +104,8 @@ export function LanguageMenu({
       <Button
         id="languages-switcher-button"
         type="action"
-        ariaHasPopup={"menu"}
-        ariaExpanded={isOpen || undefined}
+        aria-haspopup={"menu"}
+        aria-expanded={isOpen || undefined}
         icon="language"
         size="small"
         extraClasses="languages-switcher-menu"

--- a/client/src/ui/organisms/top-navigation/index.tsx
+++ b/client/src/ui/organisms/top-navigation/index.tsx
@@ -41,9 +41,9 @@ export function TopNavigation() {
           <Logo />
           <Button
             type="action"
-            ariaHasPopup={"menu"}
-            ariaLabel={assistiveText}
-            ariaExpanded={showMainMenu}
+            aria-haspopup={"menu"}
+            aria-label={assistiveText}
+            aria-expanded={showMainMenu}
             title={assistiveText}
             icon={showMainMenu ? "cancel" : "menu"}
             onClickHandler={toggleMainMenu}


### PR DESCRIPTION
- fix: pass through aira- props on Button component
- fix: improve aria labels on mobile sidebar button

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

fixes https://github.com/mdn/yari/issues/8015

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

- Sidebar button had on aria label on it.
- It was set in the code, but as `aria-label` rather than `ariaLabel` which is the prop the `Button` component was expecting
- TypeScript doesn't type check any prop with a dash in it (e.g. `aria-label` but also `foo-bar`), including not checking if a component with typed props hasn't specified it as a prop it takes, so this bug was silently introduced
  - https://github.com/microsoft/TypeScript/issues/32447

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

- Remove our camelCase aria props on `Button`, and pass through all dashed props to underlying elements in `Button` component
   - This seemed safest as there's no way of preventing a developer adding a dashed prop, so it may continue to happen anyway
   - eslint still checks `aria-` props are in the right form (e.g. I mistyped `aria-haspopup` as `aria-has-popup` and got this error: `aria-has-popup: This attribute is an invalid ARIA attribute. Did you mean to use aria-haspopup?  jsx-a11y/aria-props`)
   - if TypeScript behaviour changes, we haven't specified any dashed props in our props type, so we'll get some nice errors we can decide what to do with (either add dashed props to the type, only add `aria-` props, move back to camelCase aria props, etc.)
- Improve `aria-label` on the sidebar button, and add `aria-expanded` and `aria-controls` props

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

Clicked around in Firefox's accessibility devtools.