### PR TITLE
docs(readme): add Mac troubleshooting tips for yarn install errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,38 @@ app locally. Do this like so:
     cd yari
     yarn install
 
+<details>
+  <summary>Troubleshooting installation</summary>
+
+If you get errors while installing dependencies via yarn on a Mac, you may need
+to install some additional packages:
+
+1. First, install [brew](https://brew.sh/) if you haven’t already
+
+1. To fix problems with `gifsicle`:
+
+   ```shell
+   brew install automake autoconf libtool
+   ```
+
+1. To fix problems with `pngquant-bin`:
+
+   ```shell
+   brew install pkg-config
+   ```
+
+1. To fix problems with `mozjpeg`:
+
+   ```shell
+   brew install libpng
+   sudo ln -s /opt/homebrew/Cellar/libpng/1.6.40/lib/libpng16.a /usr/local/lib/libpng16.a
+   ```
+
+You may need to adjust the path to `libpng16.a` depending on the version of
+libpng you have installed.
+
+</details>
+
 Now copy the `.env-dist` file to `.env`:
 
     cp .env-dist .env

--- a/README.md
+++ b/README.md
@@ -308,22 +308,16 @@ name causing the problem.
 
 1. To fix problems with `gifsicle`:
 
-   ```shell
    brew install automake autoconf libtool
-   ```
 
 1. To fix problems with `pngquant-bin`:
 
-   ```shell
    brew install pkg-config
-   ```
 
 1. To fix problems with `mozjpeg`:
 
-   ```shell
-   brew install libpng
-   sudo ln -s /opt/homebrew/Cellar/libpng/1.6.40/lib/libpng16.a /usr/local/lib/libpng16.a
-   ```
+   brew install libpng sudo ln -s
+   /opt/homebrew/Cellar/libpng/1.6.40/lib/libpng16.a /usr/local/lib/libpng16.a
 
 You may need to adjust the path to `libpng16.a` depending on the version of
 `libpng` you have installed.

--- a/README.md
+++ b/README.md
@@ -41,37 +41,8 @@ app locally. Do this like so:
     cd yari
     yarn install
 
-<details>
-  <summary>Troubleshooting installation</summary>
-
-If you get errors while installing dependencies via yarn on a Mac, you may need
-to install some additional packages:
-
-1. First, install [brew](https://brew.sh/) if you haven’t already
-
-1. To fix problems with `gifsicle`:
-
-   ```shell
-   brew install automake autoconf libtool
-   ```
-
-1. To fix problems with `pngquant-bin`:
-
-   ```shell
-   brew install pkg-config
-   ```
-
-1. To fix problems with `mozjpeg`:
-
-   ```shell
-   brew install libpng
-   sudo ln -s /opt/homebrew/Cellar/libpng/1.6.40/lib/libpng16.a /usr/local/lib/libpng16.a
-   ```
-
-You may need to adjust the path to `libpng16.a` depending on the version of
-libpng you have installed.
-
-</details>
+See the [troubleshooting](#troubleshooting) section below if you run into
+problems.
 
 Now copy the `.env-dist` file to `.env`:
 
@@ -326,3 +297,33 @@ The default server port `:5042` might be in use by another process. To resolve
 this, you can pick any unused port (e.g., 6000) and run the following:
 
     echo SERVER_PORT=6000 >> .env
+
+### Yarn install errors
+
+If you get errors while installing dependencies via yarn on a Mac, you may need
+to install some additional packages. Check the error message for the package
+name causing the problem.
+
+1. First, install [brew](https://brew.sh/) if you haven’t already
+
+1. To fix problems with `gifsicle`:
+
+   ```shell
+   brew install automake autoconf libtool
+   ```
+
+1. To fix problems with `pngquant-bin`:
+
+   ```shell
+   brew install pkg-config
+   ```
+
+1. To fix problems with `mozjpeg`:
+
+   ```shell
+   brew install libpng
+   sudo ln -s /opt/homebrew/Cellar/libpng/1.6.40/lib/libpng16.a /usr/local/lib/libpng16.a
+   ```
+
+You may need to adjust the path to `libpng16.a` depending on the version of
+`libpng` you have installed.


### PR DESCRIPTION
## Summary

I discovered a few problems while installing yarn dependencies on my Mac and collected the steps required to make it work. It’s hidden in the collapsible section by default: there might be no need for troubleshooting.

### Problem

Build errors while running `yarn install`, specifically with gifsicle, pngquant-bin, and mozjpeg.

### Solution

Install additional packages via brew.