### PR TITLE
fix(build): avoid breadcrumbs over-shortening

### DIFF
--- a/build/document-utils.ts
+++ b/build/document-utils.ts
@@ -18,20 +18,17 @@ const TRANSFORM_STRINGS = new Map(
 /**
  * Temporary fix for long titles in breadcrumbs
  * @see https://github.com/mdn/yari-private/issues/612
- * @param {String} title : the title of the document
+ * @param title : the title of the document
  * @returns transformed title or original title as a string
  */
-function transformTitle(title) {
+function transformTitle(title: string) {
   // if the title contains a string like `<input>: The Input (Form Input) element`,
   // return only the `<input>` portion of the title
-  if (/<\w+>/g.test(title)) {
-    return /<\w+>/g.exec(title)[0];
-  }
-
+  const htmlTagTopic = /^<\w+>/g.exec(title)?.[0];
   // if the above did not match, see if it is one of the strings in the
   // transformStrings object and return the relevant replacement or
   // the unmodified title string
-  return TRANSFORM_STRINGS.get(title) || title;
+  return htmlTagTopic ?? TRANSFORM_STRINGS.get(title) ?? title;
 }
 
 /**

--- a/build/document-utils.ts
+++ b/build/document-utils.ts
@@ -24,7 +24,7 @@ const TRANSFORM_STRINGS = new Map(
 function transformTitle(title: string) {
   // if the title contains a string like `<input>: The Input (Form Input) element`,
   // return only the `<input>` portion of the title
-  const htmlTagTopic = /^<\w+>/g.exec(title)?.[0];
+  const htmlTagTopic = /^<\w+>/.exec(title)?.[0];
   // if the above did not match, see if it is one of the strings in the
   // transformStrings object and return the relevant replacement or
   // the unmodified title string


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

See for example:

<img width="1096" alt="image" src="https://github.com/mdn/yari/assets/55398995/31455455-fd2a-4553-b9ed-f60507b1b643">


### Solution

Changed the regex to only match HTML tags at the start of the text (which matches the editorial conventions). Also did some minor refactoring.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
