### PR TITLE
fix(style/code): prevent code blocks appear above side menus

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -536,6 +536,7 @@ pre {
 .code-example {
   color: var(--code-default);
   position: relative;
+  z-index: var(--z-index-back);
 
   .copy-icon {
     border-radius: var(--elem-radius);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

I accidentally found that the code blocks would appear on top of the sidebar menu when on tablet and mobile devices.

It's the sidebar normally for `In this article` menu, not the hamburger menu.

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

I tried adding `z-index` to the `.code-example`, and it works.

---

## Screenshots

### Before

<img width="683" alt="Screenshot 2023-03-25 at 8 58 08 PM" src="https://user-images.githubusercontent.com/124119483/227718614-f6b28897-48f5-47f6-8ac8-332d4e0eca5b.png">


### After

<img width="657" alt="Screenshot 2023-03-25 at 8 58 16 PM" src="https://user-images.githubusercontent.com/124119483/227718618-31cb3847-86ae-4392-b187-a0259e38498a.png">


---

## How did you test this change?

