### PR TITLE
fix(client): make icons in good/bad examples float

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -452,6 +452,7 @@ pre {
     content: "";
     float: right;
     height: 16px;
+    margin-left: 8px;
     width: 16px;
   }
 }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -447,14 +447,11 @@ pre {
   padding: 0 1rem;
   position: relative;
 
-  &::after {
+  &::before {
     background-size: 24px;
     content: "";
-    display: block;
+    float: right;
     height: 16px;
-    position: absolute;
-    right: 16px;
-    top: 18px;
     width: 16px;
   }
 }
@@ -467,7 +464,7 @@ pre {
 .example-bad {
   background-color: var(--background-critical);
 
-  &::after {
+  &::before {
     background-color: var(--icon-critical);
     mask-image: url("../assets/icons/no.svg");
   }
@@ -476,7 +473,7 @@ pre {
 .example-good {
   background-color: var(--background-success);
 
-  &::after {
+  &::before {
     background-color: var(--icon-success);
     mask-image: url("../assets/icons/checkmark.svg");
   }


### PR DESCRIPTION
## Summary

Fixes #7727.

### Problem

This PR fixes the problem that icons in good/bad code examples could overlap with the code content.

### Solution

This PR sets the icons as floated `::before` pseudo-elements to make the content wrap around them.

---

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/97945148/228728617-b6b88e86-a725-4d3a-b98b-c82480b019c4.png)

### After

![after](https://user-images.githubusercontent.com/97945148/228728680-3b5d17df-96b8-49a7-b40b-243c7530b5be.png)