### PR TITLE
refactor(macros): Deprecate {{bug}} and {{WebkitBug}} macros

### DIFF
--- a/kumascript/macros/WebkitBug.ejs
+++ b/kumascript/macros/WebkitBug.ejs
@@ -1,4 +1,8 @@
 <%
+// Condition for removal: no more use in any content (Feb 2023: 18 occurrences)
+// 4 occurrences left in en-US
+mdn.deprecated("This macro is deprecated; replace with `[WebKit bug <bug_id>](https://webkit.org/b/<bug_id>)`.");
+
 var bugPageURL = 'https://bugs.webkit.org/show_bug.cgi?id=' + $0;
 var s = "";
 var linkLabel = mdn.replacePlaceholders(mdn.localString({

--- a/kumascript/macros/WebkitBug.ejs
+++ b/kumascript/macros/WebkitBug.ejs
@@ -1,9 +1,7 @@
 <%
-// This macro is a simple link wrapper and should be replaced with
-// `[WebKit bug <bug_id>](https://webkit.org/b/<bug_id>)`
 // Condition for removal: no more use in any content (Feb 2023: 18 occurrences)
 // 4 occurrences left in en-US
-mdn.deprecated();
+mdn.deprecated("This macro is deprecated; replace with `[WebKit bug <bug_id>](https://webkit.org/b/<bug_id>)`.");
 
 var bugPageURL = 'https://bugs.webkit.org/show_bug.cgi?id=' + $0;
 var s = "";

--- a/kumascript/macros/WebkitBug.ejs
+++ b/kumascript/macros/WebkitBug.ejs
@@ -1,7 +1,9 @@
 <%
+// This macro is a simple link wrapper and should be replaced with
+// `[WebKit bug <bug_id>](https://webkit.org/b/<bug_id>)`
 // Condition for removal: no more use in any content (Feb 2023: 18 occurrences)
 // 4 occurrences left in en-US
-mdn.deprecated("This macro is deprecated; replace with `[WebKit bug <bug_id>](https://webkit.org/b/<bug_id>)`.");
+mdn.deprecated();
 
 var bugPageURL = 'https://bugs.webkit.org/show_bug.cgi?id=' + $0;
 var s = "";

--- a/kumascript/macros/bug.ejs
+++ b/kumascript/macros/bug.ejs
@@ -12,6 +12,10 @@
  * https://wiki.mozilla.org/Bugzilla:REST_API
  */
 
+// Condition for removal: no more use in any content (Feb 2023: 7477 occurrences)
+// 224 occurrences left in en-US
+mdn.deprecated("This macro is deprecated; replace with `[Firefox bug <bug_id>](https://bugzil.la/<bug_id>)`.");
+
 var type = $1 || 'bug';
 var bugNumber = $0;
 var bugPageURL = 'https://bugzilla.mozilla.org/show_bug.cgi?id=' + bugNumber;

--- a/kumascript/macros/bug.ejs
+++ b/kumascript/macros/bug.ejs
@@ -12,9 +12,11 @@
  * https://wiki.mozilla.org/Bugzilla:REST_API
  */
 
+// This macro is a simple link wrapper and should be replaced with
+// `[Firefox bug <bug_id>](https://bugzil.la/<bug_id>)`
 // Condition for removal: no more use in any content (Feb 2023: 7477 occurrences)
 // 224 occurrences left in en-US
-mdn.deprecated("This macro is deprecated; replace with `[Firefox bug <bug_id>](https://bugzil.la/<bug_id>)`.");
+mdn.deprecated();
 
 var type = $1 || 'bug';
 var bugNumber = $0;

--- a/kumascript/macros/bug.ejs
+++ b/kumascript/macros/bug.ejs
@@ -12,11 +12,9 @@
  * https://wiki.mozilla.org/Bugzilla:REST_API
  */
 
-// This macro is a simple link wrapper and should be replaced with
-// `[Firefox bug <bug_id>](https://bugzil.la/<bug_id>)`
 // Condition for removal: no more use in any content (Feb 2023: 7477 occurrences)
 // 224 occurrences left in en-US
-mdn.deprecated();
+mdn.deprecated("This macro is deprecated; replace with `[Firefox bug <bug_id>](https://bugzil.la/<bug_id>)`.");
 
 var type = $1 || 'bug';
 var bugNumber = $0;


### PR DESCRIPTION
This PR deprecates the `{{bug}}` and `{{WebKitBug}}` macros.  These two macros are simply wrappers to redirect to Firefox and WebKit bugs respectively, which can be replaced with a simple link.

These should both be replaceable by a simple regex call.
