### PR TITLE
fix(glean): fix url metrics

### DIFF
--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -44,6 +44,17 @@ export type GleanAnalytics = {
 const FIRST_PARTY_DATA_OPT_OUT_COOKIE_NAME = "moz-1st-party-data-opt-out";
 const GLEAN_APP_ID = "mdn-yari";
 
+function urlOrNull(url?: string, base?: string | URL) {
+  if (!url) {
+    return null;
+  }
+  try {
+    return new URL(url, base);
+  } catch (_) {
+    return null;
+  }
+}
+
 function glean(): GleanAnalytics {
   if (typeof window === "undefined" || !GLEAN_ENABLED) {
     //SSR return noop.
@@ -74,11 +85,13 @@ function glean(): GleanAnalytics {
 
   const gleanContext = {
     page: (page: PageProps) => {
-      if (page.path) {
-        pageMetric.path.set(page.path);
+      const path = urlOrNull(page.path);
+      if (path) {
+        pageMetric.path.setUrl(path);
       }
-      if (page.referrer) {
-        pageMetric.referrer.set(page.referrer);
+      const referrer = urlOrNull(page.referrer);
+      if (referrer) {
+        pageMetric.referrer.setUrl(referrer);
       }
       pageMetric.httpStatus.set(page.httpStatus);
       if (page.geo) {

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -89,7 +89,7 @@ function glean(): GleanAnalytics {
       if (path) {
         pageMetric.path.setUrl(path);
       }
-      const referrer = urlOrNull(page.referrer);
+      const referrer = urlOrNull(page.referrer, window?.location.href);
       if (referrer) {
         pageMetric.referrer.setUrl(referrer);
       }


### PR DESCRIPTION
## Summary

URL metrics did not get sent after upgrading to Glean 2.0

### Problem

[`set`](https://github.com/mozilla/glean.js/blob/a4560183c9e332ef6eac0d05e93bb0bf17e9edfa/glean/src/core/metrics/types/url.ts#L106) seems to be async and should be sync.

See https://github.com/mozilla/glean.js/issues/1753

### Solution

Use `setUrl` for now

---

## How did you test this change?

Locally with GLEAN Debug enabled
