### PR TITLE
fix(macros): add data-macro to JSRef/SVGRef

### DIFF
--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -223,7 +223,7 @@ var len = 0;
 
 // Output
 
-output  = '<section class="Quick_links" id="Quick_links" data-macro="APIRef"><ol>';
+output  = '<section class="Quick_links" id="Quick_links" data-macro="JSRef"><ol>';
 const link = web.smartLink(slug_stdlib, null, text['stdlib'], slug_stdlib, slug_stdlib, "JSRef");
 output += `<li><strong>${link}</strong></li>`;
 

--- a/kumascript/macros/JSRef.ejs
+++ b/kumascript/macros/JSRef.ejs
@@ -223,7 +223,7 @@ var len = 0;
 
 // Output
 
-output  = '<section class="Quick_links" id="Quick_links"><ol>';
+output  = '<section class="Quick_links" id="Quick_links" data-macro="APIRef"><ol>';
 const link = web.smartLink(slug_stdlib, null, text['stdlib'], slug_stdlib, slug_stdlib, "JSRef");
 output += `<li><strong>${link}</strong></li>`;
 

--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -48,7 +48,7 @@ function wrapSVGElement(name) {
 }
 
 if (s_svg_href) {  %>
-  <section class="Quick_links" id="Quick_links">
+  <section class="Quick_links" id="Quick_links" data-macro="SVGRef">
   <ol>
    <% if (foundTag) {
         for (aTitle of resultSVG) { // SVG entities matching


### PR DESCRIPTION
## Summary

### Problem

https://github.com/mdn/yari/pull/8293 added a measurement for sidebar clicks by macro, but this requires every sidebar macro to add a `data-macro` attribute to the `#Quick_links`, and I missed two occurrences.

### Solution

Add the two missing `data-macro` attributes, so clicks on those sidebars can be attributed properly.

---

## How did you test this change?

Not tested.
