### PR TITLE
chore: activate webidl language definition

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -53,7 +53,7 @@ const loadAllLanguages = lazy(() => {
     "typescript",
     "uri",
     "wasm",
-    // "webidl", // block list
+    "web-idl",
     "yaml",
   ]);
 });
@@ -63,10 +63,7 @@ const loadAllLanguages = lazy(() => {
 // Prism expects. It'd be hard to require that content writers
 // have to stick to the exact naming conventions that Prism uses
 // because Prism is an implementation detail.
-const ALIASES = new Map([
-  // ["idl", "webidl"],  // block list
-  ["sh", "shell"],
-]);
+const ALIASES = new Map([["sh", "shell"]]);
 
 // Over the years we have accumulated some weird <pre> tags whose
 // brush is more or less "junk".

--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -52,7 +52,7 @@ const loadAllLanguages = lazy(() => {
     "typescript",
     "uri",
     "wasm",
-    "web-idl",
+    "webidl",
     "yaml",
   ]);
 });

--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -46,7 +46,6 @@ const loadAllLanguages = lazy(() => {
     "regex",
     "rust",
     "scss",
-    "svelte",
     "sql",
     "toml",
     "tsx",


### PR DESCRIPTION
The `webidl` language is disabled in Prism syntax highlighting and we have build warnings because of this. It looks like we use it in the content repo, so I would propose enabling it here.

See https://github.com/mdn/yari/commit/def733d5f803f274d0db9bbe339f7a311b9e57f2