### PR TITLE
chore(sidebar): remove "Related Topics" header

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -123,6 +123,10 @@
     margin-top: 1rem;
   }
 
+  li:first-of-type strong {
+    margin-top: unset;
+  }
+
   ol {
     font-size: var(--type-smaller-font-size);
 

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -9,7 +9,7 @@ import { TOC } from "../toc";
 
 export function SidebarContainer({
   doc,
-  label = undefined,
+  label,
   children,
 }: {
   doc: any;

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -7,7 +7,15 @@ import { useUIStatus } from "../../../ui-context";
 import "./index.scss";
 import { TOC } from "../toc";
 
-export function SidebarContainer({ doc, children }) {
+export function SidebarContainer({
+  doc,
+  label = undefined,
+  children,
+}: {
+  doc: any;
+  label?: string;
+  children: React.ReactNode;
+}) {
   const { isSidebarOpen, setIsSidebarOpen } = useUIStatus();
   const [classes, setClasses] = useState<string>("sidebar");
 
@@ -49,7 +57,7 @@ export function SidebarContainer({ doc, children }) {
           onClickHandler={() => setIsSidebarOpen(!isSidebarOpen)}
           aria-label="Collapse sidebar"
         />
-        <nav className="sidebar-inner">
+        <nav aria-label={label} className="sidebar-inner">
           <div className="in-nav-toc">
             {doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}
           </div>
@@ -63,7 +71,7 @@ export function SidebarContainer({ doc, children }) {
 export function RenderSideBar({ doc }) {
   if (!doc.related_content) {
     return (
-      <SidebarContainer doc={doc}>
+      <SidebarContainer doc={doc} label="Related Topics">
         {doc.sidebarHTML && (
           <>
             <div

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "../../../ui/atoms/button";
 
 import { useUIStatus } from "../../../ui-context";
@@ -66,7 +66,6 @@ export function RenderSideBar({ doc }) {
       <SidebarContainer doc={doc}>
         {doc.sidebarHTML && (
           <>
-            <h4 className="sidebar-heading">Related Topics</h4>
             <div
               dangerouslySetInnerHTML={{
                 __html: `${doc.sidebarHTML}`,


### PR DESCRIPTION
## Summary

Removes the "Related Topics" header, as agreed upon at the Mozilla/OWD meetup.

### Problem

The header takes up unnecessary space.

### Solution

Remove it, and make sure that the [section] "headers" line up with the page title (in the middle) and "In this article" header (on the right).

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="698" alt="image" src="https://user-images.githubusercontent.com/495429/216618880-02c07565-6d93-4899-a3bc-4ea735739ec6.png"> | <img width="698" alt="image" src="https://user-images.githubusercontent.com/495429/216618942-5a86648b-49c5-4071-b1fb-8a14cac2dabb.png"> |

---

## How did you test this change?

Ran `yarn start` and opened http://localhost:3000/en-US/docs/Web/HTML locally.