### PR TITLE
chore(language-menu): use proper <a> tags

### DIFF
--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import { useGA } from "../../../../ga-context";
 import { Translation } from "../../../../../../libs/types/document";
@@ -24,23 +24,14 @@ export function LanguageMenu({
 }) {
   const menuId = "language-menu";
   const ga = useGA();
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
   const locale = useLocale();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  function translateURL(destinationLocale: string) {
-    return pathname.replace(`/${locale}/`, `/${destinationLocale}/`);
-  }
-
-  function changeLocale(event) {
-    event.preventDefault();
-
-    const preferredLocale = event.currentTarget.name;
+  const changeLocale: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
+    const preferredLocale = event.currentTarget.dataset.locale;
     // The default is the current locale itself. If that's what's chosen,
     // don't bother redirecting.
     if (preferredLocale !== locale) {
-      const localeURL = translateURL(preferredLocale);
       let cookieValueBefore = document.cookie
         .split("; ")
         .find((row) => row.startsWith(`${PREFERRED_LOCALE_COOKIE_NAME}=`));
@@ -71,16 +62,10 @@ export function LanguageMenu({
         eventAction: `Change preferred language (cookie before: ${
           cookieValueBefore || "none"
         })`,
-        eventLabel: `${window.location.pathname} to ${localeURL}`,
+        eventLabel: `${window.location.pathname} to ${event.currentTarget.href}`,
       });
-
-      navigate(localeURL);
-      window.scrollTo(0, 0);
-
-      setIsOpen(false);
-      onClose();
     }
-  }
+  };
 
   const menuEntry = {
     label: "Languages",
@@ -122,16 +107,28 @@ export function LanguageMenu({
   );
 }
 
-function LanguageMenuItem({ translation, changeLocale, native }) {
+function LanguageMenuItem({
+  translation,
+  changeLocale,
+  native,
+}: {
+  translation: Translation;
+  changeLocale: React.MouseEventHandler<HTMLAnchorElement>;
+  native: string;
+}) {
+  const { pathname } = useLocation();
+  const locale = useLocale();
+
   return (
-    <button
+    <a
       aria-current={translation.native === native || undefined}
       key={translation.locale}
-      name={translation.locale}
+      data-locale={translation.locale}
       onClick={changeLocale}
+      href={pathname.replace(`/${locale}/`, `/${translation.locale}/`)}
       className="button submenu-item"
     >
       <span>{translation.native}</span>
-    </button>
+    </a>
   );
 }


### PR DESCRIPTION

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

https://github.com/orgs/mdn/discussions/365

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

The buttons in the dropdown language switcher menu, being buttons, couldn't be middle clicked to open in another tab.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

Make them `<a>` tags, also remove another use of client side nav

---

## How did you test this change?

- `yarn && yarn dev`
- tested on a few pages on localhost:3000
- manually looked at cookies in devtools to verify that they updated
- didn't test GA, do we want to migrate this to glean, or remove the measurement entirely?
