### PR TITLE
chore(layout): make scrollbar stay inside container using margin instead of padding

### DIFF
--- a/client/src/ui/molecules/grids/_document-page.scss
+++ b/client/src/ui/molecules/grids/_document-page.scss
@@ -42,6 +42,12 @@
       padding-top: 3rem;
     }
 
+    #sidebar-quicklinks {
+      padding-top: 0;
+      padding-bottom: 0;
+      margin: 3rem 0;
+    }
+
     .sidebar {
       align-self: start;
       grid-area: sidebar;


### PR DESCRIPTION

## Summary

This PR suggests to use top and bottom margin instead of padding for scrollable sidebars.

### Problem

Top padding causes the scrollbar to extend beyond the top item in the list

* https://developer.mozilla.org/en-US/docs/Glossary
* https://developer.mozilla.org/en-US/docs/Web/CSS

### Solution

Use top & bottom margin instead of padding

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/43580235/303319ef-bb15-4298-8788-180152ddc11d)
![image](https://github.com/mdn/yari/assets/43580235/5dd0c6bf-34a8-4701-bb34-6e7f0220aa88)

layout:
![image](https://github.com/mdn/yari/assets/43580235/221505e7-e931-4484-a4a7-71f79ce1308a)


### After

![image](https://github.com/mdn/yari/assets/43580235/5e39164c-e11a-44f3-9d22-f7720a6c4967)
![image](https://github.com/mdn/yari/assets/43580235/68571a6a-8147-4151-aa4d-6710a21933d1)

layout:
![image](https://github.com/mdn/yari/assets/43580235/7aa3ba9b-a379-4d0b-82e1-c2e2c714ae87)


## How did you test this change?

Running on localhost with `yarn && yarn dev`
