### PR TITLE
fix(client): Fix exports from constants.ts

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,5 +1,6 @@
 // Constants that are used outside of the client.
-export { MDN_PLUS_TITLE, VALID_LOCALES } from "../../libs/constants";
+import { MDN_PLUS_TITLE, VALID_LOCALES } from "../../libs/constants";
+export { MDN_PLUS_TITLE, VALID_LOCALES };
 
 // Constants that are NOT used outside of the client.
 export enum FeatureId {


### PR DESCRIPTION
This fixes an issue with ./client/src/constants.ts not exporting the variables from ./lib/constants.  Something (probably TypeScript) doesn't like us attempting to combine the import and export together into one line, causing errors to appear in the dev server.
