### PR TITLE
chore(popularities): use Glean popularities

### DIFF
--- a/tool/popularities.ts
+++ b/tool/popularities.ts
@@ -14,12 +14,10 @@ import fs from "node:fs";
 import * as csv from "@fast-csv/parse";
 import got from "got";
 
-const CURRENT_URL =
-  "https://mdn-popularities-prod.s3.amazonaws.com/current.txt";
+const CURRENT_URL = "https://popularities.mdn.mozilla.net/current.csv";
 
 async function fetchPopularities() {
-  const { body: csvURL } = await got(CURRENT_URL);
-  const { body: csv } = await got(csvURL);
+  const { body: csv } = await got(CURRENT_URL);
   return csv;
 }
 


### PR DESCRIPTION
## Summary

(MP-366)

### Problem

Previously, popularities were derived from CloudFront logs, and hosted in an S3 bucket.
Now, we derive popularities from Glean data (page events) and host them at `popularities.mdn.mozilla.net`.

### Solution

Update where we download popularities from.

**Note**: This might change the order of some items in the in-page search (quicksearch)!

---

## How did you test this change?

Ran `yarn tool popularities` and verified that the `popularities.json` is generated correctly.