### PR TITLE
feat(macro-usage-report): add CSV output format

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -213,7 +213,7 @@ interface OptimizeClientBuildActionParameters extends ActionParameters {
 interface MacroUsageReportActionParameters extends ActionParameters {
   options: {
     deprecatedOnly: boolean;
-    format: "md-table" | "json";
+    format: "md-table" | "csv" | "json";
     unusedOnly: boolean;
   };
 }
@@ -1227,7 +1227,7 @@ if (Mozilla && !Mozilla.dntEnabled()) {
   .option("--deprecated-only", "Only reports deprecated macros.")
   .option("--format <type>", "Format of the report.", {
     default: "md-table",
-    validator: ["json", "md-table"],
+    validator: ["json", "md-table", "csv"],
   })
   .option("--unused-only", "Only reports unused macros.")
   .action(

--- a/tool/macro-usage-report.ts
+++ b/tool/macro-usage-report.ts
@@ -169,11 +169,7 @@ function writeMarkdownTable(
   filesByMacro: {
     [macro: string]: Iterable<string>;
   },
-  {
-    deprecatedMacros,
-  }: {
-    deprecatedMacros: string[];
-  }
+  deprecatedMacros: string[]
 ) {
   const table = createTable(filesByMacro, deprecatedMacros);
   const headerRow = table.shift();
@@ -201,11 +197,7 @@ function writeCsvTable(
   filesByMacro: {
     [macro: string]: Iterable<string>;
   },
-  {
-    deprecatedMacros,
-  }: {
-    deprecatedMacros: string[];
-  }
+  deprecatedMacros: string[]
 ) {
   const table = createTable(filesByMacro, deprecatedMacros);
   for (const row of table) {
@@ -221,11 +213,7 @@ function writeJson(
   filesByMacro: {
     [macro: string]: Iterable<string>;
   },
-  {
-    deprecatedMacros,
-  }: {
-    deprecatedMacros: string[];
-  }
+  deprecatedMacros: string[]
 ) {
   const result = {};
   const macros = Object.keys(filesByMacro);
@@ -275,12 +263,12 @@ export async function macroUsageReport({
 
   switch (format) {
     case "md-table":
-      return writeMarkdownTable(filesByMacro, { deprecatedMacros });
+      return writeMarkdownTable(filesByMacro, deprecatedMacros);
 
     case "csv":
-      return writeCsvTable(filesByMacro, { deprecatedMacros });
+      return writeCsvTable(filesByMacro, deprecatedMacros);
 
     case "json":
-      return writeJson(filesByMacro, { deprecatedMacros });
+      return writeJson(filesByMacro, deprecatedMacros);
   }
 }


### PR DESCRIPTION
This PR adds a CSV format output to the `macro-usage-report` tool.  This allows us to view what macros are still in use quickly and easily in spreadsheet format (which I often use when working on macro removal from translated-content).
