### PR TITLE
chore(telemetry): measure top-level menu link clicks

### DIFF
--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -20,6 +20,7 @@ export const PLAYGROUND = "play_action";
 export const AI_EXPLAIN = "ai_explain";
 
 export const MENU = Object.freeze({
+  CLICK_LINK: "menu_click_link",
   CLICK_MENU: "menu_click_menu",
   CLICK_SUBMENU: "menu_click_submenu",
 });

--- a/client/src/ui/molecules/main-menu/index.tsx
+++ b/client/src/ui/molecules/main-menu/index.tsx
@@ -7,6 +7,8 @@ import { PlusMenu } from "../plus-menu";
 import "./index.scss";
 import { PLUS_IS_ENABLED } from "../../../env";
 import { useLocale } from "../../../hooks";
+import { useGleanClick } from "../../../telemetry/glean-context";
+import { MENU } from "../../../telemetry/constants";
 
 export default function MainMenu({ isOpenOnMobile }) {
   const locale = useLocale();
@@ -96,9 +98,14 @@ function TopLevelMenuLink({
   to: string;
   children: React.ReactNode;
 }) {
+  const gleanClick = useGleanClick();
   return (
     <li className="top-level-entry-container">
-      <a className="top-level-entry menu-link" href={to}>
+      <a
+        className="top-level-entry menu-link"
+        href={to}
+        onClick={() => gleanClick(`${MENU.CLICK_LINK}: top-level -> ${to}`)}
+      >
         {children}
       </a>
     </li>

--- a/client/src/ui/molecules/main-menu/index.tsx
+++ b/client/src/ui/molecules/main-menu/index.tsx
@@ -79,22 +79,28 @@ export default function MainMenu({ isOpenOnMobile }) {
             toggleMenu={toggleMenu}
           />
         )}
-        <li className="top-level-entry-container">
-          <a className="top-level-entry menu-link" href="/en-US/blog/">
-            Blog
-          </a>
-        </li>
-        <li className="top-level-entry-container">
-          <a className="top-level-entry menu-link" href={`/${locale}/play`}>
-            Play
-          </a>
-        </li>
-        <li className="top-level-entry-container">
-          <a className="top-level-entry menu-link" href="/en-US/plus/ai-help/">
-            AI Help <sup className="new beta">Beta</sup>
-          </a>
-        </li>
+        <TopLevelMenuLink to="/en-US/blog/">Blog</TopLevelMenuLink>
+        <TopLevelMenuLink to={`/${locale}/play`}>Play</TopLevelMenuLink>
+        <TopLevelMenuLink to="/en-US/plus/ai-help/">
+          AI Help <sup className="new beta">Beta</sup>
+        </TopLevelMenuLink>
       </ul>
     </nav>
+  );
+}
+
+function TopLevelMenuLink({
+  to,
+  children,
+}: {
+  to: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <li className="top-level-entry-container">
+      <a className="top-level-entry menu-link" href={to}>
+        {children}
+      </a>
+    </li>
   );
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

In https://github.com/mdn/yari/pull/9918 we started measuring menu clicks, but we don't measure clicks on the top-level menu links (Blog, Play, AI Help) yet.

### Solution

Extract a common component add measure these clicks as well.

---

## How did you test this change?

Ran `yarn && yarn dev` with the following environment variables (in `.env`):

```
REACT_APP_GLEAN_DEBUG=true
REACT_APP_GLEAN_ENABLED=true
```

Then visited http://localhost:3000/en-US/, clicked on Blog, Play and AI Help and verified that these show up in our Glean debug pings viewer.