### PR TITLE
chore(macros/SeeCompatTable): localize "Experimental" title

### DIFF
--- a/kumascript/macros/SeeCompatTable.ejs
+++ b/kumascript/macros/SeeCompatTable.ejs
@@ -1,18 +1,30 @@
 <%
 
-var str = mdn.localString({
-    "es"    : "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
-    "fr"    : "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#compatibilité_des_navigateurs'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
-    "ja"    : "<strong>これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。</strong><br />本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
-    "zh-CN" : "<strong>这是一个实验中的功能</strong><br />此功能某些浏览器尚在开发中，请参考<a href='#浏览器兼容性'>浏览器兼容性表格</a>以得到在不同浏览器中适合使用的前缀。由于该功能对应的标准文档可能被重新修订，所以在未来版本的浏览器中该功能的语法和行为可能随之改变。",
-    "zh-TW" : "<strong>這是一個實驗中的功能</strong><br />此功能在某些瀏覽器尚在開發中，請參考<a href='#browser_compatibility'>兼容表格</a>以得到不同瀏覽器用的前輟。",
-    "en-US" : "<strong>This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a></strong><br />Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
-    "pt-BR" : "<strong>Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a></strong><br />Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
-    "ru"    : "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
+const str = mdn.localString({
+  "es": "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
+  "fr": "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#compatibilité_des_navigateurs'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
+  "ja": "<strong>これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。</strong><br />本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
+  "zh-CN": "<strong>这是一项<a href='/zh-CN/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#实验性'>实验性技术</a></strong><br />在将其用于生产之前，请仔细检查<a href='#浏览器兼容性'>浏览器兼容性表格</a>。",
+  "zh-TW": "<strong>這是一個<a href='/zh-TW/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#實驗性質'>實驗中的功能</a></strong><br />此功能在某些瀏覽器尚在開發中，請參考<a href='#瀏覽器相容性'>兼容表格</a>以得到不同瀏覽器用的前輟。",
+  "en-US": "<strong>This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a></strong><br />Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
+  "pt-BR": "<strong>Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a></strong><br />Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
+  "ru": "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
+});
+
+const title = mdn.localString({
+  "en-US": "Experimental",
+  "es": "Experimental",
+  "fr": "Expérimental",
+  "ja": "Experimental",
+  "ko": "Experimental",
+  "pt-BR": "Experimental",
+  "ru": "Экспериментальная возможность",
+  "zh-CN": "实验性",
+  "zh-TW": "實驗性質"
 });
 
 %>
 <div class="notecard experimental">
-    <h4>Experimental</h4>
+    <h4><%= title %></h4>
     <p><%- str %></p>
 </div>


### PR DESCRIPTION
## Summary

This PR add localization support for the title of `{{SeeCompatTable}}` macro (the translation is copied from [ExperimentalBadge](https://github.com/mdn/yari/blob/089697015fdfa521d14e3816cc02fe1f3a364889/kumascript/macros/ExperimentalBadge.ejs#L19-L29)), and also update the zh-CN translation and the `href`s of zh-TW str.

---

## Screenshots

See:

- `http://localhost:5042/zh-TW/docs/Web/API/AbortController`
- `http://localhost:5042/zh-CN/docs/Web/API/AmbientLightSensor`

### After

- zh-TW

![image](https://github.com/mdn/yari/assets/15844309/9be56862-2d48-4ba1-a786-cbee2fb2a57a)

- zh-CN

![image](https://github.com/mdn/yari/assets/15844309/2af23792-25f4-4f59-a524-173aad3c93cc)

---

## How did you test this change?

run `yarn start` and see rendered pages.
