### PR TITLE
feat(macros): Rewrite MathML sidebar

### DIFF
--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -52,7 +52,7 @@ async function getTitle(pageSlug) {
 }
 
 %>
-<section id="Quick_links">
+<section id="Quick_links" data-macro="MathMLRef">
  <ol>
   <li><a href="/<%=locale%>/docs/Web/MathML"><strong>MathML</strong></a></li>
   <li><strong><%=text['Guides']%></strong></li>

--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -1,49 +1,87 @@
 <%
-function containsTag(tagList, tag) {
-    if (!tagList || tagList == undefined) return 0;
-    tag = tag.toLowerCase();
-    for (var i = 0, len = tagList.length; i < len; i++) {
-        if (tagList[i].toLowerCase() == tag) return 1;
-    }
-    return 0;
+const locale = env.locale;
+
+const text = mdn.localStringMap({
+  'en-US': {
+    'Reference': 'Reference',
+    'Elements': 'Elements',
+    'Global attributes': 'Global attributes',
+    'Guides': 'Guides',
+    'Examples': 'Examples',
+  },
+  'fr': {
+    'Reference': 'Références',
+    'Elements': 'Éléments',
+    'Guides': 'Guides',
+  },
+  'ja': {
+    'Reference': 'リファレンス',
+    'Elements': '要素',
+  },
+  'ko': {
+    'Reference': '참고서:',
+    'Elements': '요소',
+    'Guides': '안내서:',
+  },
+  'pt-BR': {
+    'Reference': 'Referências',
+    'Elements': 'Elementos',
+    'Guides': 'Guides',
+  },
+  'ru': {
+    'Reference': 'Справочники',
+    'Elements': 'Элементы',
+    'Guides': 'Путеводитель',
+  },
+  'zh-CN': {
+    'Reference': '参考：',
+    'Elements': '元素',
+    'Guides': '指南：',
+  },
+});
+
+const sidebarURL = `/docs/Web/MathML/`;
+const baseURL = `/${env.locale}${sidebarURL}`;
+
+async function getTitle(pageSlug) {
+  let page = await wiki.getPage(`${baseURL}${pageSlug}`);
+  if (!page.title) {
+    page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
+  }
+  return page.title;
 }
 
-function safe_tags(str) {
-    return str.replace(/</g,'&lt;').replace(/>/g,'&gt;') ;
-}
-
-var s_mathml_ref_href = '/en-US/docs/Web/MathML/Element';
-var s_mathml_ref_title = 'MathML Reference';
-var s_mathml_element_tag = 'MathML:Element';
-
-switch (env.locale) {
-    case 'ru':
-        s_mathml_ref_href = '/ru/docs/Web/MathML/Element';
-        s_mathml_ref_title = 'Руководство MathML';
-        s_mathml_element_tag = 'MathML:Element';
-        break;
-    default: break;
-}
-
-// Find the pages of s_mathml_ref_href that are tagged with s_mathml_element_tag
-var pageList = await page.subpagesExpand(s_mathml_ref_href);   // Get subpages, including tags
-var result = [];
-
-for (aPage in pageList) {
-    if (containsTag(pageList[aPage].tags, s_mathml_element_tag)) {
-        result.push(pageList[aPage]);
-    }
-}
 %>
-
-<section id="Quick_links" data-macro="MathMLRef">
+<section id="Quick_links">
+ <ol>
+  <li><a href="/<%=locale%>/docs/Web/MathML"><strong>MathML</strong></a></li>
+  <li><strong><%=text['Guides']%></strong></li>
+  <li>
     <ol>
-        <li><strong><a href="<%=s_mathml_ref_href%>"><%=s_mathml_ref_title%></a></strong>
-
-        <% for (aPage in result) { %>
-            <li><a href="<%-result[aPage].url%>"><%-safe_tags(result[aPage].title)%></a></li>
-        <% } %>
-
-        </li>
+    <li><a href="/<%=locale%>/docs/Web/MathML/Authoring"><%=await getTitle("Authoring")%></a></li>
+    <li><a href="/<%=locale%>/docs/Web/MathML/Fonts"><%=await getTitle("Fonts")%></a></li>
     </ol>
+  </li>
+  <li><strong><%=text['Reference']%></strong></li>
+  <li class="toggle">
+    <details>
+      <summary><%=text['Elements']%></summary>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/MathML/Element'])%>
+    </details>
+  </li>
+  <li class="toggle">
+    <details>
+      <summary><%=text['Global attributes']%></summary>
+      <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/MathML/Global_attributes'])%>
+    </details>
+  </li>
+  <li><a href="/<%=locale%>/docs/Web/MathML/Attribute"><%=await getTitle("Attribute")%></a></li>
+  <li><strong><%=text['Examples']%></strong></li>
+  <li>
+    <ol>
+    <li><a href="/<%=locale%>/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula"><%=await getTitle("Examples/Deriving_the_Quadratic_Formula")%></a></li>
+    <li><a href="/<%=locale%>/docs/Web/MathML/Examples/MathML_Pythagorean_Theorem"><%=await getTitle("Examples/MathML_Pythagorean_Theorem")%></a></li>
+    </ol>
+  </li>
+ </ol>
 </section>


### PR DESCRIPTION
## Summary

This PR rewrites the current MathML sidebar, [MathMLRef.ejs](https://github.com/mdn/yari/blob/main/kumascript/macros/MathMLRef.ejs).

### Problem

The immediate reason for this is that the current sidebar uses tags, and we want to stop using tags.

But the current sidebar is also not very useful: it only lists elements, not attributes or any guide/tutorial content.

### Solution

This sidebar is pretty much cloned from the [PR to rewrite the SVG sidebar](https://github.com/mdn/yari/pull/8289), but the content is a little different:

* **Guides**
* **Reference**
    * **Elements**
    * **Global attributes**
    * **Attributes reference**
* **Examples**

Some notes and things.

* There's definitely scope to have a similar organization and ordering at the top level for many of our sidebars (i.e Tutorials/Guides/Reference or something) maybe based explicitly on Divio. There are definitely some pointless inconsistencies at the moment. But that's another story.
* There's also scope for making this sidebar data-driven as we are prototyping in https://github.com/mdn/yari/pull/8132. But again, another story. 
* This sidebar gets labels from page titles, and some page titles could perhaps be adjusted, like [MathML: Deriving the Quadratic Formula](https://developer.mozilla.org/en-US/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula) -> "Deriving the Quadratic Formula". We will need a follow-up anyway in content to call this sidebar everywhere, so maybe I'll do that then.

## Screenshots

### Before

<img width="1150" alt="Screen Shot 2023-02-24 at 4 52 21 PM" src="https://user-images.githubusercontent.com/432915/221326869-3db13560-ee22-4a84-8e88-87db15108b63.png">


### After

collapsed:

<img width="1146" alt="Screen Shot 2023-02-24 at 4 55 24 PM" src="https://user-images.githubusercontent.com/432915/221326881-aef86f27-077f-46a5-bfda-1fcd0e981a29.png">


expanded:

<img width="1155" alt="Screen Shot 2023-02-24 at 4 55 48 PM" src="https://user-images.githubusercontent.com/432915/221326895-d8146950-7581-469a-9918-b4bb81da578d.png">


## Testing

Testing: fire up yarn dev and visit:
* http://localhost:3000/en-US/docs/Web/MathML
* http://localhost:3000/fr/docs/Web/MathML

@teoli2003 , @hamishwillee , @fred-wang 
