### PR TITLE
fix(top-banner): adjust width

### DIFF
--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -139,6 +139,7 @@ section.place {
       grid-area: no;
       color: var(--place-top-color);
       margin: auto 0 0 2rem;
+      width: initial;
     }
   }
 }


### PR DESCRIPTION
## Summary

reset width to prevent scrolling on small screen sizes


---

## Screenshots

### Before

Click in the image to see a white space on the right.

![image](https://github.com/mdn/yari/assets/3604775/2f0111ce-ed73-42d1-88ce-c29298b1ae4c)


### After

![image](https://github.com/mdn/yari/assets/3604775/e95eb4b1-5157-4be2-bf45-66c99f5feb1f)

