### PR TITLE
fix(top-nav): top navigation not sticky

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -53,7 +53,9 @@ function Layout({ pageType, children }) {
           category ? `category-${category}` : ""
         } ${pageType}`}
       >
-        {pageType !== "document-page" && <TopNavigation />}
+        {pageType !== "document-page" && (
+          <TopNavigation extraClasses="main-document-header-container" />
+        )}
         {children}
       </div>
       <Footer />

--- a/client/src/ui/organisms/top-navigation/index.tsx
+++ b/client/src/ui/organisms/top-navigation/index.tsx
@@ -11,7 +11,7 @@ import { useLocation } from "react-router-dom";
 const DARK_NAV_ROUTES = [/\/plus\/?$/i, "_homepage", /^\/?$/];
 const TRANSPARENT_NAV_ROUTES = []; //["_homepage", /\/?$/];
 
-export function TopNavigation() {
+export function TopNavigation({ extraClasses }: { extraClasses?: string }) {
   const location = useLocation();
   const [showMainMenu, setShowMainMenu] = useState(false);
 
@@ -30,7 +30,9 @@ export function TopNavigation() {
 
   return (
     <header
-      className={`top-navigation ${showMainMenu ? "show-nav" : ""}
+      className={`top-navigation ${extraClasses || ""} ${
+        showMainMenu ? "show-nav" : ""
+      }
       ${dark ? " dark" : ""}
       ${transparent ? " is-transparent" : ""}`}
     >


### PR DESCRIPTION
## Summary

Make the top navigation sticky again.

### Problem
#8326 made the top navigation non sticky on non document pages.

### Solution
This is just a quick and dirty fix by adding the class name again. 

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://user-images.githubusercontent.com/3604775/230462375-9baf8791-7c14-4a68-a294-dea0e3de6c47.png)

### After

![image](https://user-images.githubusercontent.com/3604775/230462505-b5405d75-d6a2-4375-b182-ccaaef35ad17.png)

