### PR TITLE
ci(stage,prod): invalidate CDN asynchronously

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -376,4 +376,4 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
 
       - name: Invalidate Google Cloud CDN
-        run: gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*"
+        run: gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*" --async

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -358,22 +358,6 @@ jobs:
           SLACK_FOOTER: "Powered by prod-build.yml"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  invalidate:
-    environment: prod
-    needs: build
-    if: ${{ ! vars.SKIP_INVALIDATE }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Authenticate with GCP
-        uses: google-github-actions/auth@v1
-        with:
-          token_format: access_token
-          service_account: deploy-prod-prod-mdn-ingress@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
-          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Invalidate Google Cloud CDN
+        if: ${{ ! vars.SKIP_INVALIDATE }}
         run: gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*" --async

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -373,4 +373,4 @@ jobs:
 
       - name: Invalidate CDN
         run: |-
-          gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*"
+          gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*" --async

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -354,23 +354,6 @@ jobs:
           SLACK_FOOTER: "Powered by stage-build.yml"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  invalidate:
-    environment: stage
-    needs: build
-    if: ${{ ! vars.SKIP_INVALIDATE }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Authenticate with GCP
-        uses: google-github-actions/auth@v1
-        with:
-          token_format: access_token
-          service_account: deploy-stage-nonprod-mdn-ingre@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com
-          workload_identity_provider: projects/${{ secrets.WIP_PROJECT_ID }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Invalidate CDN
-        run: |-
-          gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*" --async
+        if: ${{ ! vars.SKIP_INVALIDATE }}
+        run: gcloud compute url-maps invalidate-cdn-cache ${{ secrets.GCP_LOAD_BALANCER_NAME }} --path "/*" --async


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

CDN invalidation takes 10 minutes in GCP, and our build is waiting for it to finish.

### Solution

Trigger CDN invalidation asynchronously with `--async`.

(Also merges the separate `invalidate` job back into the `build` job to have a single deployment job.)

---

## How did you test this change?

Not yet tested, but could trigger a stage build.