### PR TITLE
fix(ai-help): enhance issue reporting

### DIFF
--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -559,18 +559,18 @@ function ReportIssueOnGitHubLink({
   children: React.ReactNode;
 }) {
   const currentMessageIndex = messages.indexOf(currentMessage);
-  const firstMessage = messages[0];
   const questions = messages
     .slice(0, currentMessageIndex)
     .filter((message) => message.role === MessageRole.User)
     .map(({ content }) => content);
+  const lastQuestion = questions.at(-1);
 
   const url = new URL("https://github.com/");
   url.pathname = "/mdn/ai-feedback/issues/new";
 
   const sp = new URLSearchParams();
-  sp.set("title", `[AI Help] Question: ${firstMessage.content}`);
-  sp.set("questions", questions.join("---"));
+  sp.set("title", `[AI Help] Question: ${lastQuestion}`);
+  sp.set("questions", questions.map((question) => `1. ${question}`).join("\n"));
   sp.set("answer", currentMessage.content);
   sp.set(
     "sources",


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

There were two problems with issue reporting:

1. The first question was used as the issue title, not the last.
2. Multiple questions were separated with "---" (no line breaks).

### Solution

1. Use the last question.
2. Put the questions in an enumerated list instead.

---

## How did you test this change?

Ran `yarn && yarn dev`, opened http://localhost:3000/en-US/plus/ai-help locally, answered multiple questions, and clicked on the "Report an issue with this answer" link.