### PR TITLE
fix(blog): ignore hidden code blocks when calculating read time

### DIFF
--- a/build/blog.ts
+++ b/build/blog.ts
@@ -40,12 +40,16 @@ import { DEFAULT_LOCALE } from "../libs/constants/index.js";
 import { memoize } from "../content/utils.js";
 
 const READ_TIME_FILTER = /[\w<>.,!?]+/;
+const HIDDEN_CODE_BLOCK_MATCH = /```.*hidden[\s\S]*?```/g;
 
 function calculateReadTime(copy: string): number {
   return Math.max(
     1,
     Math.round(
-      copy.split(/\s+/).filter((w) => READ_TIME_FILTER.test(w)).length / 220
+      copy
+        .replace(HIDDEN_CODE_BLOCK_MATCH, "")
+        .split(/\s+/)
+        .filter((w) => READ_TIME_FILTER.test(w)).length / 220
     )
   );
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

Hidden code blocks were being included in the read time calculation for blog posts, which leads to https://developer.mozilla.org/en-US/blog/scroll-progress-animations-in-css/ for instance having a 25 minute read time, because of lots of lorem ipsum being included in the examples.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Ignore hidden code blocks when doing this calculation: the above article now has a 7 minute read time.

---

## How did you test this change?

- `yarn dev`, visited article locally
- also pasted source of article into https://regex101.com/ and checked my regex matched the intended blocks (and nothing else - I needed that non-greedy match `?`)
