### PR TITLE
chore(footer): Add Discord server to footer

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -124,7 +124,7 @@ export function Footer() {
             <li className="footer-nav-item">
               <a
                 className="footer-nav-link"
-                href="https://discord.gg/Q2rdGBg4"
+                href="https://discord.gg/aZqEtMrbr7"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -128,7 +128,7 @@ export function Footer() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Community Discord Server
+                MDN Discord Server
               </a>
             </li>
           </ul>

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -114,21 +114,11 @@ export function Footer() {
             <li className="footer-nav-item">
               <a
                 className="footer-nav-link"
-                href="https://wiki.mozilla.org/Matrix"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                MDN Chat
-              </a>
-            </li>
-            <li className="footer-nav-item">
-              <a
-                className="footer-nav-link"
                 href="https://discord.gg/aZqEtMrbr7"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                MDN Discord Server
+                MDN Chat
               </a>
             </li>
           </ul>

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -121,6 +121,16 @@ export function Footer() {
                 MDN Chat
               </a>
             </li>
+            <li className="footer-nav-item">
+              <a
+                className="footer-nav-link"
+                href="https://discord.gg/Q2rdGBg4"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Community Discord Server
+              </a>
+            </li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Summary

The Community Discord Server has been operational for a while now. People are wondering why we do not have invite link in the footer where other communication channels are mentioned.

### Solution

Add the invite to the list.

## Screenshot after change

![Screenshot_20230527_071030](https://github.com/mdn/yari/assets/87750369/60d87d64-17a0-4158-b1c5-8bf7429a3370)

## How did you test this change?

Using `yarn dev` in local.