### PR TITLE
fix(css): transparent images in dark mode issue

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -83,10 +83,12 @@
   }
 
   img {
+    /* In dark mode, required for images with black text on transparent background. */
     background: #fff;
     border: 1px solid var(--border-primary) !important;
     border-radius: var(--elem-radius);
-    color: #000;
+    /* Required for alt texts. */
+    color: #1b1b1b;
     display: inline-block;
     display: flex;
     height: auto;

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -83,9 +83,10 @@
   }
 
   img {
-    background: var(--background-primary);
+    background: #fff;
     border: 1px solid var(--border-primary) !important;
     border-radius: var(--elem-radius);
+    color: #000;
     display: inline-block;
     display: flex;
     height: auto;


### PR DESCRIPTION
- fixes https://github.com/mdn/content/issues/29755
- related to https://github.com/mdn/content/pull/29698

## Summary

The PR https://github.com/mdn/yari/pull/9250 caused a regression. It changed background color of all the images from `white` to `transparent`. Now all the transparent images in `mdn/content` are facing issues in dark mode: black lines, black text, and black boxes are appearing invisible.

### Problem

Set page in dark mode.

Before the regression: https://web.archive.org/web/20230601124043/https://developer.mozilla.org/en-US/docs/Web/Performance/Animation_performance_and_frame_rate#the_rendering_waterfall

After the regression: https://developer.mozilla.org/en-US/docs/Web/Performance/Animation_performance_and_frame_rate#the_rendering_waterfall

Before regression:
![_1](https://github.com/mdn/yari/assets/87750369/8e34bafa-c279-45aa-b6c6-33341347907d)

After regression:
![before](https://github.com/mdn/yari/assets/87750369/5e97789b-e98f-437a-a1ab-17cf7971f861)

### Solution

It is not feasible to make all the images compatible with both white and black backgrounds. Also, after the regression it is not easy to identify all the images that are affected by transparent background. We can't prevent future contributors from committing transparent illustrations.

It's better to keep the image background white. To solve original issue of alt text, set `color: black`on images.

---

## Screenshots

### Before

![before](https://github.com/mdn/yari/assets/87750369/5e97789b-e98f-437a-a1ab-17cf7971f861)

### After

![after](https://github.com/mdn/yari/assets/87750369/8e34bafa-c279-45aa-b6c6-33341347907d)

Alt text scenario
![alt text](https://github.com/mdn/yari/assets/87750369/b10dbe3e-514b-4f35-9ba6-a60f29fbddd6)

---

## How did you test this change?

In local browser after doing `yarn dev`.