### PR TITLE
fix(constants): add pl to RETIRED_LOCALES

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -23,6 +23,7 @@ export const RETIRED_LOCALES = new Map(
     "ms",
     "my",
     "nl",
+    "pl",
     "pt-PT",
     "sv-SE",
     "th",


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
### Problem

https://developer.mozilla.org/pl returns a 404 instead of redirecting to `en-US`, because it is missing in the `RETIRED_LOCALES` list.

### Solution

Add `pl` to the list.

---

## How did you test this change?

Ran `npm run copy-internal && npm start` in `/cloud-function` and verified with `curl https://localhost/pl`:

```
% curl https://localhost/pl
Found. Redirecting to /en-US/?retiredLocale=pl
```
