### PR TITLE
chore(flaws): exclude /discord from broken-link flaw

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -298,7 +298,7 @@ export function getBrokenLinksFlaws(
     } else if (
       href.startsWith("/") &&
       !href.startsWith("//") &&
-      !/^\/en-US\/blog(\/|$)/.test(href)
+      !/^\/(discord|en-US\/blog)(\/|$)/.test(href)
     ) {
       // Got to fake the domain to sensible extract the .search and .hash
       const absoluteURL = new URL(href, "http://www.example.com");


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/10006.

### Problem

We introduced a `/discord` redirect, but it is marked as a broken link.

### Solution

Exclude it from the broken-link flaw.

---

## How did you test this change?

Ran `yarn tool flaws MDN/Community/Communication_channels` locally.
