### PR TITLE
feat(user-context): show maintenance message if whoami failed

### DIFF
--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
@@ -238,20 +238,14 @@ function OfferDetails({
   );
 }
 
-function isCurrent(
-  user: UserData | null | undefined,
-  subscriptionType: SubscriptionType
-) {
+function isCurrent(user: UserData, subscriptionType: SubscriptionType) {
   if (!user?.isAuthenticated) {
     return false;
   }
   return user.subscriptionType === subscriptionType;
 }
 
-function canUpgrade(
-  user: UserData | null | undefined,
-  subscriptionType: SubscriptionType
-) {
+function canUpgrade(user: UserData, subscriptionType: SubscriptionType) {
   if (!user?.isAuthenticated) {
     return null;
   }

--- a/client/src/ui/atoms/avatar/index.tsx
+++ b/client/src/ui/atoms/avatar/index.tsx
@@ -12,17 +12,17 @@ export const Avatar = ({ userData }: { userData: UserData }) => {
     <>
       <figure
         className={
-          userData.isSubscriber ? "avatar-wrap is-subscriber" : "avatar-wrap"
+          userData?.isSubscriber ? "avatar-wrap is-subscriber" : "avatar-wrap"
         }
       >
         <img
           alt="Avatar"
           className="avatar"
-          src={userData.avatarUrl || avatarImage}
+          src={userData?.avatarUrl || avatarImage}
         />
       </figure>
       <span className="avatar-username visually-hidden">
-        {userData.username}
+        {userData?.username}
       </span>
     </>
   );

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -62,7 +62,7 @@ export class OfflineSettingsData {
   }
 }
 
-export type UserData = {
+export type User = {
   username: string | null | undefined;
   isAuthenticated: boolean;
   isBetaTester: boolean;
@@ -83,9 +83,12 @@ export type UserData = {
   mutate: () => void;
 };
 
-export const UserDataContext = React.createContext<UserData | null | undefined>(
-  undefined
-);
+export type UserData =
+  | User
+  | (Partial<User> & { maintenance: string })
+  | undefined;
+
+export const UserDataContext = React.createContext<UserData>(undefined);
 
 // The argument for using sessionStorage rather than localStorage is because
 // it's marginally simpler and "safer". For example, if we use localStorage
@@ -108,7 +111,7 @@ function getSessionStorageData() {
         // that doesn't match any of the new keys.
         return undefined;
       }
-      return parsed as UserData;
+      return parsed as User;
     }
   } catch (error: any) {
     console.warn("sessionStorage.getItem didn't work", error.toString());
@@ -150,7 +153,7 @@ function removeDeprecatedLocalStorageData() {
   }
 }
 
-function setSessionStorageData(data: UserData) {
+function setSessionStorageData(data: User) {
   try {
     sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(data));
   } catch (error: any) {
@@ -159,51 +162,51 @@ function setSessionStorageData(data: UserData) {
 }
 
 export function UserDataProvider(props: { children: React.ReactNode }) {
-  const { data, error, isLoading, mutate } = useSWR<
-    UserData | null,
-    Error | null
-  >(DISABLE_AUTH ? null : "/api/v1/whoami", async (url) => {
-    const response = await fetch(url);
-    if (!response.ok) {
-      removeSessionStorageData();
-      throw new Error(`${response.status} on ${response.url}`);
-    }
-    const data = await response.json();
-    const collectionLastModified =
-      data?.settings?.collections_last_modified_time;
-    const settings: UserPlusSettings | null = data?.settings
-      ? {
-          collectionLastModified:
-            (collectionLastModified && new Date(collectionLastModified)) ||
-            null,
-          mdnplusNewsletter: data?.settings?.mdnplus_newsletter || null,
-          noAds: data?.settings?.no_ads || null,
-        }
-      : null;
+  const { data, error, isLoading, mutate } = useSWR<User | null, Error | null>(
+    DISABLE_AUTH ? null : "/api/v1/whoami",
+    async (url) => {
+      const response = await fetch(url);
+      if (!response.ok) {
+        removeSessionStorageData();
+        throw new Error(`${response.status} on ${response.url}`);
+      }
+      const data = await response.json();
+      const collectionLastModified =
+        data?.settings?.collections_last_modified_time;
+      const settings: UserPlusSettings | null = data?.settings
+        ? {
+            collectionLastModified:
+              (collectionLastModified && new Date(collectionLastModified)) ||
+              null,
+            mdnplusNewsletter: data?.settings?.mdnplus_newsletter || null,
+            noAds: data?.settings?.no_ads || null,
+          }
+        : null;
 
-    return {
-      username: data.username || null,
-      isAuthenticated: data.is_authenticated || false,
-      isBetaTester: data.is_beta_tester || false,
-      isStaff: data.is_staff || false,
-      isSuperuser: data.is_super_user || false,
-      avatarUrl: data.avatar_url || null,
-      isSubscriber: data.is_subscriber || false,
-      subscriptionType:
-        data.subscription_type === "core"
-          ? SubscriptionType.MDN_CORE
-          : data.subscription_type ?? null,
-      subscriberNumber: data.subscriber_number || null,
-      email: data.email || null,
-      geo: {
-        country: (data.geo && data.geo.country) || DEFAULT_GEO_COUNTRY,
-      },
-      maintenance: data.maintenance,
-      settings,
-      offlineSettings: null,
-      mutate,
-    };
-  });
+      return {
+        username: data.username || null,
+        isAuthenticated: data.is_authenticated || false,
+        isBetaTester: data.is_beta_tester || false,
+        isStaff: data.is_staff || false,
+        isSuperuser: data.is_super_user || false,
+        avatarUrl: data.avatar_url || null,
+        isSubscriber: data.is_subscriber || false,
+        subscriptionType:
+          data.subscription_type === "core"
+            ? SubscriptionType.MDN_CORE
+            : data.subscription_type ?? null,
+        subscriberNumber: data.subscriber_number || null,
+        email: data.email || null,
+        geo: {
+          country: (data.geo && data.geo.country) || DEFAULT_GEO_COUNTRY,
+        },
+        maintenance: data.maintenance,
+        settings,
+        offlineSettings: null,
+        mutate,
+      };
+    }
+  );
 
   React.useEffect(() => {
     removeDeprecatedLocalStorageData();
@@ -238,7 +241,15 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
     }
   }, [data]);
 
-  const userData = isLoading ? getSessionStorageData() : error ? null : data;
+  const userData = isLoading
+    ? getSessionStorageData()
+    : error || !data
+    ? {
+        ...getSessionStorageData(),
+        ...data,
+        maintenance: `The API is down for maintenance. You can continue to browse the MDN Web Docs, but MDN Plus and Search might not be available. Thank you for your patience!`,
+      }
+    : data;
 
   return (
     <UserDataContext.Provider value={userData}>

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,5 +1,6 @@
 import { IEX_DOMAIN } from "./env";
 import { Theme } from "./types/theme";
+import { User } from "./user-context";
 
 const HOMEPAGE_RE = /^\/[A-Za-z-]*\/?(?:_homepage)?$/i;
 const DOCS_RE = /^\/[A-Za-z-]+\/docs\/.*$/i;
@@ -67,7 +68,7 @@ export function switchTheme(theme: Theme, set: (theme: Theme) => void) {
   }
 }
 
-export function isPlusSubscriber(user) {
+export function isPlusSubscriber(user): user is User {
   if (
     user?.isSubscriber &&
     user?.subscriptionType &&

--- a/server/index.ts
+++ b/server/index.ts
@@ -78,28 +78,18 @@ app.use("/bcd", bcdRouter);
 
 // Depending on if FAKE_V1_API is set, we either respond with JSON based
 // on `.json` files on disk or we proxy the requests to Kuma.
+const target = `${
+  ["developer.mozilla.org", "developer.allizom.org"].includes(PROXY_HOSTNAME)
+    ? "https://"
+    : "http://"
+}${PROXY_HOSTNAME}`;
 const proxy = FAKE_V1_API
   ? fakeV1APIRouter
   : createProxyMiddleware({
-      target: `${
-        ["developer.mozilla.org", "developer.allizom.org"].includes(
-          PROXY_HOSTNAME
-        )
-          ? "https://"
-          : "http://"
-      }${PROXY_HOSTNAME}`,
+      target,
       changeOrigin: true,
       // proxyTimeout: 20000,
       // timeout: 20000,
-      onError: (_err, req, res) => {
-        if (req.url === "/api/v1/whoami") {
-          // Fallback if rumba is not running.
-          res.writeHead(200, {
-            "Content-Type": "application/json",
-          });
-          res.end(JSON.stringify({}));
-        }
-      },
     });
 
 const pongProxy = createProxyMiddleware({


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When we migrate to GCP, the API might be temporarily unavailable for a few minutes, but our users won't notice this unless they execute any actions involving the API.

### Solution

Show a maintenance message if the whoami request fails.

---

## Screenshots

### Before

<img width="1537" alt="image" src="https://user-images.githubusercontent.com/495429/231879108-159fbb9e-c491-482e-af55-3d806df8ad10.png">

### After

<img width="1537" alt="image" src="https://user-images.githubusercontent.com/495429/231886016-c326c607-6487-43be-9cec-d94405a216ea.png">

---

## How did you test this change?

Blocked the `/api/v1/whoami` request using DevTools.