### PR TITLE
ci(stage-build): rsync with -j html,json,txt

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Sync Yari Content
         run: |-
-          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -cr client/build gs://content-stage-mdn/main
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -crj html,json,txt client/build gs://content-stage-mdn/main
 
       - name: Slack Notification
         if: failure()


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The GCP deployment is still slow, and copying `client/build` takes longer than it used to take in AWS.

### Solution

Accelerate the storage copy using the `-j` option:

> _Applies gzip transport encoding to any file upload whose extension matches the -j extension list. This is useful when uploading files with compressible content (such as .js, .css, or .html files) because it saves network bandwidth while also leaving the data uncompressed in Cloud Storage._ ([Source](https://cloud.google.com/storage/docs/gsutil/commands/rsync#options))

Note: `json`, `html` and `txt` are by far the most frequent text formats in the build.


```
% find . -type f | sed -e 's/.*\.//' | sort | uniq -c | sort -nr
81115 json
52112 html
40502 txt
2146 png
 276 jpg
 218 svg
  85 gif
  32 map
  21 js
  12 css
   9 gz
   2 xml
   2 woff2
   1 jpeg
   1 ico
```

---

## How did you test this change?

- [Before](https://github.com/mdn/yari/actions/runs/4576126367/jobs/8079843051): 10m/AWS vs 25m/GCP
- [After](https://github.com/mdn/yari/actions/runs/4576144409/jobs/8079885109): 3m/AWS vs 3m/GCP
