### PR TITLE
enhance(kumascript): make `smartLink()`'s content parameter optional

### DIFF
--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -51,12 +51,12 @@ const web = {
   // then hyperlink to corresponding en-US document is returned.
   smartLink(
     this: KumaThis,
-    href,
-    title,
-    content,
-    subpath,
-    basepath,
-    ignoreFlawMacro = null
+    href: string,
+    title: string | null,
+    content: string,
+    subpath: string | null = null,
+    basepath: string | null = null,
+    ignoreFlawMacro: string | null = null
   ) {
     let flaw;
     let flawAttribute = "";

--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -53,7 +53,7 @@ const web = {
     this: KumaThis,
     href: string,
     title: string | null,
-    content: string,
+    content: string | null = null,
     subpath: string | null = null,
     basepath: string | null = null,
     ignoreFlawMacro: string | null = null
@@ -128,6 +128,7 @@ const web = {
         }
       }
       const titleAttribute = title ? ` title="${title}"` : "";
+      content ??= page.short_title ?? page.title;
       return `<a href="${
         page.url + hrefhash
       }"${titleAttribute}${flawAttribute}>${content}</a>`;
@@ -150,6 +151,7 @@ const web = {
             flaw.macroSource
           )}"`;
         }
+        content ??= enUSPage.short_title ?? enUSPage.title;
         return (
           '<a class="only-in-en-us" ' +
           'title="Currently only available in English (US)" ' +
@@ -171,6 +173,7 @@ const web = {
       this.web.getJSONData("L10n-Common"),
       "summary"
     );
+    content ??= href;
     return `<a class="page-not-created" title="${titleWhenMissing}"${flawAttribute}>${content}</a>`;
   },
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Currently, kumascript's `smartLink()` requires to pass the link text via the `content` parameter, but this link text could be automatically derived from the page's `short-title` or `title`, like we already do in some sidebar macros (e.g. [PWASidebar](https://github.com/mdn/yari/blob/47d3686b6cb4e9734e1e40db92a22c72b0dfbf30/kumascript/macros/PWASidebar.ejs#L64-L79))

### Solution

Make the `content` parameter optional and use the page's `short-title` or `title`, if available.

---

## How did you test this change?

Planning to use this in a follow-up PRs that removes translated page titles from sidebar macros.