### PR TITLE
fix(types/document): rename shortTitle back to short_title

### DIFF
--- a/build/document-utils.ts
+++ b/build/document-utils.ts
@@ -64,13 +64,13 @@ export function addBreadcrumbData(url, document) {
     }
   }
 
-  if (!document.shortTitle) {
-    document.shortTitle = transformTitle(document.title);
+  if (!document.short_title) {
+    document.short_title = transformTitle(document.title);
   }
 
   parents.push({
     uri: url,
-    title: document.shortTitle,
+    title: document.short_title,
   });
   document.parents = parents;
 }

--- a/build/index.ts
+++ b/build/index.ts
@@ -17,7 +17,6 @@ import { FLAW_LEVELS } from "../libs/constants/index.js";
 import { extractSections } from "./extract-sections.js";
 import { extractSidebar } from "./extract-sidebar.js";
 import { extractSummary } from "./extract-summary.js";
-export { default as SearchIndex } from "./search-index.js";
 import { addBreadcrumbData } from "./document-utils.js";
 import {
   fixFixableFlaws,
@@ -29,11 +28,12 @@ import { getPageTitle } from "./page-title.js";
 import { syntaxHighlight } from "./syntax-highlight.js";
 import { formatNotecards } from "./format-notecards.js";
 import buildOptions from "./build-options.js";
-export { gather as gatherGitHistory } from "./git-history.js";
-export { buildSPAs } from "./spas.js";
 import LANGUAGES_RAW from "../libs/languages/index.js";
 import { safeDecodeURIComponent } from "../kumascript/src/api/util.js";
 import { wrapTables } from "./wrap-tables.js";
+export { default as SearchIndex } from "./search-index.js";
+export { gather as gatherGitHistory } from "./git-history.js";
+export { buildSPAs } from "./spas.js";
 
 const LANGUAGES = new Map(
   Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
@@ -628,7 +628,7 @@ export async function buildDocument(
   injectSource(doc, document, metadata);
 
   if (document.metadata["short-title"]) {
-    doc.shortTitle = document.metadata["short-title"];
+    doc.short_title = document.metadata["short-title"];
   }
   // The `titles` object should contain every possible URI->Title mapping.
   // We can use that generate the necessary information needed to build

--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -147,8 +147,8 @@ function getImplementedBy(data) {
 getImplementedBy(webAPIData[0]);
 
 function getPageTitle(page) {
-  if (page.shortTitle) {
-    return htmlEscape(page.shortTitle);
+  if (page.short_title) {
+    return htmlEscape(page.short_title);
   }
   const titleSplit = htmlEscape(page.title).split('.'); // Two cases, as sometimes the interface name is forgotten in the title:
   let title = titleSplit[titleSplit.length - 1];       // "WebGLRenderingContext.activeTexture()" and "activeTexture()" should both become "activeTexture()"

--- a/kumascript/src/info.ts
+++ b/kumascript/src/info.ts
@@ -196,7 +196,7 @@ export const info = {
       locale,
       slug,
       title,
-      shortTitle: document.metadata["short-title"],
+      short_title: document.metadata["short-title"],
       status: status || [],
       tags: tags || [],
       pageType: document.metadata["page-type"],

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -125,7 +125,7 @@ export type Toc = {
 
 export interface DocMetadata {
   title: string;
-  shortTitle: string;
+  short_title: string;
   locale: string;
   native: string;
   pageTitle: string;


### PR DESCRIPTION
## Summary

Partially reverts d6e44563d836b4534a09f0b3d3e93fb7799ba1e5.

### Problem

In https://github.com/mdn/yari/pull/7825, the `short_title` property of `Doc` was renamed to `shortTitle`, and this broke the deployment of the Updates feature, as [Rumba expects the `short_title` property](https://github.com/search?q=repo%3Amdn%2Frumba%20short_title&type=code).

### Solution

Rename the property back to `short_title`

---

## How did you test this change?

Full-text search for `shortTitle` showed no remaining occurrence.