### PR TITLE
feat(docs): add LaTeX syntax highlighting

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -39,6 +39,7 @@ const loadAllLanguages = lazy(() => {
     "java",
     "json",
     "jsx",
+    "latex",
     "less",
     "md",
     "php",


### PR DESCRIPTION
This PR enables LaTeX syntax highlighting in Yari, which will be used in https://developer.mozilla.org/en-US/docs/Learn/MathML/First_steps/Three_famous_mathematical_formulas.
