### PR TITLE
chore(deps-dev): bump @types/node from 16.18.25 to 18.16.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "@types/imagemin": "^8.0.1",
     "@types/jest": "^29.5.1",
     "@types/mdast": "^3.0.11",
-    "@types/node": "^16.18.27",
+    "@types/node": "^18.16.6",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@types/react-modal": "^3.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2500,10 +2500,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.32.tgz#8074f7106731f1a12ba993fe8bad86ee73905014"
   integrity sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==
 
-"@types/node@^16.18.27":
-  version "16.18.27"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.27.tgz#d515767a4a7bc44eaec336ac7ff1bde338a17704"
-  integrity sha512-GFfndd/RINWD19W+xNJ9Qh/sOZ5ieTiOSagA86ER/12i/l+MEnQxsbldGRF23azWjRfe7zUlAldyrwN84a1E5w==
+"@types/node@^18.16.6":
+  version "18.16.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.6.tgz#d0ffffe201b253989b17ea157ddabec677a4f4fe"
+  integrity sha512-N7KINmeB8IN3vRR8dhgHEp+YpWvGFcpDoh5XZ8jB5a00AdFKCKEyyGTOPTddUf4JqU1ZKTVxkOxakDvchNVI2Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
(It seems like Dependabot omits this major version bump.)