### PR TITLE
feat(breadcrumbs): add a space to the multiple lines layout

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -4,6 +4,8 @@
   align-items: center;
   display: flex;
   margin-right: auto;
+  padding-top: 0.5rem;
+  padding-bottom: 0.25rem;
 
   ol {
     line-height: 1.2;
@@ -11,6 +13,7 @@
 
   li {
     display: none;
+    padding-bottom: 0.25rem;
     hyphens: auto;
 
     // only show first and last on mobile


### PR DESCRIPTION
## Summary

A small fix for breadcrumbs layout.

### Problem

On 13-14" monitors, sometimes there is no space for all bread crumbs. And elements are divided into two or more lines. But this behavior is not accounted for in the layout.

### Solution

I will add a small padding to the container and for each item of breadcrumbs.

---

## Screenshots

### Before

<img width="1392" alt="before-pc" src="https://user-images.githubusercontent.com/4469056/219420121-daf2f63c-e635-4482-a683-c58c3086681d.png">

### After

<img width="1392" alt="after-pc" src="https://user-images.githubusercontent.com/4469056/219420182-35f21279-7779-49e5-9670-ebc1448c983e.png">