### PR TITLE
chore(macros): deprecate HTMLRefTable

### DIFF
--- a/kumascript/macros/HTMLRefTable.ejs
+++ b/kumascript/macros/HTMLRefTable.ejs
@@ -8,6 +8,8 @@
 //      * exclude : An array of tags, the HTML Element page must NOT have any of them to be listed
 //      * elements: An array of elements name to add to the list of HTML elements (useful for custom list or not documented elements)
 
+// Throw a MacroDeprecatedError flaw
+mdn.deprecated()
 
 // LOCALISATION
 // ------------


### PR DESCRIPTION
In mdn/content#24515, we are removing the only page in en-US using `HTMLRefTable`.

This macro is blocking us from removing the `Tags:` YAML header.

This PR marks the macro as deprecated, and we can remove it in translations before deleting it.