### PR TITLE
ci(stage-build): rsync with -c

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Sync Yari Content
         run: |-
-          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -r client/build gs://content-stage-mdn/main
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -cr client/build gs://content-stage-mdn/main
 
       - name: Slack Notification
         if: failure()


### PR DESCRIPTION
## Summary

### Problem

The GCP deployment is slow, and copying `client/build` currently takes about 100min.

### Solution

Accelerate the storage copy using the `-c` option:

> _Causes the rsync command to compute and compare checksums (instead of comparing mtime) for files if the size of source and destination match. This option increases local disk I/O and run time if either src_url or dst_url are on the local file system._ ([Source](https://cloud.google.com/storage/docs/gsutil/commands/rsync#options))

---

## How did you test this change?

- [Before](https://github.com/mdn/yari/actions/runs/4570234411)
- [After](https://github.com/mdn/yari/actions/runs/4574005117)