### PR TITLE
fix(quicksearch): opened pages don't scroll to top

### DIFF
--- a/client/src/ui/molecules/search/index.tsx
+++ b/client/src/ui/molecules/search/index.tsx
@@ -22,11 +22,9 @@ function useQueryParamState() {
 export function Search({
   id,
   isHomepageSearch,
-  onResultPicked,
 }: {
   id: string;
   isHomepageSearch?: boolean;
-  onResultPicked?: () => void;
 }) {
   const [value, setValue] = useQueryParamState();
   const [isFocused, setIsFocused] = useState(false);
@@ -51,7 +49,7 @@ export function Search({
     <div
       className={isHomepageSearch ? "homepage-hero-search" : "header-search"}
     >
-      <SearchNavigateWidget {...searchProps} onResultPicked={onResultPicked} />
+      <SearchNavigateWidget {...searchProps} />
     </div>
   );
 }

--- a/testing/tests/headless.search.spec.ts
+++ b/testing/tests/headless.search.spec.ts
@@ -33,7 +33,7 @@ test.describe("Autocomplete search", () => {
     await page.waitForLoadState("networkidle");
     expect(await page.innerText("h1")).toBe("<foo>: A test tag");
     // Should have been redirected too...
-    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo"));
+    expect(page.url()).toBe(testURL("/en-US/docs/Web/Foo/"));
   });
 
   test("find nothing by title search", async ({ page }) => {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

https://mozilla-hub.atlassian.net/browse/MP-400

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

- page doesn't scroll to top when using quicksearch
- when using keyboard to open a result, key modifiers aren't recognised, so pages can't be opened in e.g. a new tab

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

- use proper links
- dispatch a `MouseEvent` when using the keyboard - unfortunately, browser support for passing modifiers is inconsistent, I presume this is some kind of clickjacking protection

---

## How did you test this change?

- clicked on quicksearch results with mouse, using various modifier keys (or none)
- interacted with quicksearch results with keyboard, using various modifier keys (or none) across Firefox/Chromium/Epiphany (with inconsistent/consistent/no support for modifier keys respectively)
