### PR TITLE
fix(document-survey): hide for writers

### DIFF
--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -6,6 +6,7 @@ import { getSurveyState, writeSurveyState } from "./utils";
 import { useIsServer } from "../../../hooks";
 import { Icon } from "../../atoms/icon";
 import { useLocation } from "react-router";
+import { DEV_MODE, WRITER_MODE } from "../../../env";
 
 const FORCE_SURVEY_PREFIX = "#FORCE_SURVEY=";
 
@@ -18,7 +19,7 @@ export function DocumentSurvey({ doc }: { doc: Doc }) {
   const survey = React.useMemo(
     () =>
       SURVEYS.find((survey) => {
-        if (isServer) {
+        if (isServer || (WRITER_MODE && !DEV_MODE)) {
           return false;
         }
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The current `document-survey` was always shown to writers when running yari in mdn/content.

### Solution

Always hide the survey when the `WRITER_MODE` is enabled, unless `DEV_MODE` is also enabled.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1173" alt="image" src="https://github.com/mdn/yari/assets/495429/ff3b7ae1-36b6-48c6-92e6-68d3d86cdf0c">

### After

<img width="1173" alt="image" src="https://github.com/mdn/yari/assets/495429/11e612a1-8cf3-4bbb-852d-9b24e316dcb4">

---

## How did you test this change?

Set `REACT_APP_DEV_MODE=false` and `REACT_APP_WRITER_MODE=true` in my `.env`, ran `yarn && yarn dev` and opened http://localhost:3000/en-US/docs/Learn/HTML locally, comparing this branch with `main`.

Note: I had already dismissed the survey locally, so I needed to run `localStorage.removeItem('survey.DISCOVERABILITY_AUG_2023')` in the JavaScript console to get it back.