### PR TITLE
chore(macros/Firefox_for_developers): remove the parameter and add zh-CN translation

### DIFF
--- a/kumascript/macros/Firefox_for_developers.ejs
+++ b/kumascript/macros/Firefox_for_developers.ejs
@@ -2,6 +2,9 @@
 /*
  * This macro generates a list of links to Firefox release notes.
  * It should be used under the "Mozilla/Firefox/Releases" tree.
+ * 
+ * Parameters:
+ *   None
  */
 
 // for content

--- a/kumascript/macros/Firefox_for_developers.ejs
+++ b/kumascript/macros/Firefox_for_developers.ejs
@@ -1,58 +1,64 @@
-<div class="multiColumnList">
-<ul>
 <%
 /*
- * Parameters:
- * $0 = max version to show in the list
+ * This macro generates a list of links to Firefox release notes.
+ * It should be used under the "Mozilla/Firefox/Releases" tree.
  */
 
-var CURRENT_MAX_VERSION = $0;
-
-var maxVersion = CURRENT_MAX_VERSION;
-var minVersion = maxVersion - 30;
-
-if (minVersion < 4) { minVersion = 4 }
-
-// for href attr
-var slug = mdn.localString({
-    "en-US" : "Releases",
-    "fr" : "Versions"
-});
-
 // for content
-var str = mdn.localString({
-    "en-US": ["Firefox ", " for developers"],
-    "fr" : ["Firefox ", " pour les développeurs"],
-    "ko": ["Firefox", "릴리즈노트"],
-    "ru": ["Firefox ", " для разработчиков"]
+const str = mdn.localString({
+  "en-US": ["Firefox ", " for developers"],
+  "fr" : ["Firefox ", " pour les développeurs"],
+  "ko": ["Firefox", "릴리즈노트"],
+  "ru": ["Firefox ", " для разработчиков"],
+  "zh-CN": ["Firefox ", " 的开发者说明"],
 });
 
-var loc = env.locale;
+const locale = env.locale;
+const slug = env.slug;
+
+const oldVersion = ["3.6", "3.5", "3", "2", "1.5"];
+
+const versionStr = slug.split("/").at(-1);
+let maxVersion = Number(versionStr);
+
+let oldVersionStartIdx = 0;
+
+// determine the start index of old version and the max version
+if (maxVersion < 4) {
+  oldVersionStartIdx = oldVersion.indexOf(versionStr) + 1;
+} else {
+  maxVersion--;
+}
+
+let minVersion = maxVersion - 30;
+
+if (minVersion < 4) {
+  minVersion = 4;
+}
+
+// generate release links
+const releaseLinks = [];
+
+function generateReleaseLink(version) {
+  return `<li><a href="/${locale}/docs/Mozilla/Firefox/Releases/${version}">${str[0]}${version}${str[1]}</a></li>`;
+}
 
 // for newer version
-for (var i = maxVersion; i >= minVersion; i--) {
-    %><li><a href="/<%-loc%>/docs/Mozilla/Firefox/<%- slug %>/<%- i %>"><%- str[0] %><%- i %><%- str[1] %></a></li><%
+for (let i = maxVersion; i >= minVersion; i--) {
+  releaseLinks.push(generateReleaseLink(i));
 }
 
 // for older version
-if (minVersion == 4) {
-  var ov = ["3.6", "3.5", "3", "2", "1.5"];
-  var ovStart = ov.indexOf($0);
-  if (ovStart == -1) {
-    ovStart = 0;
-  }
-  for(var i = ovStart; i < ov.length; i++) {
-      %><li><a href="/<%-loc%>/docs/Mozilla/Firefox/<%- slug %>/<%- ov[i] %>"><%- str[0] %><%-ov[i]%><%- str[1] %></a></li><%
+if (minVersion === 4) {
+  for (let i = oldVersionStartIdx; i < oldVersion.length; i++) {
+    releaseLinks.push(generateReleaseLink(oldVersion[i]));
   }
 }
 
-/*
-    This template is difficult. Because, old "fr" page have other rule...
-    If the URL of your country's page is the same as the English pages,
-    You just have to add your country into the object in argument of mdn.localString.
-
-    And, some old pages have this link: "https://developer.mozilla.org/en-US/docs/Updating_web_applications_for_Firefox_3"
-*/
-
-%></ul>
+const output = releaseLinks.join("");
+%>
+<div class="multiColumnList">
+  <ul>
+    <%-output%>
+  </ul>
 </div>


### PR DESCRIPTION
## Summary

1. Added zh-CN translation for this macro.
2. Removed the usage of "version" param, as this is not really necessary (we can infer the version information from the `slug`).

### Solution

Gather the version info from the `slug`.

---

## Screenshots

| URL | Before | After |
| --- | --- | --- |
| /en-US/docs/Mozilla/Firefox/Releases/2 | ![image](https://github.com/mdn/yari/assets/15844309/d26d6ab7-f371-462e-a8ed-48fbd99d71f4) | ![image](https://github.com/mdn/yari/assets/15844309/857cad66-3acd-403c-b9fb-6d9e39d6c90c) |
| /en-US/docs/Mozilla/Firefox/Releases/3.6 | ![image](https://github.com/mdn/yari/assets/15844309/e2640896-8f18-4222-adbe-d0432542043f) | ![image](https://github.com/mdn/yari/assets/15844309/599d688d-b68e-4d0b-bdd1-3439654b19d3) |
| /en-US/docs/Mozilla/Firefox/Releases/4 | ![image](https://github.com/mdn/yari/assets/15844309/8be0c1b0-99b0-4db9-8869-576dd11f5b7e) | ![image](https://github.com/mdn/yari/assets/15844309/0aa36189-d2fc-4f50-bb9b-55767ef03796) |
| /en-US/docs/Mozilla/Firefox/Releases/24 | ![image](https://github.com/mdn/yari/assets/15844309/36202372-38bc-40b5-956c-fed35f4c7ef3) | ![image](https://github.com/mdn/yari/assets/15844309/1082e067-6f6b-4094-8999-2912634613e6) |
| /en-US/docs/Mozilla/Firefox/Releases/121 | ![image](https://github.com/mdn/yari/assets/15844309/51c7b451-3061-4d14-badf-a53c652a8e5b) | ![image](https://github.com/mdn/yari/assets/15844309/2dec18dd-52a6-442e-a7dd-a7a85c48fef1) |

Note, the lists in `/en-US/docs/Mozilla/Firefox/Releases/2` are not consistent.

---

## How did you test this change?

1. Run `yarn dev` and check rendered page
2. Run `rg -il "Firefox_for_developers"` to check the occurrences of this macro in content and translated-content.
