### PR TITLE
chore(kumascript): use url in render error

### DIFF
--- a/kumascript/index.ts
+++ b/kumascript/index.ts
@@ -91,7 +91,6 @@ export async function render(
     rawHTML,
     {
       ...metadata,
-      path: fileInfo?.path,
       url,
       tags: metadata.tags || [],
       selective_mode,

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -109,9 +109,7 @@ export default class Templates {
       return rendered.trim();
     } catch (error) {
       console.error(
-        `The ${name} macro in ${
-          args.env.path ?? args.env.url
-        } failed to render.`,
+        `The ${name} macro on ${args.env.url} failed to render.`,
         error
       );
       throw error;


### PR DESCRIPTION


## Summary


### Problem

The path is so long that it cuts in Sentry, making it harder to export a list of errors programatically.

### Solution

Use the url instead.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
