### PR TITLE
chore(csp): remove legacy hosts

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -111,7 +111,6 @@ export const CSP_DIRECTIVES = {
     "interactive-examples.mdn.allizom.net",
     "mdn.github.io",
     "yari-demos.prod.mdn.mozit.cloud",
-    "mdn.mozillademos.org",
     "yari-demos.stage.mdn.mozit.cloud",
 
     "jsfiddle.net",
@@ -131,7 +130,6 @@ export const CSP_DIRECTIVES = {
     "profile.stage.mozaws.net",
     "profile.accounts.firefox.com",
 
-    "mdn.mozillademos.org",
     "media.prod.mdn.mozit.cloud",
     "media.stage.mdn.mozit.cloud",
     "interactive-examples.mdn.mozilla.net",

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -107,7 +107,6 @@ export const CSP_DIRECTIVES = {
     "'self'",
 
     "interactive-examples.mdn.mozilla.net",
-    "interactive-examples.prod.mdn.mozilla.net",
     "interactive-examples.mdn.allizom.net",
     "mdn.github.io",
     "yari-demos.prod.mdn.mozit.cloud",
@@ -133,7 +132,6 @@ export const CSP_DIRECTIVES = {
     "media.prod.mdn.mozit.cloud",
     "media.stage.mdn.mozit.cloud",
     "interactive-examples.mdn.mozilla.net",
-    "interactive-examples.prod.mdn.mozilla.net",
     "interactive-examples.mdn.allizom.net",
 
     "wikipedia.org",


### PR DESCRIPTION
## Summary


### Problem

We no longer host `mdn.mozillademos.org`/`interactive-examples.prod.mdn.mozilla.net`, but they are still included in our CSP.

### Solution

Remove them.

---

## How did you test this change?

Didn't test, but we have disabled those hosts in CloudFront, so requests no longer come through. Removing the hosts from CSP means requests (e.g. from references in mdn/translated-content) will show up as CSP errors in the console rather than just as failed requests.