### PR TITLE
chore(macros): remove {{gecko}} macro

### DIFF
--- a/kumascript/macros/gecko.ejs
+++ b/kumascript/macros/gecko.ejs
@@ -1,7 +1,0 @@
-<%
-// Throw a MacroDeprecatedError flaw
-// Can be removed when its usage translated-content is down to 0
-mdn.deprecated();
-%>
-
-<span title="<%= await template("geckoRelease", [$0]) %>">Gecko <%=$0%></span>


### PR DESCRIPTION
## Summary

This macro has been [removed from translated-content](https://github.com/mdn/translated-content/issues/11284). Let's remove it from yari.

```bash
rg -i "\{\{\s*gecko\s*\(" | wc -l # got 0
```

![image](https://user-images.githubusercontent.com/15844309/218609253-3f92013c-a63b-4e42-a4ed-028e026cb320.png)
