### PR TITLE
fix(tool/macro-usage-report): add trailing slash for yari

### DIFF
--- a/tool/macro-usage-report.ts
+++ b/tool/macro-usage-report.ts
@@ -199,7 +199,7 @@ function writeJson(
         file
           .replace(CONTENT_ROOT, "content")
           .replace(CONTENT_TRANSLATED_ROOT, "translated-content")
-          .replace(YARI_PATH, "yari")
+          .replace(YARI_PATH, "yari/")
       ),
     };
   }


### PR DESCRIPTION
## Summary

Adds a missing `/` in the output of the `macro-usage-report`.

### Problem

`YARI_PATH` has a trailing slash, but `CONTENT*_ROOT` does not.

### Solution

When replacing `YARI_PATH`, add a trailing slash.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% yarn tool macro-usage-report --format json | grep yari
(node:37633) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
      "yarikumascript/macros/unimplementedGeneric.ejs"
      "yarikumascript/macros/WebExtAllCompatTables.ejs"
      ...
      "yarikumascript/macros/EmbedLiveSample.ejs",
      "yarikumascript/macros/LiveSampleLink.ejs"
      "translated-content/ko/orphaned/mdn/yari/index.md",
      "translated-content/pt-br/orphaned/mdn/yari/index.md",
      "translated-content/ru/orphaned/mdn/yari/index.md",
```

### After

```
% yarn tool macro-usage-report --format json | grep yari                                                                        130 ↵
(node:37563) ExperimentalWarning: Importing JSON modules is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
      "yari/kumascript/macros/unimplementedGeneric.ejs"
      "yari/kumascript/macros/WebExtAllCompatTables.ejs"
      ...
      "yari/kumascript/macros/EmbedLiveSample.ejs",
      "yari/kumascript/macros/LiveSampleLink.ejs"
      "translated-content/ko/orphaned/mdn/yari/index.md",
      "translated-content/pt-br/orphaned/mdn/yari/index.md",
      "translated-content/ru/orphaned/mdn/yari/index.md",
```

---

## How did you test this change?

Ran `yarn tool macro-usage-report --format json | grep yari`, see above.