### PR TITLE
fix(kumascript/ListGroups): get page's metadata from default locale only

### DIFF
--- a/kumascript/macros/ListGroups.ejs
+++ b/kumascript/macros/ListGroups.ejs
@@ -4,51 +4,39 @@
 // Generates a list of each group (API) from the GroupData JSON and
 // returns it. This can be used to create an index of APIs.
 
-let locale = env.locale;
-let APIHref = '/' + locale + '/docs/Web/API';
-let output = '';
+const locale = env.locale;
+const APIHref = `/${locale}/docs/Web/API/`;
+const defaultAPIHref = "/en-US/docs/Web/API/";
 
 // Conveniences to shorten names of some functions
 
-let htmlEscape = mdn.htmlEscape;
-let spacesToUnderscores = web.spacesToUnderscores;
+const htmlEscape = mdn.htmlEscape;
+const spacesToUnderscores = web.spacesToUnderscores;
 
 // Get the GroupData database
 
-let groupData = web.getJSONData("GroupData")[0];
-let groupNames = Object.keys(groupData);
+const groupData = web.getJSONData("GroupData")[0];
+const groupNames = Object.keys(groupData);
 groupNames.sort();
-
-function containsTag(tagList, tag) {
-  let ret = false;
-
-  if (!tagList || tagList == undefined) {
-    return 0;
-  }
-  tag = tag.toLowerCase();
-  tagList.forEach(function(t) {
-    if (t.toLowerCase() === tag) {
-      ret = true;
-    }
-  });
-  return ret;
-}
 
 // Start building the lists for each letter
 
-let outputByLetter = [];
+const outputByLetter = {};
 
-for(let name of groupNames) {
-  let groupObj = groupData[name];
-  let firstLetter = name[0];
-  let groupOutput = '';
+for(const name of groupNames) {
+  const groupObj = groupData[name];
+  const firstLetter = name[0];
 
-  if (groupObj.overview === undefined) {
+  if (!groupObj.overview) {
     continue;
   }
-  let overviewName = groupObj.overview;
-  let groupUrl = APIHref + "/" + spacesToUnderscores(htmlEscape(overviewName));
-  const aPage = await wiki.getPage(groupUrl);
+  const overviewName = groupObj.overview;
+  const subPath = spacesToUnderscores(htmlEscape(overviewName));
+  const defaultGroupUrl = defaultAPIHref + subPath;
+  const groupUrl = APIHref + subPath;
+  // Get page info from default locale
+  // as some pages are not localized yet
+  const aPage = await wiki.getPage(defaultGroupUrl);
 
   let pageBadges = (await page.badges(aPage)).join(" ");
 
@@ -59,7 +47,9 @@ for(let name of groupNames) {
   // Finish constructing the HTML and then append it to the text for the corresponding
   // letter group.
 
-  groupOutput = `<li><a href='${groupUrl}'>${name}</a>${pageBadges}</li>`;
+  const link = web.smartLink(groupUrl, null, name, null, APIHref, "ListGroups");
+
+  const groupOutput = `<li>${link}${pageBadges}</li>`;
 
   if (!outputByLetter[firstLetter]) {
     outputByLetter[firstLetter] = groupOutput;
@@ -70,12 +60,10 @@ for(let name of groupNames) {
 
 // Now output the whole thing
 
-let keys = Object.keys(outputByLetter);
+const keys = Object.keys(outputByLetter);
 
-keys.forEach(function(letter) {
-  output += `<h3>${letter}</h3>
-  <ul>${outputByLetter[letter]}</ul>`;
-});
+const output = keys.map(letter => `<h3>${letter}</h3>
+  <ul>${outputByLetter[letter]}</ul>`).join("\n");
 
 %><div class="index">
   <%-output%>

--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -26,11 +26,10 @@ let badgeTemplatesLoaded = false;
 
 export async function getBadgeTemplates(kuma: KumaThis, aPage: any) {
   await assertTemplatesLoaded(kuma);
-
   return badges
     .filter(
       ({ status, tag }) =>
-        (status && aPage.status.includes(status)) || page.hasTag(aPage, tag)
+        (status && aPage.status?.includes(status)) || page.hasTag(aPage, tag)
     )
     .map(({ template }) => template);
 }

--- a/kumascript/tests/macros/ListGroups.test.ts
+++ b/kumascript/tests/macros/ListGroups.test.ts
@@ -120,6 +120,10 @@ describeMacro("ListGroups", () => {
         return originalgetJSONData(name);
       }
     });
+    // Mock calls to smartLink
+    macro.ctx.web.smartLink = jest.fn((groupUrl, _, text) => {
+      return `<a href='${groupUrl}'>${text}</a>`;
+    });
   });
 
   testMacro();


### PR DESCRIPTION
## Summary

Fixes: mdn/translated-content#11499

### Problem

Some pages are not localized, so the `page.badges` function may throw an error when get an "empty object" page (the `aPage` object may be an empty object `{}`).

### Solution

Only get badge info from en-US, as the metadata of localized pages are also from `en-US` by default, see mdn/translated-content#7412.

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15844309/217530756-45bd9c87-ec34-4efe-8396-b257378ddaf4.png)

### After

![image](https://user-images.githubusercontent.com/15844309/217530968-355caa92-ebd4-4e9b-9b99-39ceddb5323e.png)

---

## How did you test this change?

Run `yari dev` and open `http://localhost:5042/zh-CN/docs/Web/API`
