### PR TITLE
refactor(build): Make Document.findAll() asynchronous

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -65,7 +65,7 @@ async function buildDocumentInteractive(
     }
 
     if (!interactive) {
-      const translations = translationsOf(document.metadata);
+      const translations = await translationsOf(document.metadata);
       if (translations && translations.length > 0) {
         document.translations = translations;
       } else {
@@ -133,7 +133,7 @@ async function buildDocuments(
 
   const metadata: GlobalMetadata = {};
 
-  const documents = Document.findAll(findAllOptions);
+  const documents = await Document.findAll(findAllOptions);
   const progressBar = new cliProgress.SingleBar(
     {},
     cliProgress.Presets.shades_grey

--- a/content/document.test.ts
+++ b/content/document.test.ts
@@ -4,13 +4,13 @@ import path from "node:path";
 import * as Document from "./document.js";
 
 describe("Document.findAll()", () => {
-  it("should always return files that exist", () => {
-    const filePaths = [...Document.findAll().iterPaths()];
+  it("should always return files that exist", async () => {
+    const filePaths = [...(await Document.findAll()).iterPaths()];
     expect(filePaths.every((value) => fs.existsSync(value))).toBeTruthy();
   });
 
-  it("all files should be either index.html or index.md", () => {
-    const filePaths = [...Document.findAll().iterPaths()];
+  it("all files should be either index.html or index.md", async () => {
+    const filePaths = [...(await Document.findAll()).iterPaths()];
     expect(
       filePaths.every(
         (value) => value.endsWith("index.html") || value.endsWith("index.md")
@@ -18,19 +18,21 @@ describe("Document.findAll()", () => {
     ).toBeTruthy();
   });
 
-  it("searching by specific file", () => {
-    const filePaths = [...Document.findAll().iterPaths()];
+  it("searching by specific file", async () => {
+    const filePaths = [...(await Document.findAll()).iterPaths()];
     const randomFile = filePaths[Math.floor(Math.random() * filePaths.length)];
     const specificFilePaths = [
-      ...Document.findAll({ files: new Set([randomFile]) }).iterPaths(),
+      ...(await Document.findAll({ files: new Set([randomFile]) })).iterPaths(),
     ];
     expect(specificFilePaths).toHaveLength(1);
     expect(specificFilePaths[0]).toBe(randomFile);
   });
 
-  it("searching by specific locales", () => {
+  it("searching by specific locales", async () => {
     const specificFilePaths = [
-      ...Document.findAll({ locales: new Map([["fr", true]]) }).iterPaths(),
+      ...(
+        await Document.findAll({ locales: new Map([["fr", true]]) })
+      ).iterPaths(),
     ];
     expect(
       specificFilePaths.every((filePath) =>
@@ -39,9 +41,9 @@ describe("Document.findAll()", () => {
     ).toBeTruthy();
   });
 
-  it("searching by specific folders", () => {
+  it("searching by specific folders", async () => {
     const specificFilePaths = [
-      ...Document.findAll({ folderSearch: "/foo/" }).iterPaths(),
+      ...(await Document.findAll({ folderSearch: "/foo/" })).iterPaths(),
     ];
     expect(
       specificFilePaths.every((filePath) =>

--- a/content/document.ts
+++ b/content/document.ts
@@ -443,7 +443,7 @@ export function findByURL(
   return doc;
 }
 
-export function findAll({
+export async function findAll({
   files = new Set<string>(),
   folderSearch = null,
   locales = new Map(),
@@ -514,7 +514,8 @@ export function findAll({
         return true;
       })
       .crawl(root);
-    filePaths.push(...(api.sync() as PathsOutput));
+    const output: PathsOutput = await api.withPromise();
+    filePaths.push(...output);
   }
   return {
     count: filePaths.length,

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -10,8 +10,8 @@ const LANGUAGES = new Map(
 
 const TRANSLATIONS_OF = new Map();
 
-function gatherTranslations() {
-  const iter = Document.findAll().iterDocs();
+async function gatherTranslations() {
+  const iter = (await Document.findAll()).iterDocs();
   for (const {
     metadata: { slug, locale, title },
   } of iter) {
@@ -37,11 +37,11 @@ function gatherTranslations() {
   }
 }
 
-export function translationsOf({ slug, locale: currentLocale }) {
+export async function translationsOf({ slug, locale: currentLocale }) {
   if (TRANSLATIONS_OF.size === 0) {
     const label = "Time to gather all translations";
     console.time(label);
-    gatherTranslations();
+    await gatherTranslations();
     console.timeEnd(label);
   }
   const translations = TRANSLATIONS_OF.get(slug.toLowerCase());

--- a/markdown/m2h/cli.ts
+++ b/markdown/m2h/cli.ts
@@ -49,7 +49,7 @@ program
   .argument("[folder]", "convert by folder")
   .action(
     tryOrExit(async ({ args, options }) => {
-      const all = Document.findAll({
+      const all = await Document.findAll({
         folderSearch: args.folder,
         locales: buildLocaleMap(options.locale),
       });

--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -99,10 +99,10 @@ describe("fixing flaws", () => {
       .split("\n")
       .filter((line) => regexPattern.test(line));
     expect(dryRunNotices).toHaveLength(4);
-    expect(dryRunNotices[0]).toContain(path.join(pattern, "bad_pre_tags"));
-    expect(dryRunNotices[1]).toContain(path.join(pattern, "deprecated_macros"));
-    expect(dryRunNotices[2]).toContain(path.join(pattern, "images"));
-    expect(dryRunNotices[3]).toContain(pattern);
+    expect(dryRunNotices[0]).toContain(pattern);
+    expect(dryRunNotices[1]).toContain(path.join(pattern, "bad_pre_tags"));
+    expect(dryRunNotices[2]).toContain(path.join(pattern, "deprecated_macros"));
+    expect(dryRunNotices[3]).toContain(path.join(pattern, "images"));
     const dryrunFiles = getChangedFiles(tempContentDir);
     expect(dryrunFiles).toHaveLength(0);
   });

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -706,7 +706,7 @@ program
     tryOrExit(async ({ args, options }: FixFlawsActionParameters) => {
       const { fixFlawsTypes } = args;
       const { locale, fileTypes } = options;
-      const allDocs = Document.findAll({
+      const allDocs = await Document.findAll({
         locales: new Map([[locale.toLowerCase(), true]]),
       });
       for (const document of allDocs.iterDocs()) {
@@ -771,7 +771,7 @@ program
       if (!fs.existsSync(CONTENT_TRANSLATED_ROOT)) {
         throw new Error(`${CONTENT_TRANSLATED_ROOT} does not exist`);
       }
-      const documents = Document.findAll();
+      const documents = await Document.findAll();
       if (!documents.count) {
         throw new Error("No documents to analyze");
       }
@@ -1001,7 +1001,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
           .map((m) => `"${m}"`)
           .join(", ")} within content folder(s) matching "${foldersearch}"`
       );
-      const documents = Document.findAll({
+      const documents = await Document.findAll({
         folderSearch: foldersearch,
       });
       if (!documents.count) {


### PR DESCRIPTION
This changes the `findAll()` function to an asynchronous function to help improve performance.