### PR TITLE
feature(tool/delete): list files pointing to the deleted document

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -388,7 +388,7 @@ program
         if (referringFiles.length) {
           console.warn(
             chalk.yellow(
-              `\n${referringFiles.length} files are referring to the deleted document.` +
+              `\n${referringFiles.length} files are referring to the deleted document. ` +
                 `Please update the following files to remove the links:\n\t${referringFiles.join(
                   "\n\t"
                 )}`


### PR DESCRIPTION
## Summary

- Fixes https://github.com/mdn/yari/issues/8372

The changes report all the files referring to the deleted docs so that the contributor will update them manually and there won't be any broken links left behind.

# Screenshots
![bug](https://user-images.githubusercontent.com/87750369/224904421-0b14f52b-39a8-4668-8f2a-3003aab0b224.png)
\* Ignore the missing space between the two sentences.

When no references:
![bug1](https://user-images.githubusercontent.com/87750369/224904464-1f378961-0619-4369-8588-13eee2f322eb.png)



/cc @teoli2003 