### PR TITLE
fix(flaws): Improve flaws display page

### DIFF
--- a/client/src/flaws/index.scss
+++ b/client/src/flaws/index.scss
@@ -1,31 +1,42 @@
 .all-flaws {
   .search-error {
-    background-color: rgb(252, 159, 159);
+    background-color: var(--background-warning);
+  }
 
-    h3,
-    h4 {
-      margin-top: 0;
+  h3 {
+    margin-top: 0;
+  }
+
+  h3 span.page {
+    color: var(--text-inactive);
+  }
+
+  td {
+    a .url-prefix,
+    .document-title-preview {
+      color: var(--text-inactive);
+      font-size: 80%;
+      margin-right: 2px;
     }
 
-    h3 span.page {
-      color: #666;
-      margin-left: 10px;
+    a,
+    .document-title-preview {
+      display: block;
     }
   }
 
-  td a .url-prefix,
-  td .document-title-preview {
-    color: rgb(159, 159, 159);
-    font-size: 80%;
-    margin-right: 2px;
-  }
+  .documents {
+    overflow-x: scroll;
+    width: 100%;
 
-  td .document-title-preview {
-    margin-left: 10px;
-  }
+    .no-popularity {
+      color: var(--text-inactive);
+    }
 
-  .document-warnings {
-    background-color: rgb(255, 215, 154);
+    .document-flaws-fixable {
+      display: block;
+      font-size: 80%;
+    }
   }
 
   .search-times {
@@ -41,7 +52,7 @@
     text-align: center;
 
     a.disabled {
-      color: rgb(159, 159, 159);
+      color: var(--text-inactive);
     }
 
     a {
@@ -50,11 +61,13 @@
   }
 
   div.filter-documents {
-    .filters {
-      // XXX Can someone please turn this into a CSS grid
-      float: left;
-      width: 300px;
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 300px 1fr;
+    margin: auto;
+    width: calc(100% - 40px);
 
+    .filters {
       h4 {
         border-bottom: 1px solid #efefef;
         margin-bottom: 10px;
@@ -70,8 +83,6 @@
     }
 
     .documents {
-      margin-left: 300px;
-
       h4.subheader {
         margin-top: 2px;
       }

--- a/client/src/flaws/index.tsx
+++ b/client/src/flaws/index.tsx
@@ -236,22 +236,9 @@ export default function AllFlaws() {
             locale={locale}
             counts={lastData.counts}
             documents={lastData.documents}
+            pageCount={pageCount}
+            page={page}
           />
-          {pageCount > 1 && (
-            <p className="pagination">
-              <PageLink number={1} disabled={page === 1}>
-                First page
-              </PageLink>{" "}
-              {page > 2 && (
-                <PageLink number={page - 1}>
-                  Previous page ({page - 1})
-                </PageLink>
-              )}{" "}
-              <PageLink number={page + 1} disabled={page + 1 > pageCount}>
-                Next page ({page + 1})
-              </PageLink>
-            </p>
-          )}
         </div>
       )}
       {data && data.counts && <AllFlawCounts counts={data.counts.flaws} />}
@@ -547,10 +534,14 @@ function DocumentsTable({
   locale,
   counts,
   documents,
+  pageCount,
+  page,
 }: {
   locale: string;
   counts: Counts;
   documents: Document[];
+  pageCount: number;
+  page: number;
 }) {
   const [filters, updateFiltersURL] = useFiltersURL();
 
@@ -577,7 +568,14 @@ function DocumentsTable({
     const bits = flaws.map((flaw) => {
       return `${humanizeFlawName(flaw.name)}: ${flaw.value}`;
     });
-    return `${bits.join(", ")} (${totalCountFixable} fixable)`;
+    return (
+      <>
+        {bits.join(", ")}{" "}
+        <span className="document-flaws-fixable">
+          ({totalCountFixable} fixable)
+        </span>
+      </>
+    );
   }
 
   function TH({ id, title }: { id: string; title: string }) {
@@ -627,7 +625,11 @@ function DocumentsTable({
     <div className="documents">
       <h3>
         Documents with flaws found ({counts.found.toLocaleString()}){" "}
-        {filters.page > 1 && <span className="page">page {filters.page}</span>}
+        {pageCount > 1 && (
+          <span className="page">
+            page {page}/{pageCount}
+          </span>
+        )}
       </h3>
       {!counts.built ? (
         <WarnAboutNothingBuilt />
@@ -664,6 +666,7 @@ function DocumentsTable({
                   </span>
                 </td>
                 <td
+                  className={doc.popularity.ranking ? "" : "no-popularity"}
                   title={
                     doc.popularity.ranking
                       ? `Meaning there are ${
@@ -676,12 +679,30 @@ function DocumentsTable({
                     ? "n/a"
                     : `${getGetOrdinal(doc.popularity.ranking)}`}
                 </td>
-                <td>{summarizeFlaws(doc.flaws)}</td>
+                <td className="document-flaws">{summarizeFlaws(doc.flaws)}</td>
               </tr>
             );
           })}
         </tbody>
       </table>
+
+      {pageCount > 1 && (
+        <p className="pagination">
+          <PageLink number={1} disabled={page === 1}>
+            ⇤ First page
+          </PageLink>{" "}
+          {page > 2 && <PageLink number={page - 1}>← Previous page</PageLink>}{" "}
+          {page}{" "}
+          {page < pageCount - 1 && (
+            <PageLink number={page + 1} disabled={page + 1 > pageCount}>
+              Next page →
+            </PageLink>
+          )}
+          <PageLink number={pageCount} disabled={page === pageCount}>
+            Last page ({pageCount}) ⇥
+          </PageLink>
+        </p>
+      )}
     </div>
   );
 }
@@ -720,7 +741,7 @@ function PageLink({
 
 function WarnAboutNothingBuilt() {
   return (
-    <div className="attention document-warnings">
+    <div className="notecard warning document-warnings">
       <h4>No documents have been built, so no flaws can be found</h4>
       <p>
         At the moment, you have to use the command line tools to build documents


### PR DESCRIPTION
This improves the flaws display page (/[locale]/_flaws) in many ways, including: utilizing a grid layout instead of floats, utilizing theme variables for colors, standardizing element display, and more.  This helps improve contrast in both dark and light theme; ensures uniform appearance with recognizable UI elements; and provides a better layout on smaller screens (ex. half-width of a laptop screen, smartphones...).

Before:
![before-screencapture-localhost-3000-en-US-flaws-2023-02-20-22_04_57](https://user-images.githubusercontent.com/5179191/220262255-4db2e2f1-78bc-4316-abba-da6e50b08bb2.png)
![before-screencapture-localhost-3000-en-US-flaws-2023-02-20-21_59_11](https://user-images.githubusercontent.com/5179191/220262249-d2ac8f01-23a0-4ed2-a63d-616d7f9cdfcc.png)

After:
![after-screencapture-localhost-3000-en-US-flaws-2023-02-20-22_03_52](https://user-images.githubusercontent.com/5179191/220262290-5577a0f3-0bf7-4084-8ae8-72a71d159e6b.png)
![after-screencapture-localhost-3000-en-US-flaws-2023-02-20-21_58_29](https://user-images.githubusercontent.com/5179191/220262284-b0b2b732-f54b-4847-a636-6e475409da24.png)
