### PR TITLE
ci(dependabot): enable for /cloud-function + /lib/{locale-utils,pong}

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,24 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: npm
+    directory: "/cloud-function"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: "/lib/locale-utils"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
+    directory: "/lib/pong"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: npm
     directory: "/lib/slug-utils"
     schedule:
       interval: daily


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Dependabot doesn't currently update dependencies in all folders.

### Solution

Enable it also for these folders:

- `/cloud-function` (MP-361)
- `/lib/locale-utils`
- `/lib/pong`

---

## How did you test this change?

Hard to test, but I just duplicated and adjusted the config from `/lib/slug-utils`.