### PR TITLE
chore(blog): enable LFS for mdn-studio

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           repository: mdn/mdn-studio
           path: mdn/mdn-studio
+          lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -86,6 +86,7 @@ jobs:
         with:
           repository: mdn/mdn-studio
           path: mdn/mdn-studio
+          lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,

--- a/.github/workflows/xyz-build.yml
+++ b/.github/workflows/xyz-build.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           repository: mdn/mdn-studio
           path: mdn/mdn-studio
+          lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

### Problem

The mdn/mdn-studio repo will enable Git LFS soon, but our deployments don't know about this.

### Solution

Enable the `lfs` option of the [checkout action](https://github.com/actions/checkout).

---

## How did you test this change?

Will kick off an xyz-build, and otherwise we will only know for sure once LFS was enabled on the repo.