### PR TITLE
chore(glean): migrate to using data-glean everywhere

### DIFF
--- a/client/src/document/code/ai-explain.ts
+++ b/client/src/document/code/ai-explain.ts
@@ -1,4 +1,5 @@
 import { SSE } from "sse.js";
+import { AI_EXPLAIN } from "../../telemetry/constants";
 
 interface ExplainRequest {
   language: string | undefined;
@@ -25,7 +26,7 @@ function explain(
 function thumbs(upDown: string, title: string, callback: () => void): Element {
   const thumbs = document.createElement("button");
   thumbs.classList.add("icon", `icon-thumbs-${upDown}`);
-  thumbs.setAttribute("data-ai-explain", `thumbs_${upDown}`);
+  thumbs.dataset.glean = `${AI_EXPLAIN}: thumbs_${upDown}`;
   thumbs.addEventListener("click", callback);
   thumbs.title = title;
   return thumbs;
@@ -80,7 +81,7 @@ export function addExplainButton(
   button.textContent = "AI Explain";
   button.classList.add("ai-explain-button");
   button.type = "button";
-  button.setAttribute("data-ai-explain", "explain");
+  button.dataset.glean = `${AI_EXPLAIN}: explain`;
   button.title = "Explain (parts of) this example";
   buttonContainer.appendChild(button);
   const info = document.createElement("div");
@@ -90,7 +91,7 @@ export function addExplainButton(
   const infoToggle = document.createElement("button");
   infoToggle.classList.add("ai-explain-info-toggle", "icon", "icon-note-info");
   infoToggle.type = "button";
-  infoToggle.setAttribute("data-ai-explain", "info-toggle");
+  infoToggle.dataset.glean = `${AI_EXPLAIN}: info-toggle`;
   infoToggle.title = "Toggle AI Explain info";
   infoToggle.addEventListener("click", () =>
     info.classList.toggle("visually-hidden")

--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -1,4 +1,5 @@
 import { EditorContent, SESSION_KEY } from "../../playground/utils";
+import { PLAYGROUND } from "../../telemetry/constants";
 
 const LIVE_SAMPLE_PARTS = ["html", "css", "js"];
 
@@ -71,7 +72,7 @@ export function addBreakoutButton(
 
   button.setAttribute("class", "play-button external");
   button.type = "button";
-  button.setAttribute("data-play", id);
+  button.dataset.glean = `${PLAYGROUND}: breakout->${id}`;
   button.title = "Open in Playground";
   element.appendChild(button);
 

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -9,7 +9,7 @@ import { useEffect, useRef } from "react";
 import { useLocation } from "react-router";
 import { useUserData } from "../user-context";
 import { handleSidebarClick } from "./sidebar-click";
-import { AI_EXPLAIN, PLAYGROUND, VIEWPORT_BREAKPOINTS } from "./constants";
+import { VIEWPORT_BREAKPOINTS } from "./constants";
 
 export type ViewportBreakpoint = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 export type HTTPStatus = "200" | "404";
@@ -128,27 +128,19 @@ const gleanAnalytics = glean();
 const GleanContext = React.createContext(gleanAnalytics);
 
 function handleButtonClick(ev: MouseEvent, click: (source: string) => void) {
-  const button = ev?.target as Element;
-  if (button?.nodeName === "BUTTON") {
-    if (button.hasAttribute?.("data-play")) {
-      click(
-        `${PLAYGROUND}: breakout->${button.getAttribute("data-play") || ""}`
-      );
-    } else if (button.hasAttribute?.("data-ai-explain")) {
-      click(`${AI_EXPLAIN}: ${button.getAttribute("data-ai-explain") || ""}}`);
-    }
+  const button = ev?.target;
+  if (button instanceof HTMLButtonElement && button.dataset.glean) {
+    click(button.dataset.glean);
   }
 }
 
 function handleLinkClick(ev: MouseEvent, click: (source: string) => void) {
   const anchor = ev?.target;
   if (anchor instanceof HTMLAnchorElement) {
-    if (anchor?.classList.contains("external")) {
-      click(`external-link: ${anchor.getAttribute("href") || ""}`);
-    } else if (anchor?.hasAttribute?.("data-pong")) {
-      click(`pong: ${anchor.getAttribute("data-pong") || ""}`);
-    } else if (anchor.dataset.glean) {
+    if (anchor.dataset.glean) {
       click(anchor.dataset.glean);
+    } else if (anchor.classList.contains("external")) {
+      click(`external-link: ${anchor.getAttribute("href") || ""}`);
     }
   }
 }

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -316,7 +316,7 @@ function RenderSideOrTopBanner({
       <p className="pong-box">
         <a
           className="pong"
-          data-pong="pong->click"
+          data-glean="pong: pong->click"
           href={`/pong/click?code=${encodeURIComponent(click)}`}
           target="_blank"
           rel="noreferrer"
@@ -333,7 +333,7 @@ function RenderSideOrTopBanner({
         {cta && (
           <a
             className="pong-cta"
-            data-pong="pong->click"
+            data-glean="pong: pong->click"
             href={`/pong/click?code=${encodeURIComponent(click)}`}
             target="_blank"
             rel="noreferrer"
@@ -344,7 +344,7 @@ function RenderSideOrTopBanner({
         <a
           href="/en-US/advertising"
           className="pong-note"
-          data-pong="pong->about"
+          data-glean="pong: pong->about"
           target="_blank"
           rel="noreferrer"
         >
@@ -354,7 +354,9 @@ function RenderSideOrTopBanner({
 
       <a
         className="no-pong"
-        data-pong={user?.isSubscriber ? "pong->settings" : "pong->plus"}
+        data-glean={
+          "pong: " + (user?.isSubscriber ? "pong->settings" : "pong->plus")
+        }
         href={
           user?.isSubscriber
             ? "/en-US/plus/settings?ref=nope"
@@ -385,7 +387,7 @@ function RenderHpPlacement({
     >
       <a
         className="pong"
-        data-pong="pong->click"
+        data-glean="pong: pong->click"
         href={`/pong/click?code=${encodeURIComponent(click)}`}
         target="_blank"
         rel="noreferrer"


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

We were using a few different dataset properties to send glean pings.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Migrate to using one `data-glean`.
Also make it take priority over external links.

---

## How did you test this change?

- `yarn && yarn dev`
- Breaking out from playground appears to send a well-formed ping: https://debug-ping-preview.firebaseapp.com/pings/mdn-dev/75a2dea1-428a-4af2-94ff-1e87eb793416
- Wasn't able to test ads, as I get a `geo_unsupported` error locally
- Wasn't able to test ai explain, as we've disabled that feature
