### PR TITLE
enhance(macros/DefaultAPISidebar): show status badges

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -64,10 +64,6 @@
 
     ol {
       li {
-        .icon {
-          margin-right: 0.01em;
-        }
-
         &.no-bullet {
           display: block;
           font-weight: var(--font-body-strong-weight);
@@ -142,7 +138,6 @@
     align-self: center;
     background-size: 14px;
     height: 14px;
-    margin-right: -0.25rem;
     mask-size: 14px;
     width: 14px;
   }

--- a/kumascript/macros/DefaultAPISidebar.ejs
+++ b/kumascript/macros/DefaultAPISidebar.ejs
@@ -41,7 +41,14 @@ var groupTutorial = webAPIGroups[0][group].tutorial || [];
 var guides = await wiki.getPages(...groupGuides);
 var tutorial = await wiki.getPages(...groupTutorial);
 
-function buildSublist(pages, title) {
+async function smartLinkWithBadges(url, content) {
+  const aPage = await wiki.getPage(url);
+  const link = web.smartLink(url, null, content, APIHref, null, "APIRef");
+  const badges = (await page.badges(aPage)).join("");
+  return link + badges;
+}
+
+async function buildSublist(pages, title) {
   var result = '<li class="toggle"><details open><summary>' + title + '</summary><ol>';
 
   for (var i in pages) {
@@ -59,7 +66,7 @@ function buildSublist(pages, title) {
     }
 
     result += '<li>';
-    result += '<a href="' + url + '">' + title + '</a>';
+    result += await smartLinkWithBadges(url, title);
     result += '</li>';
   }
 
@@ -68,11 +75,11 @@ function buildSublist(pages, title) {
   return result;
 }
 
-function buildIFList(interfaces, title) {
+async function buildIFList(interfaces, title) {
   var result = '<li class="toggle"><details open><summary>' + title + '</summary><ol>';
 
   for (let interface of interfaces) {
-    result += '<li><a href="' + APIHref + '/' + interface.target + '">' + interface.text + '</a></li>';
+    result += `<li>${await smartLinkWithBadges(APIHref + '/' + interface.target, interface.text)}</li>`;
   }
 
   result += '</ol></details></li>';
@@ -102,35 +109,35 @@ function convertEvent(eventName) {
 output = '<section id="Quick_links" data-macro="DefaultAPISidebar"><ol>';
 
 if (webAPIGroups[0][group].overview) {
-  output += '<li><strong><a href="' +  APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_') + '">' + webAPIGroups[0][group].overview[0] + '</a></strong></li>';
+  output += `<li><strong>${await smartLinkWithBadges(APIHref + '/' + webAPIGroups[0][group].overview[0].replace(/ /g, '_'), webAPIGroups[0][group].overview[0])}</strong></li>`;
 }
 
 if (guides.length > 0) {
-  output += buildSublist(guides, text['Guides']);
+  output += await buildSublist(guides, text['Guides']);
 }
 
 if (tutorial.length > 0) {
-  output += buildSublist(tutorial, text['Tutorial']);
+  output += await buildSublist(tutorial, text['Tutorial']);
 }
 
 interfaces = interfaces.map(convert);
 if (interfaces.length > 0) {
-  output += buildIFList(interfaces, text['Interfaces']);
+  output += await buildIFList(interfaces, text['Interfaces']);
 }
 
 properties = properties.map(convert);
 if (properties.length > 0) {
-  output += buildIFList(properties, text['Properties']);
+  output += await buildIFList(properties, text['Properties']);
 }
 
 methods = methods.map(convert);
 if (methods.length > 0) {
-  output += buildIFList(methods, text['Methods']);
+  output += await buildIFList(methods, text['Methods']);
 }
 
 events = events.sort().map(convertEvent).filter( e => e !== null );
 if (events.length > 0) {
-  output += buildIFList(events, text['Events']);
+  output += await buildIFList(events, text['Events']);
 }
 
 output += '</ol></section>';


### PR DESCRIPTION
## Summary

Similar to https://github.com/mdn/yari/pull/9757.

### Problem

The `DefaultAPISidebar` did not show any badges (deprecated, experimental etc).

### Solution

Add badges to all links.
---

## Screenshots

| Before | After |
|--------|--------|
| <img width="674" alt="image" src="https://github.com/mdn/yari/assets/495429/0cb322ea-81cd-4876-8d7b-f2f3a7b43502"> | <img width="674" alt="image" src="https://github.com/mdn/yari/assets/495429/6055823f-5669-48e7-957d-2b12cb7a4bd1"> |
| <img width="674" alt="image" src="https://github.com/mdn/yari/assets/495429/20f3f58e-0f5d-464a-b39f-942a823b96d2"> | <img width="674" alt="image" src="https://github.com/mdn/yari/assets/495429/7560b792-eb0e-4ece-9c35-86b52420777f"> |

---

## How did you test this change?

Ran `yarn && yarn dev` and opened http://localhost:3000/en-US/docs/Web/API/WebVR_API and http://localhost:3000/en-US/docs/Web/API/Background_Fetch_API locally.
