### PR TITLE
fix(blog): move toc to left on large screens

### DIFF
--- a/client/src/blog/post.scss
+++ b/client/src/blog/post.scss
@@ -22,21 +22,54 @@
     grid-template-columns: minmax(auto, 1fr) minmax(0, 52rem) minmax(15rem, 1fr);
   }
 
-  > .sidebar-container {
+  @media screen and (min-width: $screen-xxl) {
+    grid-template-areas:
+      "toc post place"
+      "toc newsletter place";
+    grid-template-columns: minmax(15rem, 1fr) minmax(0, 52rem) minmax(
+        15rem,
+        1fr
+      );
+  }
+
+  > .toc-container {
     --offset: var(--top-nav-height);
     display: none;
 
-    .toc-container {
-      position: unset;
-      top: auto;
-    }
-
     @media screen and (min-width: $screen-lg) {
       display: flex;
+      flex-direction: column;
       grid-area: toc;
 
       .toc > nav {
         margin-top: 2rem;
+      }
+    }
+    @media screen and (min-width: $screen-xxl) {
+      display: contents;
+
+      .place.side,
+      .toc {
+        height: max-content;
+        mask-image: linear-gradient(
+          to bottom,
+          rgba(0, 0, 0, 0) 0%,
+          rgb(0, 0, 0) 3rem calc(100% - 3rem),
+          rgba(0, 0, 0, 0) 100%
+        );
+        max-height: calc(100vh - var(--offset));
+        overflow: auto;
+        position: sticky;
+        top: var(--offset);
+      }
+
+      .place.side {
+        grid-area: place;
+        margin-top: 0;
+
+        > .pong-box {
+          margin-top: 2rem;
+        }
       }
     }
   }

--- a/client/src/blog/post.tsx
+++ b/client/src/blog/post.tsx
@@ -194,15 +194,11 @@ export function BlogPost(props: HydrationData) {
     <>
       {doc && blogMeta && (
         <main className="blog-post-container container">
-          <div className="sidebar-container">
-            <div className="toc-container">
-              <aside className="toc">
-                <nav>
-                  {doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}
-                </nav>
-              </aside>
-              {PLACEMENT_ENABLED && !blogMeta?.sponsored && <SidePlacement />}
-            </div>
+          <div className="sidebar-container toc-container">
+            <aside className="toc">
+              <nav>{doc.toc && !!doc.toc.length && <TOC toc={doc.toc} />}</nav>
+            </aside>
+            {PLACEMENT_ENABLED && !blogMeta?.sponsored && <SidePlacement />}
           </div>
           <article
             className="blog-post blog-container main-page-content"

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -792,6 +792,7 @@ kbd {
     }
   }
 
+  &.toc-container,
   .toc-container {
     .place {
       grid-area: toc;
@@ -801,7 +802,7 @@ kbd {
       display: flex;
       flex-direction: column;
       gap: 0;
-      height: calc(100vh - var(--sticky-header-with-actions-height));
+      height: calc(100vh - var(--offset));
       mask-image: linear-gradient(
         to bottom,
         rgba(0, 0, 0, 0) 0%,
@@ -810,7 +811,7 @@ kbd {
       );
       overflow: auto;
       position: sticky;
-      top: var(--sticky-header-with-actions-height);
+      top: var(--offset);
 
       .place {
         margin: 1rem 0;


### PR DESCRIPTION
## Summary

Move the blog ToC to the left on large screens.


---

## Screenshots


### Before

![image](https://github.com/mdn/yari/assets/3604775/7c8cded8-4115-42d1-b658-fe963d95955f)


### After

![image](https://github.com/mdn/yari/assets/3604775/f61fe73d-04c1-4d23-8f6d-d0455cd1e32a)


---

## How did you test this change?

Locally
