### PR TITLE
fix(offline-settings): treat initial phase like idle

### DIFF
--- a/client/src/settings/offline-settings.tsx
+++ b/client/src/settings/offline-settings.tsx
@@ -82,7 +82,9 @@ function Settings() {
   useEffect(() => {
     const mdnWorker = getMDNWorker();
     const isWorkerBusy = status?.phase
-      ? status?.phase !== ContentStatusPhase.IDLE
+      ? ![ContentStatusPhase.INITIAL, ContentStatusPhase.IDLE].includes(
+          status?.phase
+        )
       : false;
     mdnWorker.toggleKeepAlive(isWorkerBusy);
 


### PR DESCRIPTION

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

### Problem

When navigating away from the "Settings" page, a confirmation dialog would always appear, because the "Offline settings" would think that the worker is running and busy, even if disabled.

### Solution

Treat the "initial" phase like idle.

This is the default phase, even if the worker is not running, and this was interpreted as "busy", causing a dialog whenever closing the "Settings" page.

(Note: Originally, the Offline settings were on a separate page.)

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Opened http://localhost:3000/en-US/plus/settings locally and navigated away.
