### PR TITLE
fix(sidebar): end of toc cut off

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -642,6 +642,7 @@ kbd {
   max-height: var(--max-height);
   position: sticky;
   top: 5rem;
+  z-index: var(--z-index-top);
   @media screen and (min-width: $screen-md) {
     .sidebar {
       mask-image: linear-gradient(

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -642,7 +642,6 @@ kbd {
   max-height: var(--max-height);
   position: sticky;
   top: 5rem;
-  z-index: var(--z-index-top);
   @media screen and (min-width: $screen-md) {
     .sidebar {
       mask-image: linear-gradient(

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -66,13 +66,6 @@
       display: block;
       grid-area: toc;
       height: fit-content;
-      mask-image: linear-gradient(
-        to bottom,
-        rgba(0, 0, 0, 0) 0%,
-        rgb(0, 0, 0) 10% 90%,
-        rgba(0, 0, 0, 0) 100%
-      );
-      max-height: calc(100vh - var(--offset));
       padding-bottom: 0;
     }
 


### PR DESCRIPTION
fixes https://github.com/mdn/yari/issues/8610

also fixes a z-index issue with the mobile sidebar

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screen Shot 2023-04-13 at 12 15 51](https://user-images.githubusercontent.com/755354/231749336-d1600b5e-bb31-44f9-995f-99daf661a101.png)

![Screen Shot 2023-04-13 at 12 46 40](https://user-images.githubusercontent.com/755354/231749328-b08e7390-daa3-4104-9b49-f54eddb6a777.png)

### After

![Screen Shot 2023-04-13 at 12 16 02](https://user-images.githubusercontent.com/755354/231749330-373c546b-7cdd-4f3b-af28-73bb6a5a22c7.png)

![Screen Shot 2023-04-13 at 12 46 45](https://user-images.githubusercontent.com/755354/231749326-8203aa5c-b7ab-4735-bfc9-332010292979.png)



