### PR TITLE
feat(plus/search-filter): add clear button

### DIFF
--- a/client/src/plus/search-filter/index.tsx
+++ b/client/src/plus/search-filter/index.tsx
@@ -249,6 +249,10 @@ export default function SearchFilter({
           setSelectedTerms(camelUnwrap(terms))
         }
         onChangeHandler={(e) => setTerms(e.target.value)}
+        onResetHandler={() => {
+          setTerms("");
+          setSelectedTerms("");
+        }}
       />
 
       {sorts.length ? (

--- a/client/src/ui/atoms/search/index.scss
+++ b/client/src/ui/atoms/search/index.scss
@@ -31,7 +31,18 @@
     outline: var(--border-primary);
   }
 
+  &:not([value=""]):not(:focus) {
+    ~ .button.clear-search-button {
+      display: block;
+      right: 2rem;
+    }
+  }
+
   &::placeholder {
     color: var(--text-inactive);
+  }
+
+  .button.clear-search-button {
+    display: none;
   }
 }

--- a/client/src/ui/atoms/search/index.scss
+++ b/client/src/ui/atoms/search/index.scss
@@ -34,7 +34,7 @@
   &:not([value=""]) {
     ~ .button.clear-search-button {
       display: block;
-      right: 2rem;
+      right: 2.1rem;
     }
   }
 

--- a/client/src/ui/atoms/search/index.scss
+++ b/client/src/ui/atoms/search/index.scss
@@ -31,7 +31,7 @@
     outline: var(--border-primary);
   }
 
-  &:not([value=""]):not(:focus) {
+  &:not([value=""]) {
     ~ .button.clear-search-button {
       display: block;
       right: 2rem;

--- a/client/src/ui/atoms/search/index.tsx
+++ b/client/src/ui/atoms/search/index.tsx
@@ -34,7 +34,11 @@ export const Search = ({
         placeholder={placeholder}
         value={value}
         disabled={isDisabled}
-        onBlur={onBlurHandler}
+        onBlur={(e) =>
+          onBlurHandler &&
+          !e.currentTarget.parentElement?.contains(e.relatedTarget) &&
+          onBlurHandler(e)
+        }
         onFocus={onFocusHandler}
         onChange={onChangeHandler}
         onClick={onClickHandler}

--- a/client/src/ui/atoms/search/index.tsx
+++ b/client/src/ui/atoms/search/index.tsx
@@ -29,7 +29,7 @@ export const Search = ({
     <div className="search-form search-widget">
       <input
         type="search"
-        className={`search-input-field ${value ? "has-value" : ""}`}
+        className="search-input-field"
         name={name}
         placeholder={placeholder}
         value={value}

--- a/client/src/ui/atoms/search/index.tsx
+++ b/client/src/ui/atoms/search/index.tsx
@@ -44,7 +44,7 @@ export const Search = ({
         <button
           type="button"
           className="button action has-icon clear-search-button"
-          onClickCapture={onResetHandler}
+          onClick={onResetHandler}
         >
           <span className="button-wrap">
             <span className="icon icon-cancel undefined"></span>

--- a/client/src/ui/atoms/search/index.tsx
+++ b/client/src/ui/atoms/search/index.tsx
@@ -51,7 +51,7 @@ export const Search = ({
           onClick={onResetHandler}
         >
           <span className="button-wrap">
-            <span className="icon icon-cancel undefined"></span>
+            <span className="icon icon-cancel"></span>
             <span className="visually-hidden">Clear search input</span>
           </span>
         </button>
@@ -63,7 +63,7 @@ export const Search = ({
         className="button action has-icon search-button search-filter-button"
       >
         <span className="button-wrap">
-          <span className="icon icon-search undefined"></span>
+          <span className="icon icon-search"></span>
           <span className="visually-hidden">Search</span>
         </span>
       </button>

--- a/client/src/ui/atoms/search/index.tsx
+++ b/client/src/ui/atoms/search/index.tsx
@@ -11,6 +11,7 @@ type SearchProps = {
   onChangeHandler?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onClickHandler?: (event: React.MouseEvent<Element>) => void;
   onFocusHandler?: (event: React.FocusEvent<Element>) => void;
+  onResetHandler?: () => void;
 };
 
 export const Search = ({
@@ -20,6 +21,7 @@ export const Search = ({
   onChangeHandler,
   onClickHandler,
   onFocusHandler,
+  onResetHandler,
   placeholder,
   value,
 }: SearchProps) => {
@@ -27,7 +29,7 @@ export const Search = ({
     <div className="search-form search-widget">
       <input
         type="search"
-        className="search-input-field"
+        className={`search-input-field ${value ? "has-value" : ""}`}
         name={name}
         placeholder={placeholder}
         value={value}
@@ -37,6 +39,20 @@ export const Search = ({
         onChange={onChangeHandler}
         onClick={onClickHandler}
       />
+
+      {onResetHandler && (
+        <button
+          type="button"
+          className="button action has-icon clear-search-button"
+          onClickCapture={onResetHandler}
+        >
+          <span className="button-wrap">
+            <span className="icon icon-cancel undefined"></span>
+            <span className="visually-hidden">Clear search input</span>
+          </span>
+        </button>
+      )}
+
       <button
         type="submit"
         disabled={isDisabled}

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -51,13 +51,6 @@
     &:focus,
     &:valid {
       width: inherit;
-
-      /* When the search input has focus or has content,
-          show the clear search button */
-      ~ .button.clear-search-button {
-        display: block;
-        right: 2.8rem;
-      }
     }
 
     &:invalid,

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -51,6 +51,13 @@
     &:focus,
     &:valid {
       width: inherit;
+
+      /* When the search input has focus or has content,
+          show the clear search button */
+      ~ .button.clear-search-button {
+        display: block;
+        right: 2.8rem;
+      }
     }
 
     &:invalid,


### PR DESCRIPTION
## Summary

Adds a clear button to the search field on the Updates page.

### Problem

The search field on the Updates page is not consistent with the top-level search field in that it lacks a clear button.

### Solution

Adds the clear button, which is only shown if the search field has a value and is **not** focused.

The focus restriction avoids problems due to the input's blur event (which applies the current value) firing before the clear button's click event (which clears the value). Otherwise the current value would shortly pop up, which would be poor UX.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="844" alt="image" src="https://user-images.githubusercontent.com/495429/216447988-b825f276-c82c-44e3-89cb-0c8ba400fc30.png">

### After

<img width="844" alt="image" src="https://user-images.githubusercontent.com/495429/216447891-748be059-97d2-44cb-977c-d6b6ff64240b.png">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/plus/updates locally, testing with different combinations of applied value vs current value.