### PR TITLE
fix(macros/LiveSampleLink): add fallback to prebuilt samples

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -175,7 +175,7 @@ jobs:
           # secure production but this is an exception and default
           # is not insecure.
           BUILD_LIVE_SAMPLES_BASE_URL: https://live.mdnplay.dev
-          BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live-samples.mdn.mozilla.net
+          BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live.mdnplay.dev
 
           # Sign key for code samples
           BUILD_SAMPLE_SIGN_KEY: ${{ secrets.SAMPLE_SIGN_KEY }}
@@ -350,7 +350,7 @@ jobs:
             --memory=2GB \
             --timeout=60s \
             --set-env-vars="ORIGIN_MAIN=developer.mozilla.org" \
-            --set-env-vars="ORIGIN_LIVE_SAMPLES=live-samples.mdn.mozilla.net" \
+            --set-env-vars="ORIGIN_LIVE_SAMPLES=live.mdnplay.dev" \
             --set-env-vars="ORIGIN_PLAY=mdnplay.dev" \
             --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/${{ vars.GCP_BUCKET_NAME }}/main/" \
             --set-env-vars="SOURCE_API=https://api.developer.mozilla.org/" \

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -175,7 +175,7 @@ jobs:
           # secure production but this is an exception and default
           # is not insecure.
           BUILD_LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
-          BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live-samples.mdn.allizom.net
+          BUILD_LEGACY_LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
 
           # Sign key for code samples
           BUILD_SAMPLE_SIGN_KEY: ${{ secrets.SAMPLE_SIGN_KEY }}

--- a/kumascript/macros/LiveSampleLink.ejs
+++ b/kumascript/macros/LiveSampleLink.ejs
@@ -9,6 +9,6 @@
 //
 // See also : EmbedLiveSample
 //
-// We pass evn.url as $1 to LiveSampleURL to enforce fallback to prebuild samples.
+// We pass env.url as $1 to LiveSampleURL to enforce fallback to prebuild samples.
 %>
 <a href="<%= await template('LiveSampleURL', [$0, env.url]) %>"><%=$1%></a>

--- a/kumascript/macros/LiveSampleLink.ejs
+++ b/kumascript/macros/LiveSampleLink.ejs
@@ -8,5 +8,7 @@
 //  $1 - The link label
 //
 // See also : EmbedLiveSample
+//
+// We pass evn.url as $1 to LiveSampleURL to enforce fallback to prebuild samples.
 %>
-<a href="<%= await template('LiveSampleURL', [$0]) %>"><%=$1%></a>
+<a href="<%= await template('LiveSampleURL', [$0, env.url]) %>"><%=$1%></a>


### PR DESCRIPTION
## Summary

Fix `LiveSampleLink` macro for now and consolidate live samples domains.

### Problem

`LiveSampleLink` pointing to an empty page.

### Solution

Enforce fallback to prebuild samples.

---


## How did you test this change?

Deploying to stage now.
