### PR TITLE
feat(macros/AvailableInWorkers): support more distinct cases

### DIFF
--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -59,7 +59,7 @@ const textService = mdn.localString({
 });
 
 const textServiceOnly = mdn.localString({
-  "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>`,
+  "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>.`,
 })
 
 const workerType = $0 || 'default';

--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -7,6 +7,7 @@
 //      'dedicated': only in DedicatedWorker (and in Window)
 //      'dedicatedonly' only in DedicatedWorker
 //      'notservice': all workers but ServiceWorker (and in Window)
+//      'notservicenotwindow': all workers but ServiceWorker (and no window)
 //      'service': only in ServiceWorker (and in Window)
 //      'serviceonly': only in ServiceWorker
 //      null: (default) All workers (and Window)
@@ -46,6 +47,10 @@ const textNotService = mdn.localString({
   "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中使用。`,
 });
 
+const textNotServiceNotWindow = mdn.localString({
+  "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>.`,
+});
+
 const textDedicated = mdn.localString({
   "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/DedicatedWorkerGlobalScope">Dedicated Web Workers</a>.`,
 });
@@ -67,6 +72,7 @@ const workerType = $0 || 'default';
 const associatedText = {
   default: () => textDefault,
   notservice: () => textNotService,
+  notservicenotwindow: () => textNotServiceNotWindow,
   dedicated: () => textDedicated,
   dedicatedonly: () => textDedicatedOnly,
   service: () => textService,

--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -3,9 +3,14 @@
 //
 // Parameters:
 //
-//  $0 - workerType (optional)
+//  $0 - workerType (optional):
+//      'dedicated': only in DedicatedWorker (and in Window)
+//      'dedicatedonly' only in DedicatedWorker
+//      'notservice': all workers but ServiceWorker (and in Window)
+//      'service': only in ServiceWorker (and in Window)
+//      'serviceonly': only in ServiceWorker
+//      null: (default) All workers (and Window)
 //
-// The optional first argument has to be one of the ['notservice'].
 //
 //  {{AvailableInWorkers}}
 //  {{AvailableInWorkers("notservice")}}
@@ -21,37 +26,58 @@ const note = mdn.localString({
     "ko": "참고:",
     "ru": "Примечание:",
     "zh-CN": "备注：",
-    "zh-TW": "備註："
+    "zh-TW": "備註：",
 });
 
 const textDefault = mdn.localString({
-  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
-  "zh-CN": `此特性在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 中可用`,
-  "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 中使用`,
-  "es": `Esta característica está disponible en <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
-  "fr": `Cette fonctionnalité est disponible via les <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`,
-  "ja": `この機能は <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 内で利用可能です`,
-  "ko": `이 기능은 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>에서 사용할 수 있습니다`,
-  "ru": `Эта возможность доступна в <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>`
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>.`,
+  "zh-CN": `此特性在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 中可用。`,
+  "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 中使用。`,
+  "es": `Esta característica está disponible en <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>.`,
+  "fr": `Cette fonctionnalité est disponible via les <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>.`,
+  "ja": `この機能は <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a> 内で利用可能です。`,
+  "ko": `이 기능은 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>에서 사용할 수 있습니다.`,
+  "ru": `Эта возможность доступна в <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>.`,
 });
 
-const textServiceWorkers = mdn.localString({
-  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>`,
-  "zh-CN": `此特性在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中可用`,
-  "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中使用`
+const textNotService = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>.`,
+  "zh-CN": `此特性在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中可用。`,
+  "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中使用。`,
+});
+
+const textDedicated = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/DedicatedWorkerGlobalScope">Dedicated Web Workers</a>.`,
+});
+
+const textDedicatedOnly = mdn.localString({
+  "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/DedicatedWorkerGlobalScope">Dedicated Web Workers</a>.`,
+});
+
+const textService = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>.`,
+});
+
+const textServiceOnly = mdn.localString({
+  "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>`,
 })
 
-const workerType = $0;
+const workerType = $0 || 'default';
 
-let text = "";
+const associatedText = {
+  default: () => textDefault,
+  notservice: () => textNotService,
+  dedicated: () => textDedicated,
+  dedicatedonly: () => textDedicatedOnly,
+  service: () => textService,
+  serviceonly: () => textServiceOnly,
+};
 
-if (workerType === "notservice") {
-  text = textServiceWorkers;
-} else if (workerType) {
+if (!associatedText[workerType]) {
   throw new Error(`'${workerType}' is not a recognized argument to this macro`);
-} else {
-  text = textDefault;
 }
+
+const text = associatedText[workerType]();
 
 %>
 

--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -4,12 +4,12 @@
 // Parameters:
 //
 //  $0 - workerType (optional):
-//      'dedicated': only in DedicatedWorker (and in Window)
-//      'dedicatedonly' only in DedicatedWorker
-//      'notservice': all workers but ServiceWorker (and in Window)
-//      'notservicenotwindow': all workers but ServiceWorker (and no window)
-//      'service': only in ServiceWorker (and in Window)
-//      'serviceonly': only in ServiceWorker
+//      'only_dedicated_and_window': only in DedicatedWorker (and in Window)
+//      'only_dedicated' only in DedicatedWorker
+//      'except_service': all workers but ServiceWorker (and in Window)
+//      'except_service_and_window': all workers but ServiceWorker (and no window)
+//      'only_service_and_window': only in ServiceWorker (and in Window)
+//      'only_service': only in ServiceWorker
 //      null: (default) All workers (and Window)
 //
 //
@@ -71,12 +71,12 @@ const workerType = $0 || 'default';
 
 const associatedText = {
   default: () => textDefault,
-  notservice: () => textNotService,
-  notservicenotwindow: () => textNotServiceNotWindow,
-  dedicated: () => textDedicated,
-  dedicatedonly: () => textDedicatedOnly,
-  service: () => textService,
-  serviceonly: () => textServiceOnly,
+  only_service: () => textNotService,
+  except_service_and_window: () => textNotServiceNotWindow,
+  only_dedicated_and_window: () => textDedicated,
+  only_dedicated: () => textDedicatedOnly,
+  only_service_and_window: () => textService,
+  only_service: () => textServiceOnly,
 };
 
 if (!associatedText[workerType]) {

--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -4,17 +4,16 @@
 // Parameters:
 //
 //  $0 - workerType (optional):
-//      'only_dedicated_and_window': only in DedicatedWorker (and in Window)
-//      'only_dedicated' only in DedicatedWorker
-//      'except_service': all workers but ServiceWorker (and in Window)
-//      'except_service_and_window': all workers but ServiceWorker (and no window)
-//      'only_service_and_window': only in ServiceWorker (and in Window)
-//      'only_service': only in ServiceWorker
+//      'window_and_dedicated': only in DedicatedWorker (and in Window)
+//      'dedicated': only in DedicatedWorker
+//      'window_and_worker_except_service': all workers but ServiceWorker (and in Window)
+//      'worker_except_service': all workers but ServiceWorker (and no window)
+//      'window_and_service': only in ServiceWorker (and in Window)
+//      'service':  only in ServiceWorker
 //      null: (default) All workers (and Window)
 //
-//
 //  {{AvailableInWorkers}}
-//  {{AvailableInWorkers("notservice")}}
+//  {{AvailableInWorkers("worker_except_service")}}
 //
 
 const locale = env.locale;
@@ -71,12 +70,12 @@ const workerType = $0 || 'default';
 
 const associatedText = {
   default: () => textDefault,
-  only_service: () => textNotService,
-  except_service_and_window: () => textNotServiceNotWindow,
-  only_dedicated_and_window: () => textDedicated,
-  only_dedicated: () => textDedicatedOnly,
-  only_service_and_window: () => textService,
-  only_service: () => textServiceOnly,
+  window_and_worker_except_service: () => textNotService,
+  worker_except_service: () => textNotServiceNotWindow,
+  window_and_dedicated: () => textDedicated,
+  dedicated: () => textDedicatedOnly,
+  window_and_service: () => textService,
+  service: () => textServiceOnly,
 };
 
 if (!associatedText[workerType]) {


### PR DESCRIPTION

## Summary

We have the `{{AvailableInWorkers}}` macro that adds a message indicating a feature is available in web workers.

It was created a long time ago (when workers were added to the web platform) and supports only two cases:
- all web workers (and `Window`) support the feature;
- all web workers support the feature, but service workers (and `Window`).

Over the years, many other cases were added. I've found cases where a given feature is supported:
- only in a `DedicatedWorker` (and in `Window`)
- only in a `DedicatedWorker` (even not `Window`) 
- only in a `ServiceWorker` (even not `Window`)
- only in `ServiceWorker` (and in `Window`)

This PR adds these few cases.

Fixes #10009
### Problem

We have content cases where no adequate message can be displayed: E.g., https://github.com/mdn/content/pull/30191#issuecomment-1808631489. Many (read: ~50) occurrences will use it (either the macro call is missing or the text shown is not correct)

This PR fixes it by allowing more strings in parameters.

### Solution

The macro now tests more argument values and sets the correct text for each of them.

In the long term, we may want to read this info from `w3c/webref`, but there are many more global scopes (Worklets, `JsonLD`, `RTCIdentityProvider`, `InterestGroupScriptRunnerGlobalScope`…), so it would mean renaming this macro (for the least). A bit overkill for the current needs.

## Screenshots

I've added the macros in a file with the different messages:
![Capture d’écran 2023-11-15 à 12 45 52](https://github.com/mdn/yari/assets/1466293/bf06e3de-4360-455c-9a2b-fca15f5ac542)
And checked the result:
![Capture d’écran 2023-11-15 à 12 31 19](https://github.com/mdn/yari/assets/1466293/734f7f69-0e81-417a-94e7-c9b55550cfd2)

---

## How did you test this change?
Manually tested (see screenshot)