### PR TITLE
chore(macros/CSSRef): add "Using CSS math functions"

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -125,6 +125,8 @@ const text = mdn.localStringMap({
         'Floating_and_positioning': 'Floating and positioning',
         'Margins_borders_and_padding': 'Margins, borders and padding',
         'Sizing': 'Sizing',
+      'Math_functions': 'Math functions',
+        'Using_CSS_math_functions': 'Using CSS math functions'
       'Media_queries': 'Media queries',
         'Using_media_queries': 'Using media queries',
         'Using_media_queries_for_accessibility': 'Using media queries for accessibility',

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1356,6 +1356,14 @@ async function buildPropertylist(pages, title) {
   </li>
   <li class="toggle">
       <details>
+          <summary><%=text['Math_functions']%></summary>
+          <ol>
+            <li><%-smartLink(`${cssURL}CSS_Math_Functions/Using_CSS_math_functions`, null, text['Using_CSS_math_functions'], cssURL)%></li>
+          </ol>
+      </details>
+  </li>
+  <li class="toggle">
+      <details>
           <summary><%=text['Media_queries']%></summary>
           <ol>
             <li><%-smartLink(`${cssURL}CSS_Media_Queries/Using_media_queries`, null, text['Using_media_queries'], cssURL)%></li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -126,7 +126,7 @@ const text = mdn.localStringMap({
         'Margins_borders_and_padding': 'Margins, borders and padding',
         'Sizing': 'Sizing',
       'Math_functions': 'Math functions',
-        'Using_CSS_math_functions': 'Using CSS math functions'
+        'Using_CSS_math_functions': 'Using CSS math functions',
       'Media_queries': 'Media queries',
         'Using_media_queries': 'Using media queries',
         'Using_media_queries_for_accessibility': 'Using media queries for accessibility',


### PR DESCRIPTION
Adds 'Using CSS math functions' to the References > CSS > Guides sidebar.

Related PR: https://github.com/mdn/content/pull/30076