### PR TITLE
fix(eslint): support running in git submodule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,7 +12,11 @@ try {
 } catch (error) {
   if (error.code === "ENOTDIR") {
     console.log(
-      ".git/info/exclude dir doesn't exist, we're probably a submodule"
+      `${path.join(
+        ".git",
+        "info",
+        "exclude"
+      )} dir doesn't exist, we're probably a submodule`
     );
   } else {
     throw error;

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,10 +1,23 @@
+// @ts-check
 const path = require("node:path");
 const { readGitignoreFiles } = require("eslint-gitignore");
 
-const ignores = readGitignoreFiles({
-  cwd: path.join(".git", "info"),
-  patterns: ["exclude"],
-});
+/** @type {string[]} */
+let ignores = [];
+try {
+  ignores = readGitignoreFiles({
+    cwd: path.join(".git", "info"),
+    patterns: ["exclude"],
+  });
+} catch (error) {
+  if (error.code === "ENOTDIR") {
+    console.log(
+      ".git/info/exclude dir doesn't exist, we're probably a submodule"
+    );
+  } else {
+    throw error;
+  }
+}
 
 module.exports = {
   ignorePatterns: ignores,


### PR DESCRIPTION
also add some jsdoc type hinting

Trying to commit locally I was getting this error:
```
Oops! Something went wrong! :(

ESLint: 8.48.0

Error: Cannot read config file: /workspace/yari/.eslintrc.cjs
Error: ENOTDIR: not a directory, lstat '/workspace/yari/.git/info/exclude'
```

I've been running yari from a git submodule as an easier way of transferring my dev environment state between devices. I'm not sure it's a setup we want to explicitly support, but it should fail more gracefully than an error message and no commit.