### PR TITLE
ci(prod-build): use interactive-examples base url

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -136,6 +136,9 @@ jobs:
           # is not insecure.
           BUILD_LIVE_SAMPLES_BASE_URL: https://yari-demos.prod.mdn.mozit.cloud
 
+          # Use the prod version of interactive examples.
+          BUILD_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.mozilla.net
+
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 


### PR DESCRIPTION
## Summary

Fixes from where we serve interactive-examples on prod.

### Problem

On prod, we're serving interactive-examples via https://developer.mozilla.org/examples/, while on stage, we're serving them via https://interactive-examples.stage.mdn.mozilla.net/.

### Solution

Serve interactive-examples on prod via https://interactive-examples.mdn.mozilla.net/pages/css/background.html by setting the `BUILD_INTERACTIVE_EXAMPLES_BASE_URL` environment variable.

---

## How did you test this change?

This is tricky to test, but I'm relying on the fact that the `stage-deploy` already has this environment variable set.