### PR TITLE
KS Macros: Remove fx differentiators from sidebar as a companion of mdn/content#26242

### DIFF
--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -57,7 +57,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Interact with the clipboard',
     'WebExtensions/Extending_the_developer_tools': 'Extending the developer tools',
     'WebExtensions/Build_a_cross_browser_extension': 'Build a cross-browser extension',
-    'WebExtensions/Firefox_differentiators': 'Firefox differentiators',
     'WebExtensions#Firefox_workflow': 'Firefox workflow',
     'WebExtensions/Development_Tools': 'Developer tools',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Choose a Firefox version',
@@ -132,7 +131,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Interagir avec le presse-papier',
     'WebExtensions/Extending_the_developer_tools': 'Extension des outils de développement',
     'WebExtensions/Build_a_cross_browser_extension': 'Construire une extension pour les différents navigateurs',
-    'WebExtensions/Firefox_differentiators': 'Différences de Firefox',
     'WebExtensions#Firefox_workflow': 'Procédé de production avec Firefox',
     'WebExtensions/Development_Tools': 'Outils de développement',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Choisir une version de Firefox',
@@ -207,7 +205,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'クリップボードとのやりとり',
     'WebExtensions/Extending_the_developer_tools': 'developer tools の拡張',
     'WebExtensions/Build_a_cross_browser_extension': 'Build a cross-browser extension',
-    'WebExtensions/Firefox_differentiators': 'Firefox differentiators',
     'WebExtensions#Firefox_workflow': 'Firefox でのワークフロー',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Choose a Firefox version',
     'WebExtensions/User_experience_best_practices': 'ユーザー体験の成功事例',
@@ -281,7 +278,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Interact with the clipboard',
     'WebExtensions/Extending_the_developer_tools': 'Extending the developer tools',
     'WebExtensions/Build_a_cross_browser_extension': 'Build a cross-browser extension',
-    'WebExtensions/Firefox_differentiators': 'Firefox의 차별화',
     'WebExtensions/API': 'JavaScript APIs',
     'WebExtensions/manifest.json': 'Manifest 키',
     'WebExtensions/manifest.json_intro': '소개',
@@ -342,7 +338,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Extending_the_developer_tools': '扩展开发人员工具',
     'WebExtensions/Build_a_cross_browser_extension': '构建跨浏览器扩展',
     'WebExtensions#Porting': '移植',
-    'WebExtensions/Firefox_differentiators': 'Firefox的优势',
     'WebExtensions/API': 'JavaScript APIs',
     'WebExtensions/manifest.json': 'Manifest keys',
     'WebExtensions/manifest.json_intro': '介绍',
@@ -402,7 +397,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Interact with the clipboard',
     'WebExtensions/Extending_the_developer_tools': 'Extending the developer tools',
     'WebExtensions/Build_a_cross_browser_extension': 'Crie uma extensão para vários navegadores',
-    'WebExtensions/Firefox_differentiators': 'Diferenciadores do Firefox',
     'WebExtensions#Firefox_workflow': 'Fluxo de trabalho do Firefox',
     'WebExtensions/Development_Tools': 'Ferramentas de desenvolvimento',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Escolha uma versão do Firefox',
@@ -477,7 +471,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Interactuar con el portapapeles',
     'WebExtensions/Extending_the_developer_tools': 'Extending the developer tools',
     'WebExtensions/Build_a_cross_browser_extension': 'Cree una extensión multinavegador',
-    'WebExtensions/Firefox_differentiators': 'Diferenciadores de Firefox',
     'WebExtensions#Firefox_workflow': 'Flujo de trabajo de Firefox',
     'WebExtensions/Development_Tools': 'Herramientas de desarrollo',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Elige una versión de Firefox',
@@ -552,7 +545,6 @@ var text = mdn.localStringMap({
     'WebExtensions/Interact_with_the_clipboard': 'Работа с буфером обмена',
     'WebExtensions/Extending_the_developer_tools': 'Extending the developer tools',
     'WebExtensions/Build_a_cross_browser_extension': 'Build a cross-browser extension',
-    'WebExtensions/Firefox_differentiators': 'Firefox differentiators',
     'WebExtensions#Firefox_workflow': 'Firefox workflow',
     'WebExtensions/Development_Tools': 'Developer tools',
     'WebExtensions/Choose_a_Firefox_version_for_web_extension_develop': 'Choose a Firefox version',
@@ -656,7 +648,6 @@ var text = mdn.localStringMap({
         </ol>
       </details>
     </li>
-    <li><a href="<%=baseURL%>WebExtensions/Firefox_differentiators"><%=text['WebExtensions/Firefox_differentiators']%></a></li>
     <li class="toggle">
       <details <%=currentPageIsUnder('WebExtensions/API')%>>
         <summary><%=text['WebExtensions/API']%></summary>


### PR DESCRIPTION
## Summary

This goes hand in hand with mdn/content#26242

### Problem

mdn/content#26242 removes an article. An existing KS sidebar has a ref to said article.

### Solution

Update sidebar

## How did you test this change?

I did not apart from running `yarn dev` and checking the corresponding pages.
![image](https://user-images.githubusercontent.com/2413436/232383286-90c4beba-9986-49fd-be91-1c5902a7033e.png)
