### PR TITLE
enhance(docs): distinguish nested definition lists

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -183,6 +183,12 @@
           padding-left: 0;
         }
       }
+
+      dl {
+        /* Nested definition list. */
+        border-left: 1px solid var(--border-primary);
+        padding-left: 1rem;
+      }
     }
 
     p {


### PR DESCRIPTION

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-616)

### Problem

Nested definition lists are hard to distinguish from the parent definition list's item.

### Solution

Adds indentation and a border on the left.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/495429/8846bb03-d061-44a7-9b33-a8c36627cba0)

### After

![image](https://github.com/mdn/yari/assets/495429/eca2a301-9d63-42b4-9db1-15a498c2590d)

---

## How did you test this change?

Ran `yarn && yarn dev` and looked at http://localhost:3000/en-US/docs/Web/HTML/Element/img#fetchpriority locally.