### PR TITLE
fix(blog): hydration error on date

### DIFF
--- a/client/src/blog/post.tsx
+++ b/client/src/blog/post.tsx
@@ -36,7 +36,7 @@ export function TimeToRead({ readTime }: { readTime: number | undefined }) {
 
 export function PublishDate({ date }: { date: string }) {
   return (
-    <time className="date">
+    <time className="date" suppressHydrationWarning>
       {Intl.DateTimeFormat(undefined, { dateStyle: "long" }).format(
         new Date(date)
       )}


### PR DESCRIPTION
SSR renders an en-US format date, client side renders in the user's locale

---

## How did you test this change?

- `yarn dev`
- once that finishes run `yarn build:blog` in a separate terminal
- once that finishes, load http://localhost:5042/en-US/blog/ with JS disabled
- observe date in US format, e.g. "May 10, 2023"
- enable JS, reload page
- observe date in (in my case) GB format, e.g. "10 May 2023"
- observe no hydration errors in console