### PR TITLE
feat(scripts): add clean script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,27 +30,31 @@ yarn-error.log*
 /kumascript/coverage/
 /kumascript/node_modules/
 /testing/node_modules/
-/build/*.js
-/build/*.js.map
+/build/**/*.js
+/build/**/*.js.map
 /client/build
 /client/src/**/*.js
 /client/src/**/*.js.map
-/content/*.js
-/content/*.js.map
-/filecheck/*.js
-/filecheck/*.js.map
-/kumascript/*.js
-/kumascript/*.js.map
-/markdown/*.js
-/markdown/*.js.map
-/server/*.js
-/server/*.js.map
+/content/**/*.js
+/content/**/*.js.map
+/filecheck/**/*.js
+/filecheck/**/*.js.map
+/kumascript/**/*.js
+/kumascript/**/*.js.map
+/libs/types/**/*.js
+/libs/types/**/*.js.map
+/markdown/**/*.js
+/markdown/**/*.js.map
+/server/**/*.js
+/server/**/*.js.map
 /ssr/dist/
-/ssr/*.js
+/ssr/**/*.js
 !/ssr/webpack.config.js
-/ssr/*.js.map
-/tool/*.js
-/tool/*.js.map
+/ssr/**/*.js.map
+/tool/**/*.js
+/tool/**/*.js.map
+/type-fixes/**/*.js
+/type-fixes/**/*.js.map
 
 # These are an effect of the dumper still producing all locales
 # We haven't decided what to do with them but for now we're *not*

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:ssr": "cd ssr && webpack --mode=production",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
+    "clean": "git clean -dix -e '.env'",
     "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
     "dev": "yarn build:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",


### PR DESCRIPTION
## Summary

### Problem

When we run `yarn build:dist`, we end up with transpiled files that can influence the yari behavior (in the sense that the transpiled files can shadow the original TypeScript files and changes no longer propagate). And this means sometimes we recommend checking out yari freshly in case of weird errors.

### Solution

Add a script that makes it easier to remove these transpiled files, alongside all other ignored files (including `node_modules`, but **except** `.env`).

**Also**: Complete the `.gitignore` files with folders that have converted to TypeScript last.

---

## How did you test this change?

Ran `yarn script` locally.