### PR TITLE
fix(flaws): stop reporting absolute MDN blog links as broken

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -225,16 +225,6 @@ export function getBrokenLinksFlaws(
       // Note! If it's not known that the URL's domain can be turned into https://
       // we do nothing here. No flaw. It's unfortunate that we still have http://
       // links in our content but that's a reality of MDN being 15+ years old.
-    } else if (href.startsWith("https://developer.mozilla.org/")) {
-      // It might be a working 200 OK link but the link just shouldn't
-      // have the full absolute URL part in it.
-      const absoluteURL = new URL(href);
-      addBrokenLink(
-        a,
-        checked.get(href),
-        href,
-        absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
-      );
     } else if (isHomepageURL(hrefNormalized)) {
       // But did you spell it perfectly?
       const homepageLocale = hrefNormalized.split("/")[1];

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -225,6 +225,19 @@ export function getBrokenLinksFlaws(
       // Note! If it's not known that the URL's domain can be turned into https://
       // we do nothing here. No flaw. It's unfortunate that we still have http://
       // links in our content but that's a reality of MDN being 15+ years old.
+    } else if (
+      href.startsWith("https://developer.mozilla.org/") &&
+      !href.startsWith("https://developer.mozilla.org/en-US/blog/")
+    ) {
+      // It might be a working 200 OK link but the link just shouldn't
+      // have the full absolute URL part in it.
+      const absoluteURL = new URL(href);
+      addBrokenLink(
+        a,
+        checked.get(href),
+        href,
+        absoluteURL.pathname + absoluteURL.search + absoluteURL.hash
+      );
     } else if (isHomepageURL(hrefNormalized)) {
       // But did you spell it perfectly?
       const homepageLocale = hrefNormalized.split("/")[1];


### PR DESCRIPTION
## Summary

### Problem

We have a flaw that reports absolute MDN links, to ensure content uses relative links, so that they work on all environments (locally, stage and prod), and another flaw that reports relative MDN links that don't exist.

When we added relative links to MDN blog articles, this has been causing a flaw, because external contributors don't have the mdn/mdn-studio repository checked out, and even if they would, the flaw doesn't take the blog articles into consideration.

That's why relative links to MDN blog articles were replaced with absolute links, but that caused the other flaw.

### Solution

Do not consider absolute links to MDN blog articles broken.

---

## Screenshots

### Before

<img width="1419" alt="image" src="https://github.com/mdn/yari/assets/495429/4c810a38-b907-47ba-b7ef-e92dd42e6900">

### After

<img width="1419" alt="image" src="https://github.com/mdn/yari/assets/495429/d0badd34-3506-4ef9-b60b-77684412b398">

## How did you test this change?

Ran `yarn && yarn dev` (with `REACT_APP_WRITER_MODE=true` in my `.env`) and opened http://localhost:3000/en-US/docs/Web/CSS/:not#_flaws locally.
