### PR TITLE
chore(tools): better error handling for `yarn tool spas` command

### DIFF
--- a/build/utils.ts
+++ b/build/utils.ts
@@ -325,13 +325,12 @@ export function findPostFileBySlug(slug: string): string | null {
     if (status === 0) {
       const file = stdout.toString("utf-8").split("\n")[0];
       return file;
+    }
+    const message = stderr.toString();
+    if (message) {
+      console.error(`error running rg: ${message}`);
     } else {
-      const message = stderr.toString();
-      if (message) {
-        console.error(`error running rg: ${message}`);
-      } else {
-        console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
-      }
+      console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
     }
   } catch {
     console.error("rg failed");

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -330,7 +330,7 @@ export function findPostFileBySlug(slug: string): string | null {
     if (message) {
       console.error(`error running rg: ${message}`);
     } else {
-      console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
+      console.error(`Post ${slug} not found in ${BLOG_ROOT}`);
     }
   } catch {
     console.error("rg failed");

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -311,29 +311,30 @@ export function makeTOC(doc) {
 }
 
 export function findPostFileBySlug(slug: string): string | null {
-  if (BLOG_ROOT) {
-    try {
-      const { stdout, stderr, status } = spawnSync(rgPath, [
-        "-il",
-        `slug: ${slug}`,
-        BLOG_ROOT,
-      ]);
-      if (status === 0) {
-        const file = stdout.toString("utf-8").split("\n")[0];
-        return file;
-      } else {
-        const message = stderr.toString();
-        if (message) {
-          console.error(`error running rg: ${message}`);
-        } else {
-          console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
-        }
-      }
-    } catch {
-      console.error("rg failed");
-    }
-  } else {
+  if (!BLOG_ROOT) {
     console.warn("'BLOG_ROOT' not set in .env file");
+    return null;
+  }
+
+  try {
+    const { stdout, stderr, status } = spawnSync(rgPath, [
+      "-il",
+      `slug: ${slug}`,
+      BLOG_ROOT,
+    ]);
+    if (status === 0) {
+      const file = stdout.toString("utf-8").split("\n")[0];
+      return file;
+    } else {
+      const message = stderr.toString();
+      if (message) {
+        console.error(`error running rg: ${message}`);
+      } else {
+        console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
+      }
+    }
+  } catch {
+    console.error("rg failed");
   }
   return null;
 }

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -311,20 +311,29 @@ export function makeTOC(doc) {
 }
 
 export function findPostFileBySlug(slug: string): string | null {
-  try {
-    const { stdout, stderr, status } = spawnSync(rgPath, [
-      "-il",
-      `slug: ${slug}`,
-      BLOG_ROOT,
-    ]);
-    if (status === 0) {
-      const file = stdout.toString("utf-8").split("\n")[0];
-      return file;
-    } else {
-      console.error(`error running rg: ${stderr}`);
+  if (BLOG_ROOT) {
+    try {
+      const { stdout, stderr, status } = spawnSync(rgPath, [
+        "-il",
+        `slug: ${slug}`,
+        BLOG_ROOT,
+      ]);
+      if (status === 0) {
+        const file = stdout.toString("utf-8").split("\n")[0];
+        return file;
+      } else {
+        const message = stderr.toString();
+        if (message) {
+          console.error(`error running rg: ${message}`);
+        } else {
+          console.error(`Blog ${slug} not found in ${BLOG_ROOT}`);
+        }
+      }
+    } catch {
+      console.error("rg failed");
     }
-  } catch {
-    console.error("rg failed");
+  } else {
+    console.warn("'BLOG_ROOT' not set in .env file");
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Addresses https://github.com/mdn/yari/pull/8950#issuecomment-1641335798

### Problem

The blogs repo is not public so `BLOG_ROOT` environment variable has not been advertised. If the variable is not set then `yarn tool spas` command throws an error which doesn't make sense at all.

### Solution

If the variable is not set then don't run ripgrep command.

## How did you test this change?

Tested the code with the variable set and unset in the `.env` file. Also set the variable to unrelated dir to test match not found message.