### PR TITLE
chore(labeler): add more labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,22 +1,45 @@
+blog:
+  - "**/blog/**/*"
 browser-compat:
-  - "client/src/document/ingredients/browser-compatability-table/**/*"
+  - "**/browser-compatability-table/**/*"
 macros:
   - "kumascript/**/*"
+cloud-function:
+  - "cloud-function/**/*"
+copy:
+  - "copy/**/*"
 dependencies:
   - "**/poetry.lock"
   - "**/yarn.lock"
 deployer:
   - "deployer/**/*"
+filecheck:
+  - "filecheck/**/*"
 flaw-system:
   - "build/flaws/**/*"
 github-actions:
   - ".github/workflows/**/*"
 markdown:
   - "markdown/**/*"
+metrics:
+  - "**/telemetry/**/*"
+placement:
+  - "**/placement/**/*"
+  - "**/pong/**/*"
 plus:
-  - "client/src/plus/**/*"
+  - "**/plus/**/*"
+  - "**/plus-docs/**/*"
+plus:ai-help:
+  - "**/ai-help/**/*"
 plus:offline:
   - "client/pwa/src/**/*"
   - "client/src/offline-settings/**/*"
+plus:playground:
+  - "**/playground/**/*"
+plus:updates:
+  - "client/src/plus/updates/**/*"
 python:
   - "**/*.py"
+redirects:
+  - "cloud-function/src/middlewares/redirect-*"
+  - "libs/fundamental-redirects/**/*"


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We use the [actions/labeler](https://github.com/actions/labeler) action to automatically add labels to PRs based on the files they change, but the mapping of labels to file path patterns was not comprehensive.

### Solution

Add more labels to the mapping.

---

## How did you test this change?

Not really testable, we'll see when it's merged.