### PR TITLE
fix(client): resolve DOM nesting warning

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -288,9 +288,7 @@ function LoadingError({ error }) {
             <small>{error.statusText}</small>
           </p>
         ) : (
-          <p>
-            <pre>{error.toString()}</pre>
-          </p>
+          <pre>{error.toString()}</pre>
         )}
         <p>
           <button


### PR DESCRIPTION
## Summary

Resolves a DOM nesting warning.

### Problem

We have been seeing the following warning locally in the console:

```
Warning: validateDOMNesting(...): <pre> cannot appear as a descendant of <p>.
pre
p
div
div
LoadingError@http://localhost:3000/main.fb3fd037a586264c3356.hot-update.js:454:7
main
MainContentContainer@http://localhost:3000/static/js/bundle.js:13791:7
Document@http://localhost:3000/main.fb3fd037a586264c3356.hot-update.js:108:64
div
Layout@http://localhost:3000/static/js/bundle.js:1290:7
DocumentLayout@http://localhost:3000/static/js/bundle.js:1396:7
PageOrPageNotFound@http://localhost:3000/static/js/bundle.js:1411:7
RenderedRoute@http://localhost:3000/static/js/bundle.js:69520:7
Routes@http://localhost:3000/static/js/bundle.js:69984:7
RenderedRoute@http://localhost:3000/static/js/bundle.js:69520:7
Routes@http://localhost:3000/static/js/bundle.js:69984:7
App@http://localhost:3000/static/js/bundle.js:1427:51
Router@http://localhost:3000/static/js/bundle.js:69926:7
BrowserRouter@http://localhost:3000/static/js/bundle.js:68128:7
UIProvider@http://localhost:3000/static/js/bundle.js:12681:94
UserDataProvider@http://localhost:3000/static/js/bundle.js:20273:54
GAProvider@http://localhost:3000/static/js/bundle.js:6001:51
GleanProvider@http://localhost:3000/static/js/bundle.js:12553:5
```

### Solution

Remove enclosing `<p>`.

As a positive side-effect, it reduces the space between the error message and the "Try reloading the page" button.

---

## Screenshots

### Before

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/495429/220951634-e56559c5-79eb-447c-9b5f-b3b95d8323e7.png">

### After

<img width="1433" alt="image" src="https://user-images.githubusercontent.com/495429/220951472-65658f00-a024-4585-8856-2465fba18b34.png">

---

## How did you test this change?

1. Ran `yarn dev`.
2. Opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference locally.
3. Blocked http://localhost:3000/en-US/docs/Web/JavaScript/Reference/index.json via the DevTools' Network tab.