### PR TITLE
chore: update minimum node version from 18.0 to 18.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,6 +258,6 @@
     "workbox-webpack-plugin": "^7.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.16.0"
   }
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

some versions prior to 18.16 were causing ts-node to raise an error: `RangeError: Maximum call stack size exceeded`

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

bump minimum engine version in `package.json`

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

I've been using node 18.16 for months locally with no problems
