### PR TITLE
chore(deps): remove rehype-minify-whitespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "react-refresh": "^0.14",
     "react-router": "^6.3.0",
     "react-router-dom": "^6.8.1",
-    "rehype-minify-whitespace": "^4.0.5",
     "remark-prettier": "^2.0.0",
     "resolve": "^1.22.1",
     "resolve-url-loader": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10974,7 +10974,7 @@ rehype-format@^3.1.0:
     repeat-string "^1.0.0"
     unist-util-visit-parents "^3.0.0"
 
-rehype-minify-whitespace@^4.0.0, rehype-minify-whitespace@^4.0.5:
+rehype-minify-whitespace@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz#5b4781786116216f6d5d7ceadf84e2489dd7b3cd"
   integrity sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==


### PR DESCRIPTION
## Summary

### Problem

`rehype-minify-whitespace` is no longer used since https://github.com/mdn/yari/pull/6849.

See also: https://github.com/mdn/yari/pull/8173

### Solution

Remove it.

---

## How did you test this change?

Not tested, relying on the checks and the fact that `rehype-minify-whitespace` is not referenced anywhere.
