### PR TITLE
feat(build): collect errors + warnings with @sentry/node

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -219,6 +219,10 @@ jobs:
           # Placement
           REACT_APP_PLACEMENT_ENABLED: true
 
+          # Sentry.
+          SENTRY_DSN_BUILD: ${{ secrets.SENTRY_DSN_BUILD }}
+          SENTRY_ENVIRONMENT: prod
+
         run: |
 
           # Info about which CONTENT_* environment variables were set and to what.

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -222,6 +222,7 @@ jobs:
           # Sentry.
           SENTRY_DSN_BUILD: ${{ secrets.SENTRY_DSN_BUILD }}
           SENTRY_ENVIRONMENT: prod
+          SENTRY_RELEASE: ${{ github.sha }}
 
         run: |
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -216,6 +216,7 @@ jobs:
           # Sentry.
           SENTRY_DSN_BUILD: ${{ secrets.SENTRY_DSN_BUILD }}
           SENTRY_ENVIRONMENT: stage
+          SENTRY_RELEASE: ${{ github.sha }}
 
         run: |
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -213,6 +213,10 @@ jobs:
           # Placement
           REACT_APP_PLACEMENT_ENABLED: true
 
+          # Sentry.
+          SENTRY_DSN_BUILD: ${{ secrets.SENTRY_DSN_BUILD }}
+          SENTRY_ENVIRONMENT: stage
+
         run: |
 
           # Info about which CONTENT_* environment variables were set and to what.

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -14,6 +14,7 @@ import {
   CONTENT_ROOT,
   CONTENT_TRANSLATED_ROOT,
   BUILD_OUT_ROOT,
+  SENTRY_DSN_BUILD,
 } from "../libs/env/index.js";
 import { VALID_LOCALES } from "../libs/constants/index.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -29,6 +30,7 @@ import { DocMetadata, Flaws } from "../libs/types/document.js";
 import SearchIndex from "./search-index.js";
 import { makeSitemapXML, makeSitemapIndexXML } from "./sitemaps.js";
 import { humanFileSize } from "./utils.js";
+import { initSentry } from "./sentry.js";
 
 const { program } = caporal;
 const { prompt } = inquirer;
@@ -339,6 +341,10 @@ interface BuildArgsAndOptions {
     notLocale?: string[];
     sitemapIndex?: boolean;
   };
+}
+
+if (SENTRY_DSN_BUILD) {
+  initSentry(SENTRY_DSN_BUILD);
 }
 
 program

--- a/build/sentry.ts
+++ b/build/sentry.ts
@@ -1,0 +1,12 @@
+import Sentry from "@sentry/node";
+
+export function initSentry(
+  dsn: string,
+  options?: Omit<Sentry.NodeOptions, "dsn">
+) {
+  Sentry.init({
+    dsn,
+    tracesSampleRate: 1.0,
+    ...options,
+  });
+}

--- a/build/sentry.ts
+++ b/build/sentry.ts
@@ -3,10 +3,11 @@ import { CaptureConsole } from "@sentry/integrations";
 
 export function initSentry(
   dsn: string,
-  options?: Omit<Sentry.NodeOptions, "dsn" | "integrations">
+  options?: Omit<Sentry.NodeOptions, "dsn" | "environment" | "integrations">
 ) {
   Sentry.init({
     dsn,
+    environment: process.env.SENTRY_ENVIRONMENT || "dev",
     integrations: [new CaptureConsole({ levels: ["warn", "error", "assert"] })],
     tracesSampleRate: 1.0,
     ...options,

--- a/build/sentry.ts
+++ b/build/sentry.ts
@@ -1,11 +1,13 @@
 import Sentry from "@sentry/node";
+import { CaptureConsole } from "@sentry/integrations";
 
 export function initSentry(
   dsn: string,
-  options?: Omit<Sentry.NodeOptions, "dsn">
+  options?: Omit<Sentry.NodeOptions, "dsn" | "integrations">
 ) {
   Sentry.init({
     dsn,
+    integrations: [new CaptureConsole({ levels: ["warn", "error", "assert"] })],
     tracesSampleRate: 1.0,
     ...options,
   });

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -27,3 +27,4 @@ export const PROXY_HOSTNAME: string;
 export const CONTENT_HOSTNAME: string;
 export const OFFLINE_CONTENT: boolean;
 export const FAKE_V1_API: boolean;
+export const SENTRY_DSN_BUILD: string;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -64,6 +64,8 @@ export const ALWAYS_ALLOW_ROBOTS = JSON.parse(
   process.env.BUILD_ALWAYS_ALLOW_ROBOTS || "false"
 );
 
+export const SENTRY_DSN_BUILD = process.env.SENTRY_DSN_BUILD || "";
+
 // -------
 // content
 // -------

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@mdn/bcd-utils-api": "^0.0.4",
     "@mdn/browser-compat-data": "^5.2.57",
     "@mozilla/glean": "1.4.0",
+    "@sentry/integrations": "^7.51.2",
+    "@sentry/node": "^7.51.2",
     "@use-it/interval": "^1.0.0",
     "@vscode/ripgrep": "^1.15.2",
     "@webref/css": "^5.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,62 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
 
+"@sentry-internal/tracing@7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.51.2.tgz#17833047646426ca71445327018ffcb33506a699"
+  integrity sha512-OBNZn7C4CyocmlSMUPfkY9ORgab346vTHu5kX35PgW5XR51VD2nO5iJCFbyFcsmmRWyCJcZzwMNARouc2V4V8A==
+  dependencies:
+    "@sentry/core" "7.51.2"
+    "@sentry/types" "7.51.2"
+    "@sentry/utils" "7.51.2"
+    tslib "^1.9.3"
+
+"@sentry/core@7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.51.2.tgz#f2c938de334f9bf26f4416079168275832423964"
+  integrity sha512-p8ZiSBxpKe+rkXDMEcgmdoyIHM/1bhpINLZUFPiFH8vzomEr7sgnwRhyrU8y/ADnkPeNg/2YF3QpDpk0OgZJUA==
+  dependencies:
+    "@sentry/types" "7.51.2"
+    "@sentry/utils" "7.51.2"
+    tslib "^1.9.3"
+
+"@sentry/integrations@^7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-7.51.2.tgz#fce58b9ced601c7f93344b508c67c69a9c883f3d"
+  integrity sha512-ZnSptbuDQOoQ13mFX9vvLDfXlbMGjenW2fMIssi9+08B7fD6qxmetkYnWmBK+oEipjoGA//0240Fj8FUvZr0Qg==
+  dependencies:
+    "@sentry/types" "7.51.2"
+    "@sentry/utils" "7.51.2"
+    localforage "^1.8.1"
+    tslib "^1.9.3"
+
+"@sentry/node@^7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.51.2.tgz#3aa8177699a66265081f711f73652b5e37d0dc53"
+  integrity sha512-qtZ2xNVR0ZW+OZWb0Xw0Cdh2QJXOJkXjK84CGC2P4Y6jWrt+GVvwMANPItLT6mAh+ITszTJ5Gk5HHFRpYme5EA==
+  dependencies:
+    "@sentry-internal/tracing" "7.51.2"
+    "@sentry/core" "7.51.2"
+    "@sentry/types" "7.51.2"
+    "@sentry/utils" "7.51.2"
+    cookie "^0.4.1"
+    https-proxy-agent "^5.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.51.2.tgz#cb742f374d9549195f62c462c915adeafed31d65"
+  integrity sha512-/hLnZVrcK7G5BQoD/60u9Qak8c9AvwV8za8TtYPJDUeW59GrqnqOkFji7RVhI7oH1OX4iBxV+9pAKzfYE6A6SA==
+
+"@sentry/utils@7.51.2":
+  version "7.51.2"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.51.2.tgz#2a52ac2cfb00ffd128248981279c0a561b39eccb"
+  integrity sha512-EcjBU7qG4IG+DpIPvdgIBcdIofROMawKoRUNKraeKzH/waEYH9DzCaqp/mzc5/rPBhpDB4BShX9xDDSeH+8c0A==
+  dependencies:
+    "@sentry/types" "7.51.2"
+    tslib "^1.9.3"
+
 "@sidvind/better-ajv-errors@^2.0.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@sidvind/better-ajv-errors/-/better-ajv-errors-2.1.0.tgz#54f4216d2200d60e90ec25c6a27c1ea3afdc6cdf"
@@ -4357,6 +4413,11 @@ cookie@0.5.0, cookie@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+cookie@^0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
+  integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
 
 core-js-compat@^3.25.1:
   version "3.25.5"
@@ -7296,6 +7357,11 @@ imagemin@^8.0.1:
     replace-ext "^2.0.0"
     slash "^3.0.0"
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 immer@^9.0.7:
   version "9.0.15"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.15.tgz#0b9169e5b1d22137aba7d43f8a81a495dd1b62dc"
@@ -8611,6 +8677,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==
+  dependencies:
+    immediate "~3.0.5"
+
 lilconfig@2.1.0, lilconfig@^2.0.5, lilconfig@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
@@ -8679,6 +8752,13 @@ loader-utils@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
   integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
+
+localforage@^1.8.1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.10.0.tgz#5c465dc5f62b2807c3a84c0c6a1b1b3212781dd4"
+  integrity sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -8856,6 +8936,11 @@ lru-cache@^9.0.0, lru-cache@^9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-9.1.1.tgz#c58a93de58630b688de39ad04ef02ef26f1902f1"
   integrity sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
 lz-string@^1.4.4:
   version "1.4.4"
@@ -13217,7 +13302,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We emit a lot of warnings and errors during our yari builds, but we don't actively track them.

### Solution

Adds and configures [Sentry Node](https://docs.sentry.io/platforms/node/) to track `console.warn/error/assert()` calls during our builds.

*Note*: This does **not** enable Sentry for the website.

---

## How did you test this change?

Set `SENTRY_DSN_BUILD` in my `.env` file and ran `yarn build:prepare && yarn build --locale en-us --nohtml web/html`, verifying that some warnings and errors appear in our (internal) [Sentry project](https://mozilla.sentry.io/projects/mdn-yari-build/?project=4504955643428864).