### PR TITLE
fix(playground): only initialize once

### DIFF
--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -103,7 +103,11 @@
         }
       }
 
+      let initialized = false;
       function init(state) {
+        if (initialized) {
+          return;
+        }
         window.parent.postMessage({ typ: "console", prop: "clear" }, "*");
 
         const style = document.createElement("style");
@@ -118,6 +122,7 @@
         document.body.appendChild(script);
 
         dispatchEvent(new Event("load"));
+        initialized = true;
       }
       window.addEventListener("message", (event) => {
         const e = event.data;


### PR DESCRIPTION
## Summary

Navigating back and forth can try to initialized the runner multiple times. Let's not do that.
