### PR TITLE
Rename {{SeeCompatTable}} macro to {{experimental_header}}

### DIFF
--- a/kumascript/macros/SeeCompatTable.ejs
+++ b/kumascript/macros/SeeCompatTable.ejs
@@ -1,18 +1,11 @@
 <%
 
-var str = mdn.localString({
-    "es"    : "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
-    "fr"    : "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#compatibilité_des_navigateurs'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
-    "ja"    : "<strong>これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。</strong><br />本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
-    "zh-CN" : "<strong>这是一个实验中的功能</strong><br />此功能某些浏览器尚在开发中，请参考<a href='#浏览器兼容性'>浏览器兼容性表格</a>以得到在不同浏览器中适合使用的前缀。由于该功能对应的标准文档可能被重新修订，所以在未来版本的浏览器中该功能的语法和行为可能随之改变。",
-    "zh-TW" : "<strong>這是一個實驗中的功能</strong><br />此功能在某些瀏覽器尚在開發中，請參考<a href='#browser_compatibility'>兼容表格</a>以得到不同瀏覽器用的前輟。",
-    "en-US" : "<strong>This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a></strong><br />Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
-    "pt-BR" : "<strong>Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a></strong><br />Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
-    "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
-});
+// The macro has been renamed to "experimental_header". Throw a MacroDeprecatedError
+// flaw to indicate the new name should be used instead.
+// Condition for removal: no more use in any content (Feb 2023: 3030 occurrences)
+// 1330 occurrences left in en-US
+mdn.deprecated();
 
 %>
-<div class="notecard experimental">
-    <h4>Experimental</h4>
-    <p><%- str %></p>
-</div>
+
+<%- await template("experimental_header") %>

--- a/kumascript/macros/experimental_header.ejs
+++ b/kumascript/macros/experimental_header.ejs
@@ -1,0 +1,18 @@
+<%
+
+var str = mdn.localString({
+    "es"    : "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
+    "fr"    : "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#compatibilité_des_navigateurs'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
+    "ja"    : "<strong>これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。</strong><br />本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
+    "zh-CN" : "<strong>这是一个实验中的功能</strong><br />此功能某些浏览器尚在开发中，请参考<a href='#浏览器兼容性'>浏览器兼容性表格</a>以得到在不同浏览器中适合使用的前缀。由于该功能对应的标准文档可能被重新修订，所以在未来版本的浏览器中该功能的语法和行为可能随之改变。",
+    "zh-TW" : "<strong>這是一個實驗中的功能</strong><br />此功能在某些瀏覽器尚在開發中，請參考<a href='#browser_compatibility'>兼容表格</a>以得到不同瀏覽器用的前輟。",
+    "en-US" : "<strong>This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a></strong><br />Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
+    "pt-BR" : "<strong>Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a></strong><br />Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
+    "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
+});
+
+%>
+<div class="notecard experimental">
+    <h4>Experimental</h4>
+    <p><%- str %></p>
+</div>


### PR DESCRIPTION
I never really understood why this macro was called `{{SeeCompatTable}}`.  Given our other macros' names for similar notices (deprecated, secure context, etc.), I feel it makes more sense and is more self-descriptive to call the macro `{{experimental_header}}` (especially given we have an `{{experimental_inline}}` macro as well).  This PR fixes that by renaming the macro, and then creating a deprecated placeholder macro to ensure all our pages aren't broken during the transition.
