### PR TITLE
fix: Wrap SVG Mandala to reduce CPU usage

### DIFF
--- a/client/src/ui/molecules/mandala/index.scss
+++ b/client/src/ui/molecules/mandala/index.scss
@@ -11,7 +11,7 @@
   display: flex;
   justify-content: center;
 
-  .mandala-rotate > svg {
+  .mandala-rotate > .mandala-svg-container {
     animation: rotation 500s linear infinite;
   }
 

--- a/client/src/ui/molecules/mandala/index.tsx
+++ b/client/src/ui/molecules/mandala/index.tsx
@@ -23,180 +23,188 @@ function Mandala({
           rotate && !animate ? "mandala-rotate" : ""
         }`}
       >
-        <svg
-          width="675"
-          height="675"
-          viewBox="0 0 675 675"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-          className="mandala"
-        >
-          <title>Mandala</title>
-          <defs>
-            <path
-              d="M337.5,337.5 m-320,0 a320,320 0 1,1 640,0 a320,320 0 1,1 -640,0"
-              id="circle1"
-            >
-              {/*<!--<animateMotion dur="20s" repeatCount="indefinite" rotate="auto"
+        <div className="mandala-svg-container">
+          <svg
+            width="675"
+            height="675"
+            viewBox="0 0 675 675"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="mandala"
+          >
+            <title>Mandala</title>
+            <defs>
+              <path
+                d="M337.5,337.5 m-320,0 a320,320 0 1,1 640,0 a320,320 0 1,1 -640,0"
+                id="circle1"
+              >
+                {/*<!--<animateMotion dur="20s" repeatCount="indefinite" rotate="auto"
 				path="M1,1 a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0" />-->*/}
-              {animate && (
-                <animateTransform
-                  attributeName="transform"
-                  begin="0s"
-                  dur="500s"
-                  type="rotate"
-                  from="0 337.5 337.5"
-                  to="360 337.5 337.5"
-                  repeatCount="indefinite"
-                />
-              )}
-            </path>
-            <path
-              d="M337.5,337.5 m-280,0 a280,280 0 1,1 560,0 a280,280 0 1,1 -560,0"
-              id="circle2"
-            >
-              {animate && (
-                <animateTransform
-                  attributeName="transform"
-                  begin="0s"
-                  dur="500s"
-                  type="rotate"
-                  from="360 337.5 337.5"
-                  to="0 337.5 337.5"
-                  repeatCount="indefinite"
-                />
-              )}
-            </path>
-            <path
-              d="M337.5,337.5 m-240,0 a240,240 0 1,1 480,0 a240,240 0 1,1 -480,0"
-              id="circle3"
-            >
-              {animate && (
-                <animateTransform
-                  attributeName="transform"
-                  begin="0s"
-                  dur="500s"
-                  type="rotate"
-                  from="0 337.5 337.5"
-                  to="360 337.5 337.5"
-                  repeatCount="indefinite"
-                />
-              )}
-            </path>
-            <path
-              d="M337.5,337.5 m-200,0 a200,200 0 1,1 400,0 a200,200 0 1,1 -400,0"
-              id="circle4"
-            >
-              {animate && (
-                <animateTransform
-                  attributeName="transform"
-                  begin="0s"
-                  dur="500s"
-                  type="rotate"
-                  from="360 337.5 337.5"
-                  to="0 337.5 337.5"
-                  repeatCount="indefinite"
-                />
-              )}
-            </path>
-            <path
-              d="M337.5,337.5 m-160,0 a160,160 0 1,1 320,0 a160,160 0 1,1 -320,0"
-              id="circle5"
-            >
-              {animate && (
-                <animateTransform
-                  attributeName="transform"
-                  begin="0s"
-                  dur="500s"
-                  type="rotate"
-                  from="0 337.5 337.5"
-                  to="360 337.5 337.5"
-                  repeatCount="indefinite"
-                />
-              )}
-            </path>
-          </defs>
-          <text className="mandala-accent-1" dy="70" textLength="2010">
-            <textPath textLength="2010" href="#circle1">
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-              &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
-              <tspan>/</tspan>
-            </textPath>
-          </text>
-          <text className="mandala-accent-2" dy="70" textLength="1760">
-            <textPath textLength="1760" href="#circle2">
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-              &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
-            </textPath>
-          </text>
-          <text className="mandala-accent-3" dy="70" textLength="1507">
-            <textPath textLength="1507" href="#circle3">
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-              <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
-              <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>&#125;&nbsp;&nbsp;
-            </textPath>
-          </text>
-          <text className="mandala-accent-4" dy="70" textLength="1257">
-            <textPath textLength="1257" href="#circle4">
-              &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
-              &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
-              &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
-              &nbsp;&nbsp;&nbsp;../../
-            </textPath>
-          </text>
-          <text className="mandala-accent-5" dy="70" textLength="1005">
-            <textPath textLength="1005" href="#circle5">
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-              <tspan>&lt;&gt;</tspan>&lt;/&gt;
-            </textPath>
-          </text>
-        </svg>
+                {animate && (
+                  <animateTransform
+                    attributeName="transform"
+                    begin="0s"
+                    dur="500s"
+                    type="rotate"
+                    from="0 337.5 337.5"
+                    to="360 337.5 337.5"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </path>
+              <path
+                d="M337.5,337.5 m-280,0 a280,280 0 1,1 560,0 a280,280 0 1,1 -560,0"
+                id="circle2"
+              >
+                {animate && (
+                  <animateTransform
+                    attributeName="transform"
+                    begin="0s"
+                    dur="500s"
+                    type="rotate"
+                    from="360 337.5 337.5"
+                    to="0 337.5 337.5"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </path>
+              <path
+                d="M337.5,337.5 m-240,0 a240,240 0 1,1 480,0 a240,240 0 1,1 -480,0"
+                id="circle3"
+              >
+                {animate && (
+                  <animateTransform
+                    attributeName="transform"
+                    begin="0s"
+                    dur="500s"
+                    type="rotate"
+                    from="0 337.5 337.5"
+                    to="360 337.5 337.5"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </path>
+              <path
+                d="M337.5,337.5 m-200,0 a200,200 0 1,1 400,0 a200,200 0 1,1 -400,0"
+                id="circle4"
+              >
+                {animate && (
+                  <animateTransform
+                    attributeName="transform"
+                    begin="0s"
+                    dur="500s"
+                    type="rotate"
+                    from="360 337.5 337.5"
+                    to="0 337.5 337.5"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </path>
+              <path
+                d="M337.5,337.5 m-160,0 a160,160 0 1,1 320,0 a160,160 0 1,1 -320,0"
+                id="circle5"
+              >
+                {animate && (
+                  <animateTransform
+                    attributeName="transform"
+                    begin="0s"
+                    dur="500s"
+                    type="rotate"
+                    from="0 337.5 337.5"
+                    to="360 337.5 337.5"
+                    repeatCount="indefinite"
+                  />
+                )}
+              </path>
+            </defs>
+            <text className="mandala-accent-1" dy="70" textLength="2010">
+              <textPath textLength="2010" href="#circle1">
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+                &nbsp;&nbsp;&nbsp;/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>/<tspan>/</tspan>/<tspan>/</tspan>/
+                <tspan>/</tspan>
+              </textPath>
+            </text>
+            <text className="mandala-accent-2" dy="70" textLength="1760">
+              <textPath textLength="1760" href="#circle2">
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+                &nbsp;&nbsp;+<tspan>+</tspan>+<tspan>+</tspan>+<tspan>+</tspan>
+              </textPath>
+            </text>
+            <text className="mandala-accent-3" dy="70" textLength="1507">
+              <textPath textLength="1507" href="#circle3">
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+                <tspan>&#123;</tspan>&#123;<tspan>&#123;</tspan>&#123;&nbsp;
+                <tspan>&#125;</tspan>&#125;<tspan>&#125;</tspan>
+                &#125;&nbsp;&nbsp;
+              </textPath>
+            </text>
+            <text className="mandala-accent-4" dy="70" textLength="1257">
+              <textPath textLength="1257" href="#circle4">
+                &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
+                &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
+                &nbsp;&nbsp;&nbsp;../../ &nbsp;&nbsp;&nbsp;../../
+                &nbsp;&nbsp;&nbsp;../../
+              </textPath>
+            </text>
+            <text className="mandala-accent-5" dy="70" textLength="1005">
+              <textPath textLength="1005" href="#circle5">
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+                <tspan>&lt;&gt;</tspan>&lt;/&gt;
+              </textPath>
+            </text>
+          </svg>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

Closes https://github.com/mdn/yari/issues/8621

## Summary

This wraps the SVG Mandala element in a `<div>` and applies the animation there instead of directly on the SVG.

### Problem

Some changes to CSS properties cause the browser to re-raster the whole SVG. If you go to the MDN as it is today you can see the effect this has on CPU usage. See screenshots below.

### Solution

Browsers can transform SVG without having to re-raster when the transform happens outside the SVG.

## Screenshots

There are no visual changes to the Mandala on the homepage or the Contributor Spotlight section.

### Before

![image](https://user-images.githubusercontent.com/796904/231230608-7fd40649-35d9-4eb0-a2b3-7044dfb1f183.png)

### After

![image](https://user-images.githubusercontent.com/796904/231231615-c31c7c98-4d6c-4264-beee-2c784f0efe8c.png)
