### PR TITLE
chore(ai-help): use private repo for internal feedback

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -240,6 +240,9 @@ jobs:
           SENTRY_ENVIRONMENT: prod
           SENTRY_RELEASE: ${{ github.sha }}
 
+          # AI Help.
+          REACT_APP_AI_FEEDBACK_GITHUB_REPO: mdn/ai-feedback
+
         run: |
 
           # Info about which CONTENT_* environment variables were set and to what.

--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -98,6 +98,9 @@ export const GLEAN_ENABLED = Boolean(
   JSON.parse(process.env.REACT_APP_GLEAN_ENABLED || "false")
 );
 
+export const AI_FEEDBACK_GITHUB_REPO =
+  process.env.REACT_APP_AI_FEEDBACK_GITHUB_REPO || "mdn/private-ai-feedback";
+
 export function survey_duration(surveyBucket: string): {
   start: number;
   end: number;

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -22,6 +22,7 @@ import { isExternalUrl } from "./utils";
 import { useGleanClick } from "../../telemetry/glean-context";
 import { AI_HELP } from "../../telemetry/constants";
 import MDNModal from "../../ui/atoms/modal";
+import { AI_FEEDBACK_GITHUB_REPO } from "../../env";
 
 type Category = "apis" | "css" | "html" | "http" | "js" | "learn";
 
@@ -566,7 +567,7 @@ function ReportIssueOnGitHubLink({
   const lastQuestion = questions.at(-1);
 
   const url = new URL("https://github.com/");
-  url.pathname = "/mdn/ai-feedback/issues/new";
+  url.pathname = `/${AI_FEEDBACK_GITHUB_REPO}/issues/new`;
 
   const sp = new URLSearchParams();
   sp.set("title", `[AI Help] Question: ${lastQuestion}`);

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -233,6 +233,12 @@ automatically included in XHR calls on `http://localhost.org:3000`.
 Note that even if you set this, you can still continue to use
 `http://localhost:3000`.
 
+### `REACT_APP_AI_FEEDBACK_GITHUB_REPO`
+
+**Default: `mdn/private-ai-feedback`**
+
+The GitHub repository to use for reporting issues with AI Help answers.
+
 ### `REACT_APP_BCD_BASE_URL`
 
 **Default: `https://bcd.developer.allizom.org`**


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We already gather issue reports about AI Help answers from our users in a public repository, and now we would also like to collect internal feedback in the same way, but without mixing them with user reports.

### Solution

Introduce an environment variable for the repository, and use a private repository for internal feedback on all nonprod builds.

---

## How did you test this change?

Ran `yarn && yarn dev` with rumba running, opened http://localhost:3000/en-US/plus/ai-help/, clicked on "Report an issue with this answer on GitHub", and verified that it opens an issue in the private feedback repository.