### PR TITLE
fix(ci): limit failing CI from running on forks

### DIFF
--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -8,4 +8,5 @@ on:
 
 jobs:
   glean-probe-scraper:
+    if: github.repository == 'mdn/yari'
     uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.triggering_actor != 'dependabot[bot]'
+    if: github.repository == 'mdn/yari' && github.triggering_actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If I synchronize my Yari fork, the following CI runs and fails:

![image](https://user-images.githubusercontent.com/43580235/236232423-4fb93314-709a-43ff-bbb7-13600fc184be.png)


This PR limits only those failing to only run on `mdn/yari` repos