### PR TITLE
fix(sidebar): incorrect offset and z-index on mobile

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -78,14 +78,21 @@
   // + border
   --top-banner-outer-height: calc(var(--top-banner-height) + 2 * 1px);
 
-  --z-index-back: -1;
-  --z-index-top: 9999;
+  /* Z-Indexes
+     Keep this in order, and avoid reusing variables so elements each
+     exist on a distinct layer - we hit a lot of bugs if they don't */
   --z-index-a11y: 10000;
+  --z-index-modal-content: 801;
+  --z-index-modal-overlay: 800;
+  --z-index-top-banner: 701;
+  --z-index-main-header: 700;
+  --z-index-sidebar-mobile: 600;
   --z-index-mid: 500;
   --z-index-nav-menu: 200;
   --z-index-search-results: 101;
   --z-index-low: 100;
   --z-index-search-results-home: 99;
+  --z-index-back: -1;
 
   /* Features */
   --elem-radius: 0.25rem;
@@ -97,16 +104,18 @@
   --article-actions-container-height: 2rem;
   --icon-size: 1rem;
   --sticky-header-height: calc(
-    var(--top-nav-height) + var(--article-actions-container-height) + 2px
+    var(--top-nav-height) + var(--article-actions-container-height) + 3px
   );
 }
 
-.top-banner.visible ~ *,
-.top-banner.loading ~ * {
-  --sticky-header-height: calc(
-    var(--top-nav-height) + var(--article-actions-container-height) +
-      var(--top-banner-outer-height) + 2px
-  );
+@media screen and (min-width: $screen-md) {
+  .top-banner.visible ~ *,
+  .top-banner.loading ~ * {
+    --sticky-header-height: calc(
+      var(--top-nav-height) + var(--article-actions-container-height) +
+        var(--top-banner-outer-height) + 2px
+    );
+  }
 }
 
 @media screen and (min-width: $screen-md) {

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -104,7 +104,7 @@
   --article-actions-container-height: 2rem;
   --icon-size: 1rem;
   --sticky-header-height: calc(
-    var(--top-nav-height) + var(--article-actions-container-height) + 3px
+    var(--top-nav-height) + var(--article-actions-container-height) + 2px
   );
 }
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -7,7 +7,7 @@
 .main-document-header-container {
   position: sticky;
   top: 0;
-  z-index: var(--z-index-top);
+  z-index: var(--z-index-main-header);
   @media screen and (min-width: $screen-md) {
     .top-banner.visible ~ &,
     .top-banner.loading ~ & {
@@ -645,10 +645,15 @@ kbd {
     display: flex;
     flex-direction: column;
   }
+
   max-height: var(--max-height);
   position: sticky;
   top: var(--offset);
+  z-index: var(--z-index-sidebar-mobile);
+
   @media screen and (min-width: $screen-md) {
+    z-index: auto;
+
     .sidebar {
       mask-image: linear-gradient(
         to bottom,
@@ -657,6 +662,7 @@ kbd {
         rgba(0, 0, 0, 0) 100%
       );
     }
+
     @media screen and not (min-height: $screen-height-place-limit) {
       overflow: auto;
     }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -142,7 +142,6 @@
     right: 0;
     top: var(--offset);
     transform: translateX(-100%);
-    z-index: var(--z-index-top);
 
     .sidebar-inner {
       background: var(--background-primary);
@@ -159,7 +158,6 @@
       transition: 0.2s linear transform;
       width: 80vw;
       will-change: transform;
-      z-index: var(--z-index-top);
 
       .sidebar-inner-nav {
         display: contents;
@@ -205,7 +203,6 @@
       transition: opacity 0.2s linear;
       width: 100%;
       will-change: opacity;
-      z-index: var(--z-index-mid);
     }
 
     &.is-animating {

--- a/client/src/ui/_vars.scss
+++ b/client/src/ui/_vars.scss
@@ -249,12 +249,3 @@ $screen-xxl: 1441px;
 
 // screen is to small for sticky placement
 $screen-height-place-limit: 44rem;
-
-/*
- * z-index scale
- */
-$send-to-back: -1;
-$bring-to-front: 9999;
-$bottom-layer: 100;
-$middle-layer: 200;
-$top-layer: 300;

--- a/client/src/ui/atoms/modal/index.scss
+++ b/client/src/ui/atoms/modal/index.scss
@@ -15,7 +15,7 @@ body.ReactModal__Body--open {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: var(--z-index-top);
+  z-index: var(--z-index-modal-overlay);
 
   &.wait {
     &,
@@ -30,7 +30,7 @@ body.ReactModal__Body--open {
   flex-basis: 32.5rem;
   outline: none;
   padding: 1.5rem;
-  z-index: var(--z-index-top);
+  z-index: var(--z-index-modal-content);
 }
 
 .modal-header {

--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -11,6 +11,10 @@
     text-transform: initial;
   }
 
+  .article-actions-toggle {
+    display: block;
+  }
+
   @media screen and (min-width: $screen-md) {
     display: block;
 

--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -172,7 +172,7 @@ section.place {
   height: var(--top-banner-height);
   position: sticky;
   top: 0;
-  z-index: var(--z-index-top);
+  z-index: var(--z-index-top-banner);
 
   &.fallback {
     position: initial;

--- a/client/src/ui/organisms/top-navigation/index.scss
+++ b/client/src/ui/organisms/top-navigation/index.scss
@@ -5,7 +5,6 @@
   border-bottom: 1px solid var(--border-primary);
   position: relative;
   width: 100%;
-  z-index: $bottom-layer;
 
   .container {
     align-items: center;
@@ -34,7 +33,6 @@
 
   &.show-nav {
     box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
-    z-index: var(--z-index-top);
 
     .container {
       height: auto;


### PR DESCRIPTION
## Summary

fixes https://github.com/mdn/yari/issues/8646
fixes https://github.com/mdn/yari/issues/8702

remove --z-index-top variable, and split into per-element variables -
not everything can be on top!

remove some unnecessary z-indexes due to relative positioning

I intend to follow up with another PR removing the rest of the
reused/unnecessary z-indexes later - but don't want to block fixing this
issue with that

### Problem

- sidebar offset is wrong on mobile - in the past this seemed to cause part of the sidebar to be cut off, now it causes a gap between the header and sidebar
- some content shows through the sidebar

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

- correct offset
- correct z-index

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screen Shot 2023-05-15 at 11 38 22](https://github.com/mdn/yari/assets/755354/dbe67f44-5ed1-4d0c-8bef-71e66fcf1ff5)


### After

![Screen Shot 2023-05-15 at 11 44 37](https://github.com/mdn/yari/assets/755354/c0943959-1285-445d-bbc4-72e68c0d2169)
![Screen Shot 2023-05-15 at 11 43 51](https://github.com/mdn/yari/assets/755354/ae6a191d-53eb-40ea-b0bf-8474d5e265e9)
