### PR TITLE
fix(macros/JSRef): add missing `await` keyword for async function call

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -243,7 +243,7 @@ for (object in result) {
     output += `<li><strong>${link}</strong></li>`;
 
     if (resultConstructors) {
-        output += buildSublist(resultConstructors, text['Constructor'], resultOpen);
+        output += await buildSublist(resultConstructors, text['Constructor'], resultOpen);
     }
     if (resultProperties.length > 0) {
         output += await buildSublist(resultProperties, text['Properties'], resultOpen);


### PR DESCRIPTION
## Summary

Fixes: #8191

As a split part of #8134

### Problem

see issue.

### Solution

Add missing `await` keyword, as the following async function calls.
