### PR TITLE
chore(homepage): add distilled blog post to "Latest news"

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -411,6 +411,16 @@ async function fetchLatestNews() {
 
   items.push(
     {
+      title: "Responsibly empowering developers with AI on MDN",
+      url: `https://blog.mozilla.org/en/products/mdn/responsibly-empowering-developers-with-ai-on-mdn/`,
+      author: "Steve Teixeira",
+      published_at: new Date("Thu, 06 Jul 2023 14:41:20 +0000").toString(),
+      source: {
+        name: "blog.mozilla.org",
+        url: `https://blog.mozilla.org/en/latest/`,
+      },
+    },
+    {
       title: "Introducing AI Help: Your Trusted Companion for Web Development",
       url: `/${DEFAULT_LOCALE}/blog/introducing-ai-help/`,
       author: "Hermina Condei",


### PR DESCRIPTION
## Summary

### Problem

There is a new relevant blog post about MDN, and it's not linked from MDN.

### Solution

Add it to the "Latest news" section on the homepage.

---

## Screenshots

### Before

<img width="869" alt="image" src="https://github.com/mdn/yari/assets/495429/b7a193a2-7ba8-4b95-84e1-2dc9dd4f1b31">

### After

<img width="869" alt="image" src="https://github.com/mdn/yari/assets/495429/54bdc71b-813e-4923-b87b-f130a4d48f41">

---

## How did you test this change?

Ran `yarn && yarn dev` and visited http://localhost:3000/en-US/_homepage locally (got `REACT_APP_WRITER_MODE=true` in my `.env`)
