### PR TITLE
fix(tables): wrap in table-container-inner

### DIFF
--- a/build/wrap-tables.ts
+++ b/build/wrap-tables.ts
@@ -4,6 +4,8 @@
 import * as cheerio from "cheerio";
 
 export function wrapTables($: cheerio.CheerioAPI) {
-  const figure = $('<figure class="table-container"></figure>');
+  const figure = $(
+    '<figure class="table-container"><figure class="table-container-inner"></figure>'
+  );
   $("table").wrap(figure);
 }

--- a/build/wrap-tables.ts
+++ b/build/wrap-tables.ts
@@ -4,8 +4,6 @@
 import * as cheerio from "cheerio";
 
 export function wrapTables($: cheerio.CheerioAPI) {
-  const figure = $(
-    '<figure class="table-container"><figure class="table-container-inner"></figure>'
-  );
+  const figure = $('<figure class="table-container"></figure>');
   $("table").wrap(figure);
 }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -270,6 +270,10 @@ strong {
   letter-spacing: 0.02rem;
 }
 
+.table-container {
+  width: 100%;
+}
+
 table {
   border: 1px solid var(--border-primary);
   border-collapse: collapse;

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop-md.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop-md.scss
@@ -1,5 +1,5 @@
 @media screen and (min-width: $screen-md) {
-  .table-container {
+  .bc-table-outer {
     width: calc(100% + 6rem);
   }
 

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop-xl.scss
@@ -1,10 +1,10 @@
 @media screen and (min-width: $screen-xl) {
-  .table-container {
+  .bc-table-outer {
     margin: 0;
     width: 100%;
   }
 
-  .table-container-inner {
+  .bc-table-inner {
     padding: 0;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/index-desktop.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-desktop.scss
@@ -32,13 +32,13 @@
     }
   }
 
-  .table-container {
+  .bc-table-outer {
     margin: 0 -3rem;
     overflow: auto;
-    width: 100vw;
+    width: 100vw !important;
   }
 
-  .table-container-inner {
+  .bc-table-inner {
     min-width: max-content;
     padding: 0 3rem;
     position: relative;

--- a/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index-mobile.scss
@@ -25,7 +25,7 @@
     }
   }
 
-  .table-container {
+  .bc-table-outer {
     overflow-x: auto;
   }
 }

--- a/client/src/document/ingredients/browser-compatibility-table/index.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/index.tsx
@@ -175,8 +175,8 @@ export default function BrowserCompatibilityTable({
         >
           Report problems with this compatibility data on GitHub
         </a>
-        <figure className="table-container">
-          <figure className="table-container-inner">
+        <figure className="table-container bc-table-outer">
+          <figure className="bc-table-inner">
             <table key="bc-table" className="bc-table bc-table-web">
               <Headers
                 platforms={platforms}


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9962.

### Problem

Tables in blog articles were overflowing on sm/md/lg screens, because they were only wrapped in `figure.table-container`, but not in `figure.table-container-inner` (like the BCD table). 

### Solution

Wrap tables in `figure.table-container > figure.table-container.inner`.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="770" alt="image" src="https://github.com/mdn/yari/assets/495429/11f24b29-9e65-403b-a7f7-0383418bda99"> | <img width="770" alt="image" src="https://github.com/mdn/yari/assets/495429/cddd5d01-c16e-4915-8f68-e5072ec1aca2"> | 

---

## How did you test this change?

Ran `yarn && yarn dev` and opened http://localhost:3000/en-US/blog/vs-code-tips-tricks/#shortcuts_for_navigation locally (requires mdn/mdn-studio).