### PR TITLE
chore(kumascript): remove BUILD_MACROS_USED_LOGFILE feature

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -131,17 +131,6 @@ When doing local development, it's recommended to set this to
 
 The base URL used in the Interactive Example iframes.
 
-### `BUILD_MACROS_USED_LOGFILE`
-
-**Default `not set`**
-
-This needs to be a file path. E.g.
-`export BUILD_MACROS_USED_LOGFILE=/tmp/macros-used.log` It will write one line
-for every (normalized) macro name used and its arguments in rendering.
-
-This is an advanced feature to help potentially figuring out which kumascript
-macros, in the source, that aren't used.
-
 ### `BUILD_GOOGLE_ANALYTICS_ACCOUNT`
 
 **Default: `''`**

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -100,21 +100,6 @@ export default class Templates {
       // creates a more informative MacroNotFoundError
       throw new ReferenceError(`Unknown macro ${name}`);
     }
-    if (process.env.BUILD_MACROS_USED_LOGFILE) {
-      try {
-        fs.appendFileSync(
-          process.env.BUILD_MACROS_USED_LOGFILE,
-          `${name}|${args.arguments}\n`,
-          "utf-8"
-        );
-      } catch (err) {
-        console.warn(
-          "Unable to write BUILD_MACROS_USED_LOGFILE " +
-            `(${process.env.BUILD_MACROS_USED_LOGFILE})`,
-          err
-        );
-      }
-    }
     try {
       const rendered = await ejs.renderFile(path, args, {
         async: true,


### PR DESCRIPTION
## Summary

Removes an unused feature: The `BUILD_MACROS_USED_LOGFILE` env variable could be set to log used features, but we can now determine used features statically since https://github.com/mdn/yari/pull/7087.

---

## How did you test this change?

Trivial change, relying on tests otherwise.
