### PR TITLE
fix(github): include build/** in search results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build/** linguist-generated=false
+


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Currently, when [searching for yari files on GitHub](https://github.com/mdn/yari?search=1), files from the `build/` directory are excluded as per [the GitHub docs](https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files).

### Solution

Set the `linguist-generated=false` for those files in a `.gitattributes` file.

---

## How did you test this change?

We'll see!