### PR TITLE
feat(sidebar): add Colors category to Guides

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -69,6 +69,10 @@ const text = mdn.localStringMap({
       'Box_model': 'Box model',
         'Introduction_to_the_CSS_basic_box_model': 'Introduction to the CSS basic box model',
         'Mastering_margin_collapsing': 'Mastering margin collapsing',
+      'Colors': 'Colors',
+        'Applying_color_to_HTML_elements_using_CSS': 'Applying color to HTML elements using CSS',
+        'Web_Accessibility_Understanding_Colors_and_Luminance': 'Web Accessibility: Understanding colors and luminance',
+        'Color_contrast': 'Web Accessibility: Color contrast',
       'Columns': 'Columns',
         'Basic_concepts_of_Multicol': 'Basic concepts of Multicol',
         'Styling_columns': 'Styling columns',
@@ -917,6 +921,7 @@ const text = mdn.localStringMap({
 const locale = env.locale;
 const learnURL = `/${locale}/docs/Learn/`;
 const cssURL = `/${locale}/docs/Web/CSS/`;
+const accessibilityURL = `/${locale}/docs/Web/Accessibility/`;
 
 const htmlEscape = mdn.htmlEscape;
 const hasTag = page.hasTag;
@@ -1217,6 +1222,16 @@ async function buildPropertylist(pages, title) {
           <ol>
             <li><%-smartLink(`${cssURL}CSS_Box_Model/Introduction_to_the_CSS_box_model`, null, text['Introduction_to_the_CSS_basic_box_model'], cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Box_Model/Mastering_margin_collapsing`, null, text['Mastering_margin_collapsing'], cssURL)%></li>
+          </ol>
+      </details>
+  </li>
+  <li class="toggle">
+      <details>
+          <summary><%=text['Colors']%></summary>
+          <ol>
+            <li><%-smartLink(`${cssURL}CSS_colors/Applying_color`, null, text['Applying_color_to_HTML_elements_using_CSS'], cssURL)%></li>
+            <li><%-smartLink(`${accessibilityURL}Understanding_Colors_and_Luminance`, null, text['Web_Accessibility_Understanding_Colors_and_Luminance'], accessibilityURL)%></li>
+            <li><%-smartLink(`${accessibilityURL}Understanding_WCAG/Perceivable/Color_contrast`, null, text['Color_contrast'], accessibilityURL)%></li>
           </ol>
       </details>
   </li>


### PR DESCRIPTION

## Summary

This PR adds a new section for the CSSRef sidebar which links to some guides on Colors

### Problem

We do not surface Colors guides in CSS section as readily as we could

### Solution

Highlight existing guides in the CSS Sidebar. Adds links to:

* [Applying color to HTML elements using CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors/Applying_color)
* [Web Accessibility: Understanding Colors and Luminance](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_Colors_and_Luminance)
* [Web Accessibility: Color Contrast](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)

---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/43580235/4b63706c-3a22-4762-8b28-a0037d4199b3)


### After

![image](https://github.com/mdn/yari/assets/43580235/c5061f62-fd99-42d5-899b-c918c852da0a)


## How did you test this change?

`yarn && yarn dev`