### PR TITLE
fix(macros): escape page.title in sidebars

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -824,7 +824,7 @@ async function getTitle(pageSlug) {
   if (!page.title) {
     page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
   }
-  return page.title;
+  return mdn.htmlEscape(page.title);
 }
 
 async function renderSubsection(subsection) {

--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -48,7 +48,7 @@ async function getTitle(pageSlug) {
   if (!page.title) {
     page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
   }
-  return page.title;
+  return mdn.htmlEscape(page.title);
 }
 
 %>

--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -60,7 +60,7 @@ async function getTitle(pageSlug) {
   if (!page.title) {
     page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
   }
-  return page.title;
+  return mdn.htmlEscape(page.title);
 }
 
 %>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/8369, fixes https://github.com/mdn/yari/issues/8370.

### Problem

Page titles used as link text were not properly escaped, so page titles containing HTML elements (such as [`<object> 로부터 <iframe>까지 — 기타 임베딩 기술`](http://localhost:3000/ko/docs/Learn/HTML/Multimedia_and_embedding/Other_embedding_technologies])) broke the sidebar.

### Solution

Use `htmlEscape` to escape the `page.title`.

---

## Screenshots

### Before

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/495429/223568199-12d4679f-2d0f-40a1-a655-73f4d7879154.png">

### After

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/495429/223568161-e55ebe92-e652-47be-bfc9-5e5a4ed596f1.png">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/ko/docs/Learn/Getting_started_with_the_web locally.
