### PR TITLE
fix(layout): consolidate sticky header

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -71,6 +71,8 @@
       .sidebar,
       .top-navigation-main,
       .page-footer,
+      .top-banner,
+      .place,
       ul.prev-next,
       .language-menu {
         display: none !important;

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -94,16 +94,16 @@
 
   /* Major Components */
   --top-nav-height: 4rem;
-  --article-actions-bar-height: 2rem;
+  --article-actions-container-height: 2rem;
   --icon-size: 1rem;
   --sticky-header-height: calc(
-    var(--top-nav-height) + var(--article-actions-bar-height) + 2px
+    var(--top-nav-height) + var(--article-actions-container-height) + 2px
   );
 }
 
 .top-banner.visible ~ * {
   --sticky-header-height: calc(
-    var(--top-nav-height) + var(--article-actions-bar-height) +
+    var(--top-nav-height) + var(--article-actions-container-height) +
       var(--top-banner-height) + 2px
   );
 }

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -93,10 +93,19 @@
   --form-elem-height: 2rem;
 
   /* Major Components */
-  --sticky-header-height: 0;
   --top-nav-height: 4rem;
-  --main-document-header-height: 6rem;
+  --article-actions-bar-height: 2rem;
   --icon-size: 1rem;
+  --sticky-header-height: calc(
+    var(--top-nav-height) + var(--article-actions-bar-height) + 2px
+  );
+}
+
+.top-banner.visible ~ * {
+  --sticky-header-height: calc(
+    var(--top-nav-height) + var(--article-actions-bar-height) +
+      var(--top-banner-height) + 2px
+  );
 }
 
 @media screen and (min-width: $screen-md) {

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -129,6 +129,11 @@ export function useStickyHeaderHeight() {
       // SSR.
       return 0;
     }
+    const sidebar = document.querySelector(".sidebar-container");
+
+    if (sidebar) {
+      return parseFloat(getComputedStyle(sidebar).top);
+    }
 
     const styles = getComputedStyle(document.documentElement);
     const stickyHeaderHeight = styles

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -4,10 +4,6 @@
 @use "../ui/molecules/grids/grids.scss" as *;
 @use "../ui/base/typography" as *;
 
-:root {
-  --sticky-header-height: var(--main-document-header-height);
-}
-
 .main-document-header-container {
   position: sticky;
   top: 0;
@@ -630,13 +626,13 @@ kbd {
 }
 
 .sidebar-container {
-  --offset: var(--main-document-header-height);
+  --offset: var(--sticky-header-height);
   --max-height: calc(100vh - var(--offset));
 
   @media screen and (max-width: $screen-lg) {
     .mdn-cta-container ~ .document-page & {
       // minus 3 rem to ~ account for the top banner
-      --offset: calc(var(--main-document-header-height) + 3rem);
+      --offset: calc(var(--sticky-header-height) + 3rem);
     }
   }
 
@@ -646,7 +642,7 @@ kbd {
   }
   max-height: var(--max-height);
   position: sticky;
-  top: 5rem;
+  top: var(--offset);
   @media screen and (min-width: $screen-md) {
     .sidebar {
       mask-image: linear-gradient(
@@ -670,7 +666,7 @@ kbd {
       display: flex;
       flex-direction: column;
       gap: 0;
-      height: calc(100vh - var(--main-document-header-height));
+      height: calc(100vh - var(--sticky-header-height));
       mask-image: linear-gradient(
         to bottom,
         rgba(0, 0, 0, 0) 0%,
@@ -679,7 +675,7 @@ kbd {
       );
       overflow: auto;
       position: sticky;
-      top: var(--main-document-header-height);
+      top: var(--sticky-header-height);
 
       .place {
         margin: 1rem 0;

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -19,7 +19,6 @@ interface StaticPageProps {
   extraClasses?: string;
   locale: string;
   slug: string;
-  parents: DocParent[];
   fallbackData?: any;
   title?: string;
   sidebarHeader?: ReactElement;
@@ -29,7 +28,6 @@ function StaticPage({
   extraClasses = "",
   locale,
   slug,
-  parents = [],
   fallbackData = undefined,
   title = "MDN",
   sidebarHeader = <></>,
@@ -67,10 +65,6 @@ function StaticPage({
 
   return (
     <>
-      <ArticleActionsContainer
-        parents={[...parents, { uri: baseURL, title: hyData.title }]}
-      />
-
       <div className="main-wrapper">
         <SidebarContainer doc={hyData}>
           {sidebarHeader || null}

--- a/client/src/homepage/static-page/index.tsx
+++ b/client/src/homepage/static-page/index.tsx
@@ -3,10 +3,9 @@ import useSWR from "swr";
 import { CRUD_MODE } from "../../env";
 import { SidebarContainer } from "../../document/organisms/sidebar";
 import { TOC } from "../../document/organisms/toc";
-import { DocParent, Toc } from "../../../../libs/types/document";
+import { Toc } from "../../../../libs/types/document";
 import { PageNotFound } from "../../page-not-found";
 import { Loading } from "../../ui/atoms/loading";
-import { ArticleActionsContainer } from "../../ui/organisms/article-actions-container";
 
 interface StaticPageDoc {
   id: string;

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Routes, Route, useLocation, useParams } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 
 import { useIsServer } from "../hooks";
 import { Loading } from "../ui/atoms/loading";
@@ -59,11 +59,6 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
   React.useEffect(() => {
     document.title = pageTitle || MDN_PLUS_TITLE;
   }, [pageTitle]);
-
-  const { locale = "en-US" } = useParams();
-  const { pathname } = useLocation();
-
-  const parents = [{ uri: `/${locale}/plus`, title: MDN_PLUS_TITLE }];
 
   return (
     <Routes>

--- a/client/src/plus/index.tsx
+++ b/client/src/plus/index.tsx
@@ -78,9 +78,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="collections/*"
         element={
-          <Layout
-            parents={[...parents, { uri: pathname, title: "Collections" }]}
-          >
+          <Layout>
             <Collections />
           </Layout>
         }
@@ -88,7 +86,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="updates/*"
         element={
-          <Layout parents={[...parents, { uri: pathname, title: "Updates" }]}>
+          <Layout>
             <Updates />
           </Layout>
         }
@@ -96,9 +94,7 @@ export function Plus({ pageTitle, ...props }: { pageTitle?: string }) {
       <Route
         path="/settings"
         element={
-          <Layout
-            parents={[...parents, { uri: pathname, title: "My Settings" }]}
-          >
+          <Layout>
             <Settings {...props} />
           </Layout>
         }

--- a/client/src/plus/plus-docs/index.tsx
+++ b/client/src/plus/plus-docs/index.tsx
@@ -90,7 +90,6 @@ function PlusDocs({ ...props }) {
         locale,
         slug: `plus/docs/${slug}`,
         title: MDN_PLUS_TITLE,
-        parents: [{ uri: `/${locale}/plus`, title: MDN_PLUS_TITLE }],
         sidebarHeader: <PlusDocsNav />,
         fallbackData: props.hyData ? props : undefined,
       }}

--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -61,7 +61,7 @@
     padding-right: 1rem;
 
     .toc {
-      --offset: var(--main-document-header-height);
+      --offset: var(--sticky-header-height);
 
       display: block;
       grid-area: toc;

--- a/client/src/ui/organisms/article-actions-container/index.scss
+++ b/client/src/ui/organisms/article-actions-container/index.scss
@@ -5,7 +5,7 @@
   background-color: var(--background-secondary);
   border-bottom: 1px solid var(--border-primary);
   margin: 0;
-  min-height: 2rem;
+  min-height: var(--article-actions-bar-height);
   padding: 0;
   position: sticky;
   top: 0;
@@ -50,11 +50,5 @@
       padding-left: 1rem;
       padding-right: 1rem;
     }
-  }
-}
-
-@media screen and (max-width: $screen-md) {
-  :root {
-    --sticky-header-height: 2rem;
   }
 }

--- a/client/src/ui/organisms/article-actions-container/index.scss
+++ b/client/src/ui/organisms/article-actions-container/index.scss
@@ -5,7 +5,7 @@
   background-color: var(--background-secondary);
   border-bottom: 1px solid var(--border-primary);
   margin: 0;
-  min-height: var(--article-actions-bar-height);
+  min-height: var(--article-actions-container-height);
   padding: 0;
   position: sticky;
   top: 0;

--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -154,7 +154,7 @@
       bottom: auto;
       box-shadow: var(--shadow-02);
       left: var(--article-actions-position-left, initial);
-      max-height: calc(100vh - 12px - var(--main-document-header-height));
+      max-height: calc(100vh - 12px - var(--sticky-header-height));
       padding: 0;
       position: absolute;
       right: 0;


### PR DESCRIPTION
## Summary

use `--sticky-header-height` everywhere

### Problem

On prod when scrolling on an article page the toc is moving by 2px because the offset was wrong. This is worse on staging with the top banner.

### Solution

Consolidate the offset to use `-sticky-header-height`. This should fix the issue at hand without touching to much of our fragile CSS.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://user-images.githubusercontent.com/3604775/236452442-6bb43e46-a99b-4781-99b9-d63877c4f0ef.png)

### After

![image](https://user-images.githubusercontent.com/3604775/236452484-4d88f8ec-60b4-412e-b11a-11e3205dda28.png)

