### PR TITLE
chore(macros/CSSRef): add Border-radius generator

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -162,6 +162,7 @@ const text = mdn.localStringMap({
     'Tools': 'Tools',
       'Color_picker_tool': 'Color picker',
       'Box-shadow_generator': 'Box shadow generator',
+      'Border-radius_generator': 'Border radius generator',
       'Border-image_generator' : 'Border image generator',
   },
   'fr': {
@@ -307,6 +308,7 @@ const text = mdn.localStringMap({
       'Grid_wrapper': 'Conteneur de grille',
     'Tools': 'Outils',
       'Color_picker_tool': 'Sélecteur de couleurs',
+      'Border-radius_generator': 'Générateur de border-radius',
       'Box-shadow_generator': 'Générateur d\'ombre de boîte',
       'Border-image_generator' : 'Générateur d\'image de bordure',
   },
@@ -506,6 +508,7 @@ const text = mdn.localStringMap({
       'Grid_wrapper': '그리드 wrapper',
     'Tools': '도구',
       'Color_picker_tool': '색상 선택 도구',
+      'Border-radius_generator': 'Border-radius 생성기',
       'Box-shadow_generator': '박스에 그림자 생성기',
       'Border-image_generator' : '보더 이미지 생성기',
   },
@@ -705,6 +708,7 @@ const text = mdn.localStringMap({
       'Grid_wrapper': 'Обёртка сетки',
     'Tools': 'Инструменты',
       'Color_picker_tool': 'Инструмент выбора цвета',
+      'Border-radius_generator': 'Border-radius генератор',
       'Box-shadow_generator': 'Генератор теней',
       'Border-image_generator' : 'Генератор Border-image',
   },
@@ -864,6 +868,7 @@ const text = mdn.localStringMap({
       'Grid_wrapper': '网格布局包装器',
     'Tools': '工具',
       'Color_picker_tool': '取色器',
+      'Border-radius_generator': '圆角边框生成器',
       'Box-shadow_generator': 'Box shadow 生成器',
       'Border-image_generator' : '图片边框生成器',
   },
@@ -1441,6 +1446,7 @@ async function buildPropertylist(pages, title) {
       <li><%-smartLink(`${cssURL}CSS_Colors/Color_picker_tool`, null, text['Color_picker_tool'], cssURL)%></li>
       <li><%-smartLink(`${cssURL}CSS_Backgrounds_and_Borders/Box-shadow_generator`, null, text['Box-shadow_generator'], cssURL)%></li>
       <li><%-smartLink(`${cssURL}CSS_Backgrounds_and_Borders/Border-image_generator`, null, text['Border-image_generator'], cssURL)%></li>
+      <li><%-smartLink(`${cssURL}CSS_Backgrounds_and_Borders/Border-radius_generator`, null, text['Border-radius_generator'], cssURL)%></li>
     </ol>
   </li>
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9351.

### Problem

The [Border-radius generator](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Border-radius_generator) is not linked in the CSS Reference sidebar (CSSRef).

### Solution

Add the page to the sidebar.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="302" alt="image" src="https://github.com/mdn/yari/assets/495429/d9f1f982-d862-437b-987e-6826d3836da2">


### After

<img width="302" alt="image" src="https://github.com/mdn/yari/assets/495429/5d3be5ac-5fc5-4d8d-ba36-cf6ad9bb756a">

---

## How did you test this change?

Ran `yarn && yarn dev` and viewed http://localhost:3000/en-US/docs/Web/CSS/CSS_backgrounds_and_borders/Border-radius_generator.