### PR TITLE
fix(lint-staged): use negative pattern correctly

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,5 +1,5 @@
 export default {
-  "*.!{js,jsx,ts,tsx,css,scss}": "prettier --ignore-unknown --write",
+  "!*.{js,jsx,ts,tsx,css,scss}": "prettier --ignore-unknown --write",
   "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
   "*.{css,scss}": ["stylelint --fix --allow-empty-input", "prettier --write"],
 };


### PR DESCRIPTION

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-410)

### Problem

YAML files were not automatically formatted with prettier as part of `lint-staged`, because the negative pattern for other files (introduced in 6184affef801d9425d60a667579d17a2135a16f0) is not correct. (Negative patterns must start with the `!`, not contain it.)

### Solution

Fix the negative pattern.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Tested by updating a YAML file to use single quotes (`'`), staging the changes, and running `yarn lint-staged` thereafter.