### PR TITLE
fix(libs/env): get correct `ROOT` by relative path

### DIFF
--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -6,6 +6,8 @@ import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
+// Spread into two lines to get the ROOT path,
+// to prevent WebPack from treating 'new URL("../..", import.meta.url)' as an import.
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 export const ROOT = path.join(currentDir, "..", "..");
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -7,7 +7,7 @@ import dotenv from "dotenv";
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
 // Spread into two lines to get the ROOT path,
-// to prevent WebPack from treating 'new URL("../..", import.meta.url)' as an import.
+// to prevent Webpack from treating 'new URL("../..", import.meta.url)' as an import.
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 export const ROOT = path.join(currentDir, "..", "..");
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -1,12 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
-import { cwd } from "node:process";
+import { fileURLToPath } from "node:url";
 
 import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
-export const ROOT = path.join(cwd(), ".");
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.join(currentDir, "..", "..");
 
 dotenv.config({
   path: path.join(ROOT, process.env.ENV_FILE || ".env"),


### PR DESCRIPTION
## Summary

When trying to run `yarn start` in content and view some local hosted pages. The server throw an error: `Error: ENOENT: no such file or directory, stat '/path/to/content/client/build/en-us/_spas/404.html'`.

I found that the `ROOT` variable is not setted correctly (just got by `cwd()`). We still need a relative path to yari, as lib file would be in `node_modules`.

### Problem

See summary.

### Solution

Use [`import.meta.url`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta) to get the current filepath. And remove the leading slash when run on windows.

---

## How did you test this change?

Only try to run the following script on linux and windows.

```mjs
import { fileURLToPath } from "node:url";
import path from "node:path";

console.log(import.meta.url);
const currentDir = path.dirname(fileURLToPath(import.meta.url));
export const ROOT = path.join(currentDir, "..", "..");

console.log(ROOT);
```
