### PR TITLE
ci(commit-signatures): use base.sha in instructions

### DIFF
--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -38,7 +38,7 @@ jobs:
           echo ''
           echo 'Once you have set up commit signatures, you can sign your existing commits:'
           echo ''
-          echo '  git rebase main --exec "git commit --amend --gpg-sign --no-edit"'
+          echo '  git rebase ${{ github.event.pull_request.base.sha }} --exec "git commit --amend --gpg-sign --no-edit"'
           echo ''
           echo 'Then you will need to force-push your branch once:'
           echo ''


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

If a PR contains unverified/unsigned commits, the "Commit signatures" check fails and suggests to run `git rebase main ...`. However, this can cause problems if the local `main` is behind the PR branch.

### Solution

Suggest rebasing on the `base.sha` instead, which is (normally) the parent commit of the first PR commit.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
