### PR TITLE
fix(csp): add bcd.developer.mozilla/allizom.org as connect-src

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -93,6 +93,9 @@ export const CSP_DIRECTIVES = {
   "connect-src": [
     "'self'",
 
+    "bcd.developer.allizom.org",
+    "bcd.developer.mozilla.org",
+
     "updates.developer.allizom.org",
     "updates.developer.mozilla.org",
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/mdn/yari/pull/8470.

### Problem

We changed where BCD data is fetched from, but didn't update our Content-Security-Policy accordingly.

### Solution

Add `bcd.developer.mozilla/allizom.org` as `connect-src`.

---

## How did you test this change?

Noticed the issue on https://developer.allizom.xyz/en-US/docs/Web/CSS/background#browser_compatibility.
