### PR TITLE
ci(prod-build): sync build with GCS

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -275,6 +275,20 @@ jobs:
           PATHS: /*
         run: aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION" --paths "$PATHS"
 
+      - name: Authenticate with GCP
+        uses: google-github-actions/auth@v1
+        with:
+          token_format: access_token
+          service_account: deploy-prod-content@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
+          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Sync Yari Content
+        run: |-
+          gsutil -m -h "Cache-Control:public, max-age=86400" rsync -crj html,json,txt client/build gs://content-prod-mdn/main
+
       - name: Slack Notification
         if: failure()
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
## Summary

Like https://github.com/mdn/yari/pull/8456, but for prod.

### Problem

We're migrating to GCP, but right now we sync our prod build only to S3.

### Solution

Sync our build to GCS as well.

---

## How did you test this change?

I copied the steps from `stage-build` and replaced "stage" with" build, so as long as IAM permissions etc are set up the same way as for stage, this should work. But even if it doesn't right away, this doesn't have a negative impact on the current deployment in AWS, because the GCP steps come after the AWS steps.