### PR TITLE
fix(ui): gap at top of page in tablet mode

### DIFF
--- a/client/src/ui/molecules/theme-switcher/index.scss
+++ b/client/src/ui/molecules/theme-switcher/index.scss
@@ -70,6 +70,8 @@
 .theme-switcher-menu,
 .languages-switcher-menu {
   > .button {
+    display: block;
+
     .button-wrap:after {
       background-color: var(--icon-secondary);
       content: "";

--- a/client/src/ui/organisms/article-actions/bookmark-menu/index.scss
+++ b/client/src/ui/organisms/article-actions/bookmark-menu/index.scss
@@ -1,6 +1,10 @@
 @use "../../../../ui/vars" as *;
 
 .bookmark-menu {
+  > .button {
+    display: block;
+  }
+
   .is-button-row {
     flex-direction: row-reverse;
     justify-content: flex-start;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

### Problem

Header jumps around when opening the menu in tablet mode, exposing a 1px gap at the top of the page.

Icons in the article actions menu also appear cropped, due to half-pixel offset.

### Solution

Make header and article actions band full-pixel heights, rather than half pixel.

---

## Screenshots

### Before

Observe the whole page seem to shift down 1px, including the header (look at the logo), and a gap at the top you can see some text peeking through, when the menu opens. Also observe the icons in article actions be cropped at the bottom when the menu opens:

[Screencast from 2023-05-18 11-11-11.webm](https://github.com/mdn/yari/assets/755354/7d324567-2e55-4c54-9de3-ecd59c219d1d)

### After


[Screencast from 2023-05-18 11-13-37.webm](https://github.com/mdn/yari/assets/755354/e72f6904-6041-4b20-b921-473a1e37e603)


