### PR TITLE
fix(npm-publish): setup node with registry url

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -61,6 +61,6 @@ jobs:
 
       - name: Publish
         if: steps.release.outputs.release_created
-        run: npm publish --access public
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           node-version: 18
           cache: yarn
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install
         if: steps.release.outputs.release_created

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -63,4 +63,4 @@ jobs:
         if: steps.release.outputs.release_created
         run: npm publish --access public
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
## Summary

(MP-385)

### Problem

The "npm publish" workflow is failing, and the real reason (after 3 unsuccessful tries) seems to be that npm doesn't actually use `NPM_AUTH_TOKEN` or `NODE_AUTH_TOKEN`, unless these are referenced in an `.npmrc` file.

### Solution

Call the `setup-node` action with the `registry-url` input, which causes it to create an `.npmrc` file that references the `NODE_AUTH_TOKEN` environment file.

Also:
- Reverts the env rename revert.
- Reverts the `--access` revert (this is not necessary for scoped packages that are already published and public).

---

## How did you test this change?

🤞 
