### PR TITLE
Add "attribute values" guide to MathML sidebar

### DIFF
--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -60,6 +60,7 @@ async function getTitle(pageSlug) {
     <ol>
     <li><a href="/<%=locale%>/docs/Web/MathML/Authoring"><%=await getTitle("Authoring")%></a></li>
     <li><a href="/<%=locale%>/docs/Web/MathML/Fonts"><%=await getTitle("Fonts")%></a></li>
+    <li><a href="/<%=locale%>/docs/Web/MathML/Values"><%=await getTitle("Values")%></a></li>
     </ol>
   </li>
   <li><strong><%=text['Reference']%></strong></li>


### PR DESCRIPTION

## Summary

Add the "MathML Attribute Values" to the nav.

### Problem

The [MathML Attribute Values](https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values) is not visible in the nav.

### Solution

Add it to the MathMLRef macro. Note that this points to the new location of the page (after https://github.com/mdn/content/pull/26093).

Also note that if we supported [weight](https://github.com/orgs/mdn/discussions/124), then we would not have to update sidebars manually in cases like this.

## Screenshots

### Before

<img width="275" alt="Screen Shot 2023-04-10 at 11 10 53 AM" src="https://user-images.githubusercontent.com/432915/230965297-c1bdfe1a-c182-4205-aa1f-a3a9655356bc.png">


### After

<img width="261" alt="Screen Shot 2023-04-10 at 11 10 45 AM" src="https://user-images.githubusercontent.com/432915/230965375-0789a789-808b-43e6-812b-96eaa2d0acbd.png">

