### PR TITLE
fix(docs): restore behavior of description term links

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -146,19 +146,15 @@
       margin-top: 2rem;
 
       a {
-        &:link,
-        &:visited {
-          text-decoration: none;
-        }
-
-        &:hover,
-        &:focus {
-          text-decoration: underline;
-        }
-
         &[href^="#"] {
           color: inherit;
           position: relative;
+          text-decoration: none;
+
+          &:hover,
+          &:focus {
+            text-decoration: underline;
+          }
 
           &:hover::before {
             color: var(--text-inactive);

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -156,16 +156,21 @@
             text-decoration: underline;
           }
 
-          &:hover::before {
+          &::before {
             color: var(--text-inactive);
             content: "#";
             display: inline-flex;
             font-size: 0.7em;
-            left: -0.75em;
             line-height: 1;
-            position: absolute;
+            margin-left: -0.8em;
             text-decoration: none;
             top: 0.5em;
+            visibility: hidden;
+            width: 0.8em;
+          }
+
+          &:hover::before {
+            visibility: visible;
           }
         }
       }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -145,33 +145,31 @@
       margin-bottom: 0.5rem;
       margin-top: 2rem;
 
-      a {
-        &[href^="#"] {
-          color: inherit;
-          position: relative;
+      a[href^="#"] {
+        color: inherit;
+        position: relative;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+          text-decoration: underline;
+        }
+
+        &::before {
+          color: var(--text-inactive);
+          content: "#";
+          display: inline-flex;
+          font-size: 0.7em;
+          line-height: 1;
+          margin-left: -0.8em;
           text-decoration: none;
+          top: 0.5em;
+          visibility: hidden;
+          width: 0.8em;
+        }
 
-          &:hover,
-          &:focus {
-            text-decoration: underline;
-          }
-
-          &::before {
-            color: var(--text-inactive);
-            content: "#";
-            display: inline-flex;
-            font-size: 0.7em;
-            line-height: 1;
-            margin-left: -0.8em;
-            text-decoration: none;
-            top: 0.5em;
-            visibility: hidden;
-            width: 0.8em;
-          }
-
-          &:hover::before {
-            visibility: visible;
-          }
+        &:hover::before {
+          visibility: visible;
         }
       }
     }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -148,7 +148,6 @@
       a {
         &:link,
         &:visited {
-          color: inherit;
           text-decoration: none;
         }
 
@@ -158,6 +157,7 @@
         }
 
         &[href^="#"] {
+          color: inherit;
           position: relative;
 
           &:hover::before {

--- a/kumascript/src/api/util.ts
+++ b/kumascript/src/api/util.ts
@@ -224,6 +224,11 @@ export class HTMLTool {
       $element.attr("id", id);
 
       if (isDt) {
+        // Remove empty anchor links.
+        // This happens if the term already links to a page.
+        $element.find("a[data-link-to-id = true]:empty").remove();
+
+        // Link remaining anchor links to the term's ID.
         $element
           .find("a[data-link-to-id = true]")
           .attr("href", "#" + id)


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes #9810.

### Problem

https://github.com/mdn/yari/pull/8413 introduced a regression, making it unable to identify description terms (`<dt>`) that link to another page.

### Solution

Restore the style of those links, excluding anchor links.

Also makes the hashtag of the anchor links interactive.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="942" alt="image" src="https://github.com/mdn/yari/assets/495429/ccde1259-b5fb-4d1e-bb80-6076596f2e17">

### After

<img width="942" alt="image" src="https://github.com/mdn/yari/assets/495429/ba6024c8-6358-4486-8ee7-ffd17bb30e33">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/docs/Web/CSS/border#values locally.
