### PR TITLE
chore(telemetry): measure TOC clicks

### DIFF
--- a/client/src/document/organisms/toc/index.tsx
+++ b/client/src/document/organisms/toc/index.tsx
@@ -3,6 +3,8 @@ import React, { useState } from "react";
 import "./index.scss";
 import { Toc } from "../../../../../libs/types/document";
 import { useFirstVisibleElement } from "../../hooks";
+import { useGleanClick } from "../../../telemetry/glean-context";
+import { TOC_CLICK } from "../../../telemetry/constants";
 
 export function TOC({ toc }: { toc: Toc[] }) {
   const [currentViewedTocItem, setCurrentViewedTocItem] = useState("");
@@ -69,14 +71,17 @@ function TOCItem({
   sub,
   currentViewedTocItem,
 }: Toc & { currentViewedTocItem: string }) {
+  const gleanClick = useGleanClick();
+  const href = `#${id.toLowerCase()}`;
   return (
     <li className={`document-toc-item ${sub ? "document-toc-item-sub" : ""}`}>
       <a
         className="document-toc-link"
         key={id}
         aria-current={currentViewedTocItem === id.toLowerCase() || undefined}
-        href={`#${id.toLowerCase()}`}
+        href={href}
         dangerouslySetInnerHTML={{ __html: text }}
+        onClick={() => gleanClick(`${TOC_CLICK}: ${href}`)}
       />
     </li>
   );

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -4,6 +4,7 @@ export const OFFER_OVERVIEW_CLICK = "offer_overview_click";
 export const SIDEBAR_CLICK = "sidebar_click";
 export const SIDEBAR_CLICK_WITH_FILTER = "sidebar_click_with_filter";
 export const SIDEBAR_FILTER_FOCUS = "sidebar_filter_focus";
+export const TOC_CLICK = "toc_click";
 /** Replaced "top_nav_already_subscriber" in July 2023. */
 export const TOP_NAV_LOGIN = "top_nav: login";
 /** Replaced "top_nav_get_mdn_plus" in July 2023. */


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We don't know how many users click on items in the table of contents (TOC).

### Solution

Add a measurement.

---

## How did you test this change?

Ran `yarn && yarn dev` with the following environment variables (in `.env`):

```
REACT_APP_GLEAN_DEBUG=true
REACT_APP_GLEAN_ENABLED=true
```

Then visited http://localhost:3000/en-US/docs/Web/CSS, clicked on each TOC items and verified that these clicks show up as events in our Glean debug pings viewer.