### PR TITLE
chore(dependabot): group pip minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,11 +29,25 @@ updates:
     directory: "/deployer"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "/testing/integration"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: npm
     directory: "/client/pwa"


### PR DESCRIPTION
## Summary

### Problem

We update deployer/test dependencies individually, but we don't need to update those minor/patch updates separately.

### Solution

Configure grouped dependency updates for `/deployer/` and `/testing/integration` for minor/patch updates.

---

## How did you test this change?

Hard to test, but once merged, we will (hopefully) see grouped Dependabot PRs for these directories.