### PR TITLE
fix: prevent `yarn content move` from converting double quotes to single quotes

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -146,7 +146,9 @@ export function saveFile(
   const folderPath = path.dirname(filePath);
   fs.mkdirSync(folderPath, { recursive: true });
 
-  const combined = `---\n${yaml.dump(saveMetadata)}---\n\n${rawBody.trim()}\n`;
+  const combined = `---\n${yaml.dump(saveMetadata, {
+    quotingType: '"',
+  })}---\n\n${rawBody.trim()}\n`;
   fs.writeFileSync(filePath, combined);
 }
 


### PR DESCRIPTION
- Addresses https://github.com/mdn/content/pull/26132#issuecomment-1504575810

## Problem

We prefer double quotes in front-matter YAML to wrap title attributes with special characters.\
At the moment in content repo we have ~5514 double double quotes and only ~147 single quotes.

But the `yarn content move` converts double quotes to singe quotes:
```
title: "AbortSignal: abort() static method"
to
title: 'AbortSignal: abort() static method'
```

This pushes unnecessory changes to the content repo and confuses reviewers.

## Solution

Configure `js-yaml.dump()` method to use double quotes:
```js
yaml.dump(saveMetadata, {quotingType: '"'})}
```

## Testing

Tested `yarn content move` locally with and without the changes.