### PR TITLE
chore(macros/LearnSidebar): translate command_line in Japanese

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1789,7 +1789,7 @@ var text = mdn.localStringMap({
       'Client-side_web_development_tools' : 'クライアントサイドウェブ開発ツール',
         'Client-side_web_development_tools_index' : 'クライアントサイドウェブ開発ツールの理解',
         'Client-side_tooling_overview' : 'クライアントサイドツールの概要',
-        'Command_line_crash_course' : 'Command line crash course',
+        'Command_line_crash_course' : 'コマンドライン短期集中講座',
         'Package_management_basics' : 'Package management basics',
         'Introducing_a_complete_toolchain' : 'Introducing a complete toolchain',
         'Deploying_our_app' : 'Deploying our app',


### PR DESCRIPTION
## Summary

@schalkneethling @caugner 
cc @hmatrjp @potappo 
- [ Command line crash course の翻訳 #679 ](https://github.com/mozilla-japan/translation/issues/679)  のPRです。
- [ feat(translate): Command line crash course の翻訳 #11745 ](https://github.com/mdn/translated-content/pull/11745)

### Problem
still en-us only

### Solution

tranlate japanese for LearnSidebar.ejs

### NOTICE
please https://github.com/mdn/translated-content/pull/11745 will be merged after review and approve, this PR merge.

### Before

still en-us only

### After

add tranlate japanese for LearnSidebar.ejs


