### PR TITLE
fix(telemetry/sidebar-click): ignore mobile TOC clicks

### DIFF
--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -24,7 +24,7 @@ function getClickPayload(event: MouseEvent) {
     return null;
   }
 
-  if (anchor.closest(".document-toc")) {
+  if (anchor.closest(".in-nav-toc")) {
     // Click in the mobile TOC, not the actual sidebar.
     return null;
   }

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -13,17 +13,26 @@ export function handleSidebarClick(
 function getClickPayload(event: MouseEvent) {
   const { target = null } = event;
   const anchor = (target as HTMLElement)?.closest("a");
-  const sidebar = document.getElementById("sidebar-quicklinks");
 
-  if (sidebar && anchor && sidebar.contains(anchor)) {
-    const macro = sidebar.getAttribute("data-macro") ?? "?";
-    const href = anchor.getAttribute("href") ?? "?";
-
-    return {
-      macro,
-      href,
-    };
-  } else {
+  if (!anchor) {
     return null;
   }
+
+  if (anchor.closest(".document-toc")) {
+    return null;
+  }
+
+  const sidebar = document.getElementById("sidebar-quicklinks");
+
+  if (!sidebar) {
+    return null;
+  }
+
+  const macro = sidebar.getAttribute("data-macro") ?? "?";
+  const href = anchor.getAttribute("href") ?? "?";
+
+  return {
+    macro,
+    href,
+  };
 }

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -19,6 +19,7 @@ function getClickPayload(event: MouseEvent) {
   }
 
   if (anchor.closest(".document-toc")) {
+    // Click in the mobile TOC, not the actual sidebar.
     return null;
   }
 

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -25,7 +25,7 @@ function getClickPayload(event: MouseEvent) {
 
   const sidebar = document.getElementById("sidebar-quicklinks");
 
-  if (!sidebar) {
+  if (!sidebar || !sidebar.contains(anchor)) {
     return null;
   }
 

--- a/client/src/telemetry/sidebar-click.ts
+++ b/client/src/telemetry/sidebar-click.ts
@@ -18,14 +18,14 @@ function getClickPayload(event: MouseEvent) {
     return null;
   }
 
-  if (anchor.closest(".document-toc")) {
-    // Click in the mobile TOC, not the actual sidebar.
-    return null;
-  }
-
   const sidebar = document.getElementById("sidebar-quicklinks");
 
   if (!sidebar || !sidebar.contains(anchor)) {
+    return null;
+  }
+
+  if (anchor.closest(".document-toc")) {
+    // Click in the mobile TOC, not the actual sidebar.
     return null;
   }
 


### PR DESCRIPTION
## Summary

### Problem

https://github.com/mdn/yari/pull/8293 added a measurement for sidebar clicks, but it didn't consider that - on mobile - the TOC is inside `#sidebar-quicklinks`, and so those clicks are also measured.

### Solution

Check if we're inside `.document-toc`.

---

## How did you test this change?

- Added `REACT_APP_GLEAN_ENABLED=true` to my `.env`.
- Clicked in the mobile TOC and verified (via the JS console and https://debug-ping-preview.firebaseapp.com/pings/mdn-dev) that it doesn't cause a measurement (action ping).
- Clicked in the sidebar and verified that it still causes a measurement.