### PR TITLE
fix(npm-published-simulation): stale dependencies when installing tar

### DIFF
--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -57,7 +57,9 @@ jobs:
           ls -lh $TARBALL
           mv $TARBALL mdn/content/
           cd mdn/content
+          yarn cache clean --all
           yarn add file:$TARBALL
+          yarn install
 
       - name: (mdn/content) yarn yari-build --help
         working-directory: mdn/content


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Upstream: https://github.com/yarnpkg/yarn/issues/6811
Locally: https://github.com/mdn/yari/pull/5524#issuecomment-1422872041

### Problem

Installing from a tarball seems to cause some stale dependencies to hang around, see: https://github.com/mdn/yari/actions/runs/4127042686/jobs/7129752267#step:8:990

```
../content/node_modules/@mdn/yari/node_modules/unified/package.json
{
  "name": "unified",
  "version": "9.2.1",
```

This was in a PR to upgrade unified to v10.

### Solution

Followed advice from upstream issue:

- Clean yarn cache - this doesn't seem to work by itself, but it *should*
- Run yarn install

See success here: https://github.com/mdn/yari/actions/runs/4127532853/jobs/7130855135

---

## How did you test this change?

Lots of `dnm: debug` commits in this PR to trigger github actions with various configs: https://github.com/mdn/yari/pull/5524
