### PR TITLE
chore(blog): type buildBlog() param type

### DIFF
--- a/build/blog.ts
+++ b/build/blog.ts
@@ -412,8 +412,6 @@ export async function buildPost(
     throw error;
   }
 
-  doc.modified = metadata.modified || null;
-
   doc.pageTitle = `${doc.title} | MDN Blog`;
 
   doc.noIndexing = false;

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -344,8 +344,18 @@ export async function buildBlogPosts(options: {
   }
 }
 
+interface BlogPostDoc {
+  url: string;
+  rawBody: string;
+  metadata: BlogPostMetadata & { locale: string };
+  isMarkdown: boolean;
+  fileInfo: {
+    path: string;
+  };
+}
+
 export async function buildPost(
-  document
+  document: BlogPostDoc
 ): Promise<{ doc: Doc; liveSamples: any }> {
   const { metadata } = document;
 

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -368,7 +368,7 @@ export async function buildPost(
   let $ = null;
   const liveSamples: LiveSample[] = [];
 
-  [$] = await kumascript.render(document.url, {}, document);
+  [$] = await kumascript.render(document.url, {}, document as any);
 
   const liveSamplePages = await kumascript.buildLiveSamplePages(
     document.url,


### PR DESCRIPTION
## Summary

(MP-378)

### Problem

The `buildBlog()` function had an untyped parameter `document`.

### Solution

Add a new `BlogPostDoc` type for it.

Also removes setting the `modified` property, because it is always `null` and never used.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
