### PR TITLE
chore(macros/Non-standard_Header): remove "Firefox OS"

### DIFF
--- a/kumascript/macros/Non-standard_Header.ejs
+++ b/kumascript/macros/Non-standard_Header.ejs
@@ -1,6 +1,6 @@
 <%
 
-var str_inline = mdn.localString({
+var title = mdn.localString({
   "en-US": "Non-standard",
   "es":    "No estándar",
   "fr":    "Non standard",
@@ -11,7 +11,7 @@ var str_inline = mdn.localString({
   "zh-TW": "非標準"
 });
 
-var str_long = mdn.localString({
+var description = mdn.localString({
   "en-US": "This feature is non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user. There may also be large incompatibilities between implementations and the behavior may change in the future.",
   "es":    "Esta característica no es parte de los estándares. No la uses en sitios Web en producción: no funcionará para todos los usuarios. Podrían haber también incompatibilidades considerables entre distintas implementaciones y el comportamiento podría cambiar en el futuro.",
   "fr":    "Cette fonctionnalité n'est ni standard, ni en voie de standardisation. Ne l'utilisez pas pour des sites accessibles sur le Web : elle ne fonctionnera pas pour tout utilisateur. Il peut également y avoir d'importantes incompatibilités entre les implémentations et son comportement peut être modifié dans le futur.",
@@ -23,6 +23,6 @@ var str_long = mdn.localString({
 
 %>
 <div class="notecard nonstandard">
-  <h4><%-str_inline%></h4>
-  <p><%-str_long%></p>
+  <h4><%-title%></h4>
+  <p><%-description%></p>
 </div>

--- a/kumascript/macros/Non-standard_Header.ejs
+++ b/kumascript/macros/Non-standard_Header.ejs
@@ -21,39 +21,8 @@ var str_long = mdn.localString({
   "zh-CN": "该特性是非标准的，请尽量不要在生产环境中使用它！"
 });
 
-var str_fxos_long = mdn.localString({
-  "en-US": "This feature is not on a current W3C standards track, but it is supported on the Firefox OS platform. Although implementations may change in the future and it is not supported widely across browsers, it is suitable for use in code dedicated to Firefox OS apps.",
-  "es":    "Esta característica no está en ningún estándar actual del W3C, sin embargo está soportado en la plataforma Firefox OS. Aunque las implementaciones podrían cambiar en el futuro y no se soporta ampliamente por los navegadores, es apropiado usarse en código dedicado a aplicaciones de Firefox OS.",
-  "fr":    "Cette fonctionnalité n'est pas en voie de standardisation au W3C, mais elle est supportée par la plateforme Firefox OS. Bien que son implémentation puisse changer dans le futur et qu'elle n'est pas largement supportée par les différents navigateurs, elle est utilisable pour du code dédié aux applications Firefox OS.",
-  "ko":    "이 기능은 W3C 표준 기능은 아니지만, Firefox 운영체제에서 지원이 됩니다. 미래에는 동작이 바뀔 수 있고, 다른 브라우저에서는 동작 안할 수 있지만, Firefox 운영체제 앱에서는 사용 가능합니다.",
-  "ja":    "この機能は現在 W3C の標準化のプロセスに乗っていませんが、Firefox OS プラットフォームではサポートされています。将来は動作が変わるかもしれませんし、他のブラウザーで広くサポートされているわけでもありませんが、Firefox OS アプリ専用のコードで使うには適しています。",
-  "ru":    "Эта возможность не является стандартом W3C и стандартизировать её пока никто не собирается, но она поддерживается на платформе Firefox OS. Хотя возможность не поддерживается всеми браузерами и в будущем её реализация может изменяться, она может использоваться в коде приложений для Firefox OS."
-});
-
-var fxosCheck = 0;
-
-for (i = 0 ; i <= env.tags.length-1 ; i++) {
-    if (env.tags[i] == "Firefox OS") {
-      fxosCheck = 1;
-      break;        // we can break out now, to save some time
-    }
-}
-
-if (fxosCheck == 0) {
-  %>
-  <div class="notecard nonstandard">
-    <h4><%-str_inline%></h4>
-    <p><%-str_long%></p>
-  </div>
-  <%
-
-} else {
-  %>
-  <div class="notecard nonstandard">
-    <h4><%-str_inline%></h4>
-    <p><%-str_fxos_long%></p>
-  </div>
-  <%
-}
-
 %>
+<div class="notecard nonstandard">
+  <h4><%-str_inline%></h4>
+  <p><%-str_long%></p>
+</div>


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `Non-standard Header` still handles the "Firefox OS" case, even though we don't use it anymore.

### Solution

Remove it.

---

## Screenshots

n/a

---

## How did you test this change?

n/a
