### PR TITLE
Ensure search suggestion URLs include valid locale

### DIFF
--- a/client/src/page-not-found/fallback-link.tsx
+++ b/client/src/page-not-found/fallback-link.tsx
@@ -7,6 +7,7 @@ import NoteCard from "../ui/molecules/notecards";
 
 import LANGUAGES_RAW from "../../../libs/languages";
 import { RETIRED_LOCALES } from "../../../libs/constants";
+import { isValidLocale } from "../../../libs/locale-utils";
 
 const LANGUAGES = new Map(
   Object.entries(LANGUAGES_RAW).map(([locale, data]) => {
@@ -22,7 +23,8 @@ const LANGUAGES = new Map(
 // like "Did you mean: <a href=$url>$doctitle</a>?"
 
 export default function FallbackLink({ url }: { url: string }) {
-  const { locale = "en-US" } = useParams();
+  const { localeRaw } = useParams();
+  const locale = !isValidLocale(localeRaw) ? "en-US" : localeRaw;
   const location = useLocation();
 
   const [fallbackCheckURL, setFallbackCheckURL] = React.useState<null | string>(


### PR DESCRIPTION
If no locale was included in the path, en-US will be set as the locale in search suggestion links.

## Summary

Fixes #8822.

### Problem

Search suggestions were previously assuming the root of the path was a locale, even if it wasn't.

### Solution

It now validates that it is a valid locale, and if not, sets it to `en-US`.

## How did you test this change?

Manually.
