### PR TITLE
fix(macros/AddonSidebar): inline "Using_the_JavaScript_APIs" redirect

### DIFF
--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -199,7 +199,7 @@ async function getPageLinkAndTitle(slug) {
         <summary><%=text['WebExtensions#Concepts']%></summary>
         <ol>
           <%- await renderItems([
-            "/docs/Mozilla/Add-ons/WebExtensions/Using_the_JavaScript_APIs",
+            "/docs/Mozilla/Add-ons/WebExtensions/API",
             "/docs/Mozilla/Add-ons/WebExtensions/Content_scripts",
             "/docs/Mozilla/Add-ons/WebExtensions/Background_scripts",
             "/docs/Mozilla/Add-ons/WebExtensions/Match_patterns",


### PR DESCRIPTION
## Summary

Fixes #9211.

### Problem

Correct wrong AddonSidebar item.

### Solution

Replace incorrect address with correct address。

---

## How did you test this change?

1. git clone `yari`, `content`, `translated-content`. and configure them normally.
2. apply change.
3. `yarn dev` to check if it works.
