### PR TITLE
ci(stage,prod): sync everything before deleting extra files

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -278,11 +278,15 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD }}
         uses: google-github-actions/setup-gcloud@v1
 
-      - name: Sync Yari Content
+      - name: Sync build
         if: ${{ ! vars.SKIP_BUILD }}
         run: |-
+          # 1. Copy static assets to make sure they're available as soon as the first updated pages land.
           gsutil -q -m -h "Cache-Control: public, max-age=86400" cp -r client/build/static gs://${{ vars.GCP_BUCKET_NAME }}/main/static
-          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -cdrj html,json,txt client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
+          # 2. Sync everything.
+          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -crj html,json,txt client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
+          # 3. Sync everything and delete extra files.
+          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -crd client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
 
       - name: Authenticate with GCP
         if: ${{ ! vars.SKIP_FUNCTION }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -274,11 +274,15 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD }}
         uses: google-github-actions/setup-gcloud@v1
 
-      - name: Sync Yari Content
+      - name: Sync build
         if: ${{ ! vars.SKIP_BUILD }}
         run: |-
+          # 1. Copy static assets to make sure they're available as soon as the first updated pages land.
           gsutil -q -m -h "Cache-Control: public, max-age=86400" cp -r client/build/static gs://${{ vars.GCP_BUCKET_NAME }}/main/static
-          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -cdrj html,json,txt client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
+          # 2. Sync everything.
+          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -crj html,json,txt client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
+          # 3. Sync everything and delete extra files.
+          gsutil -q -m -h "Cache-Control: public, max-age=86400" rsync -crd client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
 
       - name: Authenticate with GCP
         if: ${{ ! vars.SKIP_FUNCTION }}


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We're seeing 404s on `/static/js/main.*.js` for about 10-15 minutes during deployment, because the static assets do not seem to be available when the first updated HTML files are served from the CDN.

### Solution

Sync the build in three passes:

1. Copy the static assets first (we already do this).
2. Sync the build completely (**without** deleting extra files).
3. Sync the build again (this time deleting extra files)

---

## How did you test this change?

Will trigger a stage build to see what impact on runtime this has.