### PR TITLE
feat(interactive-examples): measure actions

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -2,8 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
 import { useIsServer } from "../hooks";
 import { Doc } from "../../../libs/types/document";
-import { useGleanClick } from "../telemetry/glean-context";
-import { IEX_DOMAIN } from "../env";
 
 export function useDocumentURL() {
   const { "*": slug, locale } = useParams();
@@ -245,26 +243,4 @@ export function useFirstVisibleElement(
 
     return () => observer.disconnect();
   }, [rootMargin, observedElementsProvider, visibleElementCallback]);
-}
-
-/**
- * Forwards user interactions with interactive-examples to Glean.
- */
-export function useInteractiveExamplesActionHandler() {
-  const gleanClick = useGleanClick();
-  useEffect(() => {
-    const listener = (event: MessageEvent) => {
-      if (
-        event.origin === IEX_DOMAIN &&
-        typeof event.data === "object" &&
-        event.data.type === "action"
-      ) {
-        gleanClick(`interactive-examples: ${event.data.source}`);
-      }
-    };
-
-    window.addEventListener("message", listener);
-
-    return () => window.removeEventListener("message", listener);
-  });
 }

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSearchParams, useParams, useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
-import { CRUD_MODE } from "../env";
+import { CRUD_MODE, IEX_DOMAIN } from "../env";
 import { useGA } from "../ga-context";
 import { useIsServer } from "../hooks";
 
@@ -38,6 +38,7 @@ import "./index.scss";
 import "./interactive-examples.scss";
 import { DocumentSurvey } from "../ui/molecules/document-survey";
 import { useIncrementFrequentlyViewed } from "../plus/collections/frequently-viewed";
+import { useGleanClick } from "../telemetry/glean-context";
 // import { useUIStatus } from "../ui-context";
 
 // Lazy sub-components
@@ -171,6 +172,23 @@ export function Document(props /* TODO: define a TS interface for this */) {
     }
   }, []);
   // const { setToastData } = useUIStatus();
+
+  const gleanClick = useGleanClick();
+  React.useEffect(() => {
+    const listener = (event: MessageEvent) => {
+      if (
+        event.origin === IEX_DOMAIN &&
+        typeof event.data === "object" &&
+        event.data.type === "action"
+      ) {
+        gleanClick(`interactive-examples: ${event.data.source}`);
+      }
+    };
+
+    window.addEventListener("message", listener);
+
+    return () => window.removeEventListener("message", listener);
+  });
 
   if (!doc && !error) {
     return <Loading minHeight={800} message="Loading document..." />;

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -2,11 +2,15 @@ import React from "react";
 import { useSearchParams, useParams, useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
-import { CRUD_MODE, IEX_DOMAIN } from "../env";
+import { CRUD_MODE } from "../env";
 import { useGA } from "../ga-context";
 import { useIsServer } from "../hooks";
 
-import { useDocumentURL, useCopyExamplesToClipboard } from "./hooks";
+import {
+  useDocumentURL,
+  useCopyExamplesToClipboard,
+  useInteractiveExamplesActionHandler,
+} from "./hooks";
 import { Doc } from "../../../libs/types/document";
 // Ingredients
 import { Prose } from "./ingredients/prose";
@@ -38,7 +42,6 @@ import "./index.scss";
 import "./interactive-examples.scss";
 import { DocumentSurvey } from "../ui/molecules/document-survey";
 import { useIncrementFrequentlyViewed } from "../plus/collections/frequently-viewed";
-import { useGleanClick } from "../telemetry/glean-context";
 // import { useUIStatus } from "../ui-context";
 
 // Lazy sub-components
@@ -112,8 +115,10 @@ export function Document(props /* TODO: define a TS interface for this */) {
       refreshInterval: CRUD_MODE ? 500 : 0,
     }
   );
+
   useIncrementFrequentlyViewed(doc);
   useCopyExamplesToClipboard(doc);
+  useInteractiveExamplesActionHandler();
 
   React.useEffect(() => {
     if (!doc && !error) {
@@ -172,23 +177,6 @@ export function Document(props /* TODO: define a TS interface for this */) {
     }
   }, []);
   // const { setToastData } = useUIStatus();
-
-  const gleanClick = useGleanClick();
-  React.useEffect(() => {
-    const listener = (event: MessageEvent) => {
-      if (
-        event.origin === IEX_DOMAIN &&
-        typeof event.data === "object" &&
-        event.data.type === "action"
-      ) {
-        gleanClick(`interactive-examples: ${event.data.source}`);
-      }
-    };
-
-    window.addEventListener("message", listener);
-
-    return () => window.removeEventListener("message", listener);
-  });
 
   if (!doc && !error) {
     return <Loading minHeight={800} message="Loading document..." />;

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -6,11 +6,7 @@ import { CRUD_MODE } from "../env";
 import { useGA } from "../ga-context";
 import { useIsServer } from "../hooks";
 
-import {
-  useDocumentURL,
-  useCopyExamplesToClipboard,
-  useInteractiveExamplesActionHandler,
-} from "./hooks";
+import { useDocumentURL, useCopyExamplesToClipboard } from "./hooks";
 import { Doc } from "../../../libs/types/document";
 // Ingredients
 import { Prose } from "./ingredients/prose";
@@ -42,6 +38,7 @@ import "./index.scss";
 import "./interactive-examples.scss";
 import { DocumentSurvey } from "../ui/molecules/document-survey";
 import { useIncrementFrequentlyViewed } from "../plus/collections/frequently-viewed";
+import { useInteractiveExamplesActionHandler as useInteractiveExamplesTelemetry } from "../telemetry/interactive-examples";
 // import { useUIStatus } from "../ui-context";
 
 // Lazy sub-components
@@ -118,7 +115,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
 
   useIncrementFrequentlyViewed(doc);
   useCopyExamplesToClipboard(doc);
-  useInteractiveExamplesActionHandler();
+  useInteractiveExamplesTelemetry();
 
   React.useEffect(() => {
     if (!doc && !error) {

--- a/client/src/telemetry/interactive-examples.ts
+++ b/client/src/telemetry/interactive-examples.ts
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useGleanClick } from "./glean-context";
+import { IEX_DOMAIN } from "../env";
+
+/**
+ * Forwards user interactions with interactive-examples to Glean.
+ */
+export function useInteractiveExamplesActionHandler() {
+  const gleanClick = useGleanClick();
+  useEffect(() => {
+    const listener = (event: MessageEvent) => {
+      if (
+        event.origin === IEX_DOMAIN &&
+        typeof event.data === "object" &&
+        event.data.type === "action"
+      ) {
+        gleanClick(`interactive-examples: ${event.data.source}`);
+      }
+    };
+
+    window.addEventListener("message", listener);
+
+    return () => window.removeEventListener("message", listener);
+  });
+}

--- a/client/src/telemetry/interactive-examples.ts
+++ b/client/src/telemetry/interactive-examples.ts
@@ -7,6 +7,7 @@ import { IEX_DOMAIN } from "../env";
  */
 export function useInteractiveExamplesActionHandler() {
   const gleanClick = useGleanClick();
+
   useEffect(() => {
     const listener = (event: MessageEvent) => {
       if (
@@ -21,5 +22,5 @@ export function useInteractiveExamplesActionHandler() {
     window.addEventListener("message", listener);
 
     return () => window.removeEventListener("message", listener);
-  });
+  }, [gleanClick]);
 }


### PR DESCRIPTION
## Summary

Measures how users interact with interactive-examples.

1. [bob] https://github.com/mdn/bob/pull/1145
2. [**yari**] https://github.com/mdn/yari/pull/8337

### Problem

We don't know how many users interact with interactive-examples, and how.

### Solution

Handle interaction events that bob posts, and forward them with Glean.

---

## How did you test this change?

1. In bob, checked out the PR (`gh pr checkout 1145`) and ran the build (`npm ci && npm run start`).
3. In yari, added the following environment variables to `.env`:
   ```
   BUILD_INTERACTIVE_EXAMPLES_BASE_URL=http://localhost:4444
   REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL=http://localhost:4444
   ```
4. In yari, checked out this PR (`gh pr checkout 8337`) and ran the dev-build (`yarn && yarn dev`).
5. Opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat#try_it locally.
6. Clicked in the interactive example and executed several actions.