### PR TITLE
feat(server): return whoami fallback if rumba is not running

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -90,6 +90,15 @@ const proxy = FAKE_V1_API
       changeOrigin: true,
       // proxyTimeout: 20000,
       // timeout: 20000,
+      onError: (_err, req, res) => {
+        if (req.url === "/api/v1/whoami") {
+          // Fallback if rumba is not running.
+          res.writeHead(200, {
+            "Content-Type": "application/json",
+          });
+          res.end(JSON.stringify({}));
+        }
+      },
     });
 
 const pongProxy = createProxyMiddleware({


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We make a whoami request on each page, which is served from rumba. When developing locally, we usually set `REACT_APP_KUMA_HOST=localhost:8000`. However, if rumba is then not running, this produces multiple failed requests in the DevTools' network tab.

### Solution

If the whoami request fails during development, return an empty response.

---

## How did you test this change?

1. Set `REACT_APP_KUMA_HOST=localhost:8000` in `.env`.
2. Run `yari dev`.
3. Make sure rumba is **not** running at localhost:8000.
4. Open http://localhost:3000/en-US/docs/Web and verify in DevTools' network tab that the `/api/v1/whoami` request succeeds anyways.
