### PR TITLE
Remove "attr-" from HTML Element attribute links

### DIFF
--- a/kumascript/macros/htmlattrxref.ejs
+++ b/kumascript/macros/htmlattrxref.ejs
@@ -25,7 +25,7 @@ var text = ($2 && ($2!=undefined)) ? $2 : attrLC;
 let basePath;
 if ($1) {
     basePath = '/' + lang + '/docs/Web/HTML/Element/';
-    url = basePath + $1 + '#attr-' + attrLC;
+    url = basePath + $1 + '#' + attrLC;
 } else {
     url = '/' + lang + '/docs/Web/HTML/' + globalAttrSlug + '#' + attrLC;
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

The prefix "attr-" was currently added to URL fragment to locate the HTML element attribute on a page. However, it is impossible to follow the URL to locate its location as the "id" attribute lacks this prefix.

### Problem

For example, I can not locate "colspan" section on the "[td](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td)" page by clicking the "colspan" link on the "[table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)" page, as the URL contains the incorrect fragment "#attr-colspan". The correct fragment should be "#colspan".

### Solution

Remove the prefix "attr-" from file kumascript/macros/htmlattrxref.ejs.

---

## How did you test this change?

Ran `yarn dev` locally.
