### PR TITLE
feat(ai-help): add "Report issue with this answer on GitHub" link

### DIFF
--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -186,9 +186,16 @@
         width: 2.5rem;
       }
 
-      .glean-thumbs {
+      .ai-help-feedback {
+        display: flex;
+        flex-direction: column;
         font-size: var(--type-tiny-font-size);
-        justify-content: flex-end;
+        gap: 0.5rem;
+        text-align: right;
+
+        .glean-thumbs {
+          justify-content: flex-end;
+        }
       }
 
       &.status-pending .ai-help-message-content,


### PR DESCRIPTION
## Summary

### Problem

Currently, there is no way for users of AI Help to give qualitative feedback about an answer of low quality.

### Solution

Add a "Report issue with this answer on GitHub" link that pre-fills a GitHub issue template on a dedicated feedback repo.

---

## Screenshots

| Step 1 | Step 2 | Step 3 |
| ------ | ------- | ------ |
| <img width="814" alt="image" src="https://github.com/mdn/yari/assets/495429/b47f783f-02d2-4e42-83e6-04787e70dd90"> | ![image](https://github.com/mdn/yari/assets/495429/1213326f-d5c4-472f-9d25-dad4e2c40d44) | ![image](https://github.com/mdn/yari/assets/495429/43c5d776-1883-4b8d-ba76-8e7983028eca) |

---

## How did you test this change?

Asked a question locally and clicked on the new link.