### PR TITLE
fix(kumascript): mention path in render error message

### DIFF
--- a/kumascript/index.ts
+++ b/kumascript/index.ts
@@ -91,6 +91,7 @@ export async function render(
     rawHTML,
     {
       ...metadata,
+      path: fileInfo.path,
       url,
       tags: metadata.tags || [],
       selective_mode,

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -108,7 +108,7 @@ export default class Templates {
       });
       return rendered.trim();
     } catch (error) {
-      console.error(`${name} macro failed:`, error);
+      console.error(`The ${name} macro on ${args?.page?.uri} failed:`, error);
       throw error;
     }
   }

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -108,7 +108,10 @@ export default class Templates {
       });
       return rendered.trim();
     } catch (error) {
-      console.error(`The ${name} macro on ${args?.page?.uri} failed:`, error);
+      console.error(
+        `The ${name} macro in ${args.env.path ?? "?"} failed to render.`,
+        error
+      );
       throw error;
     }
   }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When a macro fails, the console error message mentions only the macro name and the error message, making it hard to identify which page the macro failed on.

### Solution

Add the document path to the error message.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
specifications macro failed: Error: /path/to/yari/kumascript/macros/Specifications.ejs:1
...
```

### After


```
The specifications macro in /Users/claas/github/mdn/content/files/en-us/mdn/writing_guidelines/page_structures/page_types/aria_page_template/index.md failed to render. Error: /path/to/yari/kumascript/macros/Specifications.ejs:1
...
```

---

## How did you test this change?

Ran `yarn build --locale en-us` in a VSCode Debug Console, setting a breakpoint in the catch block.
