### PR TITLE
chore(libs/pong): add TypeScript definitions

### DIFF
--- a/libs/pong/cc2ip.d.ts
+++ b/libs/pong/cc2ip.d.ts
@@ -1,0 +1,1 @@
+export default function anonymousIpByCC(countryCode: any): any;

--- a/libs/pong/cc2ip.d.ts
+++ b/libs/pong/cc2ip.d.ts
@@ -1,1 +1,1 @@
-export default function anonymousIpByCC(countryCode: any): any;
+export default function anonymousIpByCC(countryCode: string): string;

--- a/libs/pong/click.d.ts
+++ b/libs/pong/click.d.ts
@@ -1,0 +1,4 @@
+export function createPongClickHandler(coder: any): (params: any) => Promise<{
+  status: number;
+  location: string;
+}>;

--- a/libs/pong/click.d.ts
+++ b/libs/pong/click.d.ts
@@ -1,4 +1,8 @@
-export function createPongClickHandler(coder: any): (params: any) => Promise<{
+import { Coder } from "./coding.js";
+
+export function createPongClickHandler(coder: Coder): (
+  params: URLSearchParams
+) => Promise<{
   status: number;
   location: string;
 }>;

--- a/libs/pong/coding.d.ts
+++ b/libs/pong/coding.d.ts
@@ -10,5 +10,5 @@ export class Coder {
    */
   signSecret: string;
   encodeAndSign(s?: string): string;
-  decodeAndVerify(tuple?: string): string;
+  decodeAndVerify(tuple?: string): string | null;
 }

--- a/libs/pong/coding.d.ts
+++ b/libs/pong/coding.d.ts
@@ -1,0 +1,14 @@
+export class Coder {
+  /**
+   * Create a Coder to en/decode and sign/verify fields.
+   * @param {string} signSecret - The signing secret.
+   */
+  constructor(signSecret: string);
+  /**
+   * The signing secret.
+   * @type {string}
+   */
+  signSecret: string;
+  encodeAndSign(s?: string): string;
+  decodeAndVerify(tuple?: string): string;
+}

--- a/libs/pong/fallback.d.ts
+++ b/libs/pong/fallback.d.ts
@@ -1,12 +1,14 @@
+import { Coder } from "./coding.js";
+
 export function fallbackHandler(
-  coder: any,
-  carbonZoneKey: any,
-  userAgent: any,
-  anonymousIp: any
+  coder: Coder,
+  carbonZoneKey: string,
+  userAgent: string,
+  anonymousIp: string
 ): Promise<{
-  click: any;
-  view: any;
-  image: any;
-  copy: any;
-  by: any;
+  click: string;
+  view: string;
+  image: string;
+  copy: string;
+  by: string;
 }>;

--- a/libs/pong/fallback.d.ts
+++ b/libs/pong/fallback.d.ts
@@ -1,0 +1,12 @@
+export function fallbackHandler(
+  coder: any,
+  carbonZoneKey: any,
+  userAgent: any,
+  anonymousIp: any
+): Promise<{
+  click: any;
+  view: any;
+  image: any;
+  copy: any;
+  by: any;
+}>;

--- a/libs/pong/get.d.ts
+++ b/libs/pong/get.d.ts
@@ -1,0 +1,12 @@
+export function createPongGetHandler(
+  client: any,
+  coder: any,
+  env: any
+): (
+  body: any,
+  countryCode: any,
+  userAgent: any
+) => Promise<{
+  statusCode: number;
+  payload: any;
+}>;

--- a/libs/pong/get.d.ts
+++ b/libs/pong/get.d.ts
@@ -1,12 +1,34 @@
+import { Client } from "@adzerk/decision-sdk";
+import { Coder } from "./coding.js";
+
+type Payload =
+  | {
+      click: string;
+      view: string;
+      fallback: {
+        click: string;
+        view: string;
+        image: string;
+        copy: string;
+        by: string;
+      };
+    }
+  | {
+      copy: string;
+      image: string;
+      click: string;
+      view: string;
+    };
+
 export function createPongGetHandler(
-  client: any,
-  coder: any,
-  env: any
+  client: Client,
+  coder: Coder,
+  env: { KEVEL_SITE_ID: number; KEVEL_NETWORK_ID: number; SIGN_SECRET: string }
 ): (
-  body: any,
-  countryCode: any,
-  userAgent: any
+  body: string,
+  countryCode: string,
+  userAgent: string
 ) => Promise<{
   statusCode: number;
-  payload: any;
+  payload: Payload;
 }>;

--- a/libs/pong/image.d.ts
+++ b/libs/pong/image.d.ts
@@ -1,4 +1,4 @@
-export function fetchImage(src: any): Promise<{
+export function fetchImage(src: string): Promise<{
   buf: ArrayBuffer;
   contentType: string;
 }>;

--- a/libs/pong/image.d.ts
+++ b/libs/pong/image.d.ts
@@ -1,0 +1,4 @@
+export function fetchImage(src: any): Promise<{
+  buf: ArrayBuffer;
+  contentType: string;
+}>;

--- a/libs/pong/index.d.ts
+++ b/libs/pong/index.d.ts
@@ -1,0 +1,6 @@
+export * from "./coding.js";
+export * from "./get.js";
+export * from "./image.js";
+export * from "./click.js";
+export * from "./viewed.js";
+export * from "./fallback.js";

--- a/libs/pong/viewed.d.ts
+++ b/libs/pong/viewed.d.ts
@@ -1,0 +1,3 @@
+export function createPongViewedHandler(
+  coder: any
+): (params: any) => Promise<void>;

--- a/libs/pong/viewed.d.ts
+++ b/libs/pong/viewed.d.ts
@@ -1,3 +1,5 @@
+import { Coder } from "./coding.js";
+
 export function createPongViewedHandler(
-  coder: any
-): (params: any) => Promise<void>;
+  coder: Coder
+): (params: URLSearchParams) => Promise<void>;


### PR DESCRIPTION
## Summary

Extracted from https://github.com/mdn/yari/pull/8366.

### Problem

The `libs/pong` cannot be used in our Cloud Function, because it doesn't have any TypeScript definitions.

### Solution

Add the TypeScript definitions.

---

## How did you test this change?

Just extracted, so it shouldn't break anything.