### PR TITLE
fix(jest): reduce memory usage

### DIFF
--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -14,6 +14,8 @@ on:
     paths:
       - kumascript/**
       - .github/workflows/pr-kumascript.yml
+      - jest.config.json
+      - package.json
       - yarn.lock
 
 jobs:

--- a/jest.config.json
+++ b/jest.config.json
@@ -10,6 +10,7 @@
       "ts-jest",
       {
         "babelConfig": true,
+        "isolatedModules": true,
         "useESM": true
       }
     ]

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "filecheck": "ts-node filecheck/cli.ts",
     "install:all": "find . -mindepth 2 -name 'yarn.lock' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -0 sh -cx 'yarn --cwd $(dirname $0) install'",
     "install:all:npm": "find . -mindepth 2 -name 'package-lock.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -0 sh -cx 'npm --prefix $(dirname $0) install'",
-    "jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "jest": "node --experimental-vm-modules --expose-gc ./node_modules/.bin/jest --logHeapUsage",
     "m2h": "ts-node markdown/m2h/cli.ts",
     "prepack": "yarn build:dist",
     "prepare": "husky install && yarn install:all && yarn install:all:npm",


### PR DESCRIPTION
## Summary

(MP-363)

### Problem

The kumascript unit tests are failing since April, because they're reaching the maximum heap size.

### Solution

1. Combine `node --expose-gc` with `jest --logHeapUsage` to regularly collect garbage.
1. Enable ts-jest's `isolateModules` option.
1. (Make sure that the kumascript unit test runs if `jest.config.json` or `package.json` change.)

---

## How did you test this change?

- Before: https://github.com/mdn/yari/actions/runs/4862602408/jobs/8669188317
- After: https://github.com/mdn/yari/actions/runs/4876600693/jobs/8700289580