### PR TITLE
chore: add alias vue -> markup to enable syntax highlighting

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -63,7 +63,10 @@ const loadAllLanguages = lazy(() => {
 // Prism expects. It'd be hard to require that content writers
 // have to stick to the exact naming conventions that Prism uses
 // because Prism is an implementation detail.
-const ALIASES = new Map([["sh", "shell"]]);
+const ALIASES = new Map([
+  ["sh", "shell"],
+  ["vue", "markup"], // See https://github.com/PrismJS/prism/issues/1665#issuecomment-536529608
+]);
 
 // Over the years we have accumulated some weird <pre> tags whose
 // brush is more or less "junk".


### PR DESCRIPTION
## Summary

We have build errors that `vue` is not a detected language. There is no support for `vue` in Prism, an alternative is to use `markup` which is supported without additional Yari dependencies. Adding an alias will allow us to highlight the language and preserve Prettier linting in content.

### Problem

Prism does not support `vue` as a language, see:

* https://github.com/mdn/content/blob/218df89024b21bc4d1896ec4b3be727213704cca/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_computed_properties/index.md?plain=1#L75-L85
* https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_properties

### Solution

Add an alias for `markup` so that the language will be highlighted and Prettier can still format the examples.

## Screenshots

### Before
![image](https://github.com/mdn/yari/assets/43580235/22935163-7cbc-4c53-a6b1-d9783c6b85ad)

### After



![image](https://github.com/mdn/yari/assets/43580235/edbde3f3-55bb-4a78-8bcd-edfc5b404e4f)


## How did you test this change?


On http://localhost:5042/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks/Vue_computed_properties


__Other:__
Opening this one in favor of https://github.com/mdn/content/pull/26987