### PR TITLE
fix(bcd): add space before the preference name

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -294,7 +294,7 @@ function FlagsNote({
         </>
       )}
       {hasAddedVersion || hasRemovedVersion ? ": this" : "This"} feature is
-      behind the
+      behind the{" "}
       {flags.map((flag, i) => {
         const valueToSet = flag.value_to_set && (
           <>
@@ -305,7 +305,7 @@ function FlagsNote({
         return (
           <React.Fragment key={flag.name}>
             <code>{flag.name}</code>
-            {flag.type === "preference" && <> preferences{valueToSet}</>}
+            {flag.type === "preference" && <> preference{valueToSet}</>}
             {flag.type === "runtime_flag" && <> runtime flag{valueToSet}</>}
             {i < flags.length - 1 && " and the "}
           </React.Fragment>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->
Fixes #8328
### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

* The text is missing a space between "the" and the preference name
* "preferences" should be singular when only one flag needs to be enabled

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

* Add a space between "the" and the preference name
---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Captura de Pantalla 2023-03-08 a la(s) 11 01 07](https://user-images.githubusercontent.com/5327805/223779829-d3152f73-d196-474b-9516-5bcbe0b2843e.png)


### After

![Captura de Pantalla 2023-03-08 a la(s) 11 02 43](https://user-images.githubusercontent.com/5327805/223779995-3ffb71d4-33bb-4a69-b1a7-a3002785dddf.png)



---