### PR TITLE
fix(lib/env,ssr): determine env path properly 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -44,3 +44,6 @@ jest.config.js
 *.test.js
 .storybook/
 .nvmrc
+
+# Don't pack the build.
+mdn-yari-*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,7 @@ server/node_modules/
 # This won't be relevant or needed once the content is gone.
 /content/files/en-us/
 
+/client/venv/
 /deployer
 kumascript/tests
 testing/

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -1,4 +1,3 @@
-export const ROOT: string;
 export const BUILD_OUT_ROOT: string;
 export const DEFAULT_FLAW_LEVELS: string;
 export const FILES: string;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -6,7 +6,7 @@ import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
-export const ROOT = path.join(cwd(), ".");
+const ROOT = path.join(cwd(), ".");
 
 dotenv.config({
   path: path.join(ROOT, process.env.ENV_FILE || ".env"),

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { cwd } from "node:process";
+import { fileURLToPath } from "node:url";
 
 import dotenv from "dotenv";
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -6,10 +6,11 @@ import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
-const CWD = path.join(cwd(), ".");
+const dirname = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = path.join(dirname, "..", "..");
 
 dotenv.config({
-  path: path.join(CWD, process.env.ENV_FILE || ".env"),
+  path: path.join(cwd(), process.env.ENV_FILE || ".env"),
 });
 
 // -----
@@ -17,7 +18,7 @@ dotenv.config({
 // -----
 
 export const BUILD_OUT_ROOT =
-  process.env.BUILD_OUT_ROOT || path.join(CWD, "client", "build");
+  process.env.BUILD_OUT_ROOT || path.join(ROOT, "client", "build");
 
 // TODO (far future): Switch to "error" when number of flaws drops.
 export const DEFAULT_FLAW_LEVELS = process.env.BUILD_FLAW_LEVELS || "*:warn";
@@ -142,7 +143,7 @@ export const INTERACTIVE_EXAMPLES_BASE_URL =
 // ------
 
 export const STATIC_ROOT =
-  process.env.SERVER_STATIC_ROOT || path.join(CWD, "client", "build");
+  process.env.SERVER_STATIC_ROOT || path.join(ROOT, "client", "build");
 export const PROXY_HOSTNAME =
   process.env.REACT_APP_KUMA_HOST || "developer.mozilla.org";
 export const CONTENT_HOSTNAME = process.env.SERVER_CONTENT_HOST;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -1,15 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { cwd } from "node:process";
 
 import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
-// Spread into two lines to get the ROOT path,
-// to prevent Webpack from treating 'new URL("../..", import.meta.url)' as an import.
-const currentDir = path.dirname(fileURLToPath(import.meta.url));
-export const ROOT = path.join(currentDir, "..", "..");
+export const ROOT = path.join(cwd(), ".");
 
 dotenv.config({
   path: path.join(ROOT, process.env.ENV_FILE || ".env"),

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -6,10 +6,10 @@ import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 
-const ROOT = path.join(cwd(), ".");
+const CWD = path.join(cwd(), ".");
 
 dotenv.config({
-  path: path.join(ROOT, process.env.ENV_FILE || ".env"),
+  path: path.join(CWD, process.env.ENV_FILE || ".env"),
 });
 
 // -----
@@ -17,7 +17,7 @@ dotenv.config({
 // -----
 
 export const BUILD_OUT_ROOT =
-  process.env.BUILD_OUT_ROOT || path.join(ROOT, "client", "build");
+  process.env.BUILD_OUT_ROOT || path.join(CWD, "client", "build");
 
 // TODO (far future): Switch to "error" when number of flaws drops.
 export const DEFAULT_FLAW_LEVELS = process.env.BUILD_FLAW_LEVELS || "*:warn";
@@ -142,7 +142,7 @@ export const INTERACTIVE_EXAMPLES_BASE_URL =
 // ------
 
 export const STATIC_ROOT =
-  process.env.SERVER_STATIC_ROOT || path.join(ROOT, "client", "build");
+  process.env.SERVER_STATIC_ROOT || path.join(CWD, "client", "build");
 export const PROXY_HOSTNAME =
   process.env.REACT_APP_KUMA_HOST || "developer.mozilla.org";
 export const CONTENT_HOSTNAME = process.env.SERVER_CONTENT_HOST;

--- a/ssr/index.ts
+++ b/ssr/index.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import dotenv from "dotenv";
@@ -7,12 +8,10 @@ import { StaticRouter } from "react-router-dom/server";
 import { App } from "../client/src/app";
 import render from "./render";
 
-// This is necessary because the ssr.js is in dist/ssr.js
-// and we need to reach the .env this way.
+const dirname = fileURLToPath(new URL(".", import.meta.url));
+
 dotenv.config({
-  path: fileURLToPath(
-    new URL("../" + (process.env.ENV_FILE || ".env"), import.meta.url)
-  ),
+  path: path.join(dirname, "..", process.env.ENV_FILE || ".env"),
 });
 
 export function renderHTML(url, context) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/8201.

### Problem

On Windows, `yarn start` was failing with `File URL path must be absolute` when run inside the mdn/content repository, and previously it was accessing the local server showed `no such file or directory, stat '/path/to/content/client/build/en-us/_spas/404.html'` (which was partly fixed in https://github.com/mdn/yari/pull/8177).

### Solution

Properly determine the `dotenv` path in `libs/env` and `ssr/`:

- In `libs/env`, load the `dotenv` file from the current working directory (cwd).
- In `ssr`, load the `dotenv` file from the parent directory.

**Note**: What makes this a bit tricky is the fact that the `.env` file is _usually_ in the yari root, **unless** we are in the content repo. And it's _usually_ in the cwd, **unless** we build the `client`, the `client/pwa` or `ssr`.

---

## How did you test this change?

Tested on Windows 10 with https://www.npmjs.com/package/@mdn/yari/v/2.1.6-rc1, based on this branch.