### PR TITLE
fix(translations/dashboard): fix Popularity rank column header

### DIFF
--- a/client/src/translations/dashboard/index.tsx
+++ b/client/src/translations/dashboard/index.tsx
@@ -447,7 +447,7 @@ function DocumentsTable({
             <TableHead id="popularityEn" title="Popularity rank (en-US)" />
             <TableHead
               id="popularityLocale"
-              title="Popularity rank ({locale})"
+              title={`Popularity rank (${locale})`}
             />
             <TableHead id="dateDiff" title="Date delta" />
           </tr>


### PR DESCRIPTION
### Problem

Fixes rendering locale in "Popularity rank ({locale})" column header of table "List of direct subpages" on `/_translations/dashboard`.

### Solution

Adds string interpolation in `popularityLocale` table column header.

---

## Screenshots

### Before

![before](https://github.com/mdn/yari/assets/1682136/5d54b5f2-0371-4841-8ded-2ff53def80d2)

### After

![after](https://github.com/mdn/yari/assets/1682136/00c30b36-d6a7-4b25-8d9a-5ef02ecbdbd3)