### PR TITLE
Fix: Issue #8494 (Left sidebar not showing scrollbars)

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -675,6 +675,7 @@ kbd {
 
     .sidebar {
       mask-image: none;
+      overflow: auto;
     }
   }
 }


### PR DESCRIPTION
## Summary

 Fixes #8494 .
-->

### Problem

This fix solves the issue where the scrollbar on left sidebar wasn't being displayed on viewport above 1200px.

### Solution

By setting the overflow property on the sidebar.

---


### Before

![screenshot-no-scrollbar](https://user-images.githubusercontent.com/19564585/227787353-dc795988-b8fe-4674-920c-ae2112267273.png)

### After


![scrollbar-fixed](https://user-images.githubusercontent.com/19564585/227787799-1656ef9a-fd3b-4345-a6f8-988252772f6a.png)

---

## How did you test this change?

Tested the fix on Google Chrome, Mozilla Firefox and Microsoft Edge.