### PR TITLE
fix(ai-help): nonsense prepended when copying message

### DIFF
--- a/client/src/ui/atoms/avatar/index.tsx
+++ b/client/src/ui/atoms/avatar/index.tsx
@@ -9,21 +9,13 @@ export const Avatar = ({ userData }: { userData: UserData }) => {
   const avatarImage = `${process.env.PUBLIC_URL || ""}/assets/avatar.png`;
 
   return (
-    <>
-      <figure
-        className={
-          userData?.isSubscriber ? "avatar-wrap is-subscriber" : "avatar-wrap"
-        }
-      >
-        <img
-          alt="Avatar"
-          className="avatar"
-          src={userData?.avatarUrl || avatarImage}
-        />
-      </figure>
-      <span className="avatar-username visually-hidden">
-        {userData?.username}
-      </span>
-    </>
+    <div
+      className={
+        userData?.isSubscriber ? "avatar-wrap is-subscriber" : "avatar-wrap"
+      }
+      aria-hidden="true"
+    >
+      <img alt="" className="avatar" src={userData?.avatarUrl || avatarImage} />
+    </div>
   );
 };

--- a/client/src/ui/molecules/user-menu/index.tsx
+++ b/client/src/ui/molecules/user-menu/index.tsx
@@ -88,6 +88,7 @@ export const UserMenu = () => {
       >
         {hasAnyDot && <span className="visually-hidden dot">New feature</span>}
         <Avatar userData={userData} />
+        <span className="visually-hidden">User menu</span>
         <span className="user-menu-id">{userData.email}</span>
       </Button>
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

often when highlighting text to copy from ai help, something like this gets prepended:
```
Avatar
9901f5c4d49546998c4138f6d7759b46
```

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

the avatar component was defining pretty meaningless alt text, I've removed that, and added more meaningful alt text to the user menu

---

## How did you test this change?

- copied before/after
- checked the user menu button still got text in Firefox's accessibility devtools