### PR TITLE
fix(playground): don't extract inline css

### DIFF
--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -104,11 +104,7 @@ function codeForHeading(
   const nodes: Element[] = [];
   for (const part of LIVE_SAMPLE_PARTS) {
     const src = section
-      .flatMap((e) => [
-        ...e?.querySelectorAll(
-          `pre.${part}, pre[class*="brush:${part}"], pre[class*="${part};"]`
-        ),
-      ])
+      .flatMap((e) => [...e?.querySelectorAll(`pre.${part}`)])
       .map((e) => {
         nodes.push(e);
         return e.textContent;

--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -106,10 +106,9 @@ function codeForHeading(
     const src = section
       .flatMap((e) => [
         ...e?.querySelectorAll(
-          `.${part}, pre[class*="brush:${part}"], pre[class*="${part};"]`
+          `pre.${part}, pre[class*="brush:${part}"], pre[class*="${part};"]`
         ),
       ])
-
       .map((e) => {
         nodes.push(e);
         return e.textContent;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

https://mozilla-hub.atlassian.net/browse/MP-515
fixes https://github.com/mdn/yari/issues/9190

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

inline bits of css get a `css` class applied to them, so our extraction logic was treating them as "normal" css - which of course it isn't, since it doesn't have any kind of selector

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

specifically target `pre.${language_name}` rather than just `.${language_name}` - I'm going to wait for your review @fiji-flo here, because I imagine there was a reason you chose *not* to specifically target pre tags, so I want to make sure I'm not breaking anything else

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/755354/108b95bd-c54c-405d-8b7e-b38f6e80f1b6)


### After

![image](https://github.com/mdn/yari/assets/755354/e7f9ebff-6310-41af-a7c1-ba4e6dd45f0d)


---

## How did you test this change?

http://localhost:3000/en-US/docs/Web/CSS/flex-grow