### PR TITLE
fix(macros/LearnSidebar): remove duplicated accessibility section

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -587,18 +587,7 @@ const sections = [
           "Accessibility/WAI-ARIA_basics",
           "Accessibility/Multimedia",
           "Accessibility/Mobile",
-        ]
-      },
-      {
-        name: "Accessibility_assessment",
-        pages: [
-          "Accessibility/",
-          "Accessibility/What_is_accessibility",
-          "Accessibility/HTML",
-          "Accessibility/CSS_and_JavaScript",
-          "Accessibility/WAI-ARIA_basics",
-          "Accessibility/Multimedia",
-          "Accessibility/Mobile",
+          "Accessibility/Accessibility_troubleshooting",
         ]
       }
     ]


### PR DESCRIPTION

## Summary

Fixes https://github.com/mdn/yari/issues/8552. The lesson pages were duplicated and the assessment page was missing.

### Problem

The sidebar had the main set of lessons twice, and no assessment.

### Solution

This is the simplest solution, in which we just move the assessment page into the module. This is in line with the other modules. It might be nice to split assessments into a different subsection, but that should be a change to all the modules (and might end up with some edge cases).

## Screenshots

### Before

The accessibility section of the sidebar, expanded. Note the duplicated pages.

<img width="975" alt="Screen Shot 2023-04-02 at 3 37 08 PM" src="https://user-images.githubusercontent.com/432915/229391256-e83017e0-0cda-4801-bf41-dc97500062f6.png">

The sidebar when the user is on the accessibility assessment (the sidebar is not scrolled to the page, because the page isn't in the sidebar):

<img width="1189" alt="Screen Shot 2023-04-02 at 3 36 35 PM" src="https://user-images.githubusercontent.com/432915/229391322-d328e5d5-ff5f-412e-b885-8bd345a7e966.png">

### After

The accessibility section of the sidebar, expanded. Only one subsection, no duplicated pages:

<img width="361" alt="Screen Shot 2023-04-02 at 3 37 50 PM" src="https://user-images.githubusercontent.com/432915/229391395-eae73d5f-6743-433a-8ca3-aafe8d320455.png">

The sidebar when the user is on the accessibility assessment (the sidebar is scrolled to the page, now the page is in the sidebar):

<img width="1187" alt="Screen Shot 2023-04-02 at 3 35 51 PM" src="https://user-images.githubusercontent.com/432915/229391454-34342fd6-a792-4d75-8fdf-18b2ea5824a4.png">


## How did you test this change?

Ran yarn dev, looked at:

http://localhost:3000/en-US/docs/Learn/Accessibility/Accessibility_troubleshooting
http://localhost:3000/fr/docs/Learn/Accessibility/Accessibility_troubleshooting