### PR TITLE
fix(npm-publish): restore --access public option

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,6 +60,6 @@ jobs:
 
       - name: Publish
         if: steps.release.outputs.release_created
-        run: npm publish
+        run: npm publish --access public
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

(MP-385)

### Problem

The "npm publish" workflow is failing, because I removed the `--access public` parameter, yet this parameter is required for scoped packages.

### Solution

Add back the parameter.

---

## How did you test this change?

We'll see after this is merged.