### PR TITLE
fix(toolbar): reduce height if read-only

### DIFF
--- a/client/src/document/toolbar/index.tsx
+++ b/client/src/document/toolbar/index.tsx
@@ -48,11 +48,11 @@ export default function Toolbar({
         <EditActions source={doc.source} />
       </div>
       {isReadOnly && (
-        <p>
+        <div>
           <i>
             You're in <b>read-only</b> mode.
           </i>
-        </p>
+        </div>
       )}
       <ToggleDocumentFlaws doc={doc} reloadPage={reloadPage} />
     </div>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

On Preview URLs, the toolbar is unnecessarily high, because it contains a `<p>`, which has `margin: 1rem 0 2rem;`.

### Solution

Turn the `<p>` into a `<div>`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1237" alt="image" src="https://github.com/mdn/yari/assets/495429/6c94977d-2377-403a-8e44-c8cb084dda3f">


### After

<img width="1237" alt="image" src="https://github.com/mdn/yari/assets/495429/956c2524-1ed9-4b70-8f45-652c10674b70">


---

## How did you test this change?

Applied the changes directly [here](https://pr26985.content.dev.mdn.mozit.cloud/en-US/docs/Glossary/Firefox_OS).