### PR TITLE
feat(bcd): fetch compat data from bcd.developer.mozilla/allizom.org

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -155,6 +155,9 @@ jobs:
           # exception in the world where we actually want to welcome robots.
           BUILD_ALWAYS_ALLOW_ROBOTS: true
 
+          # Browser-compat data.
+          REACT_APP_BCD_BASE_URL: https://bcd.developer.mozilla.org
+
           # Offline updates
           REACT_APP_UPDATES_BASE_URL: https://updates.developer.mozilla.org
 

--- a/client/src/document/lazy-bcd-table.tsx
+++ b/client/src/document/lazy-bcd-table.tsx
@@ -14,6 +14,7 @@ import "./ingredients/browser-compatibility-table/index.scss";
 import { useLocale, useIsServer } from "../hooks";
 import NoteCard from "../ui/molecules/notecards";
 import type BCD from "@mdn/browser-compat-data/types";
+import { BCD_BASE_URL } from "../env";
 
 interface QueryJson {
   query: string;
@@ -55,7 +56,9 @@ function LazyBrowserCompatibilityTableInner({ query }: { query: string }) {
   const { error, data } = useSWR(
     query,
     async (query) => {
-      const response = await fetch(`/bcd/api/v0/current/${query}.json`);
+      const response = await fetch(
+        `${BCD_BASE_URL}/bcd/api/v0/current/${query}.json`
+      );
       if (!response.ok) {
         throw new Error(response.status.toString());
       }

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -56,7 +56,7 @@ export const DEFAULT_GEO_COUNTRY =
   process.env.REACT_APP_DEFAULT_GEO_COUNTRY || "United States";
 
 export const BCD_BASE_URL =
-  process.env.REACT_APP_BCD_BASE_URL || "https://bcd.developer.allizom.org";
+  process.env.REACT_APP_BCD_BASE_URL ?? "https://bcd.developer.allizom.org";
 
 export const IEX_DOMAIN =
   process.env.REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL ||

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -55,6 +55,9 @@ export const FXA_MANAGE_SUBSCRIPTIONS_URL =
 export const DEFAULT_GEO_COUNTRY =
   process.env.REACT_APP_DEFAULT_GEO_COUNTRY || "United States";
 
+export const BCD_BASE_URL =
+  process.env.REACT_APP_BCD_BASE_URL || "https://bcd.developer.allizom.org";
+
 export const IEX_DOMAIN =
   process.env.REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL ||
   "https://interactive-examples.mdn.mozilla.net";

--- a/client/src/plus/updates/api.ts
+++ b/client/src/plus/updates/api.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 import { useSearchParams } from "react-router-dom";
 import { useUserData } from "../../user-context";
+import { BCD_BASE_URL } from "../../env";
 
 export interface Event {
   path: string;
@@ -107,7 +108,7 @@ export function useUpdates() {
 
 export function useBCD(path: string) {
   return useSWR(
-    `/bcd/api/v0/current/${path}.json`,
+    `${BCD_BASE_URL}/bcd/api/v0/current/${path}.json`,
     async (key) => {
       const res = await fetch(key);
       if (res.ok) {

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -227,6 +227,14 @@ automatically included in XHR calls on `http://localhost.org:3000`.
 Note that even if you set this, you can still continue to use
 `http://localhost:3000`.
 
+### `REACT_APP_BCD_BASE_URL`
+
+**Default: `https://bcd.developer.allizom.org`**
+
+The base URL (without trailing slash) used to fetch data for BCD tables.
+
+If you want to use local BCD data, set `REACT_APP_BCD_BASE_URL=""`.
+
 ### `REACT_APP_KUMA_HOST`
 
 **Default: `not set`**

--- a/server/index.ts
+++ b/server/index.ts
@@ -60,6 +60,7 @@ const app = express();
 
 const bcdRouter = express.Router({ caseSensitive: true });
 
+// Note that this route will only get hit if .env has this: REACT_APP_BCD_BASE_URL=""
 bcdRouter.get("/api/v0/current/:path.json", async (req, res) => {
   const data = getBCDDataForPath(req.params.path);
   return data ? res.json(data) : res.status(404).send("BCD path not found");


### PR DESCRIPTION
## Summary

Fetches BCD data from the separate `bcd.developer.mozilla/allizom.org` host.

### Problem

We have moved the BCD data off to a separate subdomain as part of our (ongoing) migration from AWS to GCP, but we're still fetching BCD data for BCD tables from `/bcd/*`.

### Solution

- Introduce an environment variable `REACT_APP_BCD_BASE_URL`, defaulting to stage (`https://bcd.developer.allizom.org`).
- Use it for fetching the data for the BCD table.
- Use `bcd.developer.mozilla.org` for the prod build.

---

## Screenshots

### Before

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/495429/226891256-f7d21753-afb1-4261-87d0-0a5d1906b0de.png">

### After

<img width="1248" alt="image" src="https://user-images.githubusercontent.com/495429/226890963-6d50b7cd-4037-4d2c-8d6c-03dbdd61af0f.png">

---

## How did you test this change?

Ran `yarn dev`, then opened http://localhost:3000/en-US/docs/Web/CSS/background#browser_compatibility locally, verified that the BCD data is fetched from `bcd.developer.allizom.org` and properly displayed, then blocked the URL in the DevTools and verified that the BCD data is no longer displayed.
