### PR TITLE
fix(client): make alt text on images appear in dark mode

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -106,7 +106,7 @@
   }
 
   img {
-    background: #fff;
+    background: transparent;
     border: 1px solid var(--border-primary) !important;
     border-radius: var(--elem-radius);
     display: inline-block;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -106,7 +106,7 @@
   }
 
   img {
-    background: transparent;
+    background: var(--background-primary);
     border: 1px solid var(--border-primary) !important;
     border-radius: var(--elem-radius);
     display: inline-block;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->
Fixes #9130 
### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->
The alt text of images is not visible due to the way the background color is set
### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->
I made set the background color to `transparent` for the dark theme. This will make the alt text appear in dark mode. 
---
