### PR TITLE
chore(macros): remove "Inheritance" from JS sidebars

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -41,7 +41,6 @@ var text = {
     'Static methods': mdn.getLocalString(commonl10n, 'Static_methods'),
     'Instance methods': mdn.getLocalString(commonl10n, 'Instance_methods'),
     'Constructor': mdn.getLocalString(commonl10n, 'Constructor'),
-    'Inheritance': mdn.getLocalString(commonl10n, 'Inheritance'),
     'Implemented_by': mdn.getLocalString(commonl10n, 'Implemented_by'),
     'Related': mdn.getLocalString(commonl10n, 'Related_pages').replace('$1', group),
     'translate': mdn.getLocalString(commonl10n, '[Translate]'),
@@ -73,7 +72,6 @@ var staticMethods = [];
 var instanceMethods = [];
 var ctors = [];
 var events = [];
-var inheritedIF = [];
 var implementedBy = [];
 
 function collect(pageList) {
@@ -126,17 +124,6 @@ staticMethods.sort(APISort);
 instanceMethods.sort(APISort);
 ctors.sort(APISort);
 events.sort(APISort);
-
-function getInheritance(inh) {
-  if (inh.length > 0) {
-    inheritedIF.push(inh);
-    if (Object.prototype.hasOwnProperty.call(webAPIData[0], inh)) {
-        var inh = webAPIData[0][inh].inh;
-        getInheritance(inh);
-    }
-  }
-}
-getInheritance(inh);
 
 function getImplementedBy(data) {
   for (var key in data) {
@@ -249,9 +236,6 @@ if (instanceMethods.length > 0) {
 }
 if (events.length > 0) {
   output += await buildSublist(events, text['Events']);
-}
-if (inh.length > 0) {
-  output += buildIFList(inheritedIF, text['Inheritance']);
 }
 if (implementedBy.length > 0) {
   output += buildIFList(implementedBy, text['Implemented_by']);

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -18,7 +18,6 @@ var text = {
     'Constructor': mdn.getLocalString(commonl10n, 'Constructor'),
     'Properties': mdn.getLocalString(commonl10n, 'Properties'),
     'Methods': mdn.getLocalString(commonl10n, 'Methods'),
-    'Inheritance': mdn.getLocalString(commonl10n, 'Inheritance'),
     'Related': mdn.getLocalString(commonl10n, 'Related_pages_wo_group'),
 };
 
@@ -33,25 +32,6 @@ var locale = env.locale;
 var rtlLocales = ['ar', 'he', 'fa'];
 var slug_stdlib = `/${env.locale}/docs/Web/JavaScript/Reference/Global_Objects`;
 var mainObj = slug.replace('Web/JavaScript/Reference/Global_Objects/', '').split('/')[0];
-
-// Data for inheritance chain
-var inheritance = ["Object", "Function"];
-var inheritanceData = {
-    "Math": ["Object"],
-    "Date": ["Object"],
-    "Function": ["Object"],
-    "Object": [],
-    "JSON": ["Object"],
-    "Intl": ["Object"],
-    "arguments": [],
-    "Reflect": ["Object"],
-    "Proxy": [],
-    "Atomics": ["Object"],
-    "WebAssembly": ["Object"],
-};
-if (typeof inheritanceData[mainObj] != 'undefined') {
-    inheritance = inheritanceData[mainObj];
-}
 
 // Data for related pages
 var groupData = {
@@ -84,12 +64,6 @@ for(g in groupData) {
 // Collect pages
 var source = {};
 source[mainObj] = await page.subpagesExpand('/en-US/docs/Web/JavaScript/Reference/Global_Objects/' + mainObj);
-if  (inheritance.indexOf("Function") > -1) {
-    source["iFunction"] = await page.subpagesExpand('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function');
-}
-if  (inheritance.indexOf("Object") > -1) {
-    source["iObject"] = await page.subpagesExpand('/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object');
-}
 
 var result = {};
 result[mainObj] = {
@@ -99,24 +73,6 @@ result[mainObj] = {
     properties: [],
     defaultOpened: true
 };
-if  (inheritance.indexOf("Function") > -1) {
-result['iFunction'] = {
-    title: 'Function',
-    constructors: [],
-    methods: [],
-    properties: [],
-    defaultOpened: false
-};
-}
-if  (inheritance.indexOf("Object") > -1) {
-result['iObject'] = {
-    title: 'Object',
-    constructors: [],
-    methods: [],
-    properties: [],
-    defaultOpened: false
-};
-}
 
 var pageList;
 
@@ -234,10 +190,6 @@ for (object in result) {
     resultProperties   = result[object].properties || '';
     resultMethods      = result[object].methods || '';
     resultOpen         = result[object].defaultOpened || '';
-
-    if (len == 2) {
-        output += '<li><strong>'+text['Inheritance']+'</strong></li>';
-    }
 
     const link = web.smartLink(`${slug_stdlib}/${resultTitle}`, null, `<code>${resultTitle}</code>`, null, slug_stdlib, "JSRef");
     output += `<li><strong>${link}</strong></li>`;

--- a/kumascript/tests/macros/apiref.test.ts
+++ b/kumascript/tests/macros/apiref.test.ts
@@ -718,13 +718,4 @@ describeMacro("APIRef", function () {
     interfaceData: interfaceDataNoEntriesFixture,
     expected: expectedBasic,
   });
-
-  // Test with an InterfaceData that contains data for TestInterface
-  testMacro({
-    name: "slug: 'Web/API/TestInterface'; InterfaceData entries expected; no argument",
-    currentSlug: "Web/API/TestInterface",
-    argument: null,
-    interfaceData: interfaceDataFixture,
-    expected: expectedWithInterfaceData,
-  });
 });


### PR DESCRIPTION
## Summary

Removes the "Inheritance" section in the JavaScript sidebars (`APIRef` and `JSSidebar`), as agreed upon at the Mozilla/OWD meetup.

Fixes https://github.com/mdn/yari/issues/8052.

### Problem

The section is not particularly useful and makes the sidebars longer than necessary.

### Solution

Remove it.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Ran `yarn dev` and then:

- For the `APIRef` sidebar, I opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array locally.
- For the `JSRef` sidebar, I opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap locally.