### PR TITLE
ci(stage-build): switch to interactive-examples.mdn.allizom.net

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -137,7 +137,7 @@ jobs:
           BUILD_LIVE_SAMPLES_BASE_URL: https://yari-demos.stage.mdn.mozit.cloud
 
           # Use the stage version of interactive examples.
-          BUILD_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.stage.mdn.mozilla.net
+          BUILD_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
 
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
@@ -155,7 +155,7 @@ jobs:
           REACT_APP_DISABLE_AUTH: false
 
           # Use the stage version of interactive examples in react app
-          REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.stage.mdn.mozilla.net
+          REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
 
           # Firefox Accounts and SubPlat settings
           REACT_APP_FXA_SIGNIN_URL: /users/fxa/login/authenticate/

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -105,7 +105,7 @@ export const CSP_DIRECTIVES = {
 
     "interactive-examples.mdn.mozilla.net",
     "interactive-examples.prod.mdn.mozilla.net",
-    "interactive-examples.stage.mdn.mozilla.net",
+    "interactive-examples.mdn.allizom.net",
     "mdn.github.io",
     "yari-demos.prod.mdn.mozit.cloud",
     "mdn.mozillademos.org",
@@ -133,7 +133,7 @@ export const CSP_DIRECTIVES = {
     "media.stage.mdn.mozit.cloud",
     "interactive-examples.mdn.mozilla.net",
     "interactive-examples.prod.mdn.mozilla.net",
-    "interactive-examples.stage.mdn.mozilla.net",
+    "interactive-examples.mdn.allizom.net",
 
     "wikipedia.org",
 


### PR DESCRIPTION
## Summary

Updates where we the stage deployment of interactive-examples is hosted.

### Problem

Previously, the stage deployment of interactive-examples was hosted at `https://interactive-examples.stage.mdn.mozilla.net`, but now it will be at `https://interactive-examples.mdn.allizom.net`.

### Solution

Updates both the `stage-build` workflow and the CSP headers.

---

## How did you test this change?

Not tested, but used Search+Replace to avoid human errors.