### PR TITLE
Add 'Whats a PWA' to PWA sidebar

### DIFF
--- a/kumascript/macros/PWASidebar.ejs
+++ b/kumascript/macros/PWASidebar.ejs
@@ -6,6 +6,7 @@ const sidebar = {
     {
       name: "/docs/Web/Progressive_web_apps/Guides",
       contents: [
+        "/docs/Web/Progressive_web_apps/Guides/What_is_a_progressive_web_app",
         "/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable",
         "/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation",
         "/docs/Web/Progressive_web_apps/Guides/Structural_overview",


### PR DESCRIPTION


## Summary

Adds "What's a PWA" to the PWA sidebar.

### Problem

"What's a PWA", added in https://github.com/mdn/content/pull/26569, isn't in the sidebar.

### Solution

Add "What's a PWA", to the sidebar.

## Screenshots

### Before

<img width="271" alt="Screen Shot 2023-05-09 at 10 11 39 AM" src="https://github.com/mdn/yari/assets/432915/b3356dae-f203-4917-95a9-45d0478bff22">

### After

<img width="302" alt="Screen Shot 2023-05-09 at 10 13 17 AM" src="https://github.com/mdn/yari/assets/432915/720cb75d-6ead-43d9-ad47-74410bdcfae9">

## How did you test this change?

Ran yarn dev, looked at pages.
