### PR TITLE
enhancement: attempt to fall back to static html when react unmounts

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -10,6 +10,87 @@ import { GleanProvider } from "./telemetry/glean-context";
 
 // import * as serviceWorker from './serviceWorker';
 
+let attemptedFallback = false;
+window.addEventListener("error", async (error) => {
+  const root = document.querySelector("#root");
+  if (
+    !attemptedFallback &&
+    root &&
+    // only fall back if react gave up and unmounted, leaving an empty page
+    root.innerHTML.trim() === ""
+  ) {
+    attemptedFallback = true;
+    try {
+      const res = await fetch(window.location.pathname, {
+        cache: "force-cache",
+      });
+      const page = await res.text();
+      const parser = new DOMParser();
+      const fallbackRoot = parser
+        .parseFromString(page, "text/html")
+        .querySelector("#root");
+      if (fallbackRoot) {
+        root.innerHTML = fallbackRoot.innerHTML;
+        console.warn(
+          "Fell back to static HTML page due to unhandled error,",
+          "please report an issue on GitHub:",
+          generateGithubIssueLink(error.error)
+        );
+      } else {
+        throw new Error("no root");
+      }
+    } catch (fallbackError) {
+      console.warn(
+        "Failed falling back to static HTML page:",
+        fallbackError,
+        "please report an issue on GitHub:",
+        generateGithubIssueLink(error.error, fallbackError)
+      );
+    }
+  }
+  // Unlike other events, the error event is canceled by returning true from the handler instead of returning false.
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/error_event#usage_notes
+  return false;
+});
+
+function generateGithubIssueLink(error: Error, fallbackError?: any) {
+  try {
+    const params = new URLSearchParams();
+    params.append("title", `Unhandled error: ${error.message}`);
+    params.append("labels", "🐛 bug");
+    params.append(
+      "body",
+      `Location: ${"`"}${window.location}${"`"}
+
+Error:
+${"```"}
+${error.name}: ${error.message}
+${"```"}${
+        error.stack
+          ? `
+
+Stack:
+${"```"}
+${error.stack}
+${"```"}`
+          : ""
+      }${
+        fallbackError instanceof Error
+          ? `
+
+Error when attempting to fallback to HTML:
+${"```"}
+${fallbackError.name}: ${fallbackError.message}
+${"```"}`
+          : ""
+      }`
+    );
+    return `https://github.com/mdn/yari/issues/new?${params}`;
+  } catch {
+    return "https://github.com/mdn/yari/issues/new";
+  }
+}
+
 const container = document.getElementById("root");
 if (!container) {
   throw new Error("missing root element");


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

### Problem

We occasionally have bugs which cause react to totally unmount, leaving an empty page. This seems particularly silly, when we've already server side rendered the page, and sent it to the client, which could be used as a fallback instead.

### Solution

- Add an event listener for all un-handled errors
- If the react root is empty (i.e. react unmounted, leaving an empty page):
  - Fetch the static html from cache
  - Load it into the react root
  - Add a console warning urging users to report an issue, with a magic link pre-filling the error and stacktrace and everything: [an example from chromium](https://github.com/mdn/yari/issues/new?title=Unhandled+error%3A+Missing+initializer+in+const+declaration&labels=%F0%9F%90%9B+bug&body=Location%3A+%60http%3A%2F%2Flocalhost%3A3000%2Fen-US%2Fdocs%2FWeb%2FAPI%2FWebGL_API%2FTutorial%2FGetting_started_with_WebGL%60%0A%0AError%3A%0A%60%60%60%0ASyntaxError%3A+Missing+initializer+in+const+declaration%0A%60%60%60%0A%0AStack%3A%0A%60%60%60%0ASyntaxError%3A+Missing+initializer+in+const+declaration%0A++++at+http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A578%3A5%0A++++at+commitHookEffectListMount+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A57470%3A30%29%0A++++at+commitPassiveMountOnFiber+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A58963%3A17%29%0A++++at+commitPassiveMountEffects_complete+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A58935%3A13%29%0A++++at+commitPassiveMountEffects_begin+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A58925%3A11%29%0A++++at+commitPassiveMountEffects+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A58915%3A7%29%0A++++at+flushPassiveEffectsImpl+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A60800%3A7%29%0A++++at+flushPassiveEffects+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A60752%3A18%29%0A++++at+http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A60567%3A13%0A++++at+workLoop+%28http%3A%2F%2Flocalhost%3A3000%2Fstatic%2Fjs%2Fbundle.js%3A71780%3A38%29%0A%60%60%60)

---

## How did you test this change?

Tested across `:3000` and `:5042` - the former has nothing to fallback to, but will add a console message.

Sprinkled things like `eval("const a;")` and `eval("foobar")` through the code, in `useEffects` or on buttons `<button onClick={() => eval("const c;")}>Break stuff</button>`.

Ensured errors which are un-handled, but don't cause react to unmount, leave the page as it is.