### PR TITLE
fix(live-sample): use getElementsByClassName

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -159,15 +159,17 @@ function getCodeAndNodesForIframeBySampleClass(cls: string, src: string) {
 
   let empty = true;
   const nodes: Element[] = [];
-  document.querySelectorAll(`pre.live-sample___${cls}`).forEach((pre) => {
-    let lang = getLanguage(pre);
-    if (lang === null) {
-      return;
+  [...document.getElementsByClassName(`pre.live-sample___${cls}`)].forEach(
+    (pre) => {
+      let lang = getLanguage(pre);
+      if (lang === null) {
+        return;
+      }
+      empty = false;
+      nodes.push(pre);
+      code[lang] += pre.textContent;
     }
-    empty = false;
-    nodes.push(pre);
-    code[lang] += pre.textContent;
-  });
+  );
   return empty ? null : { code, nodes };
 }
 

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -159,7 +159,7 @@ function getCodeAndNodesForIframeBySampleClass(cls: string, src: string) {
 
   let empty = true;
   const nodes: Element[] = [];
-  [...document.getElementsByClassName(`pre.live-sample___${cls}`)].forEach(
+  [...document.getElementsByClassName(`live-sample___${cls}`)].forEach(
     (pre) => {
       let lang = getLanguage(pre);
       if (lang === null) {


### PR DESCRIPTION
## Summary

fixes #9177

### Problem

We were passing an raw class into querySelectorAll

### Solution

use getElementsByClassName
