### PR TITLE
feat(links): distinguish visited links (v2)

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -201,7 +201,9 @@ pre {
 }
 
 a {
-  color: var(--text-link);
+  &:link {
+    color: var(--text-link);
+  }
 
   &.external:after {
     background-color: var(--icon-primary);

--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -201,9 +201,7 @@ pre {
 }
 
 a {
-  &:link {
-    color: var(--text-link);
-  }
+  color: var(--text-link);
 
   &.external:after {
     background-color: var(--icon-primary);

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -62,7 +62,9 @@
   }
 
   a:not(.button) {
-    color: var(--text-link);
+    &:link {
+      color: var(--text-link);
+    }
     width: fit-content;
 
     &:active {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -16,7 +16,7 @@
   h6 {
     a:link,
     a:visited {
-      color: var(--text-primary);
+      color: inherit !important;
       text-decoration: none;
     }
 
@@ -154,7 +154,7 @@
       margin-top: 2rem;
 
       a[href^="#"] {
-        color: inherit;
+        color: inherit !important;
         position: relative;
         text-decoration: none;
 

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -62,10 +62,11 @@
   }
 
   a:not(.button) {
+    width: fit-content;
+
     &:link {
       color: var(--text-link);
     }
-    width: fit-content;
 
     &:active {
       background-color: var(--text-link);

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -16,7 +16,7 @@
   h6 {
     a:link,
     a:visited {
-      color: inherit !important;
+      color: var(--text-primary);
       text-decoration: none;
     }
 
@@ -62,13 +62,16 @@
   }
 
   a:not(.button) {
+    color: var(--text-link);
     width: fit-content;
 
-    &:link {
-      color: var(--text-link);
+    &:visited:not([href^="#"]) {
+      // Distinguish visited links (excl. anchor links).
+      color: revert;
     }
 
-    &:active {
+    &:active,
+    &:active:visited {
       background-color: var(--text-link);
       color: #fff;
 
@@ -154,7 +157,7 @@
       margin-top: 2rem;
 
       a[href^="#"] {
-        color: inherit !important;
+        color: inherit;
         position: relative;
         text-decoration: none;
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9672 and avoids https://github.com/mdn/yari/issues/9921.

### Problem

Visited and unvisited links are not distinguished on MDN.

### Solution

Distinguish visited links by reverting their color to the default color from the browser styles.

---

## Screenshots

_Note_: This time, the screenshots were captured on port 5042 and contain a heading.

### Before

<img width="1000" alt="image" src="https://github.com/mdn/yari/assets/495429/fc6de392-6507-4b5e-8711-cc441d6a2726">
<img width="1000" alt="image" src="https://github.com/mdn/yari/assets/495429/fb01bdef-555a-4d20-a3f1-43b6da033fda">


### After

<img width="1000" alt="image" src="https://github.com/mdn/yari/assets/495429/883db6e4-ad59-4003-acbc-6055e016e071">
<img width="1000" alt="image" src="https://github.com/mdn/yari/assets/495429/6c31ee88-b078-4011-a781-b43eeeb4a649">

---

## How did you test this change?

Ran `yarn && yarn dev` and opened http://localhost:3000/en-US/docs/Web/HTML locally.