### PR TITLE
test(build): avoid race condition in destructive test

### DIFF
--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -79,12 +79,13 @@ describe("fixing flaws", () => {
   });
 
   it("can be run in dry-run mode", () => {
+    const root = path.join(tempContentDir, "files");
     const stdout = execSync("yarn build", {
       cwd: baseDir,
       windowsHide: true,
       env: Object.assign(
         {
-          CONTENT_ROOT: path.join(tempContentDir, "files"),
+          CONTENT_ROOT: root,
           BUILD_OUT_ROOT: tempBuildDir,
           BUILD_FIX_FLAWS: "true",
           BUILD_FIX_FLAWS_DRY_RUN: "true",
@@ -94,15 +95,28 @@ describe("fixing flaws", () => {
       ),
     }).toString();
 
+    const wouldModify = [];
     const regexPattern = /Would modify "(.*)"./g;
-    const dryRunNotices = stdout
-      .split("\n")
-      .filter((line) => regexPattern.test(line));
-    expect(dryRunNotices).toHaveLength(4);
-    expect(dryRunNotices[0]).toContain(pattern);
-    expect(dryRunNotices[1]).toContain(path.join(pattern, "bad_pre_tags"));
-    expect(dryRunNotices[2]).toContain(path.join(pattern, "deprecated_macros"));
-    expect(dryRunNotices[3]).toContain(path.join(pattern, "images"));
+
+    let match: string[];
+    while ((match = regexPattern.exec(stdout)) !== null) {
+      wouldModify.push(match[1]);
+    }
+
+    expect(wouldModify).toHaveLength(4);
+    expect(wouldModify).toContain(
+      path.join(root, "en-us", pattern, "index.html")
+    );
+    expect(wouldModify).toContain(
+      path.join(root, "en-us", pattern, "bad_pre_tags", "index.html")
+    );
+    expect(wouldModify).toContain(
+      path.join(root, "en-us", pattern, "deprecated_macros", "index.html")
+    );
+    expect(wouldModify).toContain(
+      path.join(root, "en-us", pattern, "images", "index.html")
+    );
+
     const dryrunFiles = getChangedFiles(tempContentDir);
     expect(dryrunFiles).toHaveLength(0);
   });

--- a/testing/tests/destructive.test.ts
+++ b/testing/tests/destructive.test.ts
@@ -32,6 +32,17 @@ function* walker(root) {
   }
 }
 
+function extractMatchesFromString(pattern: RegExp, str: string) {
+  const matches = [];
+
+  let match: string[];
+  while ((match = pattern.exec(str)) !== null) {
+    matches.push(match[1] ?? match[0]);
+  }
+
+  return matches;
+}
+
 describe("fixing flaws", () => {
   const pattern = path.join("web", "fixable_flaws");
   const baseDir = path.resolve(".");
@@ -95,13 +106,10 @@ describe("fixing flaws", () => {
       ),
     }).toString();
 
-    const wouldModify = [];
-    const regexPattern = /Would modify "(.*)"./g;
-
-    let match: string[];
-    while ((match = regexPattern.exec(stdout)) !== null) {
-      wouldModify.push(match[1]);
-    }
+    const wouldModify = extractMatchesFromString(
+      /Would modify "(.*)"./g,
+      stdout
+    );
 
     expect(wouldModify).toHaveLength(4);
     expect(wouldModify).toContain(


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `destructive.test.ts` is flaky and regularly fails, because files are checked in a non-deterministic order.

### Solution

Make the test more resilient by making the assertions independent from the order certain file paths appear in the output.

---

## How did you test this change?

Tests are passing.