### PR TITLE
fix(glean): gleanClick changes between re-renders

### DIFF
--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -182,9 +182,12 @@ export function useGleanPage(pageNotFound: boolean) {
 export function useGleanClick() {
   const userData = useUserData();
   const glean = useGlean();
-  return (source: string) =>
-    glean.click({
-      source,
-      subscriptionType: userData?.subscriptionType || "none",
-    });
+  return React.useCallback(
+    (source: string) =>
+      glean.click({
+        source,
+        subscriptionType: userData?.subscriptionType || "none",
+      }),
+    [glean, userData?.subscriptionType]
+  );
 }


### PR DESCRIPTION
this causes any useEffects depending on it to fire on every render

should fix the underlying problem in https://github.com/mdn/yari/pull/9106 (MP-482)

---

## How did you test this change?

Set:
```
REACT_APP_GLEAN_ENABLED=true
REACT_APP_GLEAN_DEBUG=true
```
and observed glean events in console not being sent for every keypress in the sidebar filter.
