### PR TITLE
chore(lint-staged): don't run check:tsc

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,9 +1,5 @@
 module.exports = {
   "*.!{js,jsx,ts,tsx,css,scss}": "prettier --ignore-unknown --write",
-  "*.{js,jsx,ts,tsx}": [
-    () => "yarn check:tsc",
-    "eslint --fix",
-    "prettier --write",
-  ],
+  "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
   "*.{css,scss}": ["stylelint --fix --allow-empty-input", "prettier --write"],
 };


### PR DESCRIPTION
## Summary

Removes `check:tsc` from the lint-staged configuration, so it's no longer run as a pre-commit hook.

### Problem

On every commit, `yarn check:tsc` is run, but this takes more than a few seconds to run (e.g. 30s on a MacBook Pro from 2019).

### Solution

No longer run it as a pre-commit hook.

---

## How did you test this change?

Committing this change only took 3s instead of 30s+:

```
% git commit -m "chore(lint-staged): don't run check:tsc                                                                            ✚
dquote> 
dquote> It takes 30s to run on some systems,
dquote> which disrupts dev workflows."
yarn install v1.22.19
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.54s.
yarn run v1.22.19
$ /Users/claas/github/mdn/yari/node_modules/.bin/lint-staged
✔ Preparing lint-staged...
✔ Running tasks for staged files...
✔ Applying modifications from tasks...
✔ Cleaning up temporary files...
✨  Done in 3.09s.
[disable-check-tsc-on-pre-commit b9cd47736] chore(lint-staged): don't run check:tsc
 1 file changed, 1 insertion(+), 5 deletions(-)
```