### PR TITLE
feat(prism): enable Nginx syntax highlighting

### DIFF
--- a/build/syntax-highlight.ts
+++ b/build/syntax-highlight.ts
@@ -42,6 +42,7 @@ const loadAllLanguages = lazy(() => {
     "latex",
     "less",
     "md",
+    "nginx",
     "php",
     "powershell",
     "pug",


### PR DESCRIPTION
## Summary

Enables `nginx` syntax highlighting. This language is used in content already, generates some build errs:

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin

## Screenshots


### Before

![image](https://github.com/mdn/yari/assets/43580235/a97f48da-2d53-4e48-afb0-feb4f80932be)


### After


![image](https://github.com/mdn/yari/assets/43580235/159cdac9-2bf9-4ecc-8036-b39290e91f37)


---

## How did you test this change?

`yarn && yarn dev`
