### PR TITLE
chore(featured-articles): font-palette -> nesting

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -34,7 +34,7 @@ const FEATURED_ARTICLES = [
   "blog/regular-expressions-reference-updates/",
   "blog/aria-accessibility-html-landmark-roles/",
   "docs/Web/API/Performance_API",
-  "docs/Web/CSS/font-palette",
+  "docs/Web/CSS/CSS_nesting",
 ];
 
 const contributorSpotlightRoot = CONTRIBUTOR_SPOTLIGHT_ROOT;

--- a/client/src/homepage/featured-articles/index.tsx
+++ b/client/src/homepage/featured-articles/index.tsx
@@ -25,7 +25,7 @@ export default function FeaturedArticles(props: HydrationData<any>) {
 
   return hyData?.featuredArticles.length ? (
     <div className="featured-articles">
-      <h2>Featured Articles</h2>
+      <h2>Featured articles</h2>
       <div className="tile-container">
         {hyData.featuredArticles.map((article) => {
           return (


### PR DESCRIPTION
This PR makes the following updates:

- Replaces the CSS box content in "Featured Articles" on the homepage
  - The CSS box content is currently pointing to the "font-palette" article.
  - The new link points to the CSS Nesting module landing page to reflect CSS's new nesting feature now documented on MDN.
- Changes the capitalization in "Featured Articles" to "Featured articles"
  - This is to ensure consistency with other headings on the site (and also with the headings "Latest news" and "Recent contributions" on the home page).

