### PR TITLE
chore(macros): deprecate htmlattrdef + htmlattrxref macros

### DIFF
--- a/kumascript/macros/htmlattrdef.ejs
+++ b/kumascript/macros/htmlattrdef.ejs
@@ -1,2 +1,7 @@
-<%/* Example: <span class="script">htmlattrdef("placeholder")</span> */%>
+<%
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content
+// 0 occurrences left in en-US
+mdn.deprecated("This macro is deprecated; see https://github.com/orgs/mdn/discussions/347 to learn how to replace it.");
+%>
 <a id="attr-<%=$0%>" class="inline-block" href="#attr-<%=$0%>"><b><code><%=$0%></code></b></a>

--- a/kumascript/macros/htmlattrxref.ejs
+++ b/kumascript/macros/htmlattrxref.ejs
@@ -10,6 +10,12 @@
 // If the element isn't specified, the link is made to the Global Attributes
 // page.
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content
+// 0 occurrences left in en-US
+mdn.deprecated("This macro is deprecated; see https://github.com/orgs/mdn/discussions/347 to learn how to replace it.");
+
+
 var lang = env.locale;
 var url = "";
 

--- a/testing/content/files/en-us/web/bar/index.html
+++ b/testing/content/files/en-us/web/bar/index.html
@@ -12,9 +12,6 @@ tags:
 	<li>{{DOMxRef("bigfoot")}}</li>
 	<li>{{DOMxRef("Bob")}}</li>
 	<li>{{DOMxRef("Blob")}}</li>
-	<li>{{htmlattrxref("href", "bigfoot")}}</li>
-	<li>{{htmlattrxref("href", "anchor")}}</li>
-	<li>{{htmlattrxref("href", "a")}}</li>
 	<li>{{jsxref("bigfoot")}}</li>
 	<li>{{jsxref("Stern_mode")}}</li>
 	<li>{{jsxref("Strict_mode")}}</li>

--- a/testing/content/files/en-us/web/fixable_flaws/index.html
+++ b/testing/content/files/en-us/web/fixable_flaws/index.html
@@ -6,7 +6,6 @@ slug: Web/Fixable_Flaws
 <p>Some macros</p>
 <ul>
   <li>{{CSSxRef('dumber')}}</li>
-  <li>{{htmlattrxref("href", "anchor")}}</li>
   <li>{{CSSxRef("will-never-be-fixable")}}</li>
   <li>{{CSSxRef('dumber')}} second time!</li>
 </ul>

--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -153,7 +153,6 @@ describe("fixing flaws", () => {
     );
     const newRawHtml = fs.readFileSync(regularFile, "utf-8");
     expect(newRawHtml).toContain("{{CSSxRef('number')}}");
-    expect(newRawHtml).toContain('{{htmlattrxref("href", "a")}}');
     // Broken links that get fixed.
     expect(newRawHtml).toContain('href="/en-US/docs/Web/CSS/number"');
     expect(newRawHtml).toContain("href='/en-US/docs/Web/CSS/number'");

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -450,7 +450,7 @@ test("content built bar page", () => {
   // expect(doc.popularity).toBe(0.51);
   // expect(doc.modified).toBeTruthy();
   expect(doc.source).toBeTruthy();
-  expect(doc.flaws.macros).toHaveLength(12);
+  expect(doc.flaws.macros).toHaveLength(10);
   expect(doc.flaws.macros[0].name).toBe("MacroBrokenLinkError");
   expect(doc.flaws.macros[0].macroSource).toBe('{{CSSxRef("bigfoot")}}');
   expect(doc.flaws.macros[0].line).toBe(9);
@@ -474,78 +474,59 @@ test("content built bar page", () => {
   expect(doc.flaws.macros[3].redirectInfo.current).toBe("Bob");
   expect(doc.flaws.macros[3].redirectInfo.suggested).toBe("Blob");
   expect(doc.flaws.macros[4].name).toBe("MacroBrokenLinkError");
-  expect(doc.flaws.macros[4].macroSource).toBe(
-    '{{htmlattrxref("href", "bigfoot")}}'
-  );
+  expect(doc.flaws.macros[4].macroSource).toBe('{{jsxref("bigfoot")}}');
   expect(doc.flaws.macros[4].line).toBe(15);
   expect(doc.flaws.macros[4].column).toBe(6);
   expect(doc.flaws.macros[5].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[5].macroSource).toBe(
-    '{{htmlattrxref("href", "anchor")}}'
-  );
+  expect(doc.flaws.macros[5].macroSource).toBe('{{jsxref("Stern_mode")}}');
   expect(doc.flaws.macros[5].line).toBe(16);
   expect(doc.flaws.macros[5].column).toBe(6);
   expect(doc.flaws.macros[5].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[5].redirectInfo.current).toBe("anchor");
-  expect(doc.flaws.macros[5].redirectInfo.suggested).toBe("a");
-  expect(doc.flaws.macros[6].name).toBe("MacroBrokenLinkError");
-  expect(doc.flaws.macros[6].macroSource).toBe('{{jsxref("bigfoot")}}');
+  expect(doc.flaws.macros[5].redirectInfo.current).toBe("Stern_mode");
+  expect(doc.flaws.macros[5].redirectInfo.suggested).toBe("Strict_mode");
+  expect(doc.flaws.macros[6].name).toBe("MacroRedirectedLinkError");
+  expect(doc.flaws.macros[6].macroSource).toBe('{{jsxref("Flag")}}');
   expect(doc.flaws.macros[6].line).toBe(18);
   expect(doc.flaws.macros[6].column).toBe(6);
+  expect(doc.flaws.macros[6].redirectInfo).toBeDefined();
+  expect(doc.flaws.macros[6].redirectInfo.current).toBe("Flag");
+  expect(doc.flaws.macros[6].redirectInfo.suggested).toBe("Boolean");
   expect(doc.flaws.macros[7].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[7].macroSource).toBe('{{jsxref("Stern_mode")}}');
+  expect(doc.flaws.macros[7].macroSource).toBe("{{ jsxref('Flag') }}");
   expect(doc.flaws.macros[7].line).toBe(19);
   expect(doc.flaws.macros[7].column).toBe(6);
   expect(doc.flaws.macros[7].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[7].redirectInfo.current).toBe("Stern_mode");
-  expect(doc.flaws.macros[7].redirectInfo.suggested).toBe("Strict_mode");
+  expect(doc.flaws.macros[7].redirectInfo.current).toBe("Flag");
+  expect(doc.flaws.macros[7].redirectInfo.suggested).toBe("Boolean");
   expect(doc.flaws.macros[8].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[8].macroSource).toBe('{{jsxref("Flag")}}');
-  expect(doc.flaws.macros[8].line).toBe(21);
+  expect(doc.flaws.macros[8].macroSource).toBe('{{JSXref("Flag")}}');
+  expect(doc.flaws.macros[8].line).toBe(20);
   expect(doc.flaws.macros[8].column).toBe(6);
   expect(doc.flaws.macros[8].redirectInfo).toBeDefined();
   expect(doc.flaws.macros[8].redirectInfo.current).toBe("Flag");
   expect(doc.flaws.macros[8].redirectInfo.suggested).toBe("Boolean");
   expect(doc.flaws.macros[9].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[9].macroSource).toBe("{{ jsxref('Flag') }}");
-  expect(doc.flaws.macros[9].line).toBe(22);
+  expect(doc.flaws.macros[9].macroSource).toBe('{{JSXref("Flag")}}');
+  expect(doc.flaws.macros[9].line).toBe(21);
   expect(doc.flaws.macros[9].column).toBe(6);
   expect(doc.flaws.macros[9].redirectInfo).toBeDefined();
   expect(doc.flaws.macros[9].redirectInfo.current).toBe("Flag");
   expect(doc.flaws.macros[9].redirectInfo.suggested).toBe("Boolean");
-  expect(doc.flaws.macros[10].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[10].macroSource).toBe('{{JSXref("Flag")}}');
-  expect(doc.flaws.macros[10].line).toBe(23);
-  expect(doc.flaws.macros[10].column).toBe(6);
-  expect(doc.flaws.macros[10].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[10].redirectInfo.current).toBe("Flag");
-  expect(doc.flaws.macros[10].redirectInfo.suggested).toBe("Boolean");
-  expect(doc.flaws.macros[11].name).toBe("MacroRedirectedLinkError");
-  expect(doc.flaws.macros[11].macroSource).toBe('{{JSXref("Flag")}}');
-  expect(doc.flaws.macros[11].line).toBe(24);
-  expect(doc.flaws.macros[11].column).toBe(6);
-  expect(doc.flaws.macros[11].redirectInfo).toBeDefined();
-  expect(doc.flaws.macros[11].redirectInfo.current).toBe("Flag");
-  expect(doc.flaws.macros[11].redirectInfo.suggested).toBe("Boolean");
 
   const htmlFile = path.join(builtFolder, "index.html");
   expect(fs.existsSync(htmlFile)).toBeTruthy();
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
-  expect($("a[data-flaw-src]").length).toEqual(12);
+  expect($("a[data-flaw-src]").length).toEqual(10);
 
   const brokenLinks = $("a.page-not-created");
-  expect(brokenLinks.length).toEqual(4);
+  expect(brokenLinks.length).toEqual(3);
   expect(brokenLinks.eq(0).data("flaw-src")).toBe('{{CSSxRef("bigfoot")}}');
   expect(brokenLinks.eq(0).text()).toBe("bigfoot");
   expect(brokenLinks.eq(1).data("flaw-src")).toBe('{{DOMxRef("bigfoot")}}');
   expect(brokenLinks.eq(1).text()).toBe("bigfoot");
-  expect(brokenLinks.eq(2).data("flaw-src")).toBe(
-    '{{htmlattrxref("href", "bigfoot")}}'
-  );
-  expect(brokenLinks.eq(2).text()).toBe("href");
-  expect(brokenLinks.eq(3).data("flaw-src")).toBe('{{jsxref("bigfoot")}}');
-  expect(brokenLinks.eq(3).text()).toBe("bigfoot");
+  expect(brokenLinks.eq(2).data("flaw-src")).toBe('{{jsxref("bigfoot")}}');
+  expect(brokenLinks.eq(2).text()).toBe("bigfoot");
   brokenLinks.each((index, element) => {
     expect($(element).attr("title")).toMatch(
       /The documentation about this has not yet been written/
@@ -565,18 +546,6 @@ test("content built bar page", () => {
   expect(blobLinks.eq(0).data("flaw-src")).toBe('{{DOMxRef("Bob")}}');
   expect(blobLinks.eq(1).text()).toBe("Blob");
   expect(blobLinks.eq(1).data("flaw-src")).toBeFalsy();
-
-  const hrefLinks = $(
-    'a[href="/en-US/docs/Web/HTML/Element/a#attr-href"]:not([title])'
-  );
-  expect(hrefLinks.length).toEqual(2);
-  hrefLinks.each((index, element) => {
-    expect($(element).text()).toBe("href");
-  });
-  expect(hrefLinks.eq(0).data("flaw-src")).toBe(
-    '{{htmlattrxref("href", "anchor")}}'
-  );
-  expect(hrefLinks.eq(1).data("flaw-src")).toBeFalsy();
 
   const strictModeLinks = $(
     'a[href="/en-US/docs/Web/JavaScript/Reference/Strict_mode"]:not([title])'


### PR DESCRIPTION
## Summary

chore: deprecate htmlattrdef and htmlattrxref macro

As a part of: https://github.com/orgs/mdn/discussions/347

~blocked by: mdn/content#25823.~