### PR TITLE
fix(cloud-function): fix fxa webhooks

### DIFF
--- a/cloud-function/src/app.ts
+++ b/cloud-function/src/app.ts
@@ -25,7 +25,7 @@ router.all(
   handleStripePlans
 );
 router.all(
-  ["/api/*", "/admin-api/*", "/events/fxa/*", "/users/fxa/*"],
+  ["/api/*", "/admin-api/*", "/events/fxa", "/users/fxa/*"],
   requireOrigin(Origin.main),
   proxyApi
 );


### PR DESCRIPTION
## Summary

Fix 404 for fxa webhooks

### Problem

We are proxying `/events/fxa/*` but the path is `/events/fxa`.

### Solution

Proxy `/events/fxa`

