### PR TITLE
Remove Browser_compatibility_and_scroll_snap page from CSSRef

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -129,7 +129,6 @@ const text = mdn.localStringMap({
         'Understanding_CSS_z-index': 'Understanding CSS z-index',
       'Scroll_snap': 'Scroll snap',
         'Basic_concepts_of_scroll_snap': 'Basic concepts of scroll snap',
-        'Browser_compatibility_and_scroll_snap': 'Browser compatibility and scroll snap',
       'Shapes': 'Shapes',
         'Overview_of_shapes': 'Overview of shapes',
         'Shapes_from_box_values': 'Shapes from box values',
@@ -276,7 +275,6 @@ const text = mdn.localStringMap({
         'Understanding_CSS_z-index': 'Comprendre le z-index CSS',
       'Scroll_snap': 'Ancrage du défilement',
         'Basic_concepts_of_scroll_snap': 'Concepts de base pour l\'ancrage du défilement',
-        'Browser_compatibility_and_scroll_snap': 'Compatibilité des navigateurs et ancrage du défilement',
       'Shapes': 'Formes',
         'Overview_of_shapes': 'Aperçu des formes',
         'Shapes_from_box_values': 'Formes à partir des valeurs de boîtes',
@@ -476,7 +474,6 @@ const text = mdn.localStringMap({
         'Understanding_CSS_z-index': 'CSS z-index 이해하기',
       'Scroll_snap': '스크롤 스냅',
         'Basic_concepts_of_scroll_snap': '스크롤 스냅 기본 개념',
-        'Browser_compatibility_and_scroll_snap': '스크롤 스냅과 브라우저 호환성',
       'Shapes': '도형',      
         'Overview_of_shapes': '도형의 기본 개념',
         'Shapes_from_box_values': 'CSS 박스 모델로 도형 만들기',
@@ -676,7 +673,6 @@ const text = mdn.localStringMap({
         'Understanding_CSS_z-index': 'Понимание CSS z-index',
       'Scroll_snap': 'Scroll snap',
         'Basic_concepts_of_scroll_snap': 'Базовые концепции CSS Scroll Snap',
-        'Browser_compatibility_and_scroll_snap': 'Совместимость с браузером и Scroll Snap',
       'Shapes': 'Фигуры',
         'Overview_of_shapes': 'Обзор фигур',
         'Shapes_from_box_values': 'Фигуры из блочных значений',
@@ -827,7 +823,6 @@ const text = mdn.localStringMap({
         'Understanding_CSS_z-index': 'CSS z-index',
       'Scroll_snap': 'Scroll snap',
         'Basic_concepts_of_scroll_snap': 'scroll snap 基础概念',
-        'Browser_compatibility_and_scroll_snap': 'scroll snap 和浏览器兼容性',
       'Shapes': '形状',
         'Overview_of_shapes': '形状概述',
         'Shapes_from_box_values': '使用 box 值指定形状',
@@ -1347,7 +1342,6 @@ async function buildPropertylist(pages, title) {
           <summary><%=text['Scroll_snap']%></summary>
           <ol>
             <li><%-smartLink(`${cssURL}CSS_Scroll_Snap/Basic_concepts`, null, text['Basic_concepts_of_scroll_snap'], cssURL)%></li>
-            <li><%-smartLink(`${cssURL}CSS_Scroll_Snap/Browser_compat`, null, text['Browser_compatibility_and_scroll_snap'], cssURL)%></li>
           </ol>
       </details>
   </li>


### PR DESCRIPTION
The Browser_compatibility_and_scroll_snap page is now a redirect to the main article, after a fusion. It shouldn't be listed in the sidebar anymore.

This created build errors:
`In CSSRef the smartLink to /en-US/docs/Web/CSS/CSS_Scroll_Snap/Browser_compat is broken (redirects to /en-US/docs/Web/CSS/CSS_Scroll_Snap)`

and broken user experience as two consecutive entries link to the same page.

cc/ @wbamberg  for the content review