### PR TITLE
chore(deps-dev): remove @types/hast

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,6 @@
     "@testing-library/react": "^14.0.0",
     "@types/async": "^3.2.20",
     "@types/cli-progress": "^3.11.0",
-    "@types/hast": "^2.3.4",
     "@types/imagemin": "^8.0.1",
     "@types/jest": "^29.5.3",
     "@types/mdast": "^3.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,7 +2837,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hast@^2.0.0", "@types/hast@^2.3.4":
+"@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"
   integrity sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

`@types/hast` was added in #3843 in the context of HTML-to-Markdown conversion, but we no longer need it.

### Solution

Remove the dependency.

---

## How did you test this change?

Ran `yarn check:tsc`.