### PR TITLE
fix(server): point start:server to index.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
     "start:client": "cd client && cross-env NODE_ENV=development BABEL_ENV=development BROWSER=none PORT=3000 node scripts/start.js",
     "start:dev-server": "node-dev --experimental-loader ts-node/esm server/index.ts",
-    "start:server": "ts-node server",
+    "start:server": "ts-node server/index.ts",
     "start:static-server": "ts-node server/static.ts",
     "style-dictionary": "style-dictionary build -c sd-config.js",
     "stylelint": "stylelint \"**/*.scss\"",


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We [noticed an error](https://github.com/mdn/yari/pull/8188#issuecomment-1425912863) when upgrading to Node.js v18 due to `ts-node` being called on a directory.

### Solution

Call `ts-node` with the containing `index.ts` instead.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/495429/218123367-7a4ceef6-94eb-450f-9b72-f2cd3e81cb61.png">

### After

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/495429/218123431-50dc9755-6867-420b-b889-20afce291834.png">

---

## How did you test this change?

Ran `yarn start:server` locally.