### PR TITLE
chore(macros): deprecate {{xref_cssvisual}} macro

### DIFF
--- a/kumascript/macros/xref_cssvisual.ejs
+++ b/kumascript/macros/xref_cssvisual.ejs
@@ -1,3 +1,8 @@
+<%
+// Condition for removal: no more use in translated-content
+mdn.deprecated();
+%>
+
 <% if ("es" == env.locale) { %>
 <%- await template("Cssxref", ["Media/Visual", "visual"]) %>
 <% } else if ("fr" == env.locale) { %>


### PR DESCRIPTION
## Summary

This macro is not used in en-US, and it does point to the redirected page (`/en-US/docs/CSS/Media/Visual -> /en-US/docs/Web/CSS/@media`). Maybe it's time to deprecate this macro.

/cc @mdn/yari-content-css @bsmth

---

## How did you test this change?

None.
