### PR TITLE
ci(pr-commit-signatures): explain how to sign existing commits

### DIFF
--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -38,7 +38,7 @@ jobs:
           echo ''
           echo 'Once you have set up commit signatures, you can sign your existing commits:'
           echo ''
-          echo '  git rebase main -x "git commit --amend --gpg-sign --no-edit"'
+          echo '  git rebase main --exec "git commit --amend --gpg-sign --no-edit"'
           echo ''
           echo 'Then you will need to force-push your branch once:'
           echo ''

--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -35,4 +35,13 @@ jobs:
           echo "Please see the documentation about signed commits and how to sign yours on GitHub:"
           echo "- https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification"
           echo "- https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+          echo ''
+          echo 'Once you have set up commit signatures, you can sign your existing commits:'
+          echo ''
+          echo '  git rebase main -x "git commit --amend --gpg-sign --no-edit"'
+          echo ''
+          echo 'Then you will need to force-push your branch once:'
+          echo ''
+          echo '  git push --force'
+          echo ''
           exit 1


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We require all commits to be signed, we verify this with a workflow, and we point to documentation about signing commits, **but we don't explain how to sign existing unsigned commits**.

### Solution

Explain how to sign existing commits and then force-push the branch.

---

## How did you test this change?

Pushed an unsigned commit to this branch, causing [the workflow to fail](https://github.com/mdn/yari/actions/runs/4378439251/jobs/7663182846):
<img width="925" alt="image" src="https://user-images.githubusercontent.com/495429/224146141-72e15c5d-7cec-407a-acb8-f8977c17bf56.png">
