### PR TITLE
chore(sidebar-filter): remove feedback footer

### DIFF
--- a/client/src/document/organisms/sidebar/filter.scss
+++ b/client/src/document/organisms/sidebar/filter.scss
@@ -122,17 +122,6 @@
     position: relative;
     z-index: unset;
   }
-
-  .sidebar-filter-footer {
-    background: var(--background-primary);
-    border: 1px solid var(--background-primary);
-
-    .glean-thumbs {
-      font-size: var(--type-tiny-font-size);
-      margin-bottom: 0.5rem;
-      margin-left: 0.6rem;
-    }
-  }
 }
 
 .sidebar {

--- a/client/src/document/organisms/sidebar/filter.tsx
+++ b/client/src/document/organisms/sidebar/filter.tsx
@@ -1,7 +1,6 @@
 import { MutableRefObject, useEffect, useRef, useState } from "react";
 import { SidebarFilterer } from "./SidebarFilterer";
 import { Button } from "../../../ui/atoms/button";
-import { GleanThumbs } from "../../../ui/atoms/thumbs";
 
 import "./filter.scss";
 import { useGleanClick } from "../../../telemetry/glean-context";
@@ -58,13 +57,6 @@ export function SidebarFilter() {
           <span className="visually-hidden">Clear filter input</span>
         </Button>
       </div>
-      {isActive && (
-        <div className="sidebar-filter-footer">
-          <div className="sidebar-filter-thumbs">
-            <GleanThumbs feature="sidebar-filter" />
-          </div>
-        </div>
-      )}
     </section>
   );
 }

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -85,7 +85,7 @@
     z-index: var(--z-index-main-header);
 
     ~ .sidebar-inner-nav {
-      margin-top: 2.5rem; /* Reduce to 0.5rem once SidebarFilter feedback is removed. */
+      margin-top: 0.5rem;
     }
 
     @media screen and (max-width: $screen-md) {


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The sidebar filter experiment has ended (with success), but we're still requesting users to give feedback.

### Solution

Remove the feedback button.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="362" alt="image" src="https://github.com/mdn/yari/assets/495429/a12f3349-2585-4233-82ab-7d8cd80c3347">

### After

<img width="362" alt="image" src="https://github.com/mdn/yari/assets/495429/7153b439-bbe2-447b-b6bb-931d37579300">

---

## How did you test this change?

Ran `yarn && yarn dev` and opened http://localhost:3000/en-US/docs/Web/CSS locally, then clicked into the sidebar filter field.
