### PR TITLE
chore(placement): record HTTP status with fetched event

### DIFF
--- a/client/src/document/organisms/toc/placement.tsx
+++ b/client/src/document/organisms/toc/placement.tsx
@@ -60,7 +60,8 @@ export function Placement() {
         },
         body: JSON.stringify({ keywords: [] }),
       });
-      gleanClick("pong: pong->fetched");
+
+      gleanClick(`pong: pong->fetched ${response.status}`);
 
       if (!response.ok) {
         throw Error(response.statusText);


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When we count fetches, we don't distinguish between failed and successful fetches, which makes it hard to understand why there are comparatively few views.

### Solution

Add the HTTP status code (e.g. 200, 204) to the fetched event.

---

## How did you test this change?

- Enabled `REACT_APP_GLEAN_ENABLED=true` in `.env`.
- Ran `yarn dev`.
- Opened http://localhost:3000/en-US/docs/Web/HTML locally.
- Checked debug ping preview: https://debug-ping-preview.firebaseapp.com/pings/mdn-dev/78ec40b3-b0f3-49ac-97ca-2ce2ac2ab321