### PR TITLE
Webextensions sidebar remove tag dependency

### DIFF
--- a/kumascript/macros/WebExtAPISidebar.ejs
+++ b/kumascript/macros/WebExtAPISidebar.ejs
@@ -9,25 +9,28 @@ var baseURL = "/" + locale + "/docs/";
 var baseAPIPage = baseURL + "Mozilla/Add-ons/WebExtensions/API";
 
 var htmlEscape = mdn.htmlEscape;
-var rtlLocales = ['ar', 'he', 'fa'];
+var rtlLocales = ["ar", "he", "fa"];
 
-let commonl10n = web.getJSONData('L10n-Common');
+let commonl10n = web.getJSONData("L10n-Common");
 
 let text = {
-    'translate': mdn.getLocalString(commonl10n, '[Translate]'),
-    'title': mdn.getLocalString(commonl10n, 'TranslationCTA'),
-    'Methods': mdn.getLocalString(commonl10n, 'Methods'),
-    'Properties': mdn.getLocalString(commonl10n, 'Properties'),
-    'Types': mdn.getLocalString(commonl10n, 'Types'),
-    'Events': mdn.getLocalString(commonl10n, 'Events'),
+  translate: mdn.getLocalString(commonl10n, "[Translate]"),
+  title: mdn.getLocalString(commonl10n, "TranslationCTA"),
+  Methods: mdn.getLocalString(commonl10n, "Methods"),
+  Properties: mdn.getLocalString(commonl10n, "Properties"),
+  Types: mdn.getLocalString(commonl10n, "Types"),
+  Events: mdn.getLocalString(commonl10n, "Events"),
 };
 
 async function buildSublist(pages, title, ignoreBadges) {
-  var result = '<li data-default-state="open"><a href="#"><strong>' + title + '</strong></a><ol>';
+  var result =
+    '<li data-default-state="open"><a href="#"><strong>' +
+    title +
+    "</strong></a><ol>";
 
   for (var i in pages) {
     var aPage = pages[i];
-    var url = aPage.url.replace('en-US', locale);
+    var url = aPage.url.replace("en-US", locale);
     var title = htmlEscape(aPage.title);
 
     var apiComponentName = title;
@@ -36,53 +39,53 @@ async function buildSublist(pages, title, ignoreBadges) {
       apiComponentName = titlePieces[titlePieces.length - 1];
     }
 
-    if (locale != 'en-US') {
-        aPage.translations.forEach(function(translation) {
-            if(translation.locale === locale) {
-                url = translation.url;
-                title = htmlEscape(translation.title);
-            }
-        });
+    if (locale != "en-US") {
+      aPage.translations.forEach(function (translation) {
+        if (translation.locale === locale) {
+          url = translation.url;
+          title = htmlEscape(translation.title);
+        }
+      });
     }
 
-    result += '<li>';
+    result += "<li>";
 
-    let pageBadges = '';
+    let pageBadges = "";
     if (!ignoreBadges) {
-        pageBadges = (await page.badges(aPage)).join("");
+      pageBadges = (await page.badges(aPage)).join("");
     }
 
     if (rtlLocales.indexOf(locale) != -1) {
-        result += '<bdi>';
+      result += "<bdi>";
     }
 
     if (slug == aPage.slug) {
-        result += `<em><code>${apiComponentName}</code> ${pageBadges}</em>`;
+      result += `<em><code>${apiComponentName}</code> ${pageBadges}</em>`;
     } else {
-        result += `<a href="${url}"><code>${apiComponentName}</code></a>${pageBadges}`;
+      result += `<a href="${url}"><code>${apiComponentName}</code></a>${pageBadges}`;
     }
 
     if (rtlLocales.indexOf(locale) != -1) {
-        result += '</bdi>';
+      result += "</bdi>";
     }
 
-    result += '</li>';
+    result += "</li>";
   }
 
-  result += '</ol></li>';
+  result += "</ol></li>";
 
   return result;
 }
 
 function classifyPages(subpages) {
   var collection = {
-      properties: [],
-      methods: [],
-      events: [],
-      types: []
-  }
+    properties: [],
+    methods: [],
+    events: [],
+    types: [],
+  };
 
-  subpages.forEach(function(subpage) {
+  subpages.forEach(function (subpage) {
     if (hasTag(subpage, "Property")) {
       collection.properties.push(subpage);
     }
@@ -101,7 +104,7 @@ function classifyPages(subpages) {
 }
 
 async function buildSidebarForSingleAPI(apiPath) {
-  output+= '<ol>';
+  output += "<ol>";
 
   var subpages = await pageModule.subpagesExpand(apiPath);
 
@@ -111,7 +114,11 @@ async function buildSidebarForSingleAPI(apiPath) {
     output += await buildSublist(pageCollection.methods, text["Methods"], true);
   }
   if (pageCollection.properties.length > 0) {
-    output += await buildSublist(pageCollection.properties, text["Properties"], true);
+    output += await buildSublist(
+      pageCollection.properties,
+      text["Properties"],
+      true
+    );
   }
   if (pageCollection.types.length > 0) {
     output += await buildSublist(pageCollection.types, text["Types"], true);
@@ -120,14 +127,17 @@ async function buildSidebarForSingleAPI(apiPath) {
     output += await buildSublist(pageCollection.events, text["Events"], true);
   }
 
-output += '</ol>';
+  output += "</ol>";
 }
 
 async function buildSidebarForAllAPIs() {
   output = "<ol>";
-  var browserSupportURL = baseURL + "Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs";
+  var browserSupportURL =
+    baseURL +
+    "Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs";
   var browserSupportTitle = "Browser support for JavaScript APIs";
-  output +=  '<li><a href="' +  browserSupportURL + '">' + browserSupportTitle + '</a>';
+  output +=
+    '<li><a href="' + browserSupportURL + '">' + browserSupportTitle + "</a>";
 
   var subpages = await pageModule.subpagesExpand(baseAPIPage);
   for (var i = 0; i < subpages.length; i++) {
@@ -135,18 +145,21 @@ async function buildSidebarForAllAPIs() {
     var pieces = apiPage.url.split("/");
     var apiName = pieces.slice(-1);
     if (slug.indexOf(apiPage.slug) != -1) {
-      output +=  '<li class="webextension-api-sidebar"><a href="' +  apiPage.url + '">' + apiName + '</a>';
+      output +=
+        '<li class="webextension-api-sidebar"><a href="' +
+        apiPage.url +
+        '">' +
+        apiName +
+        "</a>";
       await buildSidebarForSingleAPI(baseURL + apiPage.slug);
+    } else {
+      output += '<li><a href="' + apiPage.url + '">' + apiName + "</a>";
     }
-    else {
-      output +=  '<li><a href="' +  apiPage.url + '">' + apiName + '</a>';
-    }
-    output += '</li>';
+    output += "</li>";
   }
 
-output += '</ol>';
+  output += "</ol>";
 }
-
 
 await buildSidebarForAllAPIs(baseURL);
 %>

--- a/kumascript/macros/WebExtAPISidebar.ejs
+++ b/kumascript/macros/WebExtAPISidebar.ejs
@@ -2,7 +2,6 @@
 
 var output = "";
 var pageModule = page;
-var hasTag = page.hasTag;
 var slug = env.slug;
 var locale = env.locale;
 var baseURL = "/" + locale + "/docs/";
@@ -78,27 +77,29 @@ async function buildSublist(pages, title, ignoreBadges) {
 }
 
 function classifyPages(subpages) {
-  var collection = {
+  const collection = {
     properties: [],
     methods: [],
     events: [],
     types: [],
   };
 
-  subpages.forEach(function (subpage) {
-    if (hasTag(subpage, "Property")) {
-      collection.properties.push(subpage);
+  for (const subpage of subpages) {
+    switch (subpage.pageType) {
+      case "webextension-api-property":
+        collection.properties.push(subpage);
+        break;
+      case "webextension-api-function":
+        collection.methods.push(subpage);
+        break;
+      case "webextension-api-type":
+        collection.types.push(subpage);
+        break;
+      case "webextension-api-event":
+        collection.events.push(subpage);
+        break;
     }
-    if (hasTag(subpage, "Method")) {
-      collection.methods.push(subpage);
-    }
-    if (hasTag(subpage, "Type")) {
-      collection.types.push(subpage);
-    }
-    if (hasTag(subpage, "Event")) {
-      collection.events.push(subpage);
-    }
-  });
+  }
 
   return collection;
 }


### PR DESCRIPTION
## Summary

Use page-type instead if tags in WebExtAPISidebar.

### Problem

The WebExtAPISidebar macro builds the bit of the Add-ons sidebar that lists the contents of a single Web Extension API, like this:

<img width="736" alt="Screen Shot 2023-02-17 at 12 30 36 PM" src="https://user-images.githubusercontent.com/432915/219787263-cdf8dd73-6ae0-4f03-908b-66393811782e.png">

It currently uses tags to classify the different bits (methods, properties, types, and events). But we want to phase out tags.

### Solution

Use page-type instead of tags, as we've already done for other sidebars that do the same thing, like https://github.com/mdn/yari/pull/7223.

Note though the this PR also prettifies the macro, but I kept that in a separate commit for easier reviewing:

* https://github.com/mdn/yari/commit/ca999664999a4ae3b8026023afbbc73cf170161e : Prettier
* https://github.com/mdn/yari/commit/611a0e54dc256c56ab1f7b921953b6f3b49f2a1c : Substantive change

## Screenshots

The sidebar should look exactly the same as before.

## How did you test this change?

Ran yarn dev, looked at some pages like:
- http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/API/bookmarks/getSubTree
- http://localhost:3000/en-US/docs/Mozilla/Add-ons/WebExtensions/API/captivePortal

Note that you'll need a fresh mdn/content, since the page types only just landed today: https://github.com/mdn/content/pull/24153.

