### PR TITLE
fix(ci): increase memory limit to avoid OOM error

### DIFF
--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -35,5 +35,6 @@ jobs:
       - name: Unit testing kumascript
         env:
           CONTENT_ROOT: testing/content/files
+          NODE_OPTIONS: --max_old_space_size=4096
         run: |
           yarn test:kumascript


### PR DESCRIPTION
## Summary

We just got many OOM error for kumascript testing:

- https://github.com/mdn/yari/actions/runs/4797272322/jobs/8534064012
- https://github.com/mdn/yari/actions/runs/4797255309/jobs/8534025788
- etc.

This memory limitation seens to be `2048M`.

try to increase memory limit to avoid OOM error (actions/runner-images#70)

### Solution

Use environment variable `NODE_OPTIONS=--max_old_space_size=4096` to increate the memory limitation.

---

## How did you test this change?

None.
