### PR TITLE
chore(client): fetch stripe plans from /plus/plans.json

### DIFF
--- a/client/src/plus/common/api.tsx
+++ b/client/src/plus/common/api.tsx
@@ -1,4 +1,4 @@
-export const STRIPE_PLANS_PATH = "/api/v1/stripe/plans";
+export const STRIPE_PLANS_PATH = "/plus/plans.json";
 export const SETTINGS_BASE_PATH = "/api/v1/plus/settings/";
 export const NEWSLETTER_BASE_PATH = "/api/v1/plus/newsletter/";
 
@@ -47,7 +47,7 @@ export async function getStripePlans() {
   let res;
   //This comes from edge lambda so must be from live.
   if (window.location.hostname.includes("localhost")) {
-    res = await fetch("https://developer.allizom.org/api/v1/stripe/plans");
+    res = await fetch("https://developer.allizom.org/plus/plans.json");
   } else {
     res = await fetch(STRIPE_PLANS_PATH);
   }

--- a/client/src/plus/common/api.tsx
+++ b/client/src/plus/common/api.tsx
@@ -1,4 +1,4 @@
-export const STRIPE_PLANS_PATH = "/plus/plans.json";
+export const PLUS_PLANS_PATH = "/plus/plans.json";
 export const SETTINGS_BASE_PATH = "/api/v1/plus/settings/";
 export const NEWSLETTER_BASE_PATH = "/api/v1/plus/newsletter/";
 
@@ -43,13 +43,13 @@ export async function getNewsletterSubscription(): Promise<boolean | null> {
   }
 }
 
-export async function getStripePlans() {
+export async function getPlusPlans() {
   let res;
   //This comes from edge lambda so must be from live.
   if (window.location.hostname.includes("localhost")) {
     res = await fetch("https://developer.allizom.org/plus/plans.json");
   } else {
-    res = await fetch(STRIPE_PLANS_PATH);
+    res = await fetch(PLUS_PLANS_PATH);
   }
 
   return await res.json();

--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
@@ -10,7 +10,7 @@ import {
 import { SubscriptionType, UserData, useUserData } from "../../../user-context";
 import { Switch } from "../../../ui/atoms/switch";
 import { useEffect, useState } from "react";
-import { getStripePlans } from "../../common/api";
+import { getPlusPlans } from "../../common/api";
 import { useOnlineStatus } from "../../../hooks";
 import { useGleanClick } from "../../../telemetry/glean-context";
 import { OFFER_OVERVIEW_CLICK } from "../../../telemetry/constants";
@@ -52,7 +52,7 @@ export type PlanInfo = {
   monthlyPriceInCents: number;
 };
 
-export type StripePlans = {
+export type PlusPlans = {
   currency: string;
   plans: { [key: string]: PlanInfo };
 };
@@ -264,7 +264,7 @@ function canUpgrade(
   );
 }
 
-function getLocalizedPlans(countrySpecific: StripePlans): {
+function getLocalizedPlans(countrySpecific: PlusPlans): {
   CORE: OfferDetailsProps;
   PLUS_5: OfferDetailsProps;
   PLUS_10: OfferDetailsProps;
@@ -315,7 +315,7 @@ function OfferOverviewSubscribe() {
     (async () => {
       if (isOnline) {
         try {
-          const plans: StripePlans = await getStripePlans();
+          const plans: PlusPlans = await getPlusPlans();
           setOfferDetails(getLocalizedPlans(plans));
         } catch (error) {
           //Paid subs Not supported by region just display Free subscription

--- a/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
+++ b/deployer/aws-lambda/mdn-stripe-price-ids/tests/handler.test.js
@@ -97,7 +97,7 @@ function getEventForAcceptHeaderAndCountry(
       {
         cf: {
           request: {
-            uri: "/api/v1/stripe/plans",
+            uri: "/plus/plans.json",
             method: "GET",
             clientIp: "192.168.0.1",
             origin: {


### PR DESCRIPTION
## Summary

### Problem

The `/api` path should be reserved for our rumba API, but the MDN Plus plans are currently served from `api/v1/stripe/plans`, which is actually backed by a Lambda that determines the available plans based on the country.

### Solution

Use `/plus/plans.json` instead of `/api/v1/stripe/plans`, which are both essentially the same CloudFront behavior, just with a different path.

---

## How did you test this change?

Ran `yarn dev` and visited http://localhost:3000/en-US/plus.
