### PR TITLE
feat(playground): allow img from blob and data

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -177,6 +177,7 @@ export const PLAYGROUND_UNSAFE_CSP_VALUE = cspToString({
     "'unsafe-inline'",
     "'unsafe-eval'",
   ],
+  "img-src": ["'self'", "blob:", "https:", "data:"],
   "base-uri": ["'self'"],
   "worker-src": ["'self'"],
   "manifest-src": ["'self'"],


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9463.

fixes live sample in https://developer.mozilla.org/en-US/docs/Web/API/File_API/Using_files_from_web_applications#example_using_object_urls_to_display_images

### Problem

We do not allow blob urls in the playground

### Solution

Add according CSP and also allow `data:`.

---


## How did you test this change?

Locally running the cloud function.
