### PR TITLE
ci(stage,prod): build all locales concurrently on 4core runner

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -215,19 +215,16 @@ jobs:
 
           yarn tool sync-translated-content
 
-          # Spread the work across 2 processes. Why 2? Because that's
-          # what you get in the default GitHub-hosted Linux runners.
-          # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-          yarn build --locale     en-us --locale     ja --locale     fr &
-          build1=$!
-          yarn build --not-locale en-us --not-locale ja --not-locale fr &
-          build2=$!
+          # Build using one process per locale.
+          # Note: We have 4 cores, but 9 processes is a reasonable number.
+          for locale in en-us es fr ja ko pt-br ru zh-cn zh-tw; do
+            yarn build --locale $locale 2>&1 | sed "s/^/[$locale] /"   &
+            pids+=($!)
+          done
 
-          # You must explicitly specify the job you're waiting-on to ensure
-          # that the exit status of the wait command reflects the exit status
-          # of the job it's waiting-on.
-          wait $build1
-          wait $build2
+          for pid in "${pids[@]}"; do
+            wait $pid
+          done
 
           du -sh client/build
 

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -56,7 +56,7 @@ jobs:
       contents: read
       id-token: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4core
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -56,7 +56,7 @@ jobs:
       contents: read
       id-token: write
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4core
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -210,19 +210,16 @@ jobs:
 
           yarn tool sync-translated-content
 
-          # Spread the work across 2 processes. Why 2? Because that's what you
-          # get in the default GitHub hosting Linux runners.
-          # See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-          yarn build --locale     en-us --locale     ja --locale     fr &
-          build1=$!
-          yarn build --not-locale en-us --not-locale ja --not-locale fr &
-          build2=$!
+          # Build using one process per locale.
+          # Note: We have 4 cores, but 9 processes is a reasonable number.
+          for locale in en-us es fr ja ko pt-br ru zh-cn zh-tw; do
+            yarn build --locale $locale 2>&1 | sed "s/^/[$locale] /"   &
+            pids+=($!)
+          done
 
-          # You must explicitly specify the job you're waiting-on to ensure
-          # that the exit status of the wait command reflects the exit status
-          # of the job it's waiting-on.
-          wait $build1
-          wait $build2
+          for pid in "${pids[@]}"; do
+            wait $pid
+          done
 
           du -sh client/build
 


### PR DESCRIPTION
## Summary

### Problem

Our builds are regularly slow, because we have been limited to 2core runners with varying CPU performance.

### Solution

1. Use a 4core runner (large runner).
2. Build all locales (9) concurrently.

---

## How did you test this change?

The xyz environment (in https://github.com/mdn/yari/pull/8366) has been built like this for about 2 weeks already.