### PR TITLE
enhance(opengraph): fix og:image and add og:{image:*,site_name,type}

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -52,6 +52,7 @@
     -->
     <meta property="og:url" content="https://developer.mozilla.org" />
     <meta property="og:title" content="MDN Web Docs" />
+    <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
     <meta
       property="og:description"

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -58,6 +58,13 @@
       content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."
     />
     <meta property="og:image" content="%PUBLIC_URL%/mdn-social-share.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:height" content="1080" />
+    <meta property="og:image:width" content="1920" />
+    <meta
+      property="og:image:alt"
+      content="The MDN Web Docs logo, featuring a blue accent color, displayed on a solid black background."
+    />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="MozDevNet" />
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -65,6 +65,7 @@
       property="og:image:alt"
       content="The MDN Web Docs logo, featuring a blue accent color, displayed on a solid black background."
     />
+    <meta property="og:site_name" content="MDN Web Docs" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="MozDevNet" />
 

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -52,7 +52,7 @@
     -->
     <meta property="og:url" content="https://developer.mozilla.org" />
     <meta property="og:title" content="MDN Web Docs" />
-    <meta property="og:locale" content="en-US" />
+    <meta property="og:locale" content="en_US" />
     <meta
       property="og:description"
       content="The MDN Web Docs site provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and progressive web apps."

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -233,10 +233,16 @@ export default function render(
     )
     .join("");
 
+  // Open Graph protocol expects `language_TERRITORY` format.
+  const ogLocale = (locale || (doc && doc.locale) || DEFAULT_LOCALE).replace(
+    "-",
+    "_"
+  );
+
   const og = new Map([
     ["title", escapedPageTitle],
     ["url", canonicalURL],
-    ["locale", locale || (doc && doc.locale) || "en-US"],
+    ["locale", ogLocale],
   ]);
 
   if (pageDescription) {

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -239,7 +239,7 @@ test("content built zh-CN page for hreflang tag and copying image testing", () =
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);
-  expect($('meta[property="og:locale"]').attr("content")).toBe("zh-CN");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("zh_CN");
   expect($('meta[property="og:title"]').attr("content")).toBe(
     "<foo>: 测试网页 | MDN"
   );
@@ -273,7 +273,7 @@ test("content built zh-TW page with en-US fallback image", () => {
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);
-  expect($('meta[property="og:locale"]').attr("content")).toBe("zh-TW");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("zh_TW");
   expect($('meta[property="og:title"]').attr("content")).toBe(
     "<foo>: 測試網頁 | MDN"
   );
@@ -1165,7 +1165,7 @@ test("404 page", () => {
   expect($("title").text()).toContain("Page not found");
   expect($("h1").text()).toContain("Page not found");
   expect($('meta[name="robots"]').attr("content")).toBe("noindex, nofollow");
-  expect($('meta[property="og:locale"]').attr("content")).toBe("en-US");
+  expect($('meta[property="og:locale"]').attr("content")).toBe("en_US");
 });
 
 test("plus page", () => {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/9429.

### Problem

The Open Graph meta data had two issues:

1. The `og:locale` was not in the right format, with `-` instead of `_` separating language and territory.
2. The `og:image:alt` property was missing.

### Solution

1. Fix the `og:locale` format.
2. Add `og:image:alt` as well as `og:image:{type,height,width}`.

Also adds `og:site_name` and `og:type`.

---

## How did you test this change?

Ran `yarn && yarn dev` and inspected HTML of http://localhost:5042/zh-TW/docs/Learn/HTML.