### PR TITLE
feat(macros): add GlossarySidebar macro

### DIFF
--- a/kumascript/macros/GlossarySidebar.ejs
+++ b/kumascript/macros/GlossarySidebar.ejs
@@ -1,0 +1,32 @@
+<%
+var locale = env.locale;
+var baseURL = '/' + locale + '/docs/Glossary';
+
+var text = mdn.localStringMap({
+  'en-US': {
+    'Glossary_home_page' : 'MDN Web Docs Glossary',
+  },
+  'es': {
+    'Glossary_home_page' : 'Glosario de MDN Web Docs',
+  },
+  'fr': {
+    'Glossary_home_page' : "Glossaire MDN Web Docs",
+  },
+  'ja': {
+    'Glossary_home_page' : 'MDN Web Docs 用語集',
+  },
+  'ko': {
+    'Glossary_home_page' : 'MDN Web Docs 용어집',
+  },
+  'ru': {
+    'Glossary_home_page' : 'Глоссарий MDN Web Docs',
+  }
+});
+
+%>
+
+<section id="Quick_links" data-macro="GlossarySidebar">
+  <ol>
+    <li><strong><a href="<%=baseURL%>"><%=text['Glossary_home_page']%></a></strong><%-await template("ListSubpagesForSidebar", ['/en-us/docs/Glossary', 1])%></li>
+  </ol>
+</section>

--- a/kumascript/macros/GlossarySidebar.ejs
+++ b/kumascript/macros/GlossarySidebar.ejs
@@ -1,32 +1,28 @@
 <%
 var locale = env.locale;
-var baseURL = '/' + locale + '/docs/Glossary';
 
-var text = mdn.localStringMap({
-  'en-US': {
-    'Glossary_home_page' : 'MDN Web Docs Glossary',
-  },
-  'es': {
-    'Glossary_home_page' : 'Glosario de MDN Web Docs',
-  },
-  'fr': {
-    'Glossary_home_page' : "Glossaire MDN Web Docs",
-  },
-  'ja': {
-    'Glossary_home_page' : 'MDN Web Docs 用語集',
-  },
-  'ko': {
-    'Glossary_home_page' : 'MDN Web Docs 용어집',
-  },
-  'ru': {
-    'Glossary_home_page' : 'Глоссарий MDN Web Docs',
+async function renderRootItem(slug) {
+  const [link, title] = await getPageLinkAndTitle(slug);
+  return `<li><a href="${link}"><strong>${title}</strong></a></li>`
+}
+
+async function getPageLinkAndTitle(slug) {
+  let link = `/${env.locale}${slug}`;
+  let page = await wiki.getPage(link);
+  if (!page.title && env.locale !== 'en-US') {
+    link = `/en-US${slug}`;
+    page = await wiki.getPage(link);
   }
-});
+  let title = page.short_title || page.title;
+  title = mdn.htmlEscape(title);
+  return [link, title];
+}
 
 %>
 
 <section id="Quick_links" data-macro="GlossarySidebar">
   <ol>
-    <li><strong><a href="<%=baseURL%>"><%=text['Glossary_home_page']%></a></strong><%-await template("ListSubpagesForSidebar", ['/en-us/docs/Glossary', 1])%></li>
+    <%- await renderRootItem("/docs/Glossary") %>
+    <%- await template("ListSubpagesForSidebar", ['/docs/Glossary', 1]) %></li>
   </ol>
 </section>

--- a/kumascript/macros/GlossarySidebar.ejs
+++ b/kumascript/macros/GlossarySidebar.ejs
@@ -1,6 +1,4 @@
 <%
-var locale = env.locale;
-
 async function renderRootItem(slug) {
   const [link, title] = await getPageLinkAndTitle(slug);
   return `<li><a href="${link}"><strong>${title}</strong></a></li>`

--- a/kumascript/macros/GlossarySidebar.ejs
+++ b/kumascript/macros/GlossarySidebar.ejs
@@ -23,6 +23,6 @@ async function getPageLinkAndTitle(slug) {
 <section id="Quick_links" data-macro="GlossarySidebar">
   <ol>
     <%- await renderRootItem("/docs/Glossary") %>
-    <%- await template("ListSubpagesForSidebar", ['/docs/Glossary', 1]) %></li>
+    <%- await template("ListSubpagesForSidebar", ['/docs/Glossary', 1]) %>
   </ol>
 </section>

--- a/kumascript/macros/ListSubpagesForSidebar.ejs
+++ b/kumascript/macros/ListSubpagesForSidebar.ejs
@@ -84,7 +84,7 @@ async function createLink(aPage) {
     if (wrapInCode) {
       linkContent = `<code>${linkContent}</code>`;
     }
-    
+
     const pageBadges = (await page.badges(aPage)).join("");
 
     const result = `<li><a href="${url}">${linkContent}</a>${pageBadges}</li>`;


### PR DESCRIPTION
This PR adds a dedicated `{{GlossarySidebar}}` macro.

## Related pull requests

- [ ] Content: https://github.com/mdn/content/pull/26985

### Problem

We do not have a sidebar in any Glossary sub-page. This PR introduces a macro that lists all pages under `glossary/*/index.md`

### Solution

A macro `{{GlossarySidebar}}` that will list all Glossary pages for discovery.

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/43580235/e5ad048f-3a8d-4be7-8a7d-560a96d6af72)


### After

![image](https://github.com/mdn/yari/assets/43580235/67d21ec2-6228-49f7-a957-70b353c33994)


## How did you test this change?

locally with `yarn && yarn dev`


## Open questions

- Do we need tests for this?