### PR TITLE
Remove original_slug from frontmatter keys

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -114,7 +114,6 @@ export function saveFile(
     "tags",
     "translation_of",
     "translation_of_original",
-    "original_slug",
     "browser-compat",
   ];
 

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -165,7 +165,6 @@ export interface DocFrontmatter {
   quote?: any;
   title?: string;
   slug?: string;
-  original_slug?: string;
 }
 
 export type Section = ProseSection | SpecificationsSection | BCDSection;

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -213,7 +213,6 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
   );
   if (status.moved) {
     moveContent(path.dirname(inFilePath), folderPath);
-    metadata.original_slug = oldMetadata.slug;
   }
   Document.saveFile(filePath, Document.trimLineEndings(rawBody), metadata);
 


### PR DESCRIPTION
This PR removes the code that sets `original_slug` when synchronizing translated content.  This frontmatter key is not used anywhere.
