### PR TITLE
feature(tool/move): update files pointing to the moved document(s)

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -114,8 +114,6 @@ export function saveFile(
     "tags",
     "original_slug",
     "browser-compat",
-    "status",
-    "l10n",
   ];
 
   const saveMetadata = {};

--- a/content/document.ts
+++ b/content/document.ts
@@ -114,6 +114,8 @@ export function saveFile(
     "tags",
     "original_slug",
     "browser-compat",
+    "status",
+    "l10n",
   ];
 
   const saveMetadata = {};

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -455,7 +455,10 @@ program
         for (const document of allDocs.iterDocs()) {
           const rawBody = document.rawBody;
           for (const [oldSlug, newSlug] of movedDocs) {
-            const updatedBody = rawBody.replaceAll(oldSlug, newSlug);
+            const updatedBody = rawBody.replace(
+              new RegExp(oldSlug, "g"),
+              newSlug
+            );
             if (rawBody !== updatedBody) {
               Document.saveFile(
                 document.fileInfo.path,


### PR DESCRIPTION
- Fixes https://github.com/mdn/yari/issues/8292

- Changes are almost same as https://github.com/mdn/yari/issues/8372

The PR:
- updates move command to update referring documents.
- adds `status`(new) and `l10n`(translated content) frontmatter attributes to `optionalFrontMatterKeys` array. Without this change `Document.saveFile()` removes these from metadata.
- changed `referringFiles` type from array to set in delete command. When a dirctory is deleted multiple sub pages get deleted so the array was getting duplicate entries.