### PR TITLE
chore(macros/PWASidebar): add sharing how-to article

### DIFF
--- a/kumascript/macros/PWASidebar.ejs
+++ b/kumascript/macros/PWASidebar.ejs
@@ -33,6 +33,7 @@ const sidebar = {
         "/docs/Web/Progressive_web_apps/How_to/Create_a_standalone_app",
         "/docs/Web/Progressive_web_apps/How_to/Customize_your_app_colors",
         "/docs/Web/Progressive_web_apps/How_to/Display_badge_on_app_icon",
+        "/docs/Web/Progressive_web_apps/How_to/Share_data_between_apps",
       ],
     },
     {


### PR DESCRIPTION
## Summary

This PR adds an item to the new PWA sidebar to reference an article about sharing data between web apps. The article is being added in this PR: https://github.com/mdn/content/pull/25537 which will need to be merged before this one is.

### Problem

Without an entry in the sidebar, the new article isn't discoverable.

### Solution

Adding a new item in the sidebar.
---

## Screenshots

![image](https://user-images.githubusercontent.com/1152698/236254085-1a1f3135-2efb-4840-928f-2b638d3e222f.png)

## How did you test this change?

I'm unable to test locally, I keep getting issues when trying to set the local dev environment on Windows.