### PR TITLE
chore(telemetry): send geo_iso with pings

### DIFF
--- a/client/src/env.ts
+++ b/client/src/env.ts
@@ -78,6 +78,8 @@ export const FXA_MANAGE_SUBSCRIPTIONS_URL =
 
 export const DEFAULT_GEO_COUNTRY =
   process.env.REACT_APP_DEFAULT_GEO_COUNTRY || "United States";
+export const DEFAULT_GEO_COUNTRY_ISO =
+  process.env.REACT_APP_DEFAULT_GEO_COUNTRY_ISO || "US";
 
 export const BCD_BASE_URL =
   process.env.REACT_APP_BCD_BASE_URL ?? "https://bcd.developer.allizom.org";

--- a/client/src/telemetry/generated/navigator.ts
+++ b/client/src/telemetry/generated/navigator.ts
@@ -21,6 +21,19 @@ export const geo = new StringMetricType({
 });
 
 /**
+ * The navigators ISO 3166 country code based on geo ip.
+ *
+ * Generated from `navigator.geo_iso`.
+ */
+export const geoIso = new StringMetricType({
+  category: "navigator",
+  name: "geo_iso",
+  sendInPings: ["action", "page"],
+  lifetime: "application",
+  disabled: false,
+});
+
+/**
  * The subscription type of the user. can be one of
  * 'core','mdn_plus_5m','mdn_plus_5y','mdn_plus_10m','mdn_plus_10y'
  *

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -119,7 +119,7 @@ function glean(): GleanAnalytics {
         navigatorMetric.geo.set(page.geo);
       }
       if (page.geo_iso) {
-        navigatorMetric.geo_iso.set(page.geo_iso);
+        navigatorMetric.geoIso.set(page.geo_iso);
       }
       if (page.userAgent) {
         navigatorMetric.userAgent.set(page.userAgent);

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -208,6 +208,7 @@ export function useGleanPage(pageNotFound: boolean, doc?: Doc) {
       httpStatus: pageNotFound ? "404" : "200",
       userAgent: navigator?.userAgent,
       geo: userData?.geo?.country,
+      geo_iso: userData?.geo?.country_iso,
       subscriptionType: userData?.subscriptionType || "anonymous",
       viewportBreakpoint: VIEWPORT_BREAKPOINTS.find(
         ([_, width]) => width <= window.innerWidth

--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -32,6 +32,7 @@ export type PageProps = {
   httpStatus: HTTPStatus;
   subscriptionType: string;
   geo: string | undefined;
+  geo_iso: string | undefined;
   userAgent: string | undefined;
   viewportBreakpoint: ViewportBreakpoint | undefined;
   viewportRatio: number;
@@ -116,6 +117,9 @@ function glean(): GleanAnalytics {
       pageMetric.httpStatus.set(page.httpStatus);
       if (page.geo) {
         navigatorMetric.geo.set(page.geo);
+      }
+      if (page.geo_iso) {
+        navigatorMetric.geo_iso.set(page.geo_iso);
       }
       if (page.userAgent) {
         navigatorMetric.userAgent.set(page.userAgent);

--- a/client/src/telemetry/metrics.yaml
+++ b/client/src/telemetry/metrics.yaml
@@ -121,6 +121,23 @@ navigator:
     notification_emails:
       - mdn-team@mozilla.com
     expires: 2024-09-05
+  geo_iso:
+    type: string
+    lifetime: application
+    send_in_pings:
+      - page
+      - action
+    description: |
+      The navigators ISO 3166 country code based on geo ip.
+    data_sensitivity:
+      - web_activity
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1798296
+    data_reviews:
+      - https://github.com/mdn/yari/pull/7457#issuecomment-1296934544
+    notification_emails:
+      - mdn-team@mozilla.com
+    expires: 2024-09-05
   user_agent:
     type: string
     lifetime: application

--- a/client/src/telemetry/metrics.yaml
+++ b/client/src/telemetry/metrics.yaml
@@ -128,7 +128,7 @@ navigator:
       - page
       - action
     description: |
-      The navigators ISO 3166 country code based on geo ip.
+      The navigator's two-letter ISO 3166 country code based on geo ip.
     data_sensitivity:
       - web_activity
     bugs:

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -1,7 +1,11 @@
 import * as React from "react";
 import useSWR from "swr";
 
-import { DISABLE_AUTH, DEFAULT_GEO_COUNTRY } from "./env";
+import {
+  DISABLE_AUTH,
+  DEFAULT_GEO_COUNTRY,
+  DEFAULT_GEO_COUNTRY_ISO,
+} from "./env";
 import { FREQUENTLY_VIEWED_STORAGE_KEY } from "./plus/collections/frequently-viewed";
 
 const DEPRECATED_LOCAL_STORAGE_KEYS = [
@@ -199,6 +203,8 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
         email: data.email || null,
         geo: {
           country: (data.geo && data.geo.country) || DEFAULT_GEO_COUNTRY,
+          country_iso:
+            (data.geo && data.geo.country_iso) || DEFAULT_GEO_COUNTRY_ISO,
         },
         maintenance: data.maintenance,
         settings,

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -80,6 +80,7 @@ export type User = {
   email: string | null | undefined;
   geo: {
     country: string;
+    country_iso: string;
   };
   maintenance?: string;
   settings: null | UserPlusSettings;

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -311,6 +311,14 @@ If the `/api/v1/whoami` does not include a `geo.country` value, fall back on
 this. Setting this allows you to pretend the XHR request to `/api/v1/whoami`
 included this value for `geo.country`.
 
+### `REACT_APP_DEFAULT_GEO_COUNTRY_ISO`
+
+**Default: `US`**
+
+If the `/api/v1/whoami` does not include a `geo.country_iso` value, fall back on
+this. Setting this allows you to pretend the XHR request to `/api/v1/whoami`
+included this value for `geo.country_iso`.
+
 ## Glean (Analytics)
 
 ### `REACT_APP_GLEAN_CHANNEL`


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Currently, we only send the user's country _name_ to Glean, but names change (c.f. Czechia) and may have inconsistent writings.

### Solution

Also send the user's country _code_ to Glean.

---

## How did you test this change?

TBD