### PR TITLE
fix(macros/cssxref): use en-US page to fetch front matter key

### DIFF
--- a/kumascript/macros/cssxref.ejs
+++ b/kumascript/macros/cssxref.ejs
@@ -55,7 +55,9 @@ const basePath = `/${lang}/docs/Web/CSS/`;
 urlWithoutAnchor = basePath + slug;
 url = urlWithoutAnchor + $2;
 
-const thisPage = (!$1 || !$2) ? wiki.getPage(urlWithoutAnchor) : null;
+const thisPage = (!$1 || !$2) ?
+  wiki.getPage(`/en-US/docs/Web/CSS/${slug}`) :
+  null;
 
 if (!$1) {
     // Append parameter brackets to CSS functions


### PR DESCRIPTION
## Summary

Fixes #8883.

### Problem

On non-en-US pages, `{{CSSXref}}` doesn't add parentheses in the displayed link texts for CSS functions.

### Solution

As the `page-type` front matter key is absent from l10n contents, this PR uses en-US links to fetch the key instead.

---

## How did you test this change?