### PR TITLE
fix(discord): add /discord redirect with updated signup link

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -133,7 +133,7 @@ export function Footer() {
             <li className="footer-nav-item">
               <a
                 className="footer-nav-link"
-                href="https://discord.gg/Gt4Qf6q67h"
+                href="/discord"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -133,7 +133,7 @@ export function Footer() {
             <li className="footer-nav-item">
               <a
                 className="footer-nav-link"
-                href="https://discord.gg/hkGN8VKvvD"
+                href="https://discord.gg/Gt4Qf6q67h"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/copy/plus/features/playground.md
+++ b/copy/plus/features/playground.md
@@ -57,8 +57,8 @@ involved:
 
 Sign up for an MDN Plus account if you haven't already.
 
-1. Participate in discussions, share ideas, and seek help in the
-   [Playground forums](https://discord.gg/3Pb8cQrTfB).
+1. Participate in discussions, share ideas, and seek help on
+   [Discord](https://discord.gg/Gt4Qf6q67h).
 2. Contribute to the improvement of the Playground by reporting issues or
    suggesting new features.
 3. Showcase your projects, share your knowledge, and inspire others by

--- a/copy/plus/features/playground.md
+++ b/copy/plus/features/playground.md
@@ -58,7 +58,7 @@ involved:
 Sign up for an MDN Plus account if you haven't already.
 
 1. Participate in discussions, share ideas, and seek help on
-   [Discord](https://discord.gg/Gt4Qf6q67h).
+   [Discord](/discord).
 2. Contribute to the improvement of the Playground by
    [reporting issues](https://github.com/mdn/yari/issues/new?template=bug-report.yml)
    or

--- a/copy/plus/features/playground.md
+++ b/copy/plus/features/playground.md
@@ -59,8 +59,10 @@ Sign up for an MDN Plus account if you haven't already.
 
 1. Participate in discussions, share ideas, and seek help on
    [Discord](https://discord.gg/Gt4Qf6q67h).
-2. Contribute to the improvement of the Playground by reporting issues or
-   suggesting new features.
+2. Contribute to the improvement of the Playground by
+   [reporting issues](https://github.com/mdn/yari/issues/new?template=bug-report.yml)
+   or
+   [suggesting new features](https://github.com/mdn/mdn/issues/new?template=content-or-feature-suggestion.yml).
 3. Showcase your projects, share your knowledge, and inspire others by
    contributing code examples to MDN.
 

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1116,6 +1116,9 @@ for (const [pattern, path] of [
 }
 
 const MISC_REDIRECT_PATTERNS = [
+  redirect(/^discord\/?$/i, "https://discord.gg/Gt4Qf6q67h", {
+    permanent: false,
+  }),
   redirect(/^events\/?$/i, "https://community.mozilla.org/events/", {
     permanent: false,
   }),


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9975.

### Problem

The Discord link was expired.

### Solution

Adds a redirect `/discord` to the current signup link, and use it everywhere.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="529" alt="image" src="https://github.com/mdn/yari/assets/495429/5b43d656-c0c6-425b-a4a7-f1400ea65d05">

### After

<img width="529" alt="image" src="https://github.com/mdn/yari/assets/495429/71f7a0e0-3f35-4de4-a08f-b83c9d280650">


---

## How did you test this change?

Ran `npm i && npm start` in `/cloud-function` and tested with cURL:

```console
$ curl -I http://localhost:5100/discord
HTTP/1.1 302 Found
Cache-Control: max-age=2592000,public
Location: https://discord.gg/Gt4Qf6q67h
Vary: Accept
Content-Type: text/plain; charset=utf-8
Content-Length: 51
Date: Wed, 08 Nov 2023 14:35:24 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```