### PR TITLE
chore(macros/LearnSidebar): add Japanese translation retake

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -284,7 +284,7 @@ const l10nStrings = mdn.localStringMap({
       'Cross_browser_testing' : 'Cross browser testing',
       'Git_and_GitHub' : 'Git and GitHub',
       'Client-side_web_development_tools' : 'クライアントサイドウェブ開発ツール',
-      'Introduction_to_client-side_frameworks': 'Introduction to client-side frameworks',
+      'Introduction_to_client-side_frameworks': 'クライアントサイドフレームワークの概要',
       'React': 'React',
       'Ember': 'Ember',
       'Vue': 'Vue',


### PR DESCRIPTION
## Summary

this PR is retake PR #9829

@hmatrjp @potappo 

- issue:  [Introduction to client-side frameworks の翻訳 #719](https://github.com/mozilla-japan/translation/issues/719) 
- translate-content PR: [Introduction to client-side frameworks の翻訳](https://github.com/mdn/translated-content/pull/16543) `merged`

### Problem
still en-us only

### Solution

translate japanese for LearnSidebar.ejs

### NOTICE
alreday https://github.com/mdn/translated-content/pull/16543 merged.

### Before

still en-us only

### After

add tranlate japanese for LearnSidebar.ejs

### memo
to @caugner
Please merge once mdn-yari-ja is approved.

BEGIN_COMMIT_OVERRIDE
chore(macros/LearnSidebar): add Japanese translation retake
END_COMMIT_OVERRIDE

