### PR TITLE
fix(organisms/metadata): suppress hydration error in last modified timestamp

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -4,3 +4,6 @@ CONTENT_ROOT=../content/files
 
 # See documentation in docs/envvars.md for more information about this
 #BUILD_FLAW_LEVELS=broken_links:error, macros:ignore
+
+# Use following to put the local dev server in developer.mozilla.org's time zone
+#TZ=America/Chicago

--- a/.env-dist
+++ b/.env-dist
@@ -4,6 +4,3 @@ CONTENT_ROOT=../content/files
 
 # See documentation in docs/envvars.md for more information about this
 #BUILD_FLAW_LEVELS=broken_links:error, macros:ignore
-
-# Use following to put the local dev server in developer.mozilla.org's time zone
-#TZ=America/Chicago

--- a/client/src/document/organisms/metadata/index.tsx
+++ b/client/src/document/organisms/metadata/index.tsx
@@ -16,7 +16,7 @@ export function LastModified({ value, locale }) {
   return (
     <>
       This page was last modified on{" "}
-      <time dateTime={value}>
+      <time dateTime={value} suppressHydrationWarning>
         {date.toLocaleString(locale, dateStringOptions)}
       </time>
     </>


### PR DESCRIPTION
## Summary
- Fixes: https://github.com/mdn/yari/issues/8272

### Problem

Client renders different day as per their timezone:
![bug](https://user-images.githubusercontent.com/87750369/222663374-9975b10c-06f2-4cbe-9f16-8d488fa3f72a.png)

### Solution

As per the common practice simply use `suppressHydrationWarning` on timestamps.

## How did you test this change?

I set `TZ="US/Eastern"` in `.env` file as there is >2hr difference in time from here. In local dev environment there was hydration error before fix and after fix it got resolved.

***

**Note:** These errors are very hard to diagnose. I couldn't reproduce the error on the same page as the person who reported it on MDN Matrix room. After some back and forth they shared more links and luckily I could reproduce it on `https://developer.mozilla.org/en-US/docs/Glossary/Attribute` page.\
There are some more `<time dateTime={..}>` tags in MDN Plus and translations code. We should preemptively test and mark them with `suppressHydrationWarning`.