### PR TITLE
ci(npm-publish): migrate from merge-release to release-please

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,32 +5,38 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
-    if: github.repository == 'mdn/yari' && github.triggering_actor != 'dependabot[bot]'
+    if: github.repository == 'mdn/yari'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: google-github-actions/release-please-action@v3
+        id: release
         with:
-          # Needs to be a bit more than 1 otherwise it might fail to push
-          # a new tag.
-          # With `fetch-depth: 1` which is the default you might get
-          # [remote rejected]   v0.x.x -> v0.x.y (shallow update not allowed)
-          # in the GitHub Action.
-          # So not sure what the number is but let's try something beyond 1.
-          fetch-depth: 10
+          release-type: node
+          package-name: release-please-action
+
+      - uses: actions/checkout@v3
+        if: steps.release.outputs.release_created
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
+        if: steps.release.outputs.release_created
         with:
           node-version: 18
           cache: yarn
 
       - name: Install all yarn packages
+        if: steps.release.outputs.release_created
         run: yarn --frozen-lockfile
 
       - name: Build the build
+        if: steps.release.outputs.release_created
         env:
           # What this does is it makes sure the built client is made for
           # doing CRUD work (e.g. previewing, toolbar, flaws UI, etc)
@@ -48,15 +54,14 @@ jobs:
           # so you have to set it to something. So let's (ab)use the content
           # we use for the end-to-end testing.
           CONTENT_ROOT: testing/content/files
-        run: |
-          yarn build:prepare
+        run: yarn build:prepare
 
       - name: Dry-run publish to see which files are included
-        run: |
-          npm publish --access public --dry-run
+        if: steps.release.outputs.release_created
+        run: npm publish --dry-run
 
       - name: Publish to npmjs
-        uses: mikeal/merge-release@master
+        if: steps.release.outputs.release_created
+        run: npm publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-385)

### Problem

The [mikeal/merge-release](https://github.com/mikeal/merge-release) no longer works.

### Solution

Migrate to the [release-please-action](https://github.com/google-github-actions/release-please-action).

**Note**: This means we no longer create a tag/release on every merge to main.

---

## How did you test this change?

Hard to test, but we have done this before for Rumba in https://github.com/mdn/rumba/pull/186.
