### PR TITLE
fix(ai-help): destructure embedding response properly

### DIFF
--- a/scripts/ai-help.ts
+++ b/scripts/ai-help.ts
@@ -56,7 +56,7 @@ export async function updateEmbeddings(directory: string) {
     // OpenAI recommends replacing newlines with spaces for best results (specific to embeddings)
     const input = content.replace(/\n/g, " ");
 
-    let embeddingResponse;
+    let embeddingResponse: OpenAI.Embeddings.CreateEmbeddingResponse;
     try {
       embeddingResponse = await openai.embeddings.create({
         model: "text-embedding-ada-002",
@@ -83,7 +83,7 @@ export async function updateEmbeddings(directory: string) {
     const {
       data: [{ embedding }],
       usage: { total_tokens },
-    } = embeddingResponse.data;
+    } = embeddingResponse;
 
     return {
       total_tokens,


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The "Update AI Help index" step of our deployment has been failing.


### Solution

Properly destructure the `CreateEmbeddingResponse`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
 $ ts-node scripts/ai-help.ts update-index
Retrieving all indexed documents...
-> Done.
Determining changed and deleted documents...
-> 1656 of 11955 documents were changed (or added).
-> 26 of 11886 indexed documents were deleted (or moved).
Applying updates...
-> [/en-US/docs/Games] Updating document...
!> [/en-US/docs/Games] Failed to update document. Document has been marked with null checksum to indicate that it needs to be re-generated.
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at createEmbedding (file:///Users/claas/github/mdn/yari/scripts/ai-help.ts:86:9)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async updateEmbeddings (file:///Users/claas/github/mdn/yari/scripts/ai-help.ts:165:45)
    at async Se.run (/Users/claas/github/mdn/yari/node_modules/@caporal/core/dist/index.js:1:27579)
    at async Te._run (/Users/claas/github/mdn/yari/node_modules/@caporal/core/dist/index.js:1:32257)
-> [/en-US/docs/Learn] Updating document...
!> [/en-US/docs/Learn] Failed to update document. Document has been marked with null checksum to indicate that it needs to be re-generated.
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at createEmbedding (file:///Users/claas/github/mdn/yari/scripts/ai-help.ts:86:9)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async updateEmbeddings (file:///Users/claas/github/mdn/yari/scripts/ai-help.ts:165:45)
    at async Se.run (/Users/claas/github/mdn/yari/node_modules/@caporal/core/dist/index.js:1:27579)
    at async Te._run (/Users/claas/github/mdn/yari/node_modules/@caporal/core/dist/index.js:1:32257)
```

### After

```console
$ ts-node scripts/ai-help.ts update-index
Retrieving all indexed documents...
-> Done.
Determining changed and deleted documents...
-> 1656 of 11955 documents were changed (or added).
-> 26 of 11886 indexed documents were deleted (or moved).
Applying updates...
-> [/en-US/docs/Games] Updating document...
-> [/en-US/docs/Games] Indexing 4 document sections...
-> [/en-US/docs/Learn] Updating document...
-> [/en-US/docs/Learn] Indexing 6 document sections...
```

---

## How did you test this change?

Ran `yarn ai-help update-index` locally with our Supabase Dev project, see above.