### PR TITLE
fix(signup-link): clicking led to 404

### DIFF
--- a/client/src/ui/atoms/signup-link/index.tsx
+++ b/client/src/ui/atoms/signup-link/index.tsx
@@ -15,6 +15,7 @@ export const SignUpLink = ({ toPlans = false, gleanContext = "" }) => {
   return (
     <Button
       href={href}
+      target="_self"
       extraClasses="mdn-plus-subscribe-link"
       onClickHandler={() => gleanContext && gleanClick(gleanContext)}
     >


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

- clicking "Sign up for free" button leads to a 404

### Solution

- set `target="_self"` on link to force it to be a "true" `<a>` tag
- we should make this default in future, and "opt-in" to internal links in various plus features, but this is a hotfix for now