### PR TITLE
chore(breadcrumbs): count clicks

### DIFF
--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -36,3 +36,5 @@ export const PLUS_UPDATES = Object.freeze({
   MDN_PLUS: "plus_updates_mdn_plus",
   PAGE_CHANGE: "plus_updates_page_change",
 });
+
+export const BREADCRUMB_CLICK = "breadcrumb_click";

--- a/client/src/ui/molecules/breadcrumbs/index.tsx
+++ b/client/src/ui/molecules/breadcrumbs/index.tsx
@@ -1,5 +1,7 @@
 import { DocParent } from "../../../../../libs/types/document";
 import { PreloadingDocumentLink } from "../../../document/preloading";
+import { BREADCRUMB_CLICK } from "../../../telemetry/constants";
+import { useGleanClick } from "../../../telemetry/glean-context";
 
 import "./index.scss";
 
@@ -7,6 +9,8 @@ export const Breadcrumbs = ({ parents }: { parents: DocParent[] }) => {
   if (!parents.length) {
     throw new Error("Empty parents array");
   }
+
+  const gleanClick = useGleanClick();
 
   return (
     <nav className="breadcrumbs-container" aria-label="Breadcrumb">
@@ -26,6 +30,14 @@ export const Breadcrumbs = ({ parents }: { parents: DocParent[] }) => {
                 className={isLast ? "breadcrumb-current-page" : "breadcrumb"}
                 property="item"
                 typeof="WebPage"
+                // 1/* => current, 2/* = parent, ..., n/n = top-level.
+                onClick={() =>
+                  gleanClick(
+                    `${BREADCRUMB_CLICK}: ${parents.length - i}/${
+                      parents.length
+                    }`
+                  )
+                }
               >
                 <span property="name">{parent.title}</span>
               </PreloadingDocumentLink>


### PR DESCRIPTION
## Summary

### Problem

We don't know how our breadcrumbs are used.

### Solution

Add a metric `breadcrumb_click: i/n` that measures a click on the `i`th breadcrumb of `n` (counting from the right, i.e. 1 = current page's breadcrumb).

Examples:

- `breadcrumb_click: 1/4` is a click on the current page's crumb, out of 4 crumbs.
    <img width="425" alt="image" src="https://user-images.githubusercontent.com/495429/219129153-6bb76b55-b28b-436a-9d8e-59714dadbe2f.png">
- `breadcrumb_click: 2/3` is a click on the parent page's crumb, out of 3 crumbs.
    <img width="425" alt="image" src="https://user-images.githubusercontent.com/495429/219129241-676c8462-e275-4da8-b7bb-3eb13f43c760.png">
- `breadcrumb_click: 2/2` is a click on the "top level" crumb, out of 2 crumbs.
    <img width="425" alt="image" src="https://user-images.githubusercontent.com/495429/219129403-9af95819-bc72-4486-88c4-6ebf81c68a69.png">

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
