### PR TITLE
fix(npm-publish): revert renaming of NPM_AUTH_TOKEN

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,4 +60,4 @@ jobs:
         if: steps.release.outputs.release_created
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,27 +15,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - name: Release
+        uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
           package-name: release-please-action
 
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
         if: steps.release.outputs.release_created
 
-      - name: Setup Node.js environment
+      - name: Setup
         uses: actions/setup-node@v3
         if: steps.release.outputs.release_created
         with:
           node-version: 18
           cache: yarn
 
-      - name: Install all yarn packages
+      - name: Install
         if: steps.release.outputs.release_created
         run: yarn --frozen-lockfile
 
-      - name: Build the build
+      - name: Build
         if: steps.release.outputs.release_created
         env:
           # What this does is it makes sure the built client is made for
@@ -56,7 +58,7 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: yarn build:prepare
 
-      - name: Publish to npmjs
+      - name: Publish
         if: steps.release.outputs.release_created
         run: npm publish
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -56,10 +56,6 @@ jobs:
           CONTENT_ROOT: testing/content/files
         run: yarn build:prepare
 
-      - name: Dry-run publish to see which files are included
-        if: steps.release.outputs.release_created
-        run: npm publish --dry-run
-
       - name: Publish to npmjs
         if: steps.release.outputs.release_created
         run: npm publish


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-385)

### Problem

The npm-publish workflow is now creating releases with release-please, but the npm publish fails, because I renamed an environment variable by mistake.

### Solution

Revert the rename.

Also:
- Removes the (unnecessary) dry run step.
- Renames the build steps.

---

## How did you test this change?

We'll see if this works as soon as the next release is cut.
