### PR TITLE
Remove deleted page from GamesSidebar

### DIFF
--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -10,7 +10,6 @@ const text = mdn.localStringMap({
   "en-US": {
     "Introduction": "Introduction",
       "Anatomy": "Anatomy",
-      "Examples": "Examples",
     "APIs_for_game_development": "APIs for game development",
       "Canvas": "Canvas",
       "CSS": "CSS",
@@ -66,7 +65,6 @@ const text = mdn.localStringMap({
   "es": {
     "Introduction": "Introducción para desarrollo de juegos para la Web",
       "Anatomy": "Anatomía de un videojuego",
-      "Examples": "Examples",
     "APIs_for_game_development": "APIs for game development",
       "Canvas": "Canvas",
       "CSS": "CSS",
@@ -122,7 +120,6 @@ const text = mdn.localStringMap({
   "fr": {
     "Introduction": "Introduction",
       "Anatomy": "Anatomie d'un jeu vidéo",
-      "Examples": "Exemples",
     "APIs_for_game_development": "API pour le développement de jeux",
       "Canvas": "Canvas",
       "CSS": "CSS",
@@ -178,7 +175,6 @@ const text = mdn.localStringMap({
   "ja": {
     "Introduction": "Web のゲーム開発紹介",
       "Anatomy": "ビデオゲームとの違い",
-      "Examples": "Examples",
     "APIs_for_game_development": "ツール",
       "Canvas": "Canvas",
       "CSS": "CSS",
@@ -234,7 +230,6 @@ const text = mdn.localStringMap({
   "ko": {
     "Introduction": "웹 게임 개발 소개",
       "Anatomy": "비디오 게임 구조 파악하기",
-      "Examples": "예제",
     "APIs_for_game_development": "게임 개발에 필요한 API",
       "Canvas": "Canvas",
       "CSS": "CSS",
@@ -290,7 +285,6 @@ const text = mdn.localStringMap({
   "pt-BR": {
     "Introduction": "Introdução",
       "Anatomy": "Anatomia de um video game",
-      "Examples": "Exemplos",
     "APIs_for_game_development": "APIs para desenvolvimento de jogos",
       "Canvas": "Canvas",
       "CSS": "CSS",

--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -349,7 +349,6 @@ const text = mdn.localStringMap({
             <ol>
               <li><a href="<%=baseURL%>Introduction"><%=text["Introduction"]%></a></li>
               <li><a href="<%=baseURL%>Anatomy"><%=text["Anatomy"]%></a></li>
-              <li><a href="<%=baseURL%>Examples"><%=text["Examples"]%></a></li>
             </ol>
         </details>
     </li>


### PR DESCRIPTION
We deleted the _Examples_ pages a long time ago, as:
- it was outdated
- it was unmaintainable
- it was attracting spam.


This PR only removes the link in the Games sidebar. This was reported in mdn/content#24342.