### PR TITLE
ci(stage-build): deploy on every push to main

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -52,6 +52,8 @@ on:
 jobs:
   build:
     environment: stage
+    concurrency:
+      group: ${{ github.workflow }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only run the scheduled workflows on the main repo.
-    if: github.repository == 'mdn/yari'
+    if: github.repository == 'mdn/yari' && github.triggering_actor != 'dependabot[bot]'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -15,6 +15,9 @@ env:
   DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: "0 */24 * * *"


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Currently, we deploy `stage` at the same time as `prod`, so we don't notice issues on stage until they're also on prod.

### Solution

In addition to the scheduled run, also build our stage environment on every push to `main`, except Dependabot merges.

---

## How did you test this change?

Not really testable, but I have already used the `concurrency` option in https://github.com/mdn/yari/pull/8366.