### PR TITLE
fix(content): only collect required translations

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -51,8 +51,8 @@ interface GlobalMetadata {
 }
 
 async function buildDocumentInteractive(
-  documentPath,
-  interactive,
+  documentPath: string,
+  interactive: boolean,
   invalidate = false
 ): Promise<SkippedDocumentBuild | InteractiveDocumentBuild> {
   try {
@@ -65,12 +65,10 @@ async function buildDocumentInteractive(
     }
 
     if (!interactive) {
-      const translations = await translationsOf(document.metadata);
-      if (translations && translations.length > 0) {
-        document.translations = translations;
-      } else {
-        document.translations = [];
-      }
+      document.translations = translationsOf(
+        document.metadata.slug,
+        document.metadata.locale
+      );
     }
 
     return { document, doc: await buildDocument(document), skip: false };

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -8,70 +8,51 @@ const LANGUAGES = new Map(
   })
 );
 
-const TRANSLATIONS_OF = new Map();
+type Translation = {
+  locale: string;
+  title: string;
+  native: string;
+};
 
-async function gatherTranslations() {
-  const iter = (await Document.findAll()).iterDocs();
-  for (const {
-    metadata: { slug, locale, title },
-  } of iter) {
-    if (!slug || !locale || !title) {
-      continue;
-    }
-    const translation = {
-      title,
-      locale,
-      native: LANGUAGES.get(locale.toLowerCase()).native,
-    };
-    const translations = TRANSLATIONS_OF.get(slug.toLowerCase());
-    if (translations) {
-      translations.push(translation);
-      translations.sort(({ locale: a }, { locale: b }) => {
-        if (a < b) return -1;
-        if (a > b) return 1;
-        return 0;
-      });
-    } else {
-      TRANSLATIONS_OF.set(slug.toLowerCase(), [translation]);
-    }
-  }
-}
+const TRANSLATIONS_OF = new Map<string, Array<Translation>>();
 
-export async function translationsOf({ slug, locale: currentLocale }) {
-  if (TRANSLATIONS_OF.size === 0) {
-    const label = "Time to gather all translations";
-    console.time(label);
-    await gatherTranslations();
-    console.timeEnd(label);
-  }
-  const translations = TRANSLATIONS_OF.get(slug.toLowerCase());
-  if (translations && currentLocale) {
-    return translations.filter(
-      ({ locale }) => locale.toLowerCase() !== currentLocale.toLowerCase()
-    );
-  }
-  return translations;
-}
-
-export function findDocumentTranslations(document) {
+// return all translations of a document
+export function findTranslations(
+  slug: string,
+  currentLocale: string = null
+): Array<Translation> {
   const translations = [];
-
   for (const locale of VALID_LOCALES.values()) {
-    if (document.metadata.locale === locale) {
+    if (currentLocale?.toLowerCase() === locale.toLowerCase()) {
       continue;
     }
-    const translatedDocumentURL = document.url.replace(
-      `/${document.metadata.locale}/`,
-      `/${locale}/`
-    );
-    const translatedDocument = Document.findByURL(translatedDocumentURL);
-    if (translatedDocument) {
+    const documentURL = `/${locale}/docs/${slug}`;
+    const document = Document.findByURL(documentURL);
+    if (document) {
       translations.push({
         locale,
-        title: translatedDocument.metadata.title,
+        title: document.metadata.title,
         native: LANGUAGES.get(locale.toLowerCase()).native,
       });
     }
   }
   return translations;
+}
+
+// gather and cache all translations of a document,
+// then return all translations except the current locale
+export function translationsOf(
+  slug: string,
+  currentLocale: string
+): Array<Translation> {
+  let documents = TRANSLATIONS_OF.get(slug.toLowerCase());
+  if (!documents) {
+    documents = findTranslations(slug);
+    TRANSLATIONS_OF.set(slug.toLowerCase(), documents);
+  }
+  return (
+    documents.filter(
+      ({ locale }) => locale.toLowerCase() !== currentLocale.toLowerCase()
+    ) ?? []
+  );
 }

--- a/content/translations.ts
+++ b/content/translations.ts
@@ -16,11 +16,27 @@ type Translation = {
 
 const TRANSLATIONS_OF = new Map<string, Array<Translation>>();
 
+// gather and cache all translations of a document,
+// then return all translations except the current locale
+export function translationsOf(
+  slug: string,
+  currentLocale: string
+): Translation[] {
+  let translations = TRANSLATIONS_OF.get(slug.toLowerCase());
+  if (!translations) {
+    translations = findTranslations(slug);
+    TRANSLATIONS_OF.set(slug.toLowerCase(), translations);
+  }
+  return translations.filter(
+    ({ locale }) => locale.toLowerCase() !== currentLocale.toLowerCase()
+  );
+}
+
 // return all translations of a document
 export function findTranslations(
   slug: string,
   currentLocale: string = null
-): Array<Translation> {
+): Translation[] {
   const translations = [];
   for (const locale of VALID_LOCALES.values()) {
     if (currentLocale?.toLowerCase() === locale.toLowerCase()) {
@@ -37,22 +53,4 @@ export function findTranslations(
     }
   }
   return translations;
-}
-
-// gather and cache all translations of a document,
-// then return all translations except the current locale
-export function translationsOf(
-  slug: string,
-  currentLocale: string
-): Array<Translation> {
-  let documents = TRANSLATIONS_OF.get(slug.toLowerCase());
-  if (!documents) {
-    documents = findTranslations(slug);
-    TRANSLATIONS_OF.set(slug.toLowerCase(), documents);
-  }
-  return (
-    documents.filter(
-      ({ locale }) => locale.toLowerCase() !== currentLocale.toLowerCase()
-    ) ?? []
-  );
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,7 +16,7 @@ import {
   buildLiveSamplePageFromURL,
   renderContributorsTxt,
 } from "../build/index.js";
-import { findDocumentTranslations } from "../content/translations.js";
+import { findTranslations } from "../content/translations.js";
 import { Document, Redirect, Image } from "../content/index.js";
 import { CSP_VALUE, DEFAULT_LOCALE } from "../libs/constants/index.js";
 import {
@@ -47,7 +47,7 @@ import {
   findPostPathBySlug,
 } from "../build/blog.js";
 
-async function buildDocumentFromURL(url) {
+async function buildDocumentFromURL(url: string) {
   const document = Document.findByURL(url);
   if (!document) {
     return null;
@@ -57,7 +57,10 @@ async function buildDocumentFromURL(url) {
     // When you're running the dev server and build documents
     // every time a URL is requested, you won't have had the chance to do
     // the phase that happens when you do a regular `yarn build`.
-    document.translations = findDocumentTranslations(document);
+    document.translations = findTranslations(
+      document.metadata.slug,
+      document.metadata.locale
+    );
   }
   return await buildDocument(document, documentOptions);
 }


### PR DESCRIPTION
## Summary

Trying to fix and as a part of #8301

Gather all translation would slow down the static document build in translated-content. Only gather the translations of the incoming slug might be a better idea.

### Problem

After we migrating to ESM, the PR-test ci in translated-content would spend more than 25 seconds to build a single document (as in most of PRs, the number of changed documents is only `1`). The most of time during a build is spent on
`gathering all translations` (as metioned in #8301).

### Solution

Try to gather the translations of a required slug only, this should save most of the time for build a single document.

---

Using a locale build of `yari` to check the build time.

Run `yarn build files/en-us/learn/common_questions/web_mechanics/what_is_a_web_server/index.md`
and `node node_modules/@mdn/yari/build/cli.js files/zh-tw/learn/common_questions/web_mechanics/what_is_a_web_server/index.md` to build document.

## Screenshots

### Before

`~16` seconds are used to build a single document.

![image](https://user-images.githubusercontent.com/15844309/236983216-68decfc3-99e8-40b6-81ba-f94f43d1ebea.png)

### After

![image](https://user-images.githubusercontent.com/15844309/236982911-f2425753-fe0e-447b-8b4d-c4fbc2cd7ad5.png)

`~1` seconds are used to build a single document.

run `yarn start` in content

![image](https://user-images.githubusercontent.com/15844309/236982995-79bbac30-09cf-4389-a298-405c3cc8b53b.png)

---
