### PR TITLE
fix(dev): TypeScript errors when running `yarn dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "resolutions": {
-    "lodash": ">=4.17.15"
+    "lodash": ">=4.17.15",
+    "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3"
   },
   "dependencies": {
     "@caporal/core": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6273,10 +6273,10 @@ foreman@^3.0.1:
     mustache "^2.2.1"
     shell-quote "^1.6.1"
 
-fork-ts-checker-webpack-plugin@^6.5.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz#4f67183f2f9eb8ba7df7177ce3cf3e75cdafb340"
-  integrity sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==
+fork-ts-checker-webpack-plugin@^6.5.0, fork-ts-checker-webpack-plugin@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz#eda2eff6e22476a2688d10661688c47f611b37f3"
+  integrity sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==
   dependencies:
     "@babel/code-frame" "^7.8.3"
     "@types/json-schema" "^7.0.5"


### PR DESCRIPTION
since updating to TypeScript 5 we've had errors like:
`TypeError: Cannot set property mark of #<Object> which has only a getter`

updating fork-ts-checker-webpack-plugin fixes the problem

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
yarn dev
...
Creating an optimized production build...
TypeError: Cannot set property mark of #<Object> which has only a getter
TypeError: Cannot set property mark of #<Object> which has only a getter
    at Object.connectTypeScriptPerformance (/workspace/yari/node_modules/fork-ts-checker-webpack-plugin/lib/typescript-reporter/profile/TypeScriptPerformance.js:12:36)
...
```

### After

```
yarn dev
...
Creating an optimized production build...
Compiled successfully.
...
```

---

## How did you test this change?

Ran `yarn dev`, introduced a typescript error, observed it correctly log to console.
