### PR TITLE
Add PWA icon how-to to PWA sidebar

### DIFF
--- a/kumascript/macros/PWASidebar.ejs
+++ b/kumascript/macros/PWASidebar.ejs
@@ -30,6 +30,7 @@ const sidebar = {
     {
       name: "/docs/Web/Progressive_web_apps/How_to",
       contents: [
+        "/docs/Web/Progressive_web_apps/How_to/Define_app_icons",
         "/docs/Web/Progressive_web_apps/How_to/Create_a_standalone_app",
         "/docs/Web/Progressive_web_apps/How_to/Customize_your_app_colors",
         "/docs/Web/Progressive_web_apps/How_to/Display_badge_on_app_icon",


### PR DESCRIPTION
## Summary

Add a new PWA How-To page to the PWA sidebar macro.

### Problem

A new PWA How-To page about icons was added to mdn/content but does not appear in the PWA sidebar yet.

### Solution

Just adding the new page to the PWA sidebar macro.