### PR TITLE
enhance(placement): show placement in split screen

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -617,3 +617,60 @@ kbd {
   overflow-y: scroll;
   white-space: pre;
 }
+
+.sidebar-container {
+  max-height: calc(100vh - var(--main-document-header-height));
+  overflow: auto;
+  position: sticky;
+  top: 5rem;
+
+  @media screen and (min-width: $screen-md) {
+    .sidebar {
+      mask-image: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0) 0%,
+        rgb(0, 0, 0) 3rem calc(100% - 3rem),
+        rgba(0, 0, 0, 0) 100%
+      );
+    }
+  }
+
+  .toc-container {
+    .place {
+      grid-area: toc;
+      margin: 0;
+    }
+    @media screen and (min-width: $screen-xl) {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+      height: calc(100vh - var(--main-document-header-height));
+      mask-image: linear-gradient(
+        to bottom,
+        rgba(0, 0, 0, 0) 0%,
+        rgb(0, 0, 0) 3rem calc(100% - 3rem),
+        rgba(0, 0, 0, 0) 100%
+      );
+      overflow: scroll;
+      position: sticky;
+      top: var(--main-document-header-height);
+
+      .place {
+        margin: 1rem 0;
+        padding-bottom: 3rem;
+      }
+    }
+    @media screen and (max-width: #{$screen-md - 1}) {
+      .place {
+        display: none;
+      }
+    }
+  }
+  @media screen and (min-width: $screen-xl) {
+    display: contents;
+
+    .sidebar {
+      mask-image: none;
+    }
+  }
+}

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -619,7 +619,9 @@ kbd {
 }
 
 .sidebar-container {
-  max-height: calc(100vh - var(--main-document-header-height));
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - var(--main-document-header-height) - 3rem);
   overflow: auto;
   position: sticky;
   top: 5rem;

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useSearchParams, useParams, useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
-import { CRUD_MODE } from "../env";
+import { CRUD_MODE, PLACEMENT_ENABLED } from "../env";
 import { useGA } from "../ga-context";
 import { useIsServer } from "../hooks";
 
@@ -39,6 +39,7 @@ import "./interactive-examples.scss";
 import { DocumentSurvey } from "../ui/molecules/document-survey";
 import { useIncrementFrequentlyViewed } from "../plus/collections/frequently-viewed";
 import { useInteractiveExamplesActionHandler as useInteractiveExamplesTelemetry } from "../telemetry/interactive-examples";
+import { Placement } from "../ui/organisms/placement";
 // import { useUIStatus } from "../ui-context";
 
 // Lazy sub-components
@@ -222,11 +223,15 @@ export function Document(props /* TODO: define a TS interface for this */) {
         )
       )}
       <div className="main-wrapper">
-        <RenderSideBar doc={doc} />
-
-        <aside className="toc">
-          <nav>{doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}</nav>
-        </aside>
+        <div className="sidebar-container">
+          <RenderSideBar doc={doc} />
+          <div className="toc-container">
+            <aside className="toc">
+              <nav>{doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}</nav>
+            </aside>
+            {PLACEMENT_ENABLED && <Placement />}
+          </div>
+        </div>
 
         <MainContentContainer>
           {!isServer && CRUD_MODE && !props.isPreview && doc.isActive && (

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -23,6 +23,8 @@
     .sidebar-inner {
       background: var(--background-primary);
       border-right: 1px solid var(--border-primary);
+      display: flex;
+      flex-direction: column;
       height: var(--max-height);
       max-height: var(--max-height);
       max-width: 20rem;
@@ -35,6 +37,23 @@
       width: 80vw;
       will-change: transform;
       z-index: var(--z-index-top);
+
+      .sidebar-inner-nav {
+        @media screen and (min-height: 50rem) {
+          overflow: auto;
+        }
+        mask-image: linear-gradient(
+          to bottom,
+          rgb(0, 0, 0) 0% calc(100% - 3rem),
+          rgba(0, 0, 0, 0) 100%
+        );
+        padding-bottom: 3rem;
+      }
+
+      .place {
+        align-self: center;
+        margin-bottom: 0;
+      }
     }
 
     .backdrop {
@@ -73,9 +92,17 @@
   }
 
   @media screen and (min-width: $screen-md) {
+    .place {
+      display: none;
+    }
+  }
+  @media screen and (min-width: $screen-md) {
     display: flex;
-    max-height: var(--max-height);
+    max-height: calc(var(--max-height) - 20rem);
     overflow: auto;
+  }
+  @media screen and (min-width: $screen-xl) {
+    max-height: var(--max-height);
     position: sticky;
     top: var(--offset);
   }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -235,3 +235,8 @@
     background-color: var(--icon-critical);
   }
 }
+
+.mdn-cta-container ~ .document-page .sidebar {
+  --offset: calc(var(--main-document-header-height) + 3rem);
+  --max-height: calc(100vh - var(--offset));
+}

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -3,110 +3,16 @@
 .sidebar {
   --offset: var(--main-document-header-height);
   --max-height: calc(100vh - var(--offset));
+
   color: var(--text-secondary);
+
+  .mdn-cta-container ~ .document-page & {
+    --offset: calc(var(--main-document-header-height) + 3rem);
+    --max-height: calc(100vh - var(--offset));
+  }
 
   .backdrop {
     display: none;
-  }
-
-  // apply drawer styles only to the sizes that need them.
-  @media screen and (max-width: #{$screen-md - 1}) {
-    height: 100vh;
-    left: 0;
-    max-height: 100vh;
-    position: fixed;
-    right: 0;
-    top: var(--offset);
-    transform: translateX(-100%);
-    z-index: var(--z-index-top);
-
-    .sidebar-inner {
-      background: var(--background-primary);
-      border-right: 1px solid var(--border-primary);
-      display: flex;
-      flex-direction: column;
-      height: var(--max-height);
-      max-height: var(--max-height);
-      max-width: 20rem;
-      overflow: hidden; //animations look janky if scrollbars are present
-      overflow: auto;
-      padding: 1rem;
-      position: relative;
-      transform: translateX(-100%);
-      transition: 0.2s linear transform;
-      width: 80vw;
-      will-change: transform;
-      z-index: var(--z-index-top);
-
-      .sidebar-inner-nav {
-        @media screen and (min-height: 48rem) {
-          overflow: auto;
-        }
-        mask-image: linear-gradient(
-          to bottom,
-          rgb(0, 0, 0) 0% calc(100% - 3rem),
-          rgba(0, 0, 0, 0) 100%
-        );
-        padding-bottom: 3rem;
-      }
-
-      .place {
-        align-self: center;
-        margin-bottom: 0;
-      }
-    }
-
-    .backdrop {
-      background: rgba(0, 0, 0, 0.3);
-      border-radius: 0;
-      bottom: 0;
-      cursor: default;
-
-      display: flex;
-      left: 0;
-      opacity: 0;
-      position: fixed;
-      right: 0;
-      top: 0;
-      transition: opacity 0.2s linear;
-      width: 100%;
-      will-change: opacity;
-      z-index: var(--z-index-mid);
-    }
-
-    &.is-animating {
-      transform: translateX(0);
-    }
-
-    &.is-expanded {
-      transform: translateX(0); // no transition on this one, just show it.
-
-      .sidebar-inner {
-        transform: translateX(0);
-      }
-
-      .backdrop {
-        opacity: 1;
-      }
-    }
-  }
-
-  @media screen and (min-width: $screen-md) {
-    .place {
-      display: none;
-    }
-  }
-  @media screen and (min-width: $screen-md) {
-    display: flex;
-    overflow: auto;
-    @media screen and (min-height: 48rem) {
-      max-height: calc(var(--max-height) - 20rem);
-    }
-  }
-  @media screen and (min-width: $screen-xl) {
-    max-height: var(--max-height);
-    position: sticky;
-    top: var(--offset);
   }
 
   &-heading {
@@ -234,9 +140,103 @@
   .icon-deprecated {
     background-color: var(--icon-critical);
   }
-}
 
-.mdn-cta-container ~ .document-page .sidebar {
-  --offset: calc(var(--main-document-header-height) + 3rem);
-  --max-height: calc(100vh - var(--offset));
+  // apply drawer styles only to the sizes that need them.
+  @media screen and (max-width: #{$screen-md - 1}) {
+    height: 100vh;
+    left: 0;
+    max-height: 100vh;
+    position: fixed;
+    right: 0;
+    top: var(--offset);
+    transform: translateX(-100%);
+    z-index: var(--z-index-top);
+
+    .sidebar-inner {
+      background: var(--background-primary);
+      border-right: 1px solid var(--border-primary);
+      display: flex;
+      flex-direction: column;
+      height: var(--max-height);
+      max-height: var(--max-height);
+      max-width: 20rem;
+      overflow: hidden; //animations look janky if scrollbars are present
+      overflow: auto;
+      padding: 1rem;
+      position: relative;
+      transform: translateX(-100%);
+      transition: 0.2s linear transform;
+      width: 80vw;
+      will-change: transform;
+      z-index: var(--z-index-top);
+
+      .sidebar-inner-nav {
+        @media screen and (min-height: 48rem) {
+          overflow: auto;
+        }
+        mask-image: linear-gradient(
+          to bottom,
+          rgb(0, 0, 0) 0% calc(100% - 3rem),
+          rgba(0, 0, 0, 0) 100%
+        );
+        padding-bottom: 3rem;
+      }
+
+      .place {
+        align-self: center;
+        margin-bottom: 0;
+      }
+    }
+
+    .backdrop {
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 0;
+      bottom: 0;
+      cursor: default;
+
+      display: flex;
+      left: 0;
+      opacity: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+      transition: opacity 0.2s linear;
+      width: 100%;
+      will-change: opacity;
+      z-index: var(--z-index-mid);
+    }
+
+    &.is-animating {
+      transform: translateX(0);
+    }
+
+    &.is-expanded {
+      transform: translateX(0); // no transition on this one, just show it.
+
+      .sidebar-inner {
+        transform: translateX(0);
+      }
+
+      .backdrop {
+        opacity: 1;
+      }
+    }
+  }
+
+  @media screen and (min-width: $screen-md) {
+    .place {
+      display: none;
+    }
+  }
+  @media screen and (min-width: $screen-md) {
+    display: flex;
+    @media screen and (min-height: 48rem) {
+      overflow: auto;
+    }
+  }
+  @media screen and (min-width: $screen-xl) {
+    max-height: var(--max-height);
+    position: sticky;
+    top: var(--offset);
+  }
 }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -39,7 +39,7 @@
       z-index: var(--z-index-top);
 
       .sidebar-inner-nav {
-        @media screen and (min-height: 50rem) {
+        @media screen and (min-height: 48rem) {
           overflow: auto;
         }
         mask-image: linear-gradient(
@@ -98,8 +98,10 @@
   }
   @media screen and (min-width: $screen-md) {
     display: flex;
-    max-height: calc(var(--max-height) - 20rem);
     overflow: auto;
+    @media screen and (min-height: 48rem) {
+      max-height: calc(var(--max-height) - 20rem);
+    }
   }
   @media screen and (min-width: $screen-xl) {
     max-height: var(--max-height);

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -44,7 +44,7 @@ export function SidebarContainer({
     if (sidebar && currentSidebarItem) {
       [sidebar, sidebar.querySelector(".sidebar-inner-nav")].forEach((n) =>
         n?.scrollTo({
-          top: currentSidebarItem.offsetTop - window.innerHeight / 3,
+          top: currentSidebarItem.offsetTop - window.innerHeight / 4,
         })
       );
     }

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -6,6 +6,8 @@ import { useUIStatus } from "../../../ui-context";
 
 import "./index.scss";
 import { TOC } from "../toc";
+import { PLACEMENT_ENABLED } from "../../../env";
+import { Placement } from "../../../ui/organisms/placement";
 
 export function SidebarContainer({
   doc,
@@ -40,7 +42,7 @@ export function SidebarContainer({
     const sidebar = document.querySelector("#sidebar-quicklinks");
     const currentSidebarItem = sidebar?.querySelector("em");
     if (sidebar && currentSidebarItem) {
-      [sidebar, sidebar.querySelector(".sidebar-inner")].forEach((n) =>
+      [sidebar, sidebar.querySelector(".sidebar-inner-nav")].forEach((n) =>
         n?.scrollTo({
           top: currentSidebarItem.offsetTop - window.innerHeight / 3,
         })
@@ -62,10 +64,13 @@ export function SidebarContainer({
           aria-label="Collapse sidebar"
         />
         <nav aria-label={label} className="sidebar-inner">
-          <div className="in-nav-toc">
-            {doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}
+          <div className="sidebar-inner-nav">
+            <div className="in-nav-toc">
+              {doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}
+            </div>
+            {children}
           </div>
-          {children}
+          {PLACEMENT_ENABLED && <Placement />}
         </nav>
       </aside>
     </>

--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -3,8 +3,6 @@ import React, { useState } from "react";
 import "./index.scss";
 import { Toc } from "../../../../../libs/types/document";
 import { useFirstVisibleElement } from "../../hooks";
-import { Placement } from "../../../ui/organisms/placement";
-import { PLACEMENT_ENABLED } from "../../../env";
 
 export function TOC({ toc }: { toc: Toc[] }) {
   const [currentViewedTocItem, setCurrentViewedTocItem] = useState("");

--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -61,7 +61,6 @@ export function TOC({ toc }: { toc: Toc[] }) {
           </ul>
         </section>
       </div>
-      {PLACEMENT_ENABLED && <Placement />}
     </>
   );
 }

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -73,9 +73,7 @@
         rgba(0, 0, 0, 0) 100%
       );
       max-height: calc(100vh - var(--offset));
-      overflow: auto;
-      position: sticky;
-      top: var(--offset);
+      padding-bottom: 0;
     }
 
     .in-nav-toc {

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -95,7 +95,9 @@ export function Placement() {
     }
   );
 
-  return isLoading || isValidating ? null : (
+  return isLoading || isValidating ? (
+    <section className="place"></section>
+  ) : (
     <PlacementInner pong={pong}></PlacementInner>
   );
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

The sidebar scrolling was scrolling the placement our of view. This refactors the sidebar to have it shown sticky at the bottom if there's enough vertical space.

This also starts to remove duplication of elements and should be continued.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

![image](https://user-images.githubusercontent.com/3604775/227470984-46e666bb-a094-4e91-9862-e02f644c4c8c.png)
![image](https://user-images.githubusercontent.com/3604775/227471113-04ddb715-400a-408c-b088-0eef0d919482.png)



---

## How did you test this change?

Deploying it to stage nowish.
