### PR TITLE
fix(macros/MDNSidebar): remove repeated `<details>` tag

### DIFF
--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -215,7 +215,6 @@ const text = mdn.localStringMap({
 
         <li class="toggle">
             <details>
-            <details>
                 <summary><%=text['Community_guide']%></summary>
                 <ol>
                     <li><a href="<%=baseURL%>Community"><%=text['Comm_overview']%></a></li>
@@ -246,6 +245,5 @@ const text = mdn.localStringMap({
                 </ol>
             </details>
         </li>
-
     </ol>
 </section>


### PR DESCRIPTION
## Summary

fix(macros/MDNSidebar): remove repeated `<details>` tag

### Problem

See screenshot

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15844309/216498486-f69866c8-05f8-41fc-95d8-c6dcc99030b6.png)

### After

![image](https://user-images.githubusercontent.com/15844309/216498510-7a1774b5-790b-41a2-9cb3-22953c56f15c.png)

---

## How did you test this change?

run `yarn dev`
