### PR TITLE
ci(dependabot): restrict npm updates to major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 35
     ignore:
-      # Temporarily disable updates to Dinocons
-      - dependency-name: "@mdn/dinocons"
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -29,31 +29,46 @@ updates:
     directory: "/client/pwa"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: npm
     directory: "/cloud-function"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: npm
     directory: "/lib/locale-utils"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: npm
     directory: "/lib/pong"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: npm
     directory: "/lib/slug-utils"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
     # This forces the Dependabot commit messages to conform to something
     # our auto-merge workflow can always cope with.


### PR DESCRIPTION
## Summary

(Part of MP-408)

### Problem

Dependabot creates a lot of noise by major and patch version updates of npm packages.

### Solution

Restrict Dependabot to major version updates of npm packages.

Also:
- Removes the increased 'open-pull-requests-limit', as this change will significantly reduce the number of concurrently open PRs.
- Removes a restriction for `@mdn/dinocons`, which is no longer updated.

---

## How did you test this change?

This is inconvenient to test before merging, but I followed the official docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore