### PR TITLE
chore(github): add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# ----------------------------------------------------------------------------
+# MDN Yari CODEOWNERS
+# ----------------------------------------------------------------------------
+# Order is important. The last matching pattern takes precedence.
+# For more detailed information, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# DEFAULT OWNERS
+# ----------------------------------------------------------------------------
+*    @mdn/core-dev
+
+# These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
+# If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.
+/package.json @mdn-bot
+/yarn.lock    @mdn-bot


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We don't have a `CODEOWNERS` file yet, so we don't get auto-assigned to PRs on yari.

### Solution

Add a `CODEOWNERS` file with @mdn/core-dev being the main owner.

---

## How did you test this change?

We'll see the effect only after this PR was merged.
