### PR TITLE
fix(server): import webpack dynamically

### DIFF
--- a/server/dev.ts
+++ b/server/dev.ts
@@ -1,11 +1,16 @@
-import webpack from "webpack";
-import webpackDevMiddleware from "webpack-dev-middleware";
-import webpackHotMiddleware from "webpack-hot-middleware";
 import type { WebpackConfiguration } from "webpack-dev-server";
 
 export const devMiddlewares = [];
 
 if (process.env.NODE_ENV === "development") {
+  const [webpack, webpackDevMiddleware, webpackHotMiddleware] = (
+    await Promise.all([
+      import("webpack"),
+      import("webpack-dev-middleware"),
+      import("webpack-hot-middleware"),
+    ])
+  ).map((p) => p.default);
+
   const webpackConfig: WebpackConfiguration = {
     entry: {
       app: [


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Webpack is a devDependency and not available in mdn/content, so we cannot `import` it statically.

See: https://github.com/mdn/content/actions/runs/4124165006/jobs/7123086629#step:7:20

### Solution

Use dynamic imports in combination with top-level await.

---

## How did you test this change?

Ran `yarn dev` locally,.
