### PR TITLE
chore(scripts): time build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'client/build/static/js/*.js'",
     "analyze:css": "source-map-explorer 'client/build/static/css/*.css'",
-    "build": "cross-env NODE_ENV=production ts-node build/cli.ts",
+    "build": "time cross-env NODE_ENV=production ts-node build/cli.ts",
     "build:client": "cd client && cross-env INLINE_RUNTIME_CHUNK=false node scripts/build.js",
     "build:dist": "tsc -p tsconfig.dist.json",
     "build:glean": "cd client && cross-env VIRTUAL_ENV=venv glean translate src/telemetry/metrics.yaml src/telemetry/pings.yaml -f typescript -o src/telemetry/generated",


### PR DESCRIPTION
# Summary

Runs `yarn build` through `time` to systematically measure its performance.

### Problem

We sometimes want to measure the performance impact of changes, but we cannot just run the dev build on a branch and look at its duration, because the build time varies a lot across GitHub runners.

### Solution

Use `time` to systematically time our builds, both local and in the workflows.

---

## Screenshots

n/a

---

## How did you test this change?

Ran `yarn build --help` locally, and will trigger a dev build for this PR.