### PR TITLE
fix(plus): clicking "learn more" links caused stale or broken pages

### DIFF
--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -37,7 +37,9 @@ export default function OfferOverviewFeatures() {
             the tech category you are interested in whether that is JavaScript,
             CSS, etc.
           </p>
-          <Button href="/en-US/plus/docs/features/updates">Learn more →</Button>
+          <Button href="/en-US/plus/docs/features/updates" target="_self">
+            Learn more →
+          </Button>
         </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature
@@ -56,7 +58,7 @@ export default function OfferOverviewFeatures() {
             your inner curator and collect your favorite articles in one place
             for convenient consultation.
           </p>
-          <Button href="/en-US/plus/docs/features/collections">
+          <Button href="/en-US/plus/docs/features/collections" target="_self">
             Learn more →
           </Button>
         </section>
@@ -70,7 +72,9 @@ export default function OfferOverviewFeatures() {
             inaccessible pages or cluttered tabs. With MDN Plus, have the fully
             navigable resources of MDN at your disposal even when offline.
           </p>
-          <Button href="/en-US/plus/docs/features/offline">Learn more →</Button>
+          <Button href="/en-US/plus/docs/features/offline" target="_self">
+            Learn more →
+          </Button>
         </section>
       </OfferOverviewFeature>
     </section>

--- a/client/src/ui/molecules/menu/index.tsx
+++ b/client/src/ui/molecules/menu/index.tsx
@@ -1,4 +1,3 @@
-import InternalLink from "../../atoms/internal-link";
 import { MenuEntry, Submenu } from "../submenu";
 import "./index.scss";
 

--- a/client/src/ui/molecules/menu/index.tsx
+++ b/client/src/ui/molecules/menu/index.tsx
@@ -33,14 +33,14 @@ export const Menu = ({ menu, isOpen, toggle }: MenuProps) => {
       </button>
 
       {menu.to && (
-        <InternalLink
-          to={menu.to}
+        <a
+          href={menu.to}
           className="top-level-entry"
           // @ts-ignore
           onClick={() => document?.activeElement?.blur()}
         >
           {menu.label}
-        </InternalLink>
+        </a>
       )}
 
       <Submenu


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

fixes: https://github.com/mdn/yari/issues/8106
fixes: https://github.com/mdn/yari/issues/8107

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

The above problems are related, but have different underlying causes.

The first ("Learn more" opens an empty page) is a result of doing client side navigation from homepage -> plus overview -> plus docs. The `hyData` value remains the same throughout, so when loading the plus docs is still that of the homepage's, and predictably causes the component to error out.

The second ("Learn more" opens the wrong plus docs) is a result of doing client side navigation from plus docs -> plus overview -> plus docs. Again, the `hyData` value remains the same throughout, but is at least structurally consistent, so the second load of plus docs just has outdated data, rather than erroring out.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

I have been investigating how to solve this "properly", by ensuing the correct `hyData` ends up in the correct component, and properly revalidating when necessary, but it ended up being rather a lot to unpick on a Friday evening. So, this PR is the "easy" solution of just not client-side navigating between these pages.

I didn't totally tear our the `<InternalLink>` as we do use it in a valid, and useful way, on certain plus *features* such as collections, instead I force a "proper" anchor element by setting `target="_self"` on the `<Button>` components in the plus overview.

---

## How did you test this change?

Clicking around a lot on `:5042`.
