### PR TITLE
fix(flaws): ignore casing of text fragments

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -151,6 +151,22 @@ export function getBrokenLinksFlaws(
     });
   }
 
+  function checkHash(
+    hash: string,
+    a: cheerio.Cheerio<cheerio.Element>,
+    href: string
+  ) {
+    if (hash !== hash.toLowerCase()) {
+      addBrokenLink(
+        a,
+        checked.get(href),
+        href,
+        href.replace(`#${hash}`, `#${hash.toLowerCase()}`),
+        "Anchor not lowercase"
+      );
+    }
+  }
+
   $("a[href]").each((i, element) => {
     const a = $(element);
     let href = a.attr("href");
@@ -347,30 +363,13 @@ export function getBrokenLinksFlaws(
           href,
           found.url + absoluteURL.search + absoluteURL.hash.toLowerCase()
         );
-      } else if (
-        hrefSplit.length > 1 &&
-        hrefSplit[1] !== hrefSplit[1].toLowerCase()
-      ) {
+      } else if (hrefSplit.length > 1) {
         const hash = hrefSplit[1];
-        addBrokenLink(
-          a,
-          checked.get(href),
-          href,
-          href.replace(`#${hash}`, `#${hash.toLowerCase()}`),
-          "Anchor not lowercase"
-        );
+        checkHash(hash, a, href);
       }
     } else if (href.startsWith("#")) {
       const hash = href.split("#")[1];
-      if (hash !== hash.toLowerCase()) {
-        addBrokenLink(
-          a,
-          checked.get(href),
-          href,
-          href.replace(`#${hash}`, `#${hash.toLowerCase()}`),
-          "Anchor not lowercase"
-        );
-      }
+      checkHash(hash, a, href);
     }
   });
 

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -156,6 +156,10 @@ export function getBrokenLinksFlaws(
     a: cheerio.Cheerio<cheerio.Element>,
     href: string
   ) {
+    if (hash.startsWith(":~:")) {
+      // Ignore fragment directives.
+      return;
+    }
     if (hash !== hash.toLowerCase()) {
       addBrokenLink(
         a,


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/8313.

### Problem

[Text fragments](https://developer.mozilla.org/en-US/docs/Web/Text_fragments) were reported as "broken links" if they contained a non-lowercase letter.

### Solution

Exclude hashes from the check that start with the fragment directive (`:~:`).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1454" alt="image" src="https://github.com/mdn/yari/assets/495429/eda06d3a-f856-45fe-a328-e2393abe263a">

### After

<img width="1454" alt="image" src="https://github.com/mdn/yari/assets/495429/34ecd2a7-61b6-4cdf-a1ee-601399dd2f2a">

---

## How did you test this change?

1. Locally reverted the changes of https://github.com/mdn/content/pull/28009 to [files/en-us/web/text_fragments/index.md](https://github.com/mdn/content/blob/main/files/en-us/web/text_fragments/index.md?plain=1), because it changed those fragment directives to lowercase.
2. Ran `yarn && yarn dev` with `REACT_APP_WRITER_MODE=true` and opened http://localhost:5042/en-US/docs/Web/Text_fragments#_flaws locally.