### PR TITLE
fix(kumascript): load badge templates by locale

### DIFF
--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -32,7 +32,7 @@ const badges: Array<Badge> = [
 const loadedLocales = new Set<string>();
 
 export async function getBadgeTemplates(kuma: KumaThis, aPage: any) {
-  const locale = kuma.env.locale;
+  const locale = kuma.env.locale.toLocaleLowerCase();
   await assertTemplatesLoaded(kuma, locale);
   return badges
     .filter(

--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -1,50 +1,58 @@
 import { KumaThis } from "../environment.js";
 import page from "../api/page.js";
 
-const badges = [
+type Badge = {
+  status: string;
+  tag: string;
+  macro: string;
+  template: Map<string, string>;
+};
+
+const badges: Array<Badge> = [
   {
     status: "experimental",
     tag: "Experimental",
     macro: "ExperimentalBadge",
-    template: "",
+    template: new Map(),
   },
   {
     status: "non-standard",
     tag: "Non-standard",
     macro: "NonStandardBadge",
-    template: "",
+    template: new Map(),
   },
   {
     status: "deprecated",
     tag: "Deprecated",
     macro: "DeprecatedBadge",
-    template: "",
+    template: new Map(),
   },
 ];
 
-let badgeTemplatesLoaded = false;
+const loadedLocales = new Set<string>();
 
 export async function getBadgeTemplates(kuma: KumaThis, aPage: any) {
-  await assertTemplatesLoaded(kuma);
+  const locale = kuma.env.locale;
+  await assertTemplatesLoaded(kuma, locale);
   return badges
     .filter(
       ({ status, tag }) =>
-        (status && aPage.status?.includes(status)) || page.hasTag(aPage, tag)
+        aPage.status?.includes(status) || page.hasTag(aPage, tag)
     )
-    .map(({ template }) => template);
+    .map(({ template }) => template.get(locale));
 }
 
-async function assertTemplatesLoaded(kuma: KumaThis) {
-  if (!badgeTemplatesLoaded) {
-    await loadBadgeTemplates(kuma);
-    badgeTemplatesLoaded = true;
+async function assertTemplatesLoaded(kuma: KumaThis, locale: string) {
+  if (!loadedLocales.has(locale)) {
+    await loadBadgeTemplates(kuma, locale);
+    loadedLocales.add(locale);
   }
   return badges;
 }
 
-async function loadBadgeTemplates(kuma: KumaThis) {
+async function loadBadgeTemplates(kuma: KumaThis, locale: string) {
   async function loadBadge(badge: (typeof badges)[0]) {
-    badge.template = (await kuma.template(badge.macro)) as string;
+    badge.template.set(locale, (await kuma.template(badge.macro)) as string);
   }
 
   await Promise.all(badges.map(loadBadge));

--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -50,7 +50,7 @@ async function assertTemplatesLoaded(kuma: KumaThis, locale: string) {
 }
 
 async function loadBadgeTemplates(kuma: KumaThis, locale: string) {
-  async function loadBadge(badge: (typeof badges)[0]) {
+  async function loadBadge(badge: Badge) {
     badge.template.set(locale, (await kuma.template(badge.macro)) as string);
   }
 

--- a/kumascript/src/lib/badges.ts
+++ b/kumascript/src/lib/badges.ts
@@ -47,7 +47,6 @@ async function assertTemplatesLoaded(kuma: KumaThis, locale: string) {
     await loadBadgeTemplates(kuma, locale);
     loadedLocales.add(locale);
   }
-  return badges;
 }
 
 async function loadBadgeTemplates(kuma: KumaThis, locale: string) {


### PR DESCRIPTION
## Summary

Fixes: #8237.

### Problem

We used to load badge template for only once. The loaded template are not differ by locale.

### Solution

Let the badge template be a map, we could load different template by locale.

---

## Screenshots

see http://localhost:5042/en-US/docs/Web/CSS/abs

### Before

![image](https://user-images.githubusercontent.com/15844309/219822054-a2eab6dc-2882-46a8-b1c1-7993bff53778.png)

### After

en-us

![image](https://user-images.githubusercontent.com/15844309/219822085-78151c3f-9dfa-458e-a14b-b99bb52df769.png)

fr

![image](https://user-images.githubusercontent.com/15844309/219822110-ead7420f-ea5b-42b0-84d6-c9205e9c9185.png)


---

## How did you test this change?

run `yarn dev`
