### PR TITLE
ci(stage-build): deploy Cloud Function in multiple regions

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -321,30 +321,27 @@ jobs:
       - name: Deploy Function
         run: |-
           for region in europe-west1 us-west1 asia-east1; do
-            gcloud function deploy mdn-nonprod-stage-$region \
+            gcloud functions deploy mdn-nonprod-stage-$region \
             --gen2 \
             --runtime=nodejs18 \
             --region=$region \
             --source=gcp/function \
             --trigger-http \
-            --allow-unathenticated \
+            --allow-unauthenticated \
             --entry-point=mdnHandler \
             --memory=256MB \
             --timeout=60s \
-            --set-env-vars=[\
-              ORIGIN_MAIN=developer.allizom.org,\
-              ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org,\
-              SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/,\
-              SOURCE_RUMBA=https://developer.allizom.org/,\
-            ]\
-            --set-secrets=[\
-              KEVEL_SITE_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-site-id/versions/latest,\
-              KEVEL_NETWORK_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-network-id/versions/latest,\
-              SIGN_SECRET=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-sign-secret/versions/latest,\
-              CARBON_ZONE_KEY=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-carbon-zone-key/versions/latest,\
-              CARBON_FALLBACK_ENABLED=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-fallback-enabled/versions/latest,\
-            ]
-          ; done
+            --set-env-vars="ORIGIN_MAIN=developer.allizom.org" \
+            --set-env-vars="ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org" \
+            --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/" \
+            --set-env-vars="SOURCE_RUMBA=https://developer.allizom.org/" \
+            --set-secrets="KEVEL_SITE_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-site-id/versions/latest" \
+            --set-secrets="KEVEL_NETWORK_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-network-id/versions/latest" \
+            --set-secrets="SIGN_SECRET=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-sign-secret/versions/latest" \
+            --set-secrets="CARBON_ZONE_KEY=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-carbon-zone-key/versions/latest" \
+            --set-secrets="CARBON_FALLBACK_ENABLED=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-fallback-enabled/versions/latest"
+            \
+          done
 
       - name: Slack Notification
         if: failure()

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -298,6 +298,54 @@ jobs:
         run: |-
           gsutil -m -h "Cache-Control:public, max-age=86400" rsync -r client/build gs://content-stage-mdn/main
 
+      # Deploy Function
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          service_account: deploy-stage-nonprod-mdn-ingre@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Build Function
+        working-directory: gcp/function
+        env:
+          CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
+          CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
+        run: |
+          npm ci
+          npm run build
+
+      - name: Deploy Function
+        run: |-
+          for region in europe-west1 us-west1 asia-east1; do
+            gcloud function deploy mdn-nonprod-stage-$region \
+            --gen2 \
+            --runtime=nodejs18 \
+            --region=$region \
+            --source=gcp/function \
+            --trigger-http \
+            --allow-unathenticated \
+            --entry-point=mdnHandler \
+            --memory=256MB \
+            --timeout=60s \
+            --set-env-vars=[\
+              ORIGIN_MAIN=developer.allizom.org,\
+              ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org,\
+              SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/,\
+              SOURCE_RUMBA=https://developer.allizom.org/,\
+            ]\
+            --set-secrets=[\
+              KEVEL_SITE_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-site-id/versions/latest,\
+              KEVEL_NETWORK_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-network-id/versions/latest,\
+              SIGN_SECRET=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-sign-secret/versions/latest,\
+              CARBON_ZONE_KEY=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-carbon-zone-key/versions/latest,\
+              CARBON_FALLBACK_ENABLED=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-fallback-enabled/versions/latest,\
+            ]
+          ; done
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -335,11 +335,11 @@ jobs:
             --set-env-vars="ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org" \
             --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/" \
             --set-env-vars="SOURCE_RUMBA=https://api.developer.allizom.org/" \
-            --set-secrets="KEVEL_SITE_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-site-id/versions/latest" \
-            --set-secrets="KEVEL_NETWORK_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-network-id/versions/latest" \
-            --set-secrets="SIGN_SECRET=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-sign-secret/versions/latest" \
-            --set-secrets="CARBON_ZONE_KEY=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-carbon-zone-key/versions/latest" \
-            --set-secrets="CARBON_FALLBACK_ENABLED=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-fallback-enabled/versions/latest"
+            --set-secrets="KEVEL_SITE_ID=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-kevel-site-id/versions/latest" \
+            --set-secrets="KEVEL_NETWORK_ID=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-kevel-network-id/versions/latest" \
+            --set-secrets="SIGN_SECRET=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-sign-secret/versions/latest" \
+            --set-secrets="CARBON_ZONE_KEY=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-carbon-zone-key/versions/latest" \
+            --set-secrets="CARBON_FALLBACK_ENABLED=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-fallback-enabled/versions/latest"
             \
           done
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -334,7 +334,7 @@ jobs:
             --set-env-vars="ORIGIN_MAIN=developer.allizom.org" \
             --set-env-vars="ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org" \
             --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/" \
-            --set-env-vars="SOURCE_RUMBA=https://developer.allizom.org/" \
+            --set-env-vars="SOURCE_RUMBA=https://api.developer.allizom.org/" \
             --set-secrets="KEVEL_SITE_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-site-id/versions/latest" \
             --set-secrets="KEVEL_NETWORK_ID=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-kevel-network-id/versions/latest" \
             --set-secrets="SIGN_SECRET=projects/${{ secrets.WIP_PROJECT_ID }}/secrets/stage-sign-secret/versions/latest" \

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -333,7 +333,7 @@ jobs:
             --timeout=60s \
             --set-env-vars="ORIGIN_MAIN=developer.allizom.org" \
             --set-env-vars="ORIGIN_LIVE_SAMPLES=yari-demos.developer.allizom.org" \
-            --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/" \
+            --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/content-stage-mdn/main/" \
             --set-env-vars="SOURCE_RUMBA=https://api.developer.allizom.org/" \
             --set-secrets="KEVEL_SITE_ID=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-kevel-site-id/versions/latest" \
             --set-secrets="KEVEL_NETWORK_ID=projects/${{ secrets.GCP_PROJECT_NAME }}/secrets/stage-kevel-network-id/versions/latest" \


### PR DESCRIPTION
# Summary

The existing deploy-cloud-functions GHA is limited to only running CloudFunction V1. This attempts to run the deploy command directly from gcloud instead and deploys the function in multiple regions

Github Issue:
https://github.com/google-github-actions/deploy-cloud-functions/issues/304
