### PR TITLE
chore(blog): stylise sponsored content indicator

### DIFF
--- a/client/src/blog/index.scss
+++ b/client/src/blog/index.scss
@@ -1,6 +1,7 @@
+@use "../ui/vars" as *;
+
 .blog {
   --category-color: var(--apis-accent-color);
-  --sponsored-height: 1.375rem;
 
   .top-navigation {
     --text-link: var(--category-color);
@@ -13,19 +14,27 @@
   padding: 2rem 1rem;
 
   .sponsored {
-    color: var(--category-color);
-    font-size: 0.75rem;
-    font-weight: bold;
-    height: var(--sponsored-height);
-    text-transform: uppercase;
+    color: var(--icon-primary);
+
+    &::before {
+      background-color: var(--icon-primary);
+      content: "";
+      display: inline-block;
+      height: 1em;
+      margin-bottom: -0.15em;
+      margin-right: 0.3em;
+      mask-image: url("../assets/icons/note-info.svg");
+      mask-position: center;
+      mask-repeat: no-repeat;
+      width: 1em;
+    }
+  }
+
+  h1 {
+    margin-top: 1rem;
   }
 
   &.blog-index {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 2rem;
-    justify-content: flex-start;
-
     > header {
       width: 100%;
 
@@ -43,20 +52,35 @@
       }
     }
 
+    .article-list {
+      column-gap: 2rem;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+
+      @media screen and (max-width: $screen-lg) {
+        grid-template-columns: auto;
+      }
+    }
+
     article {
       border: 1px solid var(--border-primary);
       border-radius: 1rem;
-      max-width: 40rem;
+      display: grid;
+      grid-row: span 6;
+      grid-template-rows: subgrid;
+      margin-top: 2rem;
       padding: 2rem;
-      width: 100%;
 
       a.button {
+        margin-left: auto;
         text-decoration: var(--button-bg);
       }
 
       header {
-        display: flex;
+        display: grid;
         flex-direction: column;
+        grid-row: span 3;
+        grid-template-rows: subgrid;
 
         figure.blog-image {
           margin-bottom: 0;
@@ -69,15 +93,12 @@
         }
 
         h2:first-of-type {
+          align-self: center;
           font: var(--type-heading-h3);
           font-size: 1.75rem;
           font-weight: 400;
           margin-bottom: 2.25rem;
           margin-top: 1.5rem;
-        }
-
-        .sponsored ~ h2:first-of-type {
-          margin-top: 0;
         }
       }
 
@@ -86,8 +107,10 @@
         margin-top: 1.5rem;
       }
 
-      @media screen and (min-width: 50rem) {
-        width: max(40vw, 20rem);
+      footer {
+        align-items: center;
+        align-self: end;
+        display: flex;
       }
     }
   }

--- a/client/src/blog/index.scss
+++ b/client/src/blog/index.scss
@@ -111,6 +111,8 @@
         align-items: center;
         align-self: end;
         display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
       }
     }
   }

--- a/client/src/blog/index.tsx
+++ b/client/src/blog/index.tsx
@@ -51,16 +51,18 @@ function PostPreview({ fm }: { fm: BlogPostMetadata }) {
     <article>
       <header>
         <BlogIndexImageFigure image={fm.image} height={200} slug={fm.slug} />
-        {fm.sponsored && <span className="sponsored">Sponsored</span>}
         <h2>
           <a href={`./${fm.slug}/`}>{fm.title}</a>
         </h2>
         <AuthorDateReadTime metadata={fm} />
       </header>
       <p>{fm.description}</p>
-      <Button href={`./${fm.slug}/`} target="_self">
-        Read more →
-      </Button>
+      <footer>
+        {fm.sponsored && <span className="sponsored">Sponsored</span>}
+        <Button href={`./${fm.slug}/`} target="_self">
+          Read more →
+        </Button>
+      </footer>
     </article>
   );
 }
@@ -98,9 +100,11 @@ function BlogIndex(props: HydrationData) {
         <header>
           <h1 className="mify">Blog it better</h1>
         </header>
-        {data?.posts.map((fm) => {
-          return <PostPreview key={fm.slug} fm={fm} />;
-        })}
+        <section className="article-list">
+          {data?.posts.map((fm) => {
+            return <PostPreview key={fm.slug} fm={fm} />;
+          })}
+        </section>
       </main>
       <NewsletterSignUp />
     </>

--- a/client/src/blog/post.scss
+++ b/client/src/blog/post.scss
@@ -10,33 +10,39 @@
 }
 
 .blog-container {
+  --author-gap: 1rem;
+  --avatar-size: 3rem;
+
   .date-author,
   .author {
-    --date-author-gap: 1rem;
+    align-content: start;
     align-items: center;
     display: flex;
     flex-wrap: wrap;
-    gap: var(--date-author-gap);
+  }
+
+  .date-author {
+    column-gap: 1.5rem;
+    padding-left: calc(var(--avatar-size) + var(--author-gap));
   }
 
   .author {
     font-weight: var(--font-body-strong-weight);
+    gap: var(--author-gap);
+    margin-left: calc((var(--avatar-size) + var(--author-gap)) * -1);
 
     &::after {
-      margin-left: calc(4px - var(--date-author-gap));
+      margin-left: calc(4px - var(--author-gap));
     }
 
     img {
       border: none !important;
       border-radius: 3rem;
-      height: 3rem;
+      height: var(--avatar-size);
       margin: 0;
+      object-fit: cover;
+      width: var(--avatar-size);
     }
-  }
-
-  .read-time {
-    font-size: var(--type-smaller-font-size);
-    margin-left: 0.5rem;
   }
 
   figure.blog-image {

--- a/client/src/blog/post.scss
+++ b/client/src/blog/post.scss
@@ -15,7 +15,7 @@
 
   .date-author,
   .author {
-    align-content: start;
+    align-content: flex-start;
     align-items: center;
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/MP-469

also progressively enhance with subgrid to align elements of the article cards with different lengths of titles/content

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screen Shot 2023-06-26 at 17 09 32](https://github.com/mdn/yari/assets/755354/4fc1ac54-8dc9-49b6-817f-de5b1ad686d5)
![Screen Shot 2023-06-26 at 17 09 23](https://github.com/mdn/yari/assets/755354/774032e3-c584-481f-89ac-292eec458885)


### After

![Screen Shot 2023-06-26 at 17 08 57](https://github.com/mdn/yari/assets/755354/b096860e-f7b6-4294-87d9-f5f03466ee06)
![Screen Shot 2023-06-26 at 17 08 51](https://github.com/mdn/yari/assets/755354/5594334e-f04c-4201-89ae-12c3b65b7a1f)


---

## How did you test this change?

Set `sponsored: true` to frontmatter in a blog article.

`yarn && yarn dev`
