### PR TITLE
fix: remove repeated extra class name

### DIFF
--- a/client/src/ui/organisms/top-navigation/index.tsx
+++ b/client/src/ui/organisms/top-navigation/index.tsx
@@ -30,9 +30,7 @@ export function TopNavigation() {
 
   return (
     <header
-      className={`top-navigation ${
-        showMainMenu ? "show-nav" : ""
-      }
+      className={`top-navigation ${showMainMenu ? "show-nav" : ""}
       ${dark ? " dark" : ""}
       ${transparent ? " is-transparent" : ""}`}
     >

--- a/client/src/ui/organisms/top-navigation/index.tsx
+++ b/client/src/ui/organisms/top-navigation/index.tsx
@@ -30,7 +30,7 @@ export function TopNavigation() {
 
   return (
     <header
-      className={`main-document-header-container top-navigation ${
+      className={`top-navigation ${
         showMainMenu ? "show-nav" : ""
       }
       ${dark ? " dark" : ""}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
1. Remove the repeated extra class name, and keep the code tight and clean.
2. Avoid a severe bug that causes the website to crash (seems incredible, let me explain further).

### Solution

Just remove the class name.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

#### First problem
Before the deletion, both the `div` and `header` have a `main-document-header-container` class name. Stylesheets attached to the class are:
```css
// client/src/document/index.scss
.main-document-header-container {
  position: sticky;
  top: 0;
  z-index: var(--z-index-top);
}
```

![WechatIMG10](https://user-images.githubusercontent.com/3898898/221850183-26731252-a194-4dde-9c58-88781aa62e6e.jpeg)

One of them should be deleted, but the real fatal problem is this one:

#### Second problem

Follow these steps:

1. Browser MDN pages such as [this one](https://developer.mozilla.org/en-US/docs/Web/HTML) using Chrome.
2. Open Chrome DevTools.
3. Switch to the Layers panel.

See? Chrome crashed.

<img width="989" alt="image" src="https://user-images.githubusercontent.com/3898898/221851504-0bb64070-5271-4f9f-84a6-ba69f4a5b333.png">

After some attempts, I created [this minimal reproducible example](https://ioslh.github.io/misc/crash.html). Follow the same steps, the Chrome will crash as well.
The two nested elements with both sticky positions here are to blame.
<!-- Replace this line with your screenshot (or video). -->
```html
<style>
.header {
    position: sticky;
    top: 0;
}
</style>
<div class="header">
    <div class="header">HEADER</div>
</div>
```


### After

After the deletion, everything behaves as expected. The header keeps sticky to the top of the viewport.
And I can use the Layers panel of Chrome DevTool to inspect pages.


## Root Cause & What To Do
Frankly, I don't know the root cause for now, it's highly possible that's a Chrome bug. I'll do more tests and see what happens.
Put the possible bug aside, at least the repeated class name can be safely deleted here, right?