### PR TITLE
Bump Prettier from 2.8.8 to 3.0.0

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "trailingComma": "es5",
   "overrides": [
     {
       "files": ["**/package.json"],

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -40,12 +40,16 @@ import { DEFAULT_LOCALE } from "../libs/constants/index.js";
 import { memoize } from "../content/utils.js";
 
 const READ_TIME_FILTER = /[\w<>.,!?]+/;
+const HIDDEN_CODE_BLOCK_MATCH = /```.*hidden[\s\S]*?```/g;
 
 function calculateReadTime(copy: string): number {
   return Math.max(
     1,
     Math.round(
-      copy.split(/\s+/).filter((w) => READ_TIME_FILTER.test(w)).length / 220
+      copy
+        .replace(HIDDEN_CODE_BLOCK_MATCH, "")
+        .split(/\s+/)
+        .filter((w) => READ_TIME_FILTER.test(w)).length / 220
     )
   );
 }
@@ -213,13 +217,9 @@ export const allPostFrontmatter = memoize(
   }: { includeUnpublished?: boolean } = {}): Promise<BlogPostFrontmatter[]> => {
     return (
       await Promise.all(
-        (
-          await allPostFiles()
-        ).map(
+        (await allPostFiles()).map(
           async (file) =>
-            (
-              await readPost(file, { previousNext: false })
-            ).blogMeta
+            (await readPost(file, { previousNext: false })).blogMeta
         )
       )
     )

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -315,8 +315,9 @@ async function buildDocuments(
 
   const allBrowserCompat = new Set<string>();
   Object.values(metadata).forEach((localeMeta) =>
-    localeMeta.forEach((doc) =>
-      doc.browserCompat?.forEach((query) => allBrowserCompat.add(query))
+    localeMeta.forEach(
+      (doc) =>
+        doc.browserCompat?.forEach((query) => allBrowserCompat.add(query))
     )
   );
   fs.writeFileSync(

--- a/build/flaws/index.ts
+++ b/build/flaws/index.ts
@@ -315,7 +315,7 @@ export async function fixFixableFlaws(doc: Partial<Doc>, options, document) {
         )
       );
     } else {
-      Document.update(document.url, newRawBody, document.metadata);
+      await Document.update(document.url, newRawBody, document.metadata);
       if (options.fixFlawsVerbose) {
         console.log(
           chalk.green(

--- a/build/index.ts
+++ b/build/index.ts
@@ -537,8 +537,8 @@ function addBaseline(doc: Partial<Doc>): WebFeatureStatus | undefined {
     for (const feature of Object.values<WebFeature>(webFeatures)) {
       if (
         feature.status &&
-        feature.compat_features?.some((query) =>
-          doc.browserCompat?.includes(query)
+        feature.compat_features?.some(
+          (query) => doc.browserCompat?.includes(query)
         )
       ) {
         return feature.status;
@@ -570,9 +570,7 @@ export async function buildLiveSamplePageFromURL(url: string) {
     (await kumascript.buildLiveSamplePages(
       document.url,
       document.metadata.title,
-      (
-        await kumascript.render(document.url)
-      )[0],
+      (await kumascript.render(document.url))[0],
       document.rawBody
     )) as BuiltLiveSamplePage[]
   ).find((page) => page.id.toLowerCase() == decodedSampleID);

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" prefix="og: https://ogp.me/ns#">
   <head>
     <meta charset="utf-8" />

--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/client/src/document/mathml-polyfill/mathml-font.scss
+++ b/client/src/document/mathml-polyfill/mathml-font.scss
@@ -1,7 +1,8 @@
 @font-face {
   font-family: "STIXTwoMath-Regular";
   font-weight: normal;
-  src: local("STIXTwoMath-Regular"),
+  src:
+    local("STIXTwoMath-Regular"),
     url("./font/STIXTwoMath-Regular.woff2") format("woff2");
 }
 

--- a/client/src/document/organisms/sidebar/filter.scss
+++ b/client/src/document/organisms/sidebar/filter.scss
@@ -53,7 +53,9 @@
 
     &:focus {
       border-color: var(--category-color);
-      box-shadow: 0 0 0 3px var(--blend-color), 0 0 0 3px var(--category-color);
+      box-shadow:
+        0 0 0 3px var(--blend-color),
+        0 0 0 3px var(--category-color);
       outline: 0 none;
     }
 

--- a/client/src/document/organisms/sidebar/index.tsx
+++ b/client/src/document/organisms/sidebar/index.tsx
@@ -43,10 +43,11 @@ export function SidebarContainer({
     const sidebar = document.querySelector("#sidebar-quicklinks");
     const currentSidebarItem = sidebar?.querySelector("em");
     if (sidebar && currentSidebarItem) {
-      [sidebar, sidebar.querySelector(".sidebar-inner-nav")].forEach((n) =>
-        n?.scrollTo({
-          top: currentSidebarItem.offsetTop - window.innerHeight / 4,
-        })
+      [sidebar, sidebar.querySelector(".sidebar-inner-nav")].forEach(
+        (n) =>
+          n?.scrollTo({
+            top: currentSidebarItem.offsetTop - window.innerHeight / 4,
+          })
       );
     }
   }, []);

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useSWRImmutable from "swr/immutable";
-import prettier from "prettier/standalone.mjs";
-import prettierPluginBabel from "prettier/plugins/babel.mjs";
-import prettierPluginCSS from "prettier/plugins/postcss.mjs";
+import prettier from "prettier/standalone.js";
+import prettierPluginBabel from "prettier/plugins/babel.js";
+import prettierPluginCSS from "prettier/plugins/postcss.js";
 import prettierPluginESTree from "prettier/plugins/estree.mjs";
-import prettierPluginHTML from "prettier/plugins/html.mjs";
+import prettierPluginHTML from "prettier/plugins/html.js";
 
 import { Button } from "../ui/atoms/button";
 import Editor, { EditorHandle } from "./editor";
@@ -18,13 +18,6 @@ import { FlagForm, ShareForm } from "./forms";
 import { Console, VConsole } from "./console";
 import { useGleanClick } from "../telemetry/glean-context";
 import { PLAYGROUND } from "../telemetry/constants";
-
-const prettierPlugins = [
-  prettierPluginHTML,
-  prettierPluginCSS,
-  prettierPluginBabel,
-  prettierPluginESTree,
-];
 
 const HTML_DEFAULT = "";
 const CSS_DEFAULT = "";
@@ -205,15 +198,20 @@ export default function Playground() {
       const formatted = {
         html: await prettier.format(html, {
           parser: "html",
-          plugins: prettierPlugins,
+          plugins: [
+            prettierPluginHTML,
+            prettierPluginCSS,
+            prettierPluginBabel,
+            prettierPluginESTree,
+          ],
         }),
         css: await prettier.format(css, {
           parser: "css",
-          plugins: prettierPlugins,
+          plugins: [prettierPluginCSS],
         }),
         js: await prettier.format(js, {
           parser: "babel",
-          plugins: prettierPlugins,
+          plugins: [prettierPluginBabel, prettierPluginESTree],
         }),
       };
       htmlRef.current?.setContent(formatted.html);

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -4,6 +4,7 @@ import useSWRImmutable from "swr/immutable";
 import prettier from "prettier/standalone.js";
 import prettierPluginBabel from "prettier/plugins/babel.js";
 import prettierPluginCSS from "prettier/plugins/postcss.js";
+// XXX Using .mjs until https://github.com/prettier/prettier/pull/15018 is deployed
 import prettierPluginESTree from "prettier/plugins/estree.mjs";
 import prettierPluginHTML from "prettier/plugins/html.js";
 

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -95,7 +95,7 @@ export default function Playground() {
     },
     {
       fallbackData: (!gistId && load(SESSION_KEY)) || undefined,
-    },
+    }
   );
   const htmlRef = useRef<EditorHandle | null>(null);
   const cssRef = useRef<EditorHandle | null>(null);
@@ -130,7 +130,7 @@ export default function Playground() {
         updatePlayIframe(iframe.current, getEditorContent());
       }
     },
-    [getEditorContent],
+    [getEditorContent]
   );
   useEffect(() => {
     if (state === State.initial) {
@@ -142,7 +142,7 @@ export default function Playground() {
         if (initialCode.src) {
           setCodeSrc(
             initialCode?.src &&
-              `${initialCode.src.split("/").slice(0, -1).join("/")}`,
+              `${initialCode.src.split("/").slice(0, -1).join("/")}`
           );
         }
       } else {
@@ -194,7 +194,7 @@ export default function Playground() {
       },
       {
         targetOrigin: "*",
-      },
+      }
     );
   };
 
@@ -236,7 +236,7 @@ export default function Playground() {
       PLAYGROUND_BASE_HOST.startsWith("localhost")
         ? ""
         : `${subdomain.current}.`
-    }${PLAYGROUND_BASE_HOST}`,
+    }${PLAYGROUND_BASE_HOST}`
   );
   src.pathname = `${codeSrc || ""}/runner.html`;
 

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import useSWRImmutable from "swr/immutable";
-import prettier from "prettier/standalone.js";
-import prettierPluginBabel from "prettier/plugins/babel.js";
-import prettierPluginCSS from "prettier/plugins/postcss.js";
+import prettier from "prettier/standalone";
+import prettierPluginBabel from "prettier/plugins/babel";
+import prettierPluginCSS from "prettier/plugins/postcss";
 // XXX Using .mjs until https://github.com/prettier/prettier/pull/15018 is deployed
 import prettierPluginESTree from "prettier/plugins/estree.mjs";
-import prettierPluginHTML from "prettier/plugins/html.js";
+import prettierPluginHTML from "prettier/plugins/html";
 
 import { Button } from "../ui/atoms/button";
 import Editor, { EditorHandle } from "./editor";

--- a/client/src/playground/loader.scss
+++ b/client/src/playground/loader.scss
@@ -14,9 +14,15 @@
     animation: rotate 2s linear infinite;
     border-radius: 50%;
 
-    box-shadow: inset 0 0 50px #fff, inset 20px 0 80px #f0f,
-      inset -20px 0 80px #0ff, inset 20px 0 300px #f0f, inset -20px 0 300px #0ff,
-      0 0 50px #fff, -10px 0 80px #f0f, 10px 0 80px #0ff;
+    box-shadow:
+      inset 0 0 50px #fff,
+      inset 20px 0 80px #f0f,
+      inset -20px 0 80px #0ff,
+      inset 20px 0 300px #f0f,
+      inset -20px 0 300px #0ff,
+      0 0 50px #fff,
+      -10px 0 80px #f0f,
+      10px 0 80px #0ff;
     height: 100px;
     width: 100px;
   }

--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -87,7 +87,8 @@
 
         &:focus {
           border-color: var(--category-color);
-          box-shadow: 0 0 0 3px var(--blend-color),
+          box-shadow:
+            0 0 0 3px var(--blend-color),
             0 0 0 3px var(--category-color);
           outline: 0 none;
         }

--- a/client/src/plus/index.scss
+++ b/client/src/plus/index.scss
@@ -66,8 +66,10 @@
     h1 span,
     p {
       // improve text contrast against mandala
-      text-shadow: 2px 2px 3px var(--plus-header),
-        2px -2px 3px var(--plus-header), -2px -2px 3px var(--plus-header),
+      text-shadow:
+        2px 2px 3px var(--plus-header),
+        2px -2px 3px var(--plus-header),
+        -2px -2px 3px var(--plus-header),
         -2px 2px 3px var(--plus-header);
     }
 

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -39,7 +39,7 @@ function quicksearchPing(input: string) {
 function useSearchIndex(): readonly [
   null | SearchIndex,
   null | Error,
-  () => void
+  () => void,
 ] {
   const [shouldInitialize, setShouldInitialize] = useState(false);
   const [searchIndex, setSearchIndex] = useState<null | SearchIndex>(null);

--- a/client/src/site-search/search-results.tsx
+++ b/client/src/site-search/search-results.tsx
@@ -358,9 +358,9 @@ function Results({
                 LANGUAGES.has(document.locale) && (
                   <span
                     className="locale-indicator"
-                    title={`The linked document is in ${
-                      LANGUAGES.get(document.locale)?.English
-                    } which is different from your current locale.`}
+                    title={`The linked document is in ${LANGUAGES.get(
+                      document.locale
+                    )?.English} which is different from your current locale.`}
                   >
                     {LANGUAGES.get(document.locale)?.English}
                   </span>

--- a/client/src/ui/base/_typography.scss
+++ b/client/src/ui/base/_typography.scss
@@ -4,7 +4,8 @@
   font-stretch: 75% 100%;
   font-style: oblique 0deg 20deg;
   font-weight: 1 999;
-  src: url("../../assets/fonts/Inter.var.woff2")
+  src:
+    url("../../assets/fonts/Inter.var.woff2")
       format("woff2 supports variations"),
     url("../../assets/fonts/Inter.var.woff2") format("woff2-variations");
 }

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -93,7 +93,9 @@
 
     &:focus {
       border-color: var(--category-color);
-      box-shadow: 0 0 0 3px var(--blend-color), 0 0 0 3px var(--category-color);
+      box-shadow:
+        0 0 0 3px var(--blend-color),
+        0 0 0 3px var(--category-color);
       outline: 0 none;
     }
 

--- a/content/document.ts
+++ b/content/document.ts
@@ -543,7 +543,7 @@ export function findChildren(url: string, recursive = false) {
   return childPaths.map((folder) => read(folder));
 }
 
-export function move(
+export async function move(
   oldSlug: string,
   newSlug: string,
   locale: string,
@@ -573,7 +573,7 @@ export function move(
   }
 
   doc.metadata.slug = newSlug;
-  update(oldUrl, doc.rawBody, doc.metadata);
+  await update(oldUrl, doc.rawBody, doc.metadata);
 
   return pairs;
 }

--- a/content/document.ts
+++ b/content/document.ts
@@ -46,7 +46,7 @@ const getHTMLPath = (folder: string) => path.join(folder, HTML_FILENAME);
 const getMarkdownPath = (folder: string) =>
   path.join(folder, MARKDOWN_FILENAME);
 
-export function updateWikiHistory(
+export async function updateWikiHistory(
   localeContentRoot: string,
   oldSlug: string,
   newSlug: string | null = null
@@ -81,7 +81,7 @@ export function updateWikiHistory(
       // trailing newline character. So always doing in automation removes
       // the risk of a conflict at the last line from two independent PRs
       // that edit this file.
-      toPrettyJSON(sorted)
+      await toPrettyJSON(sorted)
     );
   }
 }
@@ -355,7 +355,7 @@ export const read = memoize((folderOrFilePath: string, ...roots: string[]) => {
   };
 });
 
-export function update(url: string, rawBody: string, metadata) {
+export async function update(url: string, rawBody: string, metadata) {
   const folder = urlToFolderPath(url);
   const document = read(folder);
   const locale = document.metadata.locale;
@@ -385,7 +385,7 @@ export function update(url: string, rawBody: string, metadata) {
       frontMatterKeys
     );
     if (isNewSlug) {
-      updateWikiHistory(
+      await updateWikiHistory(
         path.join(root, metadata.locale.toLowerCase()),
         oldSlug,
         newSlug
@@ -402,7 +402,7 @@ export function update(url: string, rawBody: string, metadata) {
       const oldChildSlug = metadata.slug;
       const newChildSlug = oldChildSlug.replace(oldSlug, newSlug);
       metadata.slug = newChildSlug;
-      updateWikiHistory(
+      await updateWikiHistory(
         path.join(root, metadata.locale.toLowerCase()),
         oldChildSlug,
         newChildSlug
@@ -606,7 +606,7 @@ export function validate(slug: string, locale: string) {
   }
 }
 
-export function remove(
+export async function remove(
   slug: string,
   locale: string,
   { recursive = false, dry = false, redirect = "" } = {}
@@ -639,7 +639,10 @@ export function remove(
   const removed = [];
   for (const { metadata } of children) {
     const slug = metadata.slug;
-    updateWikiHistory(path.join(root, metadata.locale.toLowerCase()), slug);
+    await updateWikiHistory(
+      path.join(root, metadata.locale.toLowerCase()),
+      slug
+    );
     removed.push(buildURL(locale, slug));
   }
 
@@ -656,7 +659,7 @@ export function remove(
     Redirect.remove(locale, [url, ...removed]);
   }
 
-  updateWikiHistory(
+  await updateWikiHistory(
     path.join(root, metadata.locale.toLowerCase()),
     metadata.slug
   );

--- a/content/utils.ts
+++ b/content/utils.ts
@@ -108,11 +108,11 @@ export function execGit(args, opts: { cwd?: string } = {}, root = null) {
   return stdout.toString().trim();
 }
 
-export function toPrettyJSON(value: unknown) {
+export async function toPrettyJSON(value: unknown) {
   const json = JSON.stringify(value, null, 2) + "\n";
   if (prettier) {
     try {
-      return prettier.format(json, { parser: "json" });
+      return await prettier.format(json, { parser: "json" });
     } catch (e) {
       // If Prettier formatting failed, don't worry
     }

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
     "postcss-loader": "^7.3.3",
     "postcss-normalize": "^10.0.1",
     "postcss-preset-env": "^8.5.1",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "prettier-plugin-packagejson": "^2.4.5",
     "prompts": "^2.4.2",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -242,7 +242,7 @@
     "stylelint-config-recommended": "^12.0.0",
     "stylelint-config-sass-guidelines": "^10.0.0",
     "stylelint-order": "^6.0.3",
-    "stylelint-prettier": "^3.0.0",
+    "stylelint-prettier": "^4.0.0",
     "stylelint-scss": "^5.0.1",
     "swr": "^2.2.0",
     "tailwindcss": "^3.3.3",

--- a/server/document.ts
+++ b/server/document.ts
@@ -80,7 +80,7 @@ router.put("/", withDocument, async (req: RequestWithDocument, res) => {
 
 // XXX deprecated anyway and doesn't work with Markdown
 // router.put("/move", async (req, res) => {
-//   Document.move(req.query.slug, req.query.newSlug, req.query.locale);
+//   await Document.move(req.query.slug, req.query.newSlug, req.query.locale);
 //   res.sendStatus(200);
 // });
 

--- a/server/document.ts
+++ b/server/document.ts
@@ -73,7 +73,7 @@ router.get("/", withDocument, (req: RequestWithDocument, res) => {
 router.put("/", withDocument, async (req: RequestWithDocument, res) => {
   const { rawBody, metadata } = req.body;
   if (metadata.title && rawBody) {
-    Document.update(req.document.url, `${rawBody.trim()}\n`, metadata);
+    await Document.update(req.document.url, `${rawBody.trim()}\n`, metadata);
   }
   res.sendStatus(200);
 });
@@ -84,8 +84,8 @@ router.put("/", withDocument, async (req: RequestWithDocument, res) => {
 //   res.sendStatus(200);
 // });
 
-router.delete("/", (req, res) => {
-  Document.remove(req.query.slug as string, req.query.locale as string, {
+router.delete("/", async (req, res) => {
+  await Document.remove(req.query.slug as string, req.query.locale as string, {
     recursive: true,
   });
   res.sendStatus(200);

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -437,7 +437,7 @@ program
     tryOrExit(async ({ args, options }: MoveActionParameters) => {
       const { oldSlug, newSlug, locale } = args;
       const { yes } = options;
-      const changes = Document.move(oldSlug, newSlug, locale, {
+      const changes = await Document.move(oldSlug, newSlug, locale, {
         dry: true,
       });
       console.log(
@@ -459,7 +459,7 @@ program
             default: true,
           });
       if (run) {
-        const moved = Document.move(oldSlug, newSlug, locale);
+        const moved = await Document.move(oldSlug, newSlug, locale);
         console.log(chalk.green(`Moved ${moved.length} documents.`));
       }
     })
@@ -718,7 +718,7 @@ program
             redirectedDocs,
             renamedDocs,
             totalDocs,
-          } = syncAllTranslatedContent(locale);
+          } = await syncAllTranslatedContent(locale);
           console.log(chalk.green(`Syncing ${locale}:`));
           console.log(chalk.green(`Total of ${totalDocs} documents`));
           console.log(chalk.green(`Moved ${movedDocs} documents`));

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -349,7 +349,7 @@ program
     tryOrExit(async ({ args, options }: DeleteActionParameters) => {
       const { slug, locale } = args;
       const { recursive, redirect, yes } = options;
-      const changes = Document.remove(slug, locale, {
+      const changes = await Document.remove(slug, locale, {
         recursive,
         redirect,
         dry: true,
@@ -380,7 +380,7 @@ program
             default: true,
           });
       if (run) {
-        const deletedDocs = Document.remove(slug, locale, {
+        const deletedDocs = await Document.remove(slug, locale, {
           recursive,
           redirect,
         });
@@ -1117,7 +1117,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
                 console.log(`${flaw.macroSource} --> ${suggestion}`);
               }
               console.groupEnd();
-              Document.update(
+              await Document.update(
                 document.url,
                 document.rawBody,
                 document.metadata
@@ -1138,7 +1138,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
         }
         const newRawHTML = $("body").html();
         if (newRawHTML !== originalRawBody) {
-          Document.update(document.url, newRawHTML, document.metadata);
+          await Document.update(document.url, newRawHTML, document.metadata);
           console.log(`modified`);
           countModified++;
         } else {

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -28,7 +28,7 @@ const ORPHANED = "orphaned";
 
 const DEFAULT_LOCALE_LC = DEFAULT_LOCALE.toLowerCase();
 
-export function syncAllTranslatedContent(locale: string) {
+export async function syncAllTranslatedContent(locale: string) {
   if (!CONTENT_TRANSLATED_ROOT) {
     throw new Error(
       "CONTENT_TRANSLATED_ROOT must be set to sync translated content!"
@@ -56,7 +56,7 @@ export function syncAllTranslatedContent(locale: string) {
 
   for (const f of files) {
     const { conflicting, moved, followed, orphaned, redirect, renamed } =
-      syncTranslatedContent(f, locale);
+      await syncTranslatedContent(f, locale);
     if (conflicting) {
       stats.conflictingDocs += 1;
     }
@@ -101,7 +101,10 @@ function mdOrHtmlExists(folderPath: string) {
   );
 }
 
-export function syncTranslatedContent(inFilePath: string, locale: string) {
+export async function syncTranslatedContent(
+  inFilePath: string,
+  locale: string
+) {
   if (!CONTENT_TRANSLATED_ROOT) {
     throw new Error(
       "CONTENT_TRANSLATED_ROOT must be set to sync translated content!"
@@ -206,7 +209,7 @@ export function syncTranslatedContent(inFilePath: string, locale: string) {
 
   const filePath = path.join(folderPath, fileName);
   log.log(`${inFilePath} → ${filePath}`);
-  Document.updateWikiHistory(
+  await Document.updateWikiHistory(
     path.join(CONTENT_TRANSLATED_ROOT, locale.toLowerCase()),
     oldMetadata.slug,
     metadata.slug
@@ -247,13 +250,13 @@ function moveContent(inFileDir: string, outFileDir: string) {
   }
 }
 
-export function syncTranslatedContentForAllLocales() {
+export async function syncTranslatedContentForAllLocales() {
   let moved = 0;
   for (const locale of VALID_LOCALES.keys()) {
     if (locale === DEFAULT_LOCALE_LC) {
       continue;
     }
-    const { movedDocs } = syncAllTranslatedContent(locale);
+    const { movedDocs } = await syncAllTranslatedContent(locale);
     moved += movedDocs;
   }
   return moved;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11608,10 +11608,10 @@ prettier-plugin-packagejson@^2.4.5:
     sort-package-json "2.5.1"
     synckit "0.8.5"
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13374,10 +13374,10 @@ stylelint-order@^6.0.3:
     postcss "^8.4.21"
     postcss-sorting "^8.0.2"
 
-stylelint-prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-3.0.0.tgz#57028b99866ed4c3ae045ddd891bf9a77d274726"
-  integrity sha512-kIks1xw6np0zElokMT2kP6ar3S4MBoj6vUtPJuND1pFELMpZxVS/0uHPR4HDAVn0WAD3I5oF0IA3qBFxBpMkLg==
+stylelint-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-prettier/-/stylelint-prettier-4.0.0.tgz#e04f33bf9968a5d5478d2d11b20bdc5a7de2dc35"
+  integrity sha512-hYlObunQiSzc5XRttNiDyaY1W7ytW/AJtEbaDxy0rr4ioQvko+cjAgSGrRbz0iRB+yc6jiMrUmHcGkvFb+zDqw==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 


### PR DESCRIPTION
This PR bumps Prettier from 2.8.8 to 3.0.0, and then fixes issues with the content commands caused by changes to the Prettier API.  In Prettier v3.0, the `format()` command became asynchronous, so we were returning a Promise every so often, which caused errors when running commands.  This PR aims to fix this by adding an `await`, and making the rest of the function chain asynchronous.

**Note:** because the content repositories use Prettier 3.0.0, these commands are **broken** regardless of the Prettier version Yari is requesting.

**Note:** because Prettier has changed its defaults, the formatting output has also changed.  TO pass linting, all files had to be formatted, which unfortunately means a greater risk of merge conflicts.  Since this is a critical bug fix, it should be merged quickly anyways.