### PR TITLE
fix(baseline): hide banner on subgrid

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -562,7 +562,12 @@ async function addBaseline(
   doc: Partial<Doc>
 ): Promise<WebFeatureStatus | undefined> {
   if (doc.browserCompat) {
-    return await getWebFeatureStatus(...doc.browserCompat);
+    const filteredBrowserCompat = doc.browserCompat.filter(
+      (query) =>
+        // temporary blocklist while we wait for an updated baseline definition/designs
+        !["css.properties.grid-template-columns.subgrid"].includes(query)
+    );
+    return await getWebFeatureStatus(...filteredBrowserCompat);
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

subgrid should be baseline "green" by the old design and definition

### Solution

we are hopefully close to announcing a new definition and designs - it would be odd to change the banner on subgrid once, only to immediately change it again - so hiding it for now

---

## How did you test this change?

`yarn dev` & visited:
- http://localhost:3000/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid - to verify the banner was hidden
- http://localhost:3000/en-US/docs/Web/CSS/grid-template-columns - to verify the banner still shows on other pages
