### PR TITLE
enhance(search): split query at dot

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -118,6 +118,5 @@ export function splitQuery(term: string): string[] {
   return term
     .trim()
     .toLowerCase()
-    .replace(".", " .") // Allows to find `Map.prototype.get()` via `Map.get`.
-    .split(/[ ,]+/);
+    .split(/[ ,.]+/);
 }


### PR DESCRIPTION
## Summary

(MP-345)

### Problem

Since the [Web/API page retitling](https://github.com/mdn/mdn/issues/284) project, some pages like [Window: open() method](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) can no longer be found by "dot queries" like `window.open`.

### Solution

Treat the dot (`.`) as a word separator.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1415" alt="image" src="https://github.com/mdn/yari/assets/495429/96457ab0-9990-4c42-88f5-6307d46c7920">

### After

<img width="1415" alt="image" src="https://github.com/mdn/yari/assets/495429/d1ce1e65-0879-4c85-998f-3e176799165d">

---

## How did you test this change?

Ran `yarn && yarn dev` and searched for `window.open` [locally](http://localhost:3000/en-US/docs/Web/API).
