### PR TITLE
fix(spas): use cased locale for homepage, not lowercase

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -38,7 +38,10 @@ const FEATURED_ARTICLES = [
 
 const contributorSpotlightRoot = CONTRIBUTOR_SPOTLIGHT_ROOT;
 
-async function buildContributorSpotlight(locale, options) {
+async function buildContributorSpotlight(
+  locale: string,
+  options: { verbose?: boolean }
+) {
   const prefix = "community/spotlight";
   const profileImg = "profile-image.jpg";
 
@@ -49,7 +52,7 @@ async function buildContributorSpotlight(locale, options) {
     );
 
     const frontMatter = frontmatter<DocFrontmatter>(markdown);
-    const contributorHTML = await m2h(frontMatter.body, locale);
+    const contributorHTML = await m2h(frontMatter.body, { locale });
 
     const { sections } = splitSections(contributorHTML);
 
@@ -94,7 +97,10 @@ async function buildContributorSpotlight(locale, options) {
   }
 }
 
-export async function buildSPAs(options) {
+export async function buildSPAs(options: {
+  quiet?: boolean;
+  verbose?: boolean;
+}) {
   let buildCount = 0;
 
   // The URL isn't very important as long as it triggers the right route in the <App/>
@@ -184,7 +190,11 @@ export async function buildSPAs(options) {
    * @param {string} slug
    * @param {string} title
    */
-  async function buildStaticPages(dirpath, slug, title = "MDN") {
+  async function buildStaticPages(
+    dirpath: string,
+    slug: string,
+    title = "MDN"
+  ) {
     const crawler = new fdir()
       .withFullPaths()
       .withErrors()

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -9,7 +9,11 @@ import got from "got";
 
 import { m2h } from "../markdown/index.js";
 
-import { VALID_LOCALES, MDN_PLUS_TITLE } from "../libs/constants/index.js";
+import {
+  VALID_LOCALES,
+  MDN_PLUS_TITLE,
+  DEFAULT_LOCALE,
+} from "../libs/constants/index.js";
 import {
   CONTENT_ROOT,
   CONTENT_TRANSLATED_ROOT,
@@ -94,9 +98,13 @@ export async function buildSPAs(options) {
   let buildCount = 0;
 
   // The URL isn't very important as long as it triggers the right route in the <App/>
-  const url = "/en-US/404.html";
+  const url = `/${DEFAULT_LOCALE}/404.html`;
   const html = renderHTML(url, { pageNotFound: true });
-  const outPath = path.join(BUILD_OUT_ROOT, "en-us", "_spas");
+  const outPath = path.join(
+    BUILD_OUT_ROOT,
+    DEFAULT_LOCALE.toLowerCase(),
+    "_spas"
+  );
   fs.mkdirSync(outPath, { recursive: true });
   fs.writeFileSync(path.join(outPath, path.basename(url)), html);
   buildCount++;
@@ -188,7 +196,7 @@ export async function buildSPAs(options) {
       const file = filepath.replace(dirpath, "");
       const page = file.split(".")[0];
 
-      const locale = "en-us";
+      const locale = DEFAULT_LOCALE.toLowerCase();
       const markdown = fs.readFileSync(filepath, "utf-8");
 
       const frontMatter = frontmatter<DocFrontmatter>(markdown);
@@ -262,7 +270,7 @@ export async function buildSPAs(options) {
           FEATURED_ARTICLES.map(async (url) => {
             const document =
               findByURL(`/${locale}/docs/${url}`) ||
-              findByURL(`/en-US/docs/${url}`);
+              findByURL(`/${DEFAULT_LOCALE}/docs/${url}`);
             if (document) {
               const {
                 doc: { mdn_url, summary, title, parents },
@@ -366,7 +374,7 @@ async function fetchLatestNews() {
   items.push(
     {
       title: "Experimenting with advertising on MDN",
-      url: "/en-US/advertising",
+      url: `/${DEFAULT_LOCALE}/advertising`,
       author: "Mozilla",
       published_at: new Date("2023-02-15 15:00Z").toString(),
       source: {

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -64,7 +64,7 @@ async function buildContributorSpotlight(locale, options) {
     const html = renderHTML(`/${locale}/${prefix}/${contributor}`, context);
     const outPath = path.join(
       BUILD_OUT_ROOT,
-      locale,
+      locale.toLowerCase(),
       `${prefix}/${hyData.folderName}`
     );
     const filePath = path.join(outPath, "index.html");
@@ -244,11 +244,12 @@ export async function buildSPAs(options) {
     if (!root) {
       continue;
     }
-    for (const locale of fs.readdirSync(root)) {
+    for (const localeLC of fs.readdirSync(root)) {
+      const locale = VALID_LOCALES.get(localeLC) || localeLC;
       if (!isValidLocale(locale)) {
         continue;
       }
-      if (!fs.statSync(path.join(root, locale)).isDirectory()) {
+      if (!fs.statSync(path.join(root, localeLC)).isDirectory()) {
         continue;
       }
 
@@ -286,7 +287,7 @@ export async function buildSPAs(options) {
       };
       const context = { hyData };
       const html = renderHTML(url, context);
-      const outPath = path.join(BUILD_OUT_ROOT, locale);
+      const outPath = path.join(BUILD_OUT_ROOT, localeLC);
       fs.mkdirSync(outPath, { recursive: true });
       const filePath = path.join(outPath, "index.html");
       fs.writeFileSync(filePath, html);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

On https://developer.mozilla.org/en-US/, the menu links point to `en-us`, e.g. `https://developer.mozilla.org/en-us/docs/Web` instead of `https://developer.mozilla.org/en-US/docs/Web`. This causes an unnecessary redirect.

### Solution

Build the homepage using the properly cased locale (`en-US`).

(While at it, this also makes use of `DEFAULT_LOCALE` where possible.)

---

## How did you test this change?

1. On `main`, I ran `yarn build:prepare`.
2. Ran `git add -f client/build`.
3. Switched to this branch.
4. Ran `yarn build:prepare` again.
5. Looked at `git diff --word-diff client/build` and saw the following:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/495429/223727117-8f38f3ba-0bc5-4fc2-8b5f-94d431368270.png">
 