### PR TITLE
fix(ssr): use absolute href for alternate rss link

### DIFF
--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -263,7 +263,7 @@ export default function render(
       ? "noindex, nofollow"
       : "index, follow";
   const robotsMeta = `<meta name="robots" content="${robotsContent}">`;
-  const rssLink = `<link rel="alternate" type="application/rss+xml" title="MDN Blog RSS Feed" href="/${DEFAULT_LOCALE}/blog/rss.xml" hreflang="en" />`;
+  const rssLink = `<link rel="alternate" type="application/rss+xml" title="MDN Blog RSS Feed" href="${BASE_URL}/${DEFAULT_LOCALE}/blog/rss.xml" hreflang="en" />`;
   const ssr_data = [...translations, ...webfontTags, rssLink, robotsMeta];
   let html = buildHtml;
   html = html.replace(


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/9367.

### Problem

The alternate link for the rss feed had a relative href.

### Solution

Make the href absolute by prefixing it with the base url.

---

## How did you test this change?

Verified locally by running `yarn && yarn dev` and inspecting the HTML of http://localhost:5042/en-US/docs/Learn/HTML, which now has:

```html
<link rel="alternate" type="application/rss+xml" title="MDN Blog RSS Feed" href="https://developer.mozilla.org/en-US/blog/rss.xml" hreflang="en">
```

