### PR TITLE
chore(flaws): exclude /en-US/blog/* from broken-link flaw

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -275,7 +275,11 @@ export function getBrokenLinksFlaws(
           true
         );
       }
-    } else if (href.startsWith("/") && !href.startsWith("//")) {
+    } else if (
+      href.startsWith("/") &&
+      !href.startsWith("//") &&
+      !/^\/en-US\/blog(\/|$)/.test(href)
+    ) {
       // Got to fake the domain to sensible extract the .search and .hash
       const absoluteURL = new URL(href, "http://www.example.com");
       const found = Document.findByURL(hrefNormalized);


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9345.

### Problem

Blog links were reported as broken with red color and squiggly lines, because the broken-link flaw tries to find these in the content.

### Solution

Exclude blog links from the broken-link flaw.

---

## Screenshots

### Before

<img width="962" alt="image" src="https://github.com/mdn/yari/assets/495429/bd9e9b3c-7d3c-47f5-b6a3-8f581af91a96">

### After

<img width="962" alt="image" src="https://github.com/mdn/yari/assets/495429/ba3c8d2e-b178-4c82-8126-f5cb25248bbe">

---

## How did you test this change?

Ran `yarn && yarn dev` and checked http://localhost:5042/en-US/docs/Web/Accessibility/ARIA/Roles/landmark_role#see_also locally.