### PR TITLE
fix(a11y): fix tab order reset in the header

### DIFF
--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -17,6 +17,19 @@
     }
   }
 
+  .search-widget:focus-within .search-input-field,
+  .search-input-field:focus,
+  .search-input-field:valid {
+    width: inherit;
+
+    /* When the search input has focus or has content,
+          show the clear search button */
+    ~ .button.clear-search-button {
+      display: block;
+      right: 2.8rem;
+    }
+  }
+
   .search-input-field {
     // make webkit play nice with search input types
     -webkit-appearance: none; /* stylelint-disable-line property-no-vendor-prefix */
@@ -45,18 +58,6 @@
     @media screen and (min-width: $screen-lg) {
       &:invalid {
         width: 1rem;
-      }
-    }
-
-    &:focus,
-    &:valid {
-      width: inherit;
-
-      /* When the search input has focus or has content,
-          show the clear search button */
-      ~ .button.clear-search-button {
-        display: block;
-        right: 2.8rem;
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes tabbing across the search box.

### Problem

When tabbing through the header reaching the search input and pressing tab again will reset the focus to the html document.

This happened because the next item would be the cancel input button. Which will be removed via display one and then we start from the the beginning.

### Solution

Keep the search box expanding when the parent has focus within.

---

## How did you test this change?

Locally.
