### PR TITLE
enhance(document-survey): adjust margins and widths

### DIFF
--- a/client/src/ui/molecules/document-survey/index.scss
+++ b/client/src/ui/molecules/document-survey/index.scss
@@ -5,7 +5,7 @@
   border: 5px solid $mdn-color-light-theme-violet-70;
   border-radius: 0.5rem;
   color: $mdn-color-neutral-90;
-  padding: 1em;
+  padding: 1rem;
 
   &::before {
     background: transparent url("../../../assets/icons/survey.svg") center
@@ -27,7 +27,16 @@
     cursor: pointer;
   }
 
+  details {
+    iframe {
+      margin: 0.9rem;
+      margin-bottom: 0;
+      width: calc(100% - 1.2rem);
+    }
+  }
+
   summary {
+    margin-top: 1rem;
     text-decoration: underline;
 
     &:focus,

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -148,7 +148,7 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
             title={survey.question}
             src={survey.src}
             height={500}
-            style={{ overflow: "hidden", width: "100%" }}
+            style={{ overflow: "hidden" }}
           ></iframe>
         )}
       </details>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

In the document survey box, the teaser and questions aren't separated with space, and the `<details>` content isn't indented.

### Solution

Adjust margins and widths to resolve these issues.

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="790" alt="image" src="https://github.com/mdn/yari/assets/495429/1c882a00-5eea-4cab-9991-a0b19c97a43f"> | <img width="782" alt="image" src="https://github.com/mdn/yari/assets/495429/f169b122-0932-4a16-bd90-71bb313cb717"> |
| <img width="782" alt="image" src="https://github.com/mdn/yari/assets/495429/487e996d-8d29-497b-a44a-67daf175c8f6"> | <img width="782" alt="image" src="https://github.com/mdn/yari/assets/495429/8c0df8ad-a9f2-4579-9f6c-82d6584e4832"> |

---

## How did you test this change?

Ran `yarn && yarn dev`, temporarily re-opened the Blog survey, and visited http://localhost:3000/en-US/docs/Web/CSS.