### PR TITLE
feat(theme): sync body background-color with theme-color meta tag

### DIFF
--- a/client/src/ui-context.tsx
+++ b/client/src/ui-context.tsx
@@ -74,9 +74,6 @@ export function UIProvider(props: any) {
     }
     dark.addEventListener("change", setDark);
     const light = window.matchMedia("(prefers-color-scheme: light)");
-    if (dark.matches) {
-      setColorScheme("dark");
-    }
     light.addEventListener("change", setLight);
     return () => {
       light.removeEventListener("change", setLight);

--- a/client/src/ui/molecules/theme-switcher/index.tsx
+++ b/client/src/ui/molecules/theme-switcher/index.tsx
@@ -58,10 +58,8 @@ export const ThemeSwitcher = () => {
       console.warn("Unable to read theme from localStorage", e);
     }
 
-    if (theme) {
-      switchTheme(theme, setActiveTheme);
-    }
-  }, [activeTheme]);
+    switchTheme(theme ?? "os-default", setActiveTheme);
+  }, []);
 
   return (
     <DropdownMenuWrapper

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -58,6 +58,13 @@ export function switchTheme(theme: Theme, set: (theme: Theme) => void) {
   if (window && html) {
     html.className = theme;
     html.style.backgroundColor = "";
+
+    setTimeout(() => {
+      document.querySelector<HTMLMetaElement>(
+        'meta[name="theme-color"]'
+      )!.content = getComputedStyle(document.body).backgroundColor;
+    }, 1);
+
     try {
       window.localStorage.setItem("theme", theme);
     } catch (err) {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -60,9 +60,13 @@ export function switchTheme(theme: Theme, set: (theme: Theme) => void) {
     html.style.backgroundColor = "";
 
     setTimeout(() => {
-      document.querySelector<HTMLMetaElement>(
+      const meta = document.querySelector<HTMLMetaElement>(
         'meta[name="theme-color"]'
-      )!.content = getComputedStyle(document.body).backgroundColor;
+      );
+      const color = getComputedStyle(document.body).backgroundColor;
+      if (meta && color) {
+        meta.content = color;
+      }
     }, 1);
 
     try {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Fixes #7884.
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
(copied from the issue title)
> the color of status bar remains white even if dark mode is on. Because of `<meta name="theme-color" content="#ffffff" />`
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

Set "theme-color" to the background color of the page(`<body>`) on
- page load
- user changes theme
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

|Before|After|
|-|-|
|![screenshot before](https://github.com/mdn/yari/assets/59327276/a37b8d53-4d23-4c10-ac01-be6dbef6a45f)|![screenshot after](https://github.com/mdn/yari/assets/59327276/0cb22b12-edae-48d2-9690-b0263a9448e4)|

---

## How did you test this change?

Tested by running `yarn dev` and
- visiting on PC
  - Tried when dark mode on/off and checked that 
    - the class of `<html>` is set correctly
    - the "theme-color" meta tag's `content` (color)
      - is correct on first visiting the site and
      - changes on changing theme
  - on Vivaldi browser 6.1.3035.111 (based on chromium)
  - win10 22H2 19045
- visiting on Android phone
  - checked the status bar turns black after changing theme to Dark
  - my phone is too old that doesn't have dark mode so I can't test the color correct or not on first visiting with dark mode turned on
  - on Samsung browser 21.0.3.6 (based on chromium)
  - Android 9


> refactor(theme): remove a redundant if block

The if block is identical to line 72-74 and do nothing else.

> feat(theme): sync theme-color meta tag with theme

code copied from https://github.com/rust-lang/mdBook/pull/547

> fix(theme): properly initialize theme


I guess the `useEffect` (line 53) is for setting theme on page load, so I think put `activeTheme` in the dependency list (line 64) is a mistake and thus removed it.

I added `?? "os-default"` to properly set "theme-color" meta tag when:
- the user uses dark mode
- and either
  - the user didn't select a theme manually (so `localStorage.getItem` returns `null`)
  - or `localStorage.getItem` throws error

Setting theme here has a downside that "theme-color" meta tag will not be set until the content has loaded.
But I think it's OK because:
- The loading is fast on real `developer.mozilla.org`. I have never seen the loading screen before testing this PR on local.
- Users can be hinted by the status bar turning black that "the page has finished loading".
- The implementation (this PR) is simpler.

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
