### PR TITLE
chore(macros): deprecate CSSAnimatedProperties macro

### DIFF
--- a/kumascript/macros/CSSAnimatedProperties.ejs
+++ b/kumascript/macros/CSSAnimatedProperties.ejs
@@ -4,6 +4,11 @@
   in columns
 */
 
+// Throw a MacroDeprecatedError flaw
+// Condition for removal: no more use in translated-content
+// 0 occurrences left in en-US
+mdn.deprecated();
+
 // Read all CSSData and extract animated properties
 
 const data = require('mdn-data/css');


### PR DESCRIPTION
## Summary

As a part of: #8704

Deprecate the CSSAnimatedProperties macro, see [discussion here](https://github.com/orgs/mdn/discussions/367#discussioncomment-5644688).
