### PR TITLE
chore(macros): remove usage of the obsolete tag

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -188,10 +188,6 @@ async function buildSublist(pages, title) {
     
     const pageBadges = (await page.badges(aPage)).join("");
 
-    if (hasTag(aPage, 'Obsolete')) {
-        result += '<s class="obsoleteElement">';
-    }
-
     if (rtlLocales.indexOf(locale) != -1) {
         result += '<bdi>';
     }
@@ -205,10 +201,6 @@ async function buildSublist(pages, title) {
 
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
-    }
-
-    if (hasTag(aPage, 'Obsolete')) {
-        result += '</s>';
     }
 
     result += '</li>';

--- a/kumascript/macros/CSS_Ref.ejs
+++ b/kumascript/macros/CSS_Ref.ejs
@@ -9,7 +9,7 @@
   $1 - Item grouping type
        (valid values: 'alphabetically', 'no'; defaults to 'alphabetically')
   $2 - Array of strings used to filter the items by their status
-       (valid values: 'standard', 'experimental', "nonstandard', 'obsolete';
+       (valid values: 'standard', 'experimental', "nonstandard';
        defaults to ['standard', 'experimental'])
 */
 

--- a/kumascript/macros/Deprecated_Inline.ejs
+++ b/kumascript/macros/Deprecated_Inline.ejs
@@ -2,8 +2,7 @@
 // Inserts an inline indicator noting that an inline item is deprecated.
 //
 // NOTE:    "Deprecated" means that the item should no longer be used, but
-//          still functions. If you mean that it no longer works at all,
-//          use the term "obsolete."
+//          still functions.
 //
 // Parameters:
 //

--- a/kumascript/macros/HTMLRefTable.ejs
+++ b/kumascript/macros/HTMLRefTable.ejs
@@ -134,7 +134,7 @@ for(let page of HTMLDocPages) {
                                    template("HTMLelement", ['h6'])
                                ])).join(', ')),
             summary      : (p?.summary?.()) || "",
-            deprecated   : hasCommonTag(tags, ['deprecated', 'obsolete']),
+            deprecated   : hasCommonTag(tags, ['deprecated']),
             experimental : hasCommonTag(tags, ['experimental']),
             html5        : hasCommonTag(tags, ['html5']),
             component    : hasCommonTag(tags, ['html components'])

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -194,10 +194,6 @@ async function buildSublist(pages, title, opened) {
 
     const pageBadges = (await page.badges(aPage)).join("");
 
-    if (containsTag(aPage, 'Obsolete')) {
-        result += '<s class="obsoleteElement">';
-    }
-
     if (rtlLocales.indexOf(locale) != -1) {
         result += '<bdi>';
     }
@@ -207,10 +203,6 @@ async function buildSublist(pages, title, opened) {
 
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
-    }
-
-    if (containsTag(aPage, 'Obsolete')) {
-        result += '</s>';
     }
 
     result += '</li>';

--- a/kumascript/macros/WebExtAPISidebar.ejs
+++ b/kumascript/macros/WebExtAPISidebar.ejs
@@ -49,12 +49,7 @@ async function buildSublist(pages, title, ignoreBadges) {
 
     let pageBadges = '';
     if (!ignoreBadges) {
-
         pageBadges = (await page.badges(aPage)).join("");
-
-        if (containsTag(aPage, 'Obsolete')) {
-            result += '<s class="obsoleteElement">';
-        }
     }
 
     if (rtlLocales.indexOf(locale) != -1) {
@@ -69,10 +64,6 @@ async function buildSublist(pages, title, ignoreBadges) {
 
     if (rtlLocales.indexOf(locale) != -1) {
         result += '</bdi>';
-    }
-
-    if (hasTag(aPage, 'Obsolete')) {
-        result += '</s>';
     }
 
     result += '</li>';

--- a/kumascript/macros/spec2.ejs
+++ b/kumascript/macros/spec2.ejs
@@ -107,13 +107,6 @@ var label = {
     'pt-BR' : 'Rascunho',
     'ru'    : 'Черновик',
   }),
-  'Obsolete' : mdn.localString({
-      'en-US' : 'Obsolete',
-      'ja'    : '廃止',
-      'ko'    : '폐기됨',
-      'pt-BR' : 'Obsoleto',
-      'ru'    : 'Устаревшая'
-  }),
   'LC' : mdn.localString({
       'en-US' : 'Last Call Working Draft',
       'ja'    : '最終草案',

--- a/kumascript/macros/spec2.ejs
+++ b/kumascript/macros/spec2.ejs
@@ -107,6 +107,13 @@ var label = {
     'pt-BR' : 'Rascunho',
     'ru'    : 'Черновик',
   }),
+  'Obsolete' : mdn.localString({
+      'en-US' : 'Obsolete',
+      'ja'    : '廃止',
+      'ko'    : '폐기됨',
+      'pt-BR' : 'Obsoleto',
+      'ru'    : 'Устаревшая'
+  }),
   'LC' : mdn.localString({
       'en-US' : 'Last Call Working Draft',
       'ja'    : '最終草案',

--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -17,11 +17,6 @@ const badges = [
     macro: "DeprecatedBadge",
     template: "",
   },
-  {
-    tag: "Obsolete",
-    macro: "ObsoleteBadge",
-    template: "",
-  },
 ];
 
 let badgeTemplatesLoaded = false;

--- a/kumascript/tests/macros/apiref.test.ts
+++ b/kumascript/tests/macros/apiref.test.ts
@@ -137,12 +137,7 @@ const expectedStaticMethods = {
         "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestStaticMethod3",
       target: "/en-US/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
@@ -165,12 +160,7 @@ const expectedStaticMethods = {
         "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestStaticMethod3",
       target: "/fr/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
@@ -193,12 +183,7 @@ const expectedStaticMethods = {
         "The MyTestStaticMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestStaticMethod3",
       target: "/ja/docs/Web/API/TestInterface/MyTestStaticMethod3",
       title:
@@ -224,12 +209,7 @@ const expectedInstanceMethods = {
         "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestInstanceMethod3",
       target: "/en-US/docs/Web/API/TestInterface/MyTestInstanceMethod3",
       title:
@@ -252,12 +232,7 @@ const expectedInstanceMethods = {
         "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard.",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestInstanceMethod3",
       target: "/fr/docs/Web/API/TestInterface/MyTestInstanceMethod3",
       title:
@@ -280,12 +255,7 @@ const expectedInstanceMethods = {
         "The MyTestInstanceMethod2 property of the TestInterface interface is deprecated and non-standard (ja translation).",
     },
     {
-      badges: [
-        "icon-experimental",
-        "icon-deprecated",
-        "icon-nonstandard",
-        "obsolete",
-      ],
+      badges: ["icon-experimental", "icon-deprecated", "icon-nonstandard"],
       text: "MyTestInstanceMethod3",
       target: "/ja/docs/Web/API/TestInterface/MyTestInstanceMethod3",
       title:

--- a/kumascript/tests/macros/fixtures/apiref/subpages.json
+++ b/kumascript/tests/macros/fixtures/apiref/subpages.json
@@ -76,7 +76,7 @@
   },
 
   {
-    "tags": ["Deprecated", "Non-standard", "Obsolete", "Experimental"],
+    "tags": ["Deprecated", "Non-standard", "Experimental"],
     "pageType": "web-api-static-method",
     "locale": "en-US",
     "translations": [
@@ -133,7 +133,7 @@
   },
 
   {
-    "tags": ["Deprecated", "Non-standard", "Obsolete", "Experimental"],
+    "tags": ["Deprecated", "Non-standard", "Experimental"],
     "pageType": "web-api-instance-method",
     "locale": "en-US",
     "translations": [


### PR DESCRIPTION
## Summary

Removes usages of the deprecated "Obsolete" tag, which is no longer used in content.

Replaces https://github.com/mdn/yari/pull/7827.

**Note**: This does not remove the "Obsolete" macros, which are still used in translated-content.

---

## How did you test this change?

Relying on the kumascript tests.