### PR TITLE
perf(content): use `translationsOf()` to get cached translations

### DIFF
--- a/content/translations.ts
+++ b/content/translations.ts
@@ -1,5 +1,4 @@
 import * as Document from "./document.js";
-import { VALID_LOCALES } from "../libs/constants/index.js";
 import LANGUAGES_RAW from "../libs/languages/index.js";
 
 const LANGUAGES = new Map(

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -7,7 +7,13 @@ const LANGUAGES = new Map(
   })
 );
 
-const TRANSLATIONS_OF = new Map();
+type Translation = {
+  title: string;
+  locale: string;
+  native: string;
+};
+
+const TRANSLATIONS_OF = new Map<string, Array<Translation>>();
 
 function gatherTranslations() {
   const iter = Document.findAll().iterDocs();

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -52,26 +52,3 @@ export function translationsOf({ slug, locale: currentLocale }) {
   }
   return translations;
 }
-
-export function findDocumentTranslations(document) {
-  const translations = [];
-
-  for (const locale of VALID_LOCALES.values()) {
-    if (document.metadata.locale === locale) {
-      continue;
-    }
-    const translatedDocumentURL = document.url.replace(
-      `/${document.metadata.locale}/`,
-      `/${locale}/`
-    );
-    const translatedDocument = Document.findByURL(translatedDocumentURL);
-    if (translatedDocument) {
-      translations.push({
-        locale,
-        title: translatedDocument.metadata.title,
-        native: LANGUAGES.get(locale.toLowerCase()).native,
-      });
-    }
-  }
-  return translations;
-}

--- a/server/index.ts
+++ b/server/index.ts
@@ -51,7 +51,7 @@ async function buildDocumentFromURL(url) {
     // When you're running the dev server and build documents
     // every time a URL is requested, you won't have had the chance to do
     // the phase that happens when you do a regular `yarn build`.
-    document.translationsOf = translationsOf({
+    document.translations = translationsOf({
       slug: document.metadata.slug,
       locale: document.metadata.locale,
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,7 @@ import {
   buildLiveSamplePageFromURL,
   renderContributorsTxt,
 } from "../build/index.js";
-import { findDocumentTranslations } from "../content/translations.js";
+import { translationsOf } from "../content/translations.js";
 import { Document, Redirect, Image } from "../content/index.js";
 import { CSP_VALUE, DEFAULT_LOCALE } from "../libs/constants/index.js";
 import {
@@ -51,7 +51,10 @@ async function buildDocumentFromURL(url) {
     // When you're running the dev server and build documents
     // every time a URL is requested, you won't have had the chance to do
     // the phase that happens when you do a regular `yarn build`.
-    document.translations = findDocumentTranslations(document);
+    document.translationsOf = translationsOf({
+      slug: document.metadata.slug,
+      locale: document.metadata.locale,
+    });
   }
   return await buildDocument(document, documentOptions);
 }


### PR DESCRIPTION
## Summary

We just use findDocumentTranslations to gather translations, but actually we
could use `translationsOf()` instead. As we have gather all translations before.

By using `translationsOf()` instead, we could build documents faster (should be).

---

## How did you test this change?

run `yarn build` with env `ENV_FILE=.env.testing`
