### PR TITLE
chore: svelte is implicitly loaded, typo

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -47,6 +47,7 @@ const loadAllLanguages = lazy(() => {
     "rust",
     "scss",
     "sql",
+    // 'svelte', // Loaded by `prism-svelte` extension
     "toml",
     "tsx",
     "typescript",

--- a/content/document.ts
+++ b/content/document.ts
@@ -261,7 +261,7 @@ export const read = memoize((folderOrFilePath: string, ...roots: string[]) => {
     );
   }
   // Use Boolean() because otherwise, `isTranslated` might become `undefined`
-  // rather than an actuall boolean value.
+  // rather than an actual boolean value.
   const isTranslated = Boolean(
     CONTENT_TRANSLATED_ROOT && filePath.startsWith(CONTENT_TRANSLATED_ROOT)
   );


### PR DESCRIPTION
Minor follow-up to add code comment about `svelte` lang implicitly loaded by `prism-svelte`. Taking the opportunity to bundle in a typo fix while I'm at it.

__Related:__

- [x] https://github.com/mdn/yari/pull/8899
- https://github.com/mdn/yari/pull/8899#discussion_r1199432583