### PR TITLE
fix(tool/sync-translated-content): find document by dir only

### DIFF
--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -94,11 +94,10 @@ function resolve(slug: string) {
   return doc?.metadata.slug ?? slug;
 }
 
-function mdOrHtmlExists(filePath: string) {
-  const dir = path.dirname(filePath);
+function mdOrHtmlExists(folderPath: string) {
   return (
-    fs.existsSync(path.join(dir, MARKDOWN_FILENAME)) ||
-    fs.existsSync(path.join(dir, HTML_FILENAME))
+    fs.existsSync(path.join(folderPath, MARKDOWN_FILENAME)) ||
+    fs.existsSync(path.join(folderPath, HTML_FILENAME))
   );
 }
 
@@ -156,19 +155,16 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
     metadata.slug = metadata.slug.substring(0, hash);
   };
 
-  const getFilePath = () => {
-    const folderPath = path.join(
+  const getFileDir = () => {
+    return path.join(
       CONTENT_TRANSLATED_ROOT,
       locale,
       slugToFolder(metadata.slug)
     );
-
-    const filePath = path.join(folderPath, fileName);
-    return filePath;
   };
 
   dehash();
-  let filePath = getFilePath();
+  let folderPath = getFileDir();
 
   status.orphaned = !mdOrHtmlExists(
     path.join(CONTENT_ROOT, DEFAULT_LOCALE_LC, slugToFolder(metadata.slug))
@@ -183,22 +179,23 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
     status.followed = false;
     metadata.slug = `${ORPHANED}/${metadata.slug}`;
     status.moved = true;
-    filePath = getFilePath();
-    if (mdOrHtmlExists(filePath)) {
+    folderPath = getFileDir();
+    if (mdOrHtmlExists(folderPath)) {
+      const filePath = path.join(folderPath, fileName);
       log.log(`${inFilePath} → ${filePath}`);
       throw new Error(`file: ${filePath} already exists!`);
     }
-  } else if (status.moved && mdOrHtmlExists(filePath)) {
+  } else if (status.moved && mdOrHtmlExists(folderPath)) {
     console.log(`unrooting ${inFilePath} (conflicting translation)`);
     metadata.slug = `${CONFLICTING}/${metadata.slug}`;
     status.conflicting = true;
-    filePath = getFilePath();
-    if (mdOrHtmlExists(filePath)) {
+    folderPath = getFileDir();
+    if (mdOrHtmlExists(folderPath)) {
       metadata.slug = `${metadata.slug}_${crypto
         .createHash("md5")
         .update(oldMetadata.slug)
         .digest("hex")}`;
-      filePath = getFilePath();
+      folderPath = getFileDir();
     }
   }
 
@@ -207,6 +204,7 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
     buildURL(VALID_LOCALES.get(locale), metadata.slug),
   ];
 
+  const filePath = path.join(folderPath, fileName);
   log.log(`${inFilePath} → ${filePath}`);
   Document.updateWikiHistory(
     path.join(CONTENT_TRANSLATED_ROOT, locale.toLowerCase()),
@@ -214,7 +212,7 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
     metadata.slug
   );
   if (status.moved) {
-    moveContent(path.dirname(inFilePath), path.dirname(filePath));
+    moveContent(path.dirname(inFilePath), folderPath);
     metadata.original_slug = oldMetadata.slug;
   }
   Document.saveFile(filePath, Document.trimLineEndings(rawBody), metadata);


### PR DESCRIPTION
### Problem

The `mdOrHtmlExists` function would treat the param as a regular file, so we can't get the correct status for orphaned document. I didn't get notice this before (see: https://github.com/mdn/yari/pull/7886/files#diff-a7e07f3cdd78c4694f3af5102aa12cf9db651315ad11b1e4ac10518129492ff7R173). Really sorry about this.

### Solution

treat the param as a file dir.

---

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/15844309/219823461-fa612aa1-7614-4829-8383-c1322b6a3b20.png)

Be moved to orphaned folder ):

### After

![image](https://user-images.githubusercontent.com/15844309/219823423-84b34495-9801-4fd3-853a-f518f7da8055.png)

---

## How did you test this change?

run `yarn tool sync-translated-content zh-cn`
