### PR TITLE
fix(kumascript): ignore smartlink warning for links with fallback

### DIFF
--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -20,17 +20,13 @@ const _warned = new Map();
 // broken link. But that problem lies with the `CSSRef.ejs` macro, which we
 // don't entirely want to swallow and forget. But we don't want to point this
 // out on every single page that *uses* that `CSSRef` macro.
-function warnBrokenFlawByMacro(macro, href, extra = "") {
+function warnBrokenFlawByMacro(macro: string, href: string, notes: string) {
   if (!_warned.has(macro)) {
     _warned.set(macro, new Set());
   }
   if (!_warned.get(macro).has(href)) {
     _warned.get(macro).add(href);
-    console.warn(
-      `In ${macro} the smartLink to ${href} is broken${
-        extra ? ` (${extra})` : ""
-      }`
-    );
+    console.warn(`In ${macro} the smartLink to ${href} is broken! (${notes})`);
   }
 }
 
@@ -162,7 +158,7 @@ const web = {
       }
     }
     if (ignoreFlawMacro) {
-      warnBrokenFlawByMacro(ignoreFlawMacro, href);
+      warnBrokenFlawByMacro(ignoreFlawMacro, href, "does not exist");
     } else {
       flaw = this.env.recordNonFatalError(
         "broken-link",

--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -145,9 +145,7 @@ const web = {
       if (enUSPage.url) {
         // But it's still a flaw. Record it so that translators can write a
         // translated document to "fill the hole".
-        if (ignoreFlawMacro) {
-          warnBrokenFlawByMacro(ignoreFlawMacro, href);
-        } else {
+        if (!ignoreFlawMacro) {
           flaw = this.env.recordNonFatalError(
             "broken-link",
             `${hrefpath} does not exist but fell back to ${enUSPage.url}`


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Background

The macro helper function `web.smartlink()` is used to create clever links, especially following redirects and providing a fallback in `en-US` if the page doesn't exist in the specified locale.

Usually, `smartlink()` emits flaws when it follows redirects or provides a `en-US` fallback.

However, as a lot of pages are not available in all locales, this would cause a lot of flaws (one for each missing page on every page using the sidebar macro), so a parameter `ignoreFlawMacro` exists to emit console warnings once for each distinct warning.

### Problem

For smartlinks where the page does not exist in the current locale but exists in `en-US`, it is too verbose and not useful to emit a console warning.

### Solution

Omit neither a console warning nor a flaw for fallback links if `ignoreFlawMacro` is set.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% yarn tool spas                                                                                                                                                                                                                                   ✭
yarn run v1.22.19
$ ts-node tool/cli.ts spas
(node:32688) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Language does not exist: svelte
In CSSRef the smartLink to /es/docs/Learn/CSS/Building_blocks/Cascade_layers is broken
In CSSRef the smartLink to /es/docs/Learn/CSS/Building_blocks/Organizing is broken
In CSSRef the smartLink to /es/docs/Learn/CSS/Building_blocks/Creating_fancy_letterheaded_paper is broken
In CSSRef the smartLink to /es/docs/Learn/CSS/Building_blocks/A_cool_looking_box is broken
...
In CSSRef the smartLink to /zh-CN/docs/Web/CSS/Layout_cookbook/Sticky_footers is broken
In CSSRef the smartLink to /zh-CN/docs/Web/CSS/Layout_cookbook/List_group_with_badges is broken
In CSSRef the smartLink to /zh-CN/docs/Web/CSS/Layout_cookbook/Pagination is broken
In CSSRef the smartLink to /zh-CN/docs/Web/CSS/Layout_cookbook/Grid_wrapper is broken
Built 124 SPA related files
✨  Done in 18.81s.
```

### After

```
% yarn tool spas                                                                                                                                                                                                                                   ✭
yarn run v1.22.19
$ ts-node tool/cli.ts spas
(node:32553) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Language does not exist: svelte
Built 124 SPA related files
✨  Done in 18.62s.
```

---

## How did you test this change?

Ran `yarn tool spas`, which is called as part of `yarn dev` and has been emitting 673 warnings before this PR.
