### PR TITLE
feat(telemetry): add sidebar_click measurement

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -237,6 +237,7 @@ async function buildDocuments(
       body: _,
       toc: __,
       sidebarHTML: ___,
+      sidebarMacro: ____,
       ...builtMetadata
     } = builtDocument;
     builtMetadata.hash = hash;

--- a/build/extract-sidebar.ts
+++ b/build/extract-sidebar.ts
@@ -39,5 +39,6 @@ export function extractSidebar($: cheerio.CheerioAPI, doc: Partial<Doc>) {
   });
 
   doc.sidebarHTML = search.html();
+  doc.sidebarMacro = search.attr("data-macro");
   search.remove();
 }

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -50,7 +50,11 @@ export function SidebarContainer({
 
   return (
     <>
-      <aside id="sidebar-quicklinks" className={classes}>
+      <aside
+        id="sidebar-quicklinks"
+        className={classes}
+        data-macro={doc.sidebarMacro}
+      >
         <Button
           extraClasses="backdrop"
           type="action"

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -22,6 +22,7 @@ export const NEW_COLLECTION_MODAL_SUBMIT_COLLECTIONS_PAGE =
 export const NEW_COLLECTION_MODAL_UPGRADE_LINK =
   "new_collection_modal_upgrade_link";
 export const OFFER_OVERVIEW_CLICK = "offer_overview_click";
+export const SIDEBAR_CLICK = "sidebar_click";
 export const TOP_NAV_ALREADY_SUBSCRIBER = "top_nav_already_subscriber";
 export const TOP_NAV_GET_MDN_PLUS = "top_nav_get_mdn_plus";
 export const TOGGLE_PLUS_OFFLINE_DISABLED = "toggle_plus_offline_disabled";

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -9,6 +9,7 @@ import { useEffect, useRef } from "react";
 import { useLocation } from "react-router";
 import { useIsServer } from "../hooks";
 import { useUserData } from "../user-context";
+import { handleSidebarClick } from "./sidebar-click";
 
 export type PageProps = {
   referrer: string | undefined;
@@ -89,22 +90,15 @@ function glean(): GleanAnalytics {
       pings.action.submit();
     },
   };
+  const gleanClick = (source: string) => {
+    gleanContext.click({
+      source,
+      subscriptionType: "",
+    });
+  };
   window?.addEventListener("click", (ev) => {
-    const anchor = ev?.target as Element;
-    if (anchor?.nodeName === "A") {
-      if (anchor?.classList.contains("external")) {
-        gleanContext.click({
-          source: `external-link: ${anchor.getAttribute("href") || ""}`,
-          subscriptionType: "",
-        });
-      }
-      if (anchor?.hasAttribute?.("data-pong")) {
-        gleanContext.click({
-          source: `pong: ${anchor.getAttribute("data-pong") || ""}`,
-          subscriptionType: "",
-        });
-      }
-    }
+    handleLinkClick(ev, gleanClick);
+    handleSidebarClick(ev, gleanClick);
   });
 
   return gleanContext;
@@ -112,6 +106,18 @@ function glean(): GleanAnalytics {
 
 const gleanAnalytics = glean();
 const GleanContext = React.createContext(gleanAnalytics);
+
+function handleLinkClick(ev: MouseEvent, click: (source: string) => void) {
+  const anchor = ev?.target as Element;
+  if (anchor?.nodeName === "A") {
+    if (anchor?.classList.contains("external")) {
+      click(`external-link: ${anchor.getAttribute("href") || ""}`);
+    }
+    if (anchor?.hasAttribute?.("data-pong")) {
+      click(`pong: ${anchor.getAttribute("data-pong") || ""}`);
+    }
+  }
+}
 
 export function GleanProvider(props: { children: React.ReactNode }) {
   return (

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -1,0 +1,27 @@
+import { SIDEBAR_CLICK } from "./constants";
+
+export function handleSidebarClick(
+  event: MouseEvent,
+  record: (source: string) => void
+) {
+  const payload = getClickPayload(event);
+  if (payload) {
+    record(`${SIDEBAR_CLICK}: ${payload.macro}`);
+  }
+}
+
+function getClickPayload(event: MouseEvent) {
+  const { target = null } = event;
+  const anchor = (target as HTMLElement)?.closest("a");
+  const sidebar = document.getElementById("sidebar-quicklinks");
+
+  if (sidebar && anchor && sidebar.contains(anchor)) {
+    const macro = sidebar.getAttribute("data-macro") ?? "?";
+
+    return {
+      macro,
+    };
+  } else {
+    return null;
+  }
+}

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -6,7 +6,7 @@ export function handleSidebarClick(
 ) {
   const payload = getClickPayload(event);
   if (payload) {
-    record(`${SIDEBAR_CLICK}: ${payload.macro}`);
+    record(`${SIDEBAR_CLICK}: ${payload.macro} ${payload.href}`);
   }
 }
 
@@ -17,9 +17,11 @@ function getClickPayload(event: MouseEvent) {
 
   if (sidebar && anchor && sidebar.contains(anchor)) {
     const macro = sidebar.getAttribute("data-macro") ?? "?";
+    const href = anchor.getAttribute("href") ?? "?";
 
     return {
       macro,
+      href,
     };
   } else {
     return null;

--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -225,7 +225,7 @@ function buildIFList(interfaces, title) {
 }
 
 // output
-output = '<section id="Quick_links"><ol>';
+output = '<section id="Quick_links" data-macro="APIRef"><ol>';
 if (group && webAPIGroups[0][group] && webAPIGroups[0][group].overview) {
   output += `<li><strong>${web.smartLink(APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_'), null, webAPIGroups[0][group].overview[0], APIHref, null, "APIRef")}</strong></li>`;
 }

--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -586,7 +586,7 @@ var text = mdn.localStringMap({
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="AddonSidebar">
   <ol>
     <li><a href="<%=baseURL%>WebExtensions"><strong><%=text['WebExtensions']%></strong></a></li>
     <li class="toggle">

--- a/kumascript/macros/AddonSidebarMain.ejs
+++ b/kumascript/macros/AddonSidebarMain.ejs
@@ -61,7 +61,7 @@ var text = mdn.localStringMap({
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="AddonSidebarMain">
   <ol>
     <li><a href="<%=baseURL%>WebExtensions"><strong><%=text['WebExtensions']%></strong></a></li>
     <li><a href="https://extensionworkshop.com/documentation/themes/"><strong><%=text['Themes']%></strong></a></li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1077,7 +1077,7 @@ async function buildPropertylist(pages, title) {
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="CSSRef">
 
 <ol>
   <li><a href="/<%=locale%>/docs/Web/CSS"><strong>CSS</strong></a></li>

--- a/kumascript/macros/DefaultAPISidebar.ejs
+++ b/kumascript/macros/DefaultAPISidebar.ejs
@@ -99,7 +99,7 @@ function convertEvent(eventName) {
 }
 
 // output
-output = '<section id="Quick_links"><ol>';
+output = '<section id="Quick_links" data-macro="DefaultAPISidebar"><ol>';
 
 if (webAPIGroups[0][group].overview) {
   output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';

--- a/kumascript/macros/FirefoxSidebar.ejs
+++ b/kumascript/macros/FirefoxSidebar.ejs
@@ -91,7 +91,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="FirefoxSidebar">
   <ol>
     <li class="toggle">
         <details>

--- a/kumascript/macros/GamesSidebar.ejs
+++ b/kumascript/macros/GamesSidebar.ejs
@@ -341,7 +341,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="GamesSidebar">
   <ol>
     <li class="toggle">
         <details>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -313,7 +313,7 @@ var text = mdn.localStringMap({
   },
 });
 %>
-<section id="Quick_links">
+<section id="Quick_links" data-macro="HTMLSidebar">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/HTML"><strong>HTML</strong></a></li>
   <li><a href="<%=learnBaseURL%>HTML"><strong><%=text['Tutorials']%></strong></a></li>

--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -278,7 +278,7 @@ var text = mdn.localStringMap({
 %>
 
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="HTTPSidebar">
   <ol>
     <li><a href="/<%=locale%>/docs/Web/HTTP"><strong><%=text['HTTP']%></strong></a></li>
     <li><strong><%=text['Guides']%></strong></li>

--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -397,7 +397,7 @@ var text = mdn.localStringMap({
   },
 });
 %>
-<section id="Quick_links">
+<section id="Quick_links" data-macro="JsSidebar">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/JavaScript"><strong>JavaScript</strong></a></li>
   <li><a href="/<%=locale%>/docs/Web/JavaScript/Tutorials"><strong><%=text['Tutorials']%></strong></a></li>

--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -2155,7 +2155,7 @@ var text = mdn.localStringMap({
 });
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="LearnSidebar">
 
 <ol>
   <li data-default-state="<%=currentPageIsUnder('Getting_started_with_the_web')%>"><a href="<%=baseURL%>Getting_started_with_the_web"><strong><%=text['Complete_beginners_start_here']%></strong></a></li>

--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -207,7 +207,7 @@ const text = mdn.localStringMap({
 
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="MDNSidebar">
     <ol>
         <li>
             <a href="<%=baseURL%>"><%=text['MDN_project']%></a>

--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -36,7 +36,7 @@ for (aPage in pageList) {
 }
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="MathMLRef">
     <ol>
         <li><strong><a href="<%=s_mathml_ref_href%>"><%=s_mathml_ref_title%></a></strong>
 

--- a/kumascript/macros/QuickLinksWithSubpages.ejs
+++ b/kumascript/macros/QuickLinksWithSubpages.ejs
@@ -9,6 +9,6 @@
 //
 //  $0  Optional; the page whose subpages are to be included.
 %>
-<section id="Quick_links">
+<section id="Quick_links" data-macro="QuickLinksWithSubpages">
 <%-await template("ListSubpages", [$0, 2, 0, 1])%>
 </section>

--- a/kumascript/macros/WebAssemblySidebar.ejs
+++ b/kumascript/macros/WebAssemblySidebar.ejs
@@ -58,7 +58,7 @@ var text = mdn.localStringMap({
 });
 %>
 
-<section id="Quick_links">
+<section id="Quick_links" data-macro="WebAssemblySidebar">
 
 <ol>
   <li data-default-state="open"><a href="<%=baseURL%>"><strong><%=text['WebAssembly_home_page']%></strong></a>

--- a/kumascript/tests/macros/WebAssemblySidebar.test.ts
+++ b/kumascript/tests/macros/WebAssemblySidebar.test.ts
@@ -1,7 +1,7 @@
 import { assert, itMacro, describeMacro } from "./utils.js";
 
 const expected = `\
-<section id="Quick_links">
+<section id="Quick_links" data-macro="WebAssemblySidebar">
 
 <ol>
   <li data-default-state="open"><a href="/en-US/docs/WebAssembly"><strong>WebAssembly home page</strong></a>

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -150,6 +150,7 @@ export interface DocMetadata {
 
 export interface Doc extends DocMetadata {
   sidebarHTML: string;
+  sidebarMacro?: string;
   toc: Toc[];
   body: Section[];
 }


### PR DESCRIPTION
## Summary

This is a simpler version of https://github.com/mdn/yari/pull/8273 that doesn't require a data review.

### Problem

We don't know how often users click on links on the sidebars, but knowing this allows us to observe the impact of upcoming improvements to the sidebar.

### Solution

Record clicks on links in the sidebar as `sidebar_click: <MACRO> <HREF>`.

Examples:

- `sidebar_click: LearnSidebar /en-US/docs/Learn/CSS/First_steps`
- `sidebar_click: JsSidebar /en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer`

---

## How did you test this change?

Set `REACT_APP_GLEAN_ENABLED=true` in my `.env` and clicked on sidebar links, then looked at the pings [here](https://debug-ping-preview.firebaseapp.com/pings/mdn-dev/) (note: there is a small processing delay).