### PR TITLE
fix(client): deal with css disabled

### DIFF
--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -115,7 +115,7 @@ export function useStickyHeaderHeight() {
       const topFloat = parseFloat(top);
       if (Number.isNaN(topFloat)) {
         console.warn(
-          `[useStickyHeaderHeight] .sidebar-container->top has unexpected unit: ${top}`
+          `[useStickyHeaderHeight] .sidebar-container[top] has unexpected unit: ${top}`
         );
         return 0;
       }

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -111,7 +111,15 @@ export function useStickyHeaderHeight() {
     const sidebar = document.querySelector(".sidebar-container");
 
     if (sidebar) {
-      return parseFloat(getComputedStyle(sidebar).top);
+      const top = getComputedStyle(sidebar).top;
+      const topFloat = parseFloat(top);
+      if (Number.isNaN(topFloat)) {
+        console.warn(
+          `[useStickyHeaderHeight] .sidebar-container->top has unexpected unit: ${top}`
+        );
+        return 0;
+      }
+      return topFloat;
     }
 
     const styles = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary

fixes #9695

### Problem

We didn't deal with `top` being `auto`. Which happens if CSS is disabled.

### Solution

Guard against `NaN`.
