### PR TITLE
fix(client): place hash before headings

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -38,7 +38,6 @@
     a:active {
       background-color: transparent;
     }
-    
     a[href^="#"] {
       &::before {
         color: var(--text-inactive);

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -38,7 +38,7 @@
     a:active {
       background-color: transparent;
     }
-    
+
     a[href^="#"] {
       &::before {
         color: var(--text-inactive);
@@ -51,7 +51,7 @@
         visibility: hidden;
         width: 0.8em;
       }
-      
+
       &:hover {
         &::before {
           visibility: visible;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -50,7 +50,6 @@
         visibility: hidden;
         width: 0.8em;
       }
-      
       &:hover {
         &::before {
           visibility: visible;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -27,7 +27,6 @@
     a:link,
     a:visited {
       color: var(--text-primary);
-      position: relative;
       text-decoration: none;
     }
 
@@ -39,20 +38,24 @@
     a:active {
       background-color: transparent;
     }
-
-    a[href^="#"]:hover {
-      &:before {
-        align-items: center;
-        bottom: 0;
+    
+    a[href^="#"] {
+      &::before {
         color: var(--text-inactive);
         content: "#";
         display: inline-flex;
         font-size: 0.7em;
         line-height: 1;
         margin-left: -0.8em;
-        position: absolute;
         text-decoration: none;
-        top: 0;
+        visibility: hidden;
+        width: 0.8em;
+      }
+      
+      &:hover {
+        &::before {
+          visibility: visible;
+        }
       }
     }
   }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -42,7 +42,7 @@
       &::before {
         color: var(--text-inactive);
         content: "#";
-        display: inline-flex;
+        display: inline-block;
         font-size: 0.7em;
         line-height: 1;
         margin-left: -0.8em;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -38,6 +38,7 @@
     a:active {
       background-color: transparent;
     }
+    
     a[href^="#"] {
       &::before {
         color: var(--text-inactive);
@@ -50,6 +51,7 @@
         visibility: hidden;
         width: 0.8em;
       }
+      
       &:hover {
         &::before {
           visibility: visible;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -27,6 +27,7 @@
     a:link,
     a:visited {
       color: var(--text-primary);
+      position: relative;
       text-decoration: none;
     }
 
@@ -40,14 +41,18 @@
     }
 
     a[href^="#"]:hover {
-      &:after {
+      &:before {
+        align-items: center;
+        bottom: 0;
         color: var(--text-inactive);
         content: "#";
         display: inline-flex;
         font-size: 0.7em;
         line-height: 1;
-        margin-left: 4px;
+        margin-left: -0.8em;
+        position: absolute;
         text-decoration: none;
+        top: 0;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #6647.

### Problem

This PR places the hash in front of section headings to make it stay on the same line.

### Solution

This PR uses absolutely-positioned `::before` pseudo-elements to generate the hash, and `align-items: center` to center it.

Alternative:

Put the hash in `::marker`. (It's less optimal in that `::marker` inherits `text-decoration` from its parent, which cannot be nullified.)

---

## Screenshots

### Before

![before](https://user-images.githubusercontent.com/97945148/228734970-d1c70496-78a0-45e9-b766-2aeaf7026dcb.png)

### After

![after_1](https://user-images.githubusercontent.com/97945148/228897249-34553c8f-322c-46fa-b2c6-5dcc5395220a.png)