### PR TITLE
chore(tool): print error.stack if error.message is empty

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -236,7 +236,11 @@ function tryOrExit<T extends ActionParameters>(
       await f({ options, ...args } as T);
     } catch (e) {
       const error = e as Error;
-      if (options.verbose || options.v) {
+      if (
+        options.verbose ||
+        options.v ||
+        (error instanceof Error && !error.message)
+      ) {
         console.error(chalk.red(error.stack));
       }
       throw error;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Sometimes `yarn tool spas` fails with an error message that is not very helpful:

```
$ ts-node tool/cli.ts spas
(node:13884) ExperimentalWarning: Import assertions are not a stable feature of the JavaScript language. Avoid relying on their current behavior and syntax as those might change in a future version of Node.js.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:13884) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time

error: 

error Command failed with exit code 1.
```

This happens when the `Error` has an empty `message`.

(Note: That `yarn tool spas --verbose` always prints the Error stack before the message.)

### Solution

Print the Error stack if the Error message is empty.

---

## Screenshots


### Before

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/495429/236247562-49d2ab9a-0b97-4bbf-a49c-2e8199a60fd2.png">

### After

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/495429/236247467-905e81cc-6d69-4767-84be-bb05113365a5.png">

---

## How did you test this change?

Ran `yarn tool spas` while it was failing systematically locally.