### PR TITLE
feat(ai-help): use prism for syntax highlighting

### DIFF
--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -219,10 +219,11 @@
       &.status-pending .ai-help-message-content,
       &.status-in-progress .ai-help-message-content {
         &.empty::after,
-        > :not(ol):not(ul):not(pre):last-child:after,
+        > :not(ol):not(ul):not(pre):not(div.code-example):last-child:after,
         > ol:last-child li:last-child:after,
         > pre:last-child code:after,
-        > ul:last-child li:last-child:after {
+        > ul:last-child li:last-child:after,
+        > div.code-example:last-child pre:last-child code:after {
           animation: blink 1s steps(5, start) infinite;
           content: "▋";
           margin-left: 0.25rem;

--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -270,6 +270,10 @@
         &:last-child {
           margin-bottom: 0;
         }
+
+        &.example-header {
+          margin-bottom: 0;
+        }
       }
 
       ul,

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -221,11 +221,11 @@ export function AIHelpInner() {
                             return <a {...props} />;
                           },
                           pre: ({ node, className, children, ...props }) => {
-                            let code = Children.toArray(children)
+                            const code = Children.toArray(children)
                               .map(
                                 (child) =>
                                   /language-(\w+)/.exec(
-                                    (child as any)?.props?.className || ""
+                                    (child as ReactElement)?.props?.className || ""
                                   )?.[1]
                               )
                               .find(Boolean);
@@ -263,7 +263,7 @@ export function AIHelpInner() {
                                     lang
                                   ),
                                 }}
-                              ></code>
+                              />
                             ) : (
                               <code {...props} className={className}>
                                 {children}

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -1,5 +1,5 @@
 import Prism from "prismjs";
-import { Children, MutableRefObject, useEffect, useRef, useState } from "react";
+import { Children, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -1,4 +1,5 @@
-import { MutableRefObject, useEffect, useRef, useState } from "react";
+import Prism from "prismjs";
+import { Children, MutableRefObject, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -218,6 +219,56 @@ export function AIHelpInner() {
                             }
                             // eslint-disable-next-line jsx-a11y/anchor-has-content
                             return <a {...props} />;
+                          },
+                          pre: ({ node, className, children, ...props }) => {
+                            let code = Children.toArray(children)
+                              .map(
+                                (child) =>
+                                  /language-(\w+)/.exec(
+                                    (child as any)?.props?.className || ""
+                                  )?.[1]
+                              )
+                              .find(Boolean);
+
+                            if (!code) {
+                              return (
+                                <pre {...props} className={className}>
+                                  {children}
+                                </pre>
+                              );
+                            }
+                            return (
+                              <div className="code-example">
+                                <p className="example-header">
+                                  <span className="language-name">{code}</span>
+                                </p>
+                                <pre className={`brush: ${code}`}>
+                                  {children}
+                                </pre>
+                              </div>
+                            );
+                          },
+                          code: ({ inline, className, children, ...props }) => {
+                            const match = /language-(\w+)/.exec(
+                              className || ""
+                            );
+                            const lang = Prism.languages[match?.[1]];
+                            return !inline && lang ? (
+                              <code
+                                {...props}
+                                className={className}
+                                dangerouslySetInnerHTML={{
+                                  __html: Prism.highlight(
+                                    String(children),
+                                    lang
+                                  ),
+                                }}
+                              ></code>
+                            ) : (
+                              <code {...props} className={className}>
+                                {children}
+                              </code>
+                            );
                           },
                         }}
                       >

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -1,5 +1,12 @@
 import Prism from "prismjs";
-import { Children, MutableRefObject, ReactElement, useEffect, useRef, useState } from "react";
+import {
+  Children,
+  MutableRefObject,
+  ReactElement,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -225,7 +232,8 @@ export function AIHelpInner() {
                               .map(
                                 (child) =>
                                   /language-(\w+)/.exec(
-                                    (child as ReactElement)?.props?.className || ""
+                                    (child as ReactElement)?.props?.className ||
+                                      ""
                                   )?.[1]
                               )
                               .find(Boolean);


### PR DESCRIPTION
## Summary

Syntax highlighting for AI-Help answers.

### Problem

Code examples looked different than anywhere else.

### Solution

Use prism to style code samples in AI-Help answers.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/3604775/06da53dc-b37a-48b1-97ad-ae9d1168be7f)

### After

![image](https://github.com/mdn/yari/assets/3604775/31450119-505e-40d1-a306-e62c8c241859)
