### PR TITLE
fix(lambda): decode html entities via he

### DIFF
--- a/deployer/aws-lambda/kevel/env.js
+++ b/deployer/aws-lambda/kevel/env.js
@@ -1,0 +1,6 @@
+// generated
+export const KEVEL_SITE_ID = undefined;
+export const KEVEL_NETWORK_ID = undefined;
+export const SIGN_SECRET = "undefined";
+export const CARBON_ZONE_KEY = "undefined";
+export const FALLBACK_ENABLED = false;

--- a/deployer/aws-lambda/kevel/env.js
+++ b/deployer/aws-lambda/kevel/env.js
@@ -1,6 +1,0 @@
-// generated
-export const KEVEL_SITE_ID = undefined;
-export const KEVEL_NETWORK_ID = undefined;
-export const SIGN_SECRET = "undefined";
-export const CARBON_ZONE_KEY = "undefined";
-export const FALLBACK_ENABLED = false;

--- a/deployer/aws-lambda/kevel/index.js
+++ b/deployer/aws-lambda/kevel/index.js
@@ -9,6 +9,7 @@ import {
   SIGN_SECRET,
   CARBON_ZONE_KEY,
   FALLBACK_ENABLED,
+  // eslint-disable-next-line n/no-missing-import
 } from "./env.js";
 import cc2ip from "./cc2ip.js";
 

--- a/deployer/aws-lambda/kevel/index.js
+++ b/deployer/aws-lambda/kevel/index.js
@@ -2,6 +2,7 @@
 import { createHmac } from "node:crypto";
 
 import { Client } from "@adzerk/decision-sdk";
+import { he } from "he";
 import {
   KEVEL_SITE_ID,
   KEVEL_NETWORK_ID,
@@ -124,7 +125,9 @@ export async function handler(event) {
       }
     } else {
       payload = {
-        copy: contents?.[0]?.data?.title || "This is an ad without copy?!",
+        copy: he.decode(
+          contents?.[0]?.data?.title || "This is an ad without copy?!"
+        ),
         image: encodeAndSign(contents[0]?.data?.imageUrl),
         click: encodeAndSign(clickUrl),
         view: encodeAndSign(impressionUrl),

--- a/deployer/aws-lambda/kevel/index.js
+++ b/deployer/aws-lambda/kevel/index.js
@@ -2,14 +2,13 @@
 import { createHmac } from "node:crypto";
 
 import { Client } from "@adzerk/decision-sdk";
-import { he } from "he";
+import he from "he";
 import {
   KEVEL_SITE_ID,
   KEVEL_NETWORK_ID,
   SIGN_SECRET,
   CARBON_ZONE_KEY,
   FALLBACK_ENABLED,
-  // eslint-disable-next-line n/no-missing-import
 } from "./env.js";
 import cc2ip from "./cc2ip.js";
 

--- a/deployer/aws-lambda/kevel/package.json
+++ b/deployer/aws-lambda/kevel/package.json
@@ -14,7 +14,8 @@
     "make-package": "yarn build && yarn install --production && zip -r -X function.zip . -i index.js package.json env.js cc2ip.js 'node_modules/*'"
   },
   "dependencies": {
-    "@adzerk/decision-sdk": "^1.0.0-beta.20"
+    "@adzerk/decision-sdk": "^1.0.0-beta.20",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.3"

--- a/deployer/aws-lambda/kevel/yarn.lock
+++ b/deployer/aws-lambda/kevel/yarn.lock
@@ -49,6 +49,11 @@ form-data@^2.5.1:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+he@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 isomorphic-unfetch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"


### PR DESCRIPTION
## Summary

Kevel sends us encoded stings. Since we do not use `innerHTML` but only `textContent` we must decode these in the lambda.