### PR TITLE
feat: Add Prism key for syntax highlighting apache code as 'apacheconf'

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -20,6 +20,7 @@ const loadAllLanguages = lazy(() => {
   // - C-like (clike)
   // - JavaScript (javascript, js)
   loadLanguages([
+    "apacheconf",
     "bash",
     "batch",
     "c",


### PR DESCRIPTION

## Summary
This PR supports `apacheconf` syntax highlighting.

### Problem

We reference `apache` in some code blocks in `mdn/content` but the correct key is `apacheconf`. Neither language is explicitly loaded, so neither currently work.

### Solution

Add `apacheconf` to list of Prism loaded languages.

## Screenshots

### Before

https://developer.mozilla.org/en-US/docs/Learn/Server-side/Apache_Configuration_htaccess

![image](https://github.com/mdn/yari/assets/43580235/21a31337-07fa-4724-be83-e568a03ba576)

### After

on localhost whith code block using `apacheconf`:

![image](https://github.com/mdn/yari/assets/43580235/af77cc18-df09-4daf-b23e-dc2ef6ba616d)


## How did you test this change?

on localhost.

__Related issues and pull requests:__
- [x] https://github.com/mdn/content/pull/26786
