### PR TITLE
fix(client): avoid CSS warning in Firefox

### DIFF
--- a/client/src/ui/organisms/top-navigation-main/index.scss
+++ b/client/src/ui/organisms/top-navigation-main/index.scss
@@ -92,7 +92,7 @@
       align-self: flex-start;
     }
 
-    @media screen and (max-width: #{$screen-lg -1}) {
+    @media screen and (max-width: #{$screen-lg - 1}) {
       &.button {
         --button-color: var(--text-secondary);
         --button-padding: 0;


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

See: #9350

### Problem

Firefox shows the following CSS warning in the DevTools when opening https://developer.mozilla.org/en-US/docs/Web/CSS/mask-type:

> Unexpected token ‘-1’ in media list.

### Solution

Add the missing space between `-` and `1`.

---

## How did you test this change?

TBD