### PR TITLE
Remove structural overview page from PWA sidebar

### DIFF
--- a/kumascript/macros/PWASidebar.ejs
+++ b/kumascript/macros/PWASidebar.ejs
@@ -9,7 +9,6 @@ const sidebar = {
         "/docs/Web/Progressive_web_apps/Guides/What_is_a_progressive_web_app",
         "/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable",
         "/docs/Web/Progressive_web_apps/Guides/Offline_and_background_operation",
-        "/docs/Web/Progressive_web_apps/Guides/Structural_overview",
       ],
     },
     {


### PR DESCRIPTION

## Summary

Removes https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Structural_overview from PWA sidebar.

### Problem

https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Structural_overview is in the sidebar, but we want to delete it: https://github.com/mdn/content/pull/26711 because it's not very useful.

### Solution

Remove https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Structural_overview from the sidebar.


## Screenshots




### Before

<img width="294" alt="Screen Shot 2023-05-11 at 3 26 45 PM" src="https://github.com/mdn/yari/assets/432915/4f512f77-241a-49db-81fa-added674e414">

### After

<img width="285" alt="Screen Shot 2023-05-11 at 3 29 36 PM" src="https://github.com/mdn/yari/assets/432915/7c248ad0-a6ce-41fe-9661-e1600eaa12f0">


---

## How did you test this change?

Ran yarn dev, looked at the page.
