### PR TITLE
refactor(kumascript): add mdn.deprecatedParams() for deprecated macro parameters

### DIFF
--- a/kumascript/macros/Compat.ejs
+++ b/kumascript/macros/Compat.ejs
@@ -31,7 +31,7 @@ Example calls
 */
 
 if ($0) {
-  mdn.deprecated(`Calling the Compat macro with any arguments is
+  mdn.deprecatedParams(`Calling the Compat macro with any arguments is
   deprecated; instead use the 'browser-compat' front-matter key.`);
 }
 

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -19,7 +19,7 @@
 // When there will be 0 use left on translated-content (May 2022: 203 occurrences for $4),
 // we will be able to simplify this macro (and likely the whole of MDN).
 if ($4 !== "" || $5 !== "" || $6 !== "") {
-  mdn.deprecated("The fourth to sixth parameters of 'EmbedLiveSample' are deprecated");
+  mdn.deprecatedParams("The fourth to sixth parameters of 'EmbedLiveSample' are deprecated");
 }
 
 var sampleIdOrOffset = $0 || $token.location.start.offset;

--- a/kumascript/macros/Specifications.ejs
+++ b/kumascript/macros/Specifications.ejs
@@ -14,7 +14,7 @@ Example calls
 */
 
 if ($0) {
-  mdn.deprecated(`Calling the Specifications macro with any arguments is
+  mdn.deprecatedParams(`Calling the Specifications macro with any arguments is
   deprecated; instead use either the 'browser-compat' or 'spec-urls'
   front-matter key.`);
 }

--- a/kumascript/src/api/mdn.ts
+++ b/kumascript/src/api/mdn.ts
@@ -131,6 +131,16 @@ const mdn = {
     this.env.recordNonFatalError("deprecated", message);
   },
 
+  /**
+   * Throw a deprecation error for parameters to macros.
+   */
+  deprecatedParams(
+    this: KumaThis,
+    message = "Parameters for this macro have been deprecated and should be removed."
+  ) {
+    this.env.recordNonFatalError("deprecated", message);
+  },
+
   async fetchWebExtExamples() {
     if (!webExtExamples) {
       try {

--- a/tool/macro-usage-report.ts
+++ b/tool/macro-usage-report.ts
@@ -121,7 +121,7 @@ async function isMacroDeprecated(macro: string) {
   const file = path.join(MACROS_PATH, `${macro}.ejs`);
   const content = await fs.readFile(file, "utf-8");
 
-  return content.includes("mdn.deprecated()");
+  return content.includes("mdn.deprecated(");
 }
 
 function formatCell(files: string[]): string {


### PR DESCRIPTION
This PR introduces a new `mdn.deprecatedParams()` method for macros for when the parameters of a macro are deprecated.  This allows us to add comments to macro deprecation, such as to explain how to replace the macro.  Requested in https://github.com/mdn/yari/pull/8298#discussion_r1116735165.
