### PR TITLE
fix(csp): remove unsafe-eval from script-src-elem

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -158,18 +158,16 @@ export const cspToString = (csp) =>
 
 export const CSP_VALUE = cspToString(CSP_DIRECTIVES);
 
-const PLAYGROUND_UNSAFE_CSP_SCRIPT_SRC_VALUES = [
-  "'self'",
-  "https:",
-  "'unsafe-eval'",
-  "'unsafe-inline'",
-  "'wasm-unsafe-eval'",
-];
-
 export const PLAYGROUND_UNSAFE_CSP_VALUE = cspToString({
   "default-src": ["'self'", "https:"],
-  "script-src": PLAYGROUND_UNSAFE_CSP_SCRIPT_SRC_VALUES,
-  "script-src-elem": PLAYGROUND_UNSAFE_CSP_SCRIPT_SRC_VALUES,
+  "script-src": [
+    "'self'",
+    "https:",
+    "'unsafe-eval'",
+    "'unsafe-inline'",
+    "'wasm-unsafe-eval'",
+  ],
+  "script-src-elem": ["'self'", "https:", "'unsafe-inline'"],
   "style-src": [
     "'report-sample'",
     "'self'",


### PR DESCRIPTION
## Summary

See: https://github.com/mdn/yari/issues/9350

### Problem

Firefox displays the following DevTools warning:
> Content-Security-Policy: Ignoring ‘unsafe-eval’ or
> ‘wasm-unsafe-eval’ inside “script-src-elem”.

See: https://w3c.github.io/webappsec-csp/#directive-script-src-elem
> script-src-elem’s value is not used for JavaScript execution sink
> checks that are gated on the "unsafe-eval" check.

### Solution

Remove `unsafe-eval` and `wasm-unsafe-eval` from the `script-src-elem` CSP directive for the Playground.

---

## How did you test this change?

TBD
