### PR TITLE
style(sass): disallow concatenated selectors

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -43,6 +43,7 @@
     "order/properties-alphabetical-order": true,
     "property-no-vendor-prefix": null,
     "selector-class-pattern": null,
+    "selector-disallowed-list": ["/^&-/"],
     "selector-max-compound-selectors": null,
     "selector-max-id": null,
     "selector-no-qualifying-type": null,

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -43,7 +43,7 @@
     "order/properties-alphabetical-order": true,
     "property-no-vendor-prefix": null,
     "selector-class-pattern": null,
-    "selector-disallowed-list": ["/^&-/"],
+    "selector-disallowed-list": ["/^&[^,.:[#]/"],
     "selector-max-compound-selectors": null,
     "selector-max-id": null,
     "selector-no-qualifying-type": null,

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -7,7 +7,7 @@
     display: none;
   }
 
-  &-heading {
+  .sidebar-heading {
     color: var(--text-primary);
     font: var(--type-heading-h5);
     letter-spacing: 1.5px;

--- a/client/src/document/organisms/toc/index.scss
+++ b/client/src/document/organisms/toc/index.scss
@@ -12,14 +12,14 @@
   }
 
   // double classes to override specificity from root styles
-  &-heading.document-toc-heading {
+  .document-toc-heading.document-toc-heading {
     font: var(--type-heading-h5);
     letter-spacing: 1.5px;
     margin: 0 0 1rem;
   }
 
   // double classes to override specificity from root styles
-  &-list.document-toc-list {
+  .document-toc-list.document-toc-list {
     font-size: var(--type-smaller-font-size);
     list-style: none;
     padding-left: 0;
@@ -30,7 +30,7 @@
   }
 
   // double classes to override specificity from root styles
-  &-link.document-toc-link:not(.button) {
+  .document-toc-link.document-toc-link:not(.button) {
     border-left: 2px solid var(--border-secondary);
     color: var(--text-secondary);
     display: block;
@@ -49,7 +49,7 @@
     }
   }
 
-  &-item-sub > .document-toc-link:not(.button) {
+  .document-toc-item-sub > .document-toc-link:not(.button) {
     padding-left: 2rem;
   }
 

--- a/client/src/document/toolbar/index.scss
+++ b/client/src/document/toolbar/index.scss
@@ -14,7 +14,7 @@
   margin: 0.5rem;
   padding: 0.5rem 1rem;
 
-  &-first-row,
+  .toolbar-first-row,
   .edit-actions {
     display: flex;
     gap: 1rem;

--- a/client/src/plus/icon-card/index.scss
+++ b/client/src/plus/icon-card/index.scss
@@ -35,7 +35,7 @@
     margin-bottom: 1rem;
   }
 
-  &-icon {
+  .icon-card-icon {
     align-items: center;
     background-color: var(--http-accent-color);
     border-radius: 0.125rem;
@@ -74,7 +74,7 @@
     }
   }
 
-  &-title-wrap {
+  .icon-card-title-wrap {
     display: flex;
     gap: 1rem;
 
@@ -88,7 +88,7 @@
     }
   }
 
-  &-title {
+  .icon-card-title {
     font-size: var(--type-base-font-size-rem);
     font-weight: var(--font-body-strong-weight);
     margin: 0;
@@ -97,14 +97,16 @@
     word-wrap: break-word;
   }
 
-  &-description {
+  .icon-card-description {
     color: var(--text-secondary);
     font-size: var(--type-smaller-font-size);
   }
 
-  &-actions {
+  .icon-card-actions {
+    align-self: center;
     display: flex;
     gap: 0.5rem;
+    margin-left: auto;
   }
 
   .icon-card-content {
@@ -119,11 +121,6 @@
       overflow: hidden;
       text-overflow: ellipsis;
     }
-  }
-
-  .icon-card-actions {
-    align-self: center;
-    margin-left: auto;
   }
 
   .breadcrumbs {

--- a/client/src/plus/updates/index.scss
+++ b/client/src/plus/updates/index.scss
@@ -182,7 +182,7 @@
         margin: 0;
         width: auto;
 
-        &-inner {
+        .table-container-inner {
           padding: 0;
         }
       }

--- a/client/src/ui/atoms/avatar/index.scss
+++ b/client/src/ui/atoms/avatar/index.scss
@@ -3,7 +3,7 @@
 .avatar {
   border-radius: 50%;
 
-  &-wrap {
+  .avatar-wrap {
     border-radius: 50%;
     height: 32px;
     /* pull the avatar into the space on the left

--- a/client/src/ui/atoms/toast/index.scss
+++ b/client/src/ui/atoms/toast/index.scss
@@ -17,7 +17,7 @@
   transform: translate(-50%, 0);
   width: 90vw;
 
-  &-content {
+  .toast-content {
     color: var(--toast-color);
     margin-right: auto;
   }
@@ -37,16 +37,16 @@
     --toast-color: #fff;
   }
 
-  &-verbose-text {
+  .toast-verbose-text {
     display: none;
   }
 
   @media screen and (min-width: $screen-md) {
-    &-verbose-text {
+    .toast-verbose-text {
       display: inline;
     }
 
-    &-short-text {
+    .toast-short-text {
       display: none;
     }
   }

--- a/client/src/ui/molecules/dropdown/index.scss
+++ b/client/src/ui/molecules/dropdown/index.scss
@@ -1,7 +1,7 @@
 .dropdown {
   position: relative;
 
-  &-list {
+  .dropdown-list {
     background: var(--background-secondary);
     border: 1px solid var(--border-primary);
     border-radius: var(--elem-radius);
@@ -18,7 +18,7 @@
     right: 0;
   }
 
-  &-item {
+  .dropdown-item {
     .button.action {
       width: 100%;
 

--- a/client/src/ui/molecules/pagination/index.scss
+++ b/client/src/ui/molecules/pagination/index.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   padding: 1rem 0;
 
-  &-label {
+  .pagination-label {
     font-size: var(--type-smaller-font-size);
   }
 }

--- a/client/src/ui/organisms/article-actions/index.scss
+++ b/client/src/ui/organisms/article-actions/index.scss
@@ -172,7 +172,7 @@
       padding: 1rem var(--gutter-padding);
       text-align: center;
 
-      &-inner {
+      .header-inner {
         justify-content: center;
       }
 

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -5,7 +5,7 @@
   padding: (1rem * 2) 1rem;
   position: relative;
 
-  &-grid {
+  .page-footer-grid {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
@@ -18,20 +18,20 @@
     color: var(--text-secondary);
   }
 
-  &-logo-col {
+  .page-footer-logo-col {
     p {
       margin-top: 0;
       max-width: 55ch;
     }
   }
 
-  &-app-list {
+  .page-footer-app-list {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
   }
 
-  &-app-dl {
+  .page-footer-app-dl {
     display: block;
     max-width: 130px;
 
@@ -45,7 +45,7 @@
     }
   }
 
-  &-moz {
+  .page-footer-moz {
     align-items: center;
     border-top: 1px solid var(--border-primary);
     display: flex;
@@ -55,7 +55,7 @@
     padding-top: 1.5rem;
   }
 
-  &-legal-text {
+  .page-footer-legal-text {
     font-size: var(--type-tiny-font-size);
     margin: 0;
 
@@ -70,18 +70,18 @@
 }
 
 .footer-moz {
-  &-list {
+  .footer-moz-list {
     display: flex;
     flex-wrap: wrap;
     font-size: var(--type-tiny-font-size);
     gap: 1rem;
   }
 
-  &-logo-link {
+  .footer-moz-logo-link {
     display: flex;
   }
 
-  &-link {
+  .footer-moz-link {
     text-decoration: underline;
 
     &:hover {
@@ -112,25 +112,25 @@
 }
 
 .footer-nav {
-  &-heading {
+  .footer-nav-heading {
     font: var(--type-smaller-font-size);
     margin: 0 0 0.5rem;
   }
 
-  &-list {
+  .footer-nav-list {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
   }
 
-  &-item {
+  .footer-nav-item {
     font-size: var(--type-smaller-font-size);
   }
 }
 
 @media screen and (min-width: $screen-sm) {
   .page-footer {
-    &-grid {
+    .page-footer-grid {
       display: grid;
       gap: 2.5rem;
       grid-template-areas:
@@ -142,43 +142,43 @@
       grid-template-columns: 1fr 1fr;
     }
 
-    &-logo-col {
+    .page-footer-logo-col {
       grid-area: logo;
     }
 
-    &-nav-col-1 {
+    .page-footer-nav-col-1 {
       grid-area: nav1;
     }
 
-    &-nav-col-2 {
+    .page-footer-nav-col-2 {
       grid-area: nav2;
     }
 
-    &-nav-col-3 {
+    .page-footer-nav-col-3 {
       grid-area: nav3;
     }
 
-    &-nav-col-4 {
+    &.page-footer-nav-col-4 {
       grid-area: nav4;
     }
 
-    &-app-col {
+    .page-footer-app-col {
       grid-area: app;
     }
 
-    &-moz {
+    .page-footer-moz {
       grid-area: moz;
     }
 
-    &-legal {
+    .page-footer-legal {
       grid-area: legal;
     }
 
-    &-app-list {
+    .page-footer-app-list {
       flex-direction: row;
     }
 
-    &-app-dl {
+    .page-footer-app-dl {
       img,
       svg {
         height: 38px;
@@ -189,7 +189,7 @@
 
 @media screen and (min-width: $screen-md) {
   .page-footer {
-    &-grid {
+    .page-footer-grid {
       gap: 1rem;
       grid-template-areas:
         "logo  nav1  nav2  nav3  nav4"
@@ -198,11 +198,11 @@
       grid-template-columns: minmax(260px, 2fr) repeat(4, minmax(0, 1fr));
     }
 
-    &-app-list {
+    .page-footer-app-list {
       flex-direction: column;
     }
 
-    &-app-dl {
+    .page-footer-app-dl {
       img,
       svg {
         height: auto;
@@ -213,7 +213,7 @@
 
 @media screen and (min-width: $screen-xxl) {
   .page-footer {
-    &-grid {
+    .page-footer-grid {
       gap: 2.5rem;
     }
   }

--- a/client/src/ui/organisms/footer/index.scss
+++ b/client/src/ui/organisms/footer/index.scss
@@ -158,7 +158,7 @@
       grid-area: nav3;
     }
 
-    &.page-footer-nav-col-4 {
+    .page-footer-nav-col-4 {
       grid-area: nav4;
     }
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Selectors can be concatenated in Sass, but this prevents those selectors from being found via the search.

### Solution

Disallow selector concatenating, as [described here](https://stackoverflow.com/questions/74598779/how-to-disallow-concatenated-selectors).

---

## How did you test this change?

Ran `yarn stylelint` and manually reviewed the changes once more in this PR to make sure I used the correct replacement in each case.