### PR TITLE
refactor(flaws): Make flaws functions asynchronous

### DIFF
--- a/build/flaws/bad-bcd-queries.ts
+++ b/build/flaws/bad-bcd-queries.ts
@@ -6,7 +6,7 @@ import { packageBCD } from "../resolve-bcd.js";
 //
 //    <div class="bc-data" id="bcd:never.ever.heard.of">
 
-export function getBadBCDQueriesFlaws(doc, $) {
+export async function getBadBCDQueriesFlaws(doc, $) {
   return $("div.bc-data")
     .map((i, element) => {
       const $element = $(element);

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-
+import fse from "fs-extra";
 import { fromMarkdown } from "mdast-util-from-markdown";
 import { visit } from "unist-util-visit";
 
@@ -27,11 +26,9 @@ const _safeToHttpsDomains = new Map();
 
 function getSafeToHttpDomains() {
   if (!_safeToHttpsDomains.size) {
-    const fileParsed = JSON.parse(
-      fs.readFileSync(
-        new URL("safe-to-https-domains.json", import.meta.url),
-        "utf-8"
-      )
+    const fileParsed = await fse.readJson(
+      new URL("safe-to-https-domains.json", import.meta.url),
+      "utf-8"
     );
     Object.entries(fileParsed).forEach(([key, value]) =>
       _safeToHttpsDomains.set(key, value)

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -77,7 +77,7 @@ function mutateLink(
 
 // The 'broken_links' flaw check looks for internal links that
 // link to a document that's going to fail with a 404 Not Found.
-export function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
+export async function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
   const flaws = [];
 
   // This is needed because the same href can occur multiple time.

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -22,9 +22,8 @@ function findMatchesInMarkdown(rawContent, href) {
   return matches;
 }
 
-const _safeToHttpsDomains = new Map();
-
-function getSafeToHttpDomains() {
+async function getSafeToHttpsDomains() {
+  const _safeToHttpsDomains = new Map();
   if (!_safeToHttpsDomains.size) {
     const fileParsed = await fse.readJson(
       new URL("safe-to-https-domains.json", import.meta.url),
@@ -36,6 +35,8 @@ function getSafeToHttpDomains() {
   }
   return _safeToHttpsDomains;
 }
+
+const safeToHttpsDomains = await getSafeToHttpsDomains();
 
 function isHomepageURL(url) {
   // Return true if the URL is something like `/` or `/en-US` or `/fr/`
@@ -204,7 +205,7 @@ export async function getBrokenLinksFlaws(doc, $, { rawContent }, level) {
       // Using `.get(domain)` is smart because if the domain isn't known you
       // get `undefined` otherwise you get `true` or `false`. And we're only
       // interested in the `true`.
-      if (getSafeToHttpDomains().get(domain)) {
+      if (safeToHttpsDomains.get(domain)) {
         addBrokenLink(
           a,
           checked.get(href),

--- a/build/flaws/heading-links.ts
+++ b/build/flaws/heading-links.ts
@@ -5,7 +5,7 @@ import { findMatchesInText } from "../matches-in-text.js";
 // I.e. a source of `<h2 id="foo">Foo</h2>` renders out as:
 // `<h2 id="foo"><a href="#foo">Foo</a></h2>` in the final HTML. That makes
 // it easy to (perma)link to specific headings in the document.
-export function getHeadingLinksFlaws(doc, $, { rawContent }) {
+export async function getHeadingLinksFlaws(doc, $, { rawContent }) {
   const flaws = [];
 
   $("h2 a, h3 a").each((i, element) => {

--- a/build/flaws/index.ts
+++ b/build/flaws/index.ts
@@ -33,9 +33,14 @@ export interface Flaw {
   difference?: any;
 }
 
-type GetFlawsFunction = (doc: any, $: any, document: any, level: any) => Flaw[];
+type GetFlawsFunction = (
+  doc: any,
+  $: any,
+  document: any,
+  level: any
+) => Promise<Flaw[]>;
 
-export function injectFlaws(doc, $, options, document) {
+export async function injectFlaws(doc, $, options, document) {
   const flawChecks: Array<[string, GetFlawsFunction, boolean]> = [
     ["unsafe_html", getUnsafeHTMLFlaws, false],
     ["broken_links", getBrokenLinksFlaws, true],
@@ -68,7 +73,7 @@ export function injectFlaws(doc, $, options, document) {
     }
 
     // The flaw injection function will mutate the `doc.flaws` object.
-    const flaws = func(doc, $, document, level);
+    const flaws = await func(doc, $, document, level);
     if (flaws.length > 0) {
       doc.flaws[flawName] = flaws;
     }

--- a/build/flaws/pre-tags.ts
+++ b/build/flaws/pre-tags.ts
@@ -8,7 +8,7 @@ const escapeHTML = (s) =>
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
 
-export function getPreTagFlaws(doc, $, { rawContent }) {
+export async function getPreTagFlaws(doc, $, { rawContent }) {
   const flaws = [];
 
   // Over the years, we've accumulated a lot of Kuma-HTML where the <pre> tags

--- a/build/flaws/sections.ts
+++ b/build/flaws/sections.ts
@@ -1,6 +1,6 @@
 import { FLAW_LEVELS } from "../../libs/constants/index.js";
 
-export function injectSectionFlaws(doc, flaws, options) {
+export async function injectSectionFlaws(doc, flaws, options) {
   if (!flaws.length) {
     return;
   }

--- a/build/flaws/translation-differences.ts
+++ b/build/flaws/translation-differences.ts
@@ -3,7 +3,11 @@ import { Flaw } from "./index.js";
 import { Document, Translation } from "../../content/index.js";
 import { DEFAULT_LOCALE } from "../../libs/constants/index.js";
 
-export function injectTranslationDifferences(doc, $, document): Flaw[] {
+export async function injectTranslationDifferences(
+  doc,
+  $,
+  document
+): Promise<Flaw[]> {
   const flaws = [];
 
   const englishDocument = Document.read(

--- a/build/flaws/unsafe-html.ts
+++ b/build/flaws/unsafe-html.ts
@@ -23,7 +23,7 @@ if (INTERACTIVE_EXAMPLES_BASE_URL) {
   safeIFrameSrcs.push(INTERACTIVE_EXAMPLES_BASE_URL.toLowerCase());
 }
 
-function getAndMarkupUnsafeHTMLFlaws(doc, $, { rawContent, fileInfo }) {
+export async function getUnsafeHTMLFlaws(doc, $, { rawContent, fileInfo }) {
   const flaws = [];
 
   function addFlaw(element, explanation) {
@@ -108,5 +108,3 @@ function getAndMarkupUnsafeHTMLFlaws(doc, $, { rawContent, fileInfo }) {
 
   return flaws;
 }
-
-export const getUnsafeHTMLFlaws = getAndMarkupUnsafeHTMLFlaws;

--- a/build/index.ts
+++ b/build/index.ts
@@ -510,7 +510,7 @@ export async function buildDocument(
 
   // With the sidebar out of the way, go ahead and check the rest
   try {
-    injectFlaws(doc, $, options, document);
+    await injectFlaws(doc, $, options, document);
   } catch (error) {
     console.warn(
       `Injecting flaws into ${document.fileInfo.path} (${document.url}) failed.`


### PR DESCRIPTION
Turning the flaws into asynchronous functions is required for the new `wrong_language` flaw (introduced in #8254), as it relies on an async function from a library.
