### PR TITLE
fix(sidebar-filter): avoid duplicate focus events

### DIFF
--- a/client/src/document/organisms/sidebar/filter.tsx
+++ b/client/src/document/organisms/sidebar/filter.tsx
@@ -8,14 +8,16 @@ import { useGleanClick } from "../../../telemetry/glean-context";
 import { SIDEBAR_FILTER_FOCUS } from "../../../telemetry/constants";
 
 export function SidebarFilter() {
-  const [isActive, setActive] = useState<Boolean>(false);
+  const [isActive, setActive] = useState<boolean>(false);
+  const wasActive = useRef(false);
   const { query, setQuery, matchCount } = useSidebarFilter();
   const gleanClick = useGleanClick();
 
   useEffect(() => {
-    if (isActive) {
+    if (isActive && !wasActive.current) {
       gleanClick(SIDEBAR_FILTER_FOCUS);
     }
+    wasActive.current = isActive;
   }, [gleanClick, isActive]);
 
   return (


### PR DESCRIPTION
## Summary

(MP-482)

### Problem

We measure how many users click into the sidebar filter input, but unfortunately each keypress also triggers the event.

### Solution

Distinguish the activation change.

---

## How did you test this change?

Added a `console.log()` call to the `useEffect()`'s inner block to verify it's only called when (re-)activating the sidebar filter.