### PR TITLE
fix(style): Fix double border in HTML & CSS interactive examples

### DIFF
--- a/client/src/document/interactive-examples.scss
+++ b/client/src/document/interactive-examples.scss
@@ -2,7 +2,7 @@
 
 .interactive {
   background-color: var(--background-secondary);
-  border: 1px solid var(--border-primary);
+  border: none;
   border-radius: var(--elem-radius);
   color: var(--text-primary);
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes double grey border in HTML & CSS interactive examples. This border is now meant to be set by only BOB. This change was introduced by [#1004](https://github.com/mdn/bob/pull/1004), but it was published with BOB version 3 today.

### Before
![image](https://user-images.githubusercontent.com/100634371/221267375-f8ac877e-afe9-4b7c-bb8e-0416d1e8f09b.png)

<!-- Replace this line with your screenshot (or video). -->

### After
![image](https://user-images.githubusercontent.com/100634371/221267443-aa8f55cd-55e9-414d-ae6e-c95174e574d2.png)

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
