### PR TITLE
feat(fundamental-redirects): redirect archived media

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1233,19 +1233,14 @@ const MISC_REDIRECT_PATTERNS = [
     { permanent: true }
   ),
   // Content archived as part of the GCP migration.
-  redirect(/^diagrams\/?$/i, "https://mdn.dev/archives/media/diagrams/", {
-    permanent: false,
-  }),
   redirect(
-    /^presentations\/?$/i,
-    "https://mdn.dev/archives/media/presentations/",
+    /^(?<prefix>diagrams|presentations|samples)(?<subPath>\/.*)?$/i,
+    ({ prefix, subPath = "" }) =>
+      `https://mdn.dev/archives/media/${prefix}${subPath}`,
     {
       permanent: false,
     }
   ),
-  redirect(/^samples\/?$/i, "https://mdn.dev/archives/media/samples/", {
-    permanent: false,
-  }),
 ];
 
 const REDIRECT_PATTERNS = [].concat(


### PR DESCRIPTION
## Summary

(MP-354)

### Problem

We archived some content that was available under https://developer.mozilla.org/, but we don't redirect to the archives yet.

### Solution

Add fundamental redirects.

---

## How did you test this change?

~~Will deploy to stage next week to verify.~~

Tested locally:

```
cd cloud-function
npm run copy-internal
npm start &
curl -i http://localhost:5100/presentations
curl -i http://localhost:5100/presentations/
curl -i http://localhost:5100/presentations/test
```

Also [deployed to stage](https://github.com/mdn/yari/pull/8785#event-9199452524).