### PR TITLE
fix(CSS): last elements inside blockquotes do not need bottom margin

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -230,6 +230,10 @@
         color: inherit;
       }
     }
+
+    blockquote > :last-child {
+      margin-bottom: 0;
+    }
   }
 
   @media screen and (min-width: $screen-sm) {


### PR DESCRIPTION
## Summary

This PR adds a CSS rule to strip the bottom margin from last elements inside blockquotes.

See:

* https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Writing_style_guide
* https://developer.mozilla.org/en-US/blog/aria-accessibility-html-landmark-roles/

### Problem

The styles for blockquotes looks a little wobbly and difficult to read.

### Solution

Add a rule like the following:

```css
.main-page-content .section-content blockquote > :last-child {
  margin-bottom: 0;
}
```

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/43580235/42dc21c0-e88f-4a21-9dde-5cb4ab463826)


![image](https://github.com/mdn/yari/assets/43580235/c4eb38e8-61f1-4e05-b72b-14128e488a16)

### After

![image](https://github.com/mdn/yari/assets/43580235/153b0f37-9dea-4cef-be2c-6b9b181a6ed7)

---

## How did you test this change?

Running on localhost.