### PR TITLE
fix(dotenv): import * as dotenv

### DIFF
--- a/build/build-options.ts
+++ b/build/build-options.ts
@@ -1,4 +1,4 @@
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 dotenv.config();
 
 import { FLAW_LEVELS, VALID_FLAW_CHECKS } from "../libs/constants/index.js";

--- a/client/config/env.js
+++ b/client/config/env.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 import paths from "./paths.js";
 
 // Double-check to make sure NODE_ENV is defined

--- a/deployer/aws-lambda/content-origin-request/build.js
+++ b/deployer/aws-lambda/content-origin-request/build.js
@@ -2,7 +2,7 @@ import { VALID_LOCALES } from "@yari-internal/constants";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { cwd } from "node:process";
 import { fileURLToPath } from "node:url";
 
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 

--- a/ssr/index.ts
+++ b/ssr/index.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import dotenv from "dotenv";
+import * as dotenv from "dotenv";
 import React from "react";
 import { StaticRouter } from "react-router-dom/server";
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We currently `import dotenv from "dotenv";`, but the recommended way is to `import * as dotenv from "dotenv";`. In https://github.com/mdn/yari/pull/8366, this caused the following error:

```
    TypeError: Cannot read properties of undefined (reading 'config')

      4 | import { cwd } from "node:process";
      5 |
    > 6 | dotenv.config({
        |        ^
      7 |   path: path.join(cwd(), process.env["ENV_FILE"] || ".env"),
      8 | });
      9 |
```

### Solution

Update the imports accordingly.

---

## How did you test this change?

Ran `yarn && yarn dev` without any issues.