### PR TITLE
fix(on-github): include entire text in links

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -6,23 +6,23 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       <h3>Found a content problem with this page?</h3>
       <ul>
         <li>
-          Edit the page <EditOnGitHubLink doc={doc} />.
+          <EditOnGitHubLink doc={doc} />.
         </li>
         <li>
-          Report the <NewIssueOnGitHubLink doc={doc} />.
+          <NewIssueOnGitHubLink doc={doc} />.
         </li>
         <li>
-          View the source <SourceOnGitHubLink doc={doc} />.
+          <SourceOnGitHubLink doc={doc} />.
         </li>
       </ul>
-      Want to get more involved? Learn{" "}
+      Want to get more involved?{" "}
       <a
         href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
         title={`This will take you to our contribution guidelines on GitHub.`}
         target="_blank"
         rel="noopener noreferrer"
       >
-        how to contribute
+        Learn how to contribute
       </a>
       .
     </div>
@@ -38,7 +38,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      on GitHub
+      Edit the page on GitHub
     </a>
   );
 }
@@ -98,7 +98,7 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      content issue
+      Report the content issue
     </a>
   );
 }
@@ -112,7 +112,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      on GitHub
+      View the source on GitHub
     </a>
   );
 }

--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -6,13 +6,20 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
       <h3>Found a content problem with this page?</h3>
       <ul>
         <li>
-          <EditOnGitHubLink doc={doc} />.
+          <EditOnGitHubLink doc={doc}>Edit the page on GitHub</EditOnGitHubLink>
+          .
         </li>
         <li>
-          <NewIssueOnGitHubLink doc={doc} />.
+          <NewIssueOnGitHubLink doc={doc}>
+            Report the content issue
+          </NewIssueOnGitHubLink>
+          .
         </li>
         <li>
-          <SourceOnGitHubLink doc={doc} />.
+          <SourceOnGitHubLink doc={doc}>
+            View the source on GitHub
+          </SourceOnGitHubLink>
+          .
         </li>
       </ul>
       Want to get more involved?{" "}
@@ -29,7 +36,13 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
   );
 }
 
-function EditOnGitHubLink({ doc }: { doc: Doc }) {
+function EditOnGitHubLink({
+  doc,
+  children,
+}: {
+  doc: Doc;
+  children: React.ReactNode;
+}) {
   const { github_url } = doc.source;
   return (
     <a
@@ -38,7 +51,7 @@ function EditOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Edit the page on GitHub
+      {children}
     </a>
   );
 }
@@ -71,7 +84,13 @@ function fillMetadata(string, doc) {
     .trim();
 }
 
-function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
+function NewIssueOnGitHubLink({
+  doc,
+  children,
+}: {
+  doc: Doc;
+  children: React.ReactNode;
+}) {
   const { locale } = doc;
   const url = new URL("https://github.com/");
   const sp = new URLSearchParams();
@@ -98,12 +117,18 @@ function NewIssueOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      Report the content issue
+      {children}
     </a>
   );
 }
 
-function SourceOnGitHubLink({ doc }: { doc: Doc }) {
+function SourceOnGitHubLink({
+  doc,
+  children,
+}: {
+  doc: Doc;
+  children: React.ReactNode;
+}) {
   const { github_url, folder } = doc.source;
   return (
     <a
@@ -112,7 +137,7 @@ function SourceOnGitHubLink({ doc }: { doc: Doc }) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      View the source on GitHub
+      {children}
     </a>
   );
 }


### PR DESCRIPTION
## Summary

This is a follow up to fix the concern raised in the pull request https://github.com/mdn/yari/pull/7809#issuecomment-1398668433.

### Problem

The links were on a partial set of phrases. This does not help with tab navigation on links and with screens readers.

### Solution

All links in the footer box now span the entire text. This will help with accessibility.
