### PR TITLE
fix(csp,fundamental-redirects): replace media.*.mdn.mozit.cloud with mdn.dev

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -130,8 +130,7 @@ export const CSP_DIRECTIVES = {
     "profile.stage.mozaws.net",
     "profile.accounts.firefox.com",
 
-    "media.prod.mdn.mozit.cloud",
-    "media.stage.mdn.mozit.cloud",
+    "mdn.dev",
     "interactive-examples.mdn.mozilla.net",
     "interactive-examples.mdn.allizom.net",
 

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -682,7 +682,7 @@ const SCL3_REDIRECT_PATTERNS = [
   redirect(
     /^samples\/(?<sample_path>.*)$/i,
     ({ sample_path }) =>
-      `https://media.prod.mdn.mozit.cloud/samples/${sample_path}`,
+      `https://mdn.dev/archives/media/samples/${sample_path}`,
     { permanent: false }
   ),
   // Bug 887428 - Misprinted URL in promo materials


### PR DESCRIPTION
## Summary

(Part of MP-354)

Related:
- https://github.com/mdn/content/pull/26809
- https://github.com/mdn/translated-content/pull/13291

### Problem

We migrated to GCP and archived the legacy media files (including samples) under https://mdn.dev/archives/media/, but we're still redirecting to the old host.

### Solution

Update the redirect, and the CSP header.

---

## How did you test this change?

Ran `npm start` in `cloud-function` and checked with curl:

```
% curl localhost:5100/samples/foo
Found. Redirecting to https://mdn.dev/archives/media/samples/foo
```