### PR TITLE
fix(build): sort meta files

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -316,6 +316,8 @@ async function buildDocuments(
     );
   }
 
+  // allBrowserCompat.txt is used by differy, see:
+  // https://github.com/search?q=repo%3Amdn%2Fdiffery+allBrowserCompat&type=code
   const allBrowserCompat = new Set<string>();
   Object.values(metadata).forEach((localeMeta) =>
     localeMeta.forEach(

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -322,7 +322,7 @@ async function buildDocuments(
   );
   fs.writeFileSync(
     path.join(BUILD_OUT_ROOT, "allBrowserCompat.txt"),
-    [...allBrowserCompat].join(" ")
+    [...allBrowserCompat].sort().join(" ")
   );
 
   return { slugPerLocale: docPerLocale, peakHeapBytes, totalFlaws };

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -139,7 +139,7 @@ async function buildDocuments(
     cliProgress.Presets.shades_grey
   );
 
-  const docPerLocale = {};
+  const docPerLocale: Record<string, { slug: string; modified: string }[]> = {};
   const searchIndex = new SearchIndex();
 
   if (!documents.count) {

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -307,9 +307,12 @@ async function buildDocuments(
   }
 
   for (const [locale, meta] of Object.entries(metadata)) {
+    const sortedMeta = meta
+      .slice()
+      .sort((a, b) => a.mdn_url.localeCompare(b.mdn_url));
     fs.writeFileSync(
       path.join(BUILD_OUT_ROOT, locale.toLowerCase(), "metadata.json"),
-      JSON.stringify(meta)
+      JSON.stringify(sortedMeta)
     );
   }
 

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -1,4 +1,10 @@
-export function makeSitemapXML(locale, docs) {
+export function makeSitemapXML(
+  locale: string,
+  docs: { slug: string; modified: string }[]
+) {
+  docs = docs.slice();
+  docs.sort((a, b) => a.slug.localeCompare(b.slug));
+
   // Based on https://support.google.com/webmasters/answer/183668?hl=en
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
@@ -15,7 +21,10 @@ export function makeSitemapXML(locale, docs) {
   ].join("\n");
 }
 
-export function makeSitemapIndexXML(pathnames) {
+export function makeSitemapIndexXML(pathnames: string[]) {
+  pathnames = pathnames.slice();
+  pathnames.sort();
+
   // Based on https://support.google.com/webmasters/answer/75712
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -2,14 +2,13 @@ export function makeSitemapXML(
   locale: string,
   docs: { slug: string; modified: string }[]
 ) {
-  docs = docs.slice();
-  docs.sort((a, b) => a.slug.localeCompare(b.slug));
+  const sortedDocs = docs.slice().sort((a, b) => a.slug.localeCompare(b.slug));
 
   // Based on https://support.google.com/webmasters/answer/183668?hl=en
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    ...docs.map((doc) => {
+    ...sortedDocs.map((doc) => {
       const loc = `<loc>https://developer.mozilla.org/${locale}/docs/${doc.slug}</loc>`;
       const modified = doc.modified
         ? `<lastmod>${doc.modified.toString().split("T")[0]}</lastmod>`
@@ -21,18 +20,17 @@ export function makeSitemapXML(
   ].join("\n");
 }
 
-export function makeSitemapIndexXML(pathnames: string[]) {
-  pathnames = pathnames.slice();
-  pathnames.sort();
+export function makeSitemapIndexXML(paths: string[]) {
+  const sortedPaths = paths.slice().sort();
 
   // Based on https://support.google.com/webmasters/answer/75712
   return [
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
-    ...pathnames.map((pathname) => {
+    ...sortedPaths.map((path) => {
       return (
         "<sitemap>" +
-        `<loc>https://developer.mozilla.org${pathname}</loc>` +
+        `<loc>https://developer.mozilla.org${path}</loc>` +
         `<lastmod>${new Date().toISOString().split("T")[0]}</lastmod>` +
         "</sitemap>"
       );


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The content of `allBrowserCompat.txt`, `metadata.json` and `sitemaps/*/sitemap.xml.gz` differs from build to build, because the order of its values is not deterministic.

### Solution

Sort the values before writing them to the files.

---

## How did you test this change?

1. Ran `yarn build --locale en-us -n` and looked at `allBrowserCompat.txt` and `metadata.json`.
2. Then ran `yarn build --locale en-us --sitemap-index` and looked at `sitemaps/en-us/sitemap.xml.gz` (with `zless`).
