### PR TITLE
chore(client): remove MDN Plus launch banner

### DIFF
--- a/client/src/banners/active-banner.tsx
+++ b/client/src/banners/active-banner.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { ReactComponent as CloseIcon } from "@mdn/dinocons/general/close.svg";
 import { useGA } from "../ga-context";
 import { BannerId } from "./ids";
-import { usePlusUrl } from "../plus/utils";
 import { useGleanClick } from "../telemetry/glean-context";
 import {
   BANNER_MULTIPLE_COLLECTIONS_DISMISSED,
@@ -82,37 +81,6 @@ function useSendCTAEventToGA() {
       eventLabel: "banner",
     });
   };
-}
-
-function PlusLaunchAnnouncementBanner({
-  onDismissed,
-}: {
-  onDismissed: () => void;
-}) {
-  const bannerId = BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
-  const sendCTAEventToGA = useSendCTAEventToGA();
-  const plusUrl = usePlusUrl();
-
-  return (
-    <Banner id={bannerId} onDismissed={onDismissed}>
-      <p className="mdn-cta-copy">
-        <a href={plusUrl} className="mdn-plus">
-          MDN Plus
-        </a>{" "}
-        now available in <span className="underlined">your</span> country!
-        Support MDN <span className="underlined">and</span> make it your own.{" "}
-        <a
-          href="https://hacks.mozilla.org/2022/04/mdn-plus-now-available-in-more-markets"
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() => sendCTAEventToGA(bannerId)}
-        >
-          Learn more
-        </a>{" "}
-        ✨
-      </p>
-    </Banner>
-  );
 }
 
 function PreviewFeaturesBanner({ onDismissed }: { onDismissed: () => void }) {
@@ -211,13 +179,6 @@ export default function ActiveBanner({
   onDismissed: () => void;
 }) {
   switch (id) {
-    case BannerId.PLUS_LAUNCH_ANNOUNCEMENT:
-      return (
-        <>
-          <PlusLaunchAnnouncementBanner onDismissed={onDismissed} />
-        </>
-      );
-
     case BannerId.MULTIPLE_COLLECTIONS:
       return (
         <>

--- a/client/src/banners/index.tsx
+++ b/client/src/banners/index.tsx
@@ -23,7 +23,7 @@ export function Banner() {
     ? NEWSLETTER_ENABLED && !userData?.settings?.mdnplusNewsletter
       ? BannerId.NEWSLETTER_ANNOUNCEMENT
       : BannerId.MULTIPLE_COLLECTIONS
-    : BannerId.PLUS_LAUNCH_ANNOUNCEMENT;
+    : null;
   if (currentBannerId && (CRUD_MODE || !isEmbargoed(currentBannerId))) {
     return (
       <React.Suspense fallback={null}>


### PR DESCRIPTION
## Summary

Resolves MP-321.

### Problem

The MDN Plus launch announcement banner is outdated and links to an outdated blog post.

### Solution

Remove the banner.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="945" alt="image" src="https://user-images.githubusercontent.com/495429/230033082-22fc6e8b-b9e5-4d71-8274-0ec4a817f022.png">

### After

<img width="945" alt="image" src="https://user-images.githubusercontent.com/495429/230033122-dc305920-1a31-42c2-96be-a836b0313b57.png">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/_homepage locally.