### PR TITLE
chore(ci): limit testing CI from running on forks

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,6 +13,7 @@ jobs:
   lint:
     if: github.repository == 'mdn/yari'
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
   lint:
+    if: github.repository == 'mdn/yari'
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
@@ -49,6 +49,7 @@ jobs:
         run: yarn check:tsc
 
   test:
+    if: github.repository == 'mdn/yari'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If I synchronize my Yari fork, the following CI runs and fails:

![image](https://github.com/mdn/yari/assets/43580235/2b6f87d2-acf0-41c7-b0ef-18c9b846fbd4)

This PR limits only those failing to only run on `mdn/yari` repos