### PR TITLE
fix(livesamples): use correct legacy url

### DIFF
--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -8,18 +8,20 @@
 // $1   The URL from which to pull the sample; if not provided,
 //      the current page is assumed.
 
+let id = $0;
+let remoteUrl = $1;
 let pagePath = env.url;
 let baseUrl = env.live_samples.base_url;
 let samplePath = `${pagePath}/runner.html`.replace(/\/\/+/g, "/");
 
-if ($1 && $1.length > 0) {
-    pagePath = $1;
+if (remoteUrl && remoteUrl.length > 0) {
+    pagePath = remoteUrl;
     baseUrl = env.live_samples.legacy_url;
-    samplePath = `${pagePath}/_sample_.${web.slugify(web.safeDecodeURIComponent($0))}.html`.replace(/\/\/+/g, "/");
+    samplePath = `${pagePath}/_sample_.${web.slugify(web.safeDecodeURIComponent(id))}.html`.replace(/\/\/+/g, "/");
 }
 
 wiki.ensureExistence(pagePath);
-const searchParams = new URLSearchParams([["id", $0], ["url", $1]].filter(([_,v]) => Boolean(v)));
+const searchParams = new URLSearchParams([["id", id], ["url", remoteUrl]].filter(([_,v]) => Boolean(v)));
 
 let url;
 if (baseUrl.includes('://')) {

--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -4,8 +4,8 @@
 //
 // Parameters:
 //
-// $0 - The ID of the sample's section or containing block.
-// $1 - (Deprecated)  The URL from which to pull the sample; if not provided,
+// $0   The ID of the sample's section or containing block.
+// $1   The URL from which to pull the sample; if not provided,
 //      the current page is assumed.
 
 let pagePath = env.url;
@@ -13,7 +13,6 @@ let baseUrl = env.live_samples.base_url;
 let samplePath = `${pagePath}/runner.html`.replace(/\/\/+/g, "/");
 
 if ($1 && $1.length > 0) {
-    mdn.deprecatedParams("The second parameter of 'LiveSampleURL' is deprecated");
     pagePath = $1;
     baseUrl = env.live_samples.legacy_url;
     samplePath = `${pagePath}/_sample_.${web.slugify(web.safeDecodeURIComponent($0))}.html`.replace(/\/\/+/g, "/");

--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -4,25 +4,27 @@
 //
 // Parameters:
 //
-// $0   The ID of the sample's section or containing block.
-// $1   The URL from which to pull the sample; if not provided,
+// $0 - The ID of the sample's section or containing block.
+// $1 - (Deprecated)  The URL from which to pull the sample; if not provided,
 //      the current page is assumed.
 
-var pagePath = env.url;
+let pagePath = env.url;
+let baseUrl = env.live_samples.base_url;
+let samplePath = `${pagePath}/runner.html`.replace(/\/\/+/g, "/");
 
 if ($1 && $1.length > 0) {
+    mdn.deprecatedParams("The second parameter of 'LiveSampleURL' is deprecated");
     pagePath = $1;
+    baseUrl = env.live_samples.legacy_url;
+    samplePath = `${pagePath}/_sample_.${web.slugify(web.safeDecodeURIComponent($0))}.html`.replace(/\/\/+/g, "/");
 }
 
-const searchParams = new URLSearchParams([["id", $0], ["url", $1]].filter(([_,v]) => Boolean(v)));
 wiki.ensureExistence(pagePath);
-const samplePath = $1 ?
-  `${pagePath}/_sample_.${web.slugify(web.safeDecodeURIComponent($0))}.html`.replace(/\/\/+/g, "/")
-  : `${pagePath}/runner.html`.replace(/\/\/+/g, "/");
+const searchParams = new URLSearchParams([["id", $0], ["url", $1]].filter(([_,v]) => Boolean(v)));
 
 let url;
-if (env.live_samples.base_url.includes('://')) {
-    url = new URL($1 ? env.live_samples.legacy_url : env.live_samples.base_url);
+if (baseUrl.includes('://')) {
+    url = new URL(baseUrl);
     url.pathname = samplePath;
     url.search = searchParams.toString();
 } else {

--- a/kumascript/macros/LiveSampleURL.ejs
+++ b/kumascript/macros/LiveSampleURL.ejs
@@ -22,7 +22,7 @@ const samplePath = $1 ?
 
 let url;
 if (env.live_samples.base_url.includes('://')) {
-    url = new URL(env.live_samples.base_url);
+    url = new URL($1 ? env.live_samples.legacy_url : env.live_samples.base_url);
     url.pathname = samplePath;
     url.search = searchParams.toString();
 } else {

--- a/kumascript/tests/macros/EmbedLiveSample.test.ts
+++ b/kumascript/tests/macros/EmbedLiveSample.test.ts
@@ -4,7 +4,8 @@ import { assert, itMacro, describeMacro, beforeEachMacro } from "./utils.js";
 describeMacro("EmbedLiveSample", function () {
   beforeEachMacro(function (macro) {
     macro.ctx.env.live_samples = {
-      base_url: "https://mdn.mozillademos.org",
+      base_url: "https://live.mdnplay.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.info.hasPage = jest.fn(() => true);
   });
@@ -15,7 +16,7 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><p class="example-header"></p><iframe class="sample-code-frame"' +
         ' title="Quotations sample"' +
         ' id="frame_quotations"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/runner.html?id=quotations">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=quotations">' +
         "</iframe></div>"
     );
   });
@@ -27,7 +28,7 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><p class="example-header"></p><iframe class="sample-code-frame"' +
         ' title="SVG &amp;lt;switch&amp;gt; example sample"' +
         ' id="frame_svg_ltswitchgt_example"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_ltswitchgt_example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_ltswitchgt_example">' +
         "</iframe></div>"
     );
   });
@@ -38,7 +39,7 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><p class="example-header"></p><iframe class="sample-code-frame"' +
         ' title="SVG %3Cswitch%3E example sample"' +
         ' id="frame_svg_switch_example"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_switch_example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_switch_example">' +
         "</iframe></div>"
     );
   });
@@ -50,7 +51,7 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><p class="example-header"></p><iframe class="sample-code-frame"' +
         ' title="Dégradés linéaires simples sample"' +
         ' id="frame_dégradés_linéaires_simples"' +
-        ' src="https://mdn.mozillademos.org/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS/runner.html?id=d%C3%A9grad%C3%A9s_lin%C3%A9aires_simples">' +
+        ' src="https://live.mdnplay.dev/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS/runner.html?id=d%C3%A9grad%C3%A9s_lin%C3%A9aires_simples">' +
         "</iframe></div>"
     );
   });
@@ -61,7 +62,7 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><p class="example-header"></p><iframe class="sample-code-frame"' +
         ' title="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt; sample"' +
         ' id="frame_scriptalertxssscript"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/runner.html?id=scriptalertxssscript">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=scriptalertxssscript">' +
         "</iframe></div>"
     );
   });
@@ -73,7 +74,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Example sample"' +
         ' id="frame_example"' +
         ' width="100%"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
         "</iframe></div>"
     );
   });
@@ -85,7 +86,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Example sample"' +
         ' id="frame_example"' +
         ' width="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
         "</iframe></div>"
     );
   });
@@ -97,7 +98,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Images sample"' +
         ' id="frame_images"' +
         ' width="100%" height="250"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
         "</iframe></div>"
     );
   });
@@ -110,7 +111,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="增加关键帧 sample"' +
         ' id="frame_增加关键帧"' +
         ' width="100%" height="250"' +
-        ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations/runner.html?id=%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7">' +
+        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations/runner.html?id=%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7">' +
         "</iframe></div>"
     );
   });
@@ -126,7 +127,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6 sample"' +
         ' id="frame_一个模板骨架"' +
         ' width="160" height="160"' +
-        ' src="https://mdn.mozillademos.org/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage/runner.html?id=%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6">' +
+        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage/runner.html?id=%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6">' +
         "</iframe></div>"
     );
   });
@@ -138,7 +139,7 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Images sample"' +
         ' id="frame_images"' +
         ' width="100%" height="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
-        ' src="https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
         "</iframe></div>"
     );
   });
@@ -147,7 +148,7 @@ describeMacro("EmbedLiveSample", function () {
     ' title="Examples sample"' +
     ' id="frame_examples"' +
     ' width="700px" height="700px"' +
-    ' src="https://mdn.mozillademos.org/en-US/docs/Web/CSS/flex-wrap/runner.html?id=examples">' +
+    ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/flex-wrap/runner.html?id=examples">' +
     "</iframe></div>";
   itMacro("Three arguments: ID, width, height (same slug)", function (macro) {
     macro.ctx.env.url = "/en-US/docs/Web/CSS/flex-wrap";

--- a/kumascript/tests/macros/LiveSampleURL.test.ts
+++ b/kumascript/tests/macros/LiveSampleURL.test.ts
@@ -7,17 +7,19 @@ describeMacro("LiveSampleURL", function () {
   });
   itMacro("Production settings", function (macro) {
     macro.ctx.env.live_samples = {
-      base_url: "https://mdn.mozillademos.org",
+      base_url: "https://live.mdnplay.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.env.url = "/en-US/docs/Web/HTML/Element/p";
     return assert.eventually.equal(
       macro.call("Example"),
-      "https://mdn.mozillademos.org/en-US/docs/Web/HTML/Element/p/runner.html?id=Example"
+      "https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/p/runner.html?id=Example"
     );
   });
   itMacro("Override page URL", function (macro) {
     macro.ctx.env.live_samples = {
-      base_url: "https://mdn.mozillademos.org",
+      base_url: "https://live.mdnplay.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.env.url =
       "/en-US/docs/Learn/HTML/Forms/How_to_build_custom_form_widgets";
@@ -31,7 +33,8 @@ describeMacro("LiveSampleURL", function () {
   });
   itMacro("Override with nonexistent page URL", async (macro) => {
     macro.ctx.env.live_samples = {
-      base_url: "https://mdn.mozillademos.org",
+      base_url: "https://live.mdnplay.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.info.hasPage = jest.fn(() => false);
     macro.ctx.info.getDescription = jest.fn((url: string) => url.toLowerCase());
@@ -44,12 +47,13 @@ describeMacro("LiveSampleURL", function () {
   });
   itMacro("Staging settings", function (macro) {
     macro.ctx.env.live_samples = {
-      base_url: "https://files-stage.mdn.mozit.cloud",
+      base_url: "https://live.mdnyalp.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.env.url = "/en-US/docs/Web/CSS/background-color";
     return assert.eventually.equal(
       macro.call("Examples"),
-      "https://files-stage.mdn.mozit.cloud/en-US/docs/Web/CSS/background-color/runner.html?id=Examples"
+      "https://live.mdnyalp.dev/en-US/docs/Web/CSS/background-color/runner.html?id=Examples"
     );
   });
   itMacro("Development default settings", function (macro) {
@@ -62,12 +66,13 @@ describeMacro("LiveSampleURL", function () {
   });
   itMacro("Unicode ID", function (macro) {
     macro.ctx.env.live_samples = {
-      base_url: "https://mdn.mozillademos.org",
+      base_url: "https://live.mdnplay.dev",
+      legacy_url: "https://mdn.mozillademos.org",
     };
     macro.ctx.env.url = "/zh-CN/docs/Web/CSS/flex-direction";
     return assert.eventually.equal(
       macro.call("例子"),
-      "https://mdn.mozillademos.org/zh-CN/docs/Web/CSS/flex-direction/runner.html?id=%E4%BE%8B%E5%AD%90"
+      "https://live.mdnplay.dev/zh-CN/docs/Web/CSS/flex-direction/runner.html?id=%E4%BE%8B%E5%AD%90"
     );
   });
   itMacro("Development demo settings", function (macro) {


### PR DESCRIPTION
## Summary

We did not use the legacy URL in LiveSampleURL.ejs

### Problem

Live samples translated from another page (deprecated), resulted in to 404 iframe. 

### Solution

Use the legacy url in LiveSampleURL.ejs to point to the legacy live sample.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/3604775/667b5df6-2fda-4299-8ad9-90a4ade34e0b)


### After

![image](https://github.com/mdn/yari/assets/3604775/6ca27584-f8dd-48ba-99a3-0e247040d279)


---

## How did you test this change?

https://developer.mozilla.org/en-US/docs/Learn/Forms/How_to_build_custom_form_controls

With:
```
BUILD_LIVE_SAMPLES_BASE_URL=https://live.mdnplay.dev
BUILD_LEGACY_LIVE_SAMPLES_BASE_URL=https://live-samples.mdn.mozilla.net
```

Use a `yarn build files/en-us/learn/forms/how_to_build_custom_form_controls/index.md` and check that the iframes in the resulting html file have `live-samples.mdn.mozilla.net` as domain if they are not using the `runner.html`.