### PR TITLE
chore(build): remove the translation_of metadata

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -516,26 +516,7 @@ export async function buildDocument(
 
   doc.modified = metadata.modified || null;
 
-  const otherTranslations = document.translations || [];
-  if (!otherTranslations.length && metadata.translation_of) {
-    // If built just-in-time, we won't have a record of all the other translations
-    // available. But if the current document has a translation_of, we can
-    // at least use that.
-    const translationOf = Document.findByURL(
-      `/en-US/docs/${metadata.translation_of}`
-    );
-    if (translationOf) {
-      otherTranslations.push({
-        locale: "en-US",
-        title: translationOf.metadata.title,
-        native: LANGUAGES.get("en-us")?.native,
-      });
-    }
-  }
-
-  if (otherTranslations.length) {
-    doc.other_translations = otherTranslations;
-  }
+  doc.other_translations = document.translations || [];
 
   injectSource(doc, document, metadata);
 

--- a/content/document.ts
+++ b/content/document.ts
@@ -112,8 +112,6 @@ export function saveFile(
   const optionalFrontMatterKeys = [
     "page-type",
     "tags",
-    "translation_of",
-    "translation_of_original",
     "original_slug",
     "browser-compat",
   ];

--- a/kumascript/tests/macros/fixtures/documentData1.json
+++ b/kumascript/tests/macros/fixtures/documentData1.json
@@ -176,7 +176,6 @@
     "summary": "El protocolo HTTP es un protocolo ampliable, es decir se puede añadir \"vocabulario\". HTTP está basado en unos pocos conceptos básicos como el concepto de recursos y URIs, una estructura sencilla de mensajes, y una arquitectura de cliente-servidor para ordenar el flujo de las comunicaciones. A demás de estos conceptos, a lo largo de su desarrollo han aparecido otros nuevos y se han añadido funcionalidades y reglas semánticas, creando nuevos métodos y cabeceras.",
     "slug": "Web/HTTP/Basics_of_HTTP",
     "modified": "2019-03-24T01:25:02.168Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP",
     "tags": ["HTTP", "NeedsTranslation", "Overview", "TopicStub"]
   },
   "/es/docs/web/http/basics_of_http/choosing_between_www_and_non-www_urls": {
@@ -186,17 +185,15 @@
     "summary": "Una cuestión recurrente entre los dueños de sitios web consiste en elegir entre un no-www y www URLs. Esta página contiene algunos consejos sobre qué es mejor.",
     "slug": "Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs",
     "modified": "2019-03-19T00:22:07.450Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs",
     "tags": ["Guía", "HTTP", "URL", "WWW", "no www"]
   },
-  "/es/docs/web/http/basics_of_http/datos_uris": {
-    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/Datos_URIs",
+  "/es/docs/web/http/basics_of_http/data_uris": {
+    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/Data_URIs",
     "title": "Datos URIs",
     "locale": "es",
     "summary": "Datos URIs, URLs prefijados con los datos: esquema, permiten a los creadores de contenido incorporar pequeños archivos en linea en los documentos.",
-    "slug": "Web/HTTP/Basics_of_HTTP/Datos_URIs",
+    "slug": "Web/HTTP/Basics_of_HTTP/Data_URIs",
     "modified": "2019-03-24T01:24:54.977Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Data_URIs",
     "tags": ["Base 64", "Guia(2)", "Intermedio", "URI", "URL"]
   },
   "/es/docs/web/http/basics_of_http/evolution_of_http": {
@@ -205,17 +202,15 @@
     "locale": "es",
     "summary": "HTTP es el protocolo en el que se basa la Web. Fue inventado por Tim Berners-Lee entre los años 1989-1991, HTTP ha visto muchos cambios, manteniendo la mayor parte de su simplicidad y desarrollando su flexibilidad. HTTP ha evolucionado, desde un protocolo destinado al intercambio de archivos en un entorno de un laboratorio semi-seguro, al actual laberinto de Internet, sirviendo ahora para el intercambio de imágenes, vídeos en alta resolución y en 3D.",
     "slug": "Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP",
-    "modified": "2019-03-24T01:10:11.567Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP"
+    "modified": "2019-03-24T01:10:11.567Z"
   },
-  "/es/docs/web/http/basics_of_http/identificación_recursos_en_la_web": {
-    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/Identificación_recursos_en_la_Web",
+  "/es/docs/web/http/basics_of_http/identifying_resources_on_the_web": {
+    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web",
     "title": "Identificación de recursos web",
     "locale": "es",
     "summary": "El objetivo de una solicitud HTTP se denomina \"recurso\", (es decir: datos), y dicho recurso, no posee un tipo definido por defecto; puede ser un documento, o una foto, o cualquier otra posibilidad. Cada recurso es identificado por un Identificador Uniforme de Recursos (URI)  y es utilizado a través de HTTP, para la identificación del tipo de recurso.",
-    "slug": "Web/HTTP/Basics_of_HTTP/Identificación_recursos_en_la_Web",
-    "modified": "2019-03-24T01:24:51.387Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web"
+    "slug": "Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web",
+    "modified": "2019-03-24T01:24:51.387Z"
   },
   "/es/docs/web/http/basics_of_http/mime_types": {
     "url": "/es/docs/Web/HTTP/Basics_of_HTTP/MIME_types",
@@ -224,7 +219,6 @@
     "summary": "El tipo Extensiones multipropósito de Correo de Internet (MIME) es una forma estandarizada de indicar la naturaleza y el formato de un documento, archivo o conjunto de datos. Está definido y estandarizado en IETF RFC 6838. La Autoridad de Números Asignados de Internet (IANA) es el organismo oficial responsable de realizar un seguimiento de todos los tipos MIME oficiales, y puede encontrar la lista más actualizada y completa en la página de tipos de medios (Media Types).",
     "slug": "Web/HTTP/Basics_of_HTTP/MIME_types",
     "modified": "2019-11-18T11:03:54.325Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/MIME_types",
     "tags": [
       "Cabecera de solicitud",
       "Guide",
@@ -235,14 +229,13 @@
       "application/json"
     ]
   },
-  "/es/docs/web/http/basics_of_http/mime_types/lista_completa_de_tipos_mime": {
-    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Lista_completa_de_tipos_MIME",
+  "/es/docs/web/http/basics_of_http/mime_types/complete_list_of_mime_types": {
+    "url": "/es/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types",
     "title": "Lista completa de tipos MIME",
     "locale": "es",
     "summary": "Aquí está una lista completa de tipos de MIME, asociados por tipo de documentos y  ordenados por su extensión común.",
-    "slug": "Web/HTTP/Basics_of_HTTP/MIME_types/Lista_completa_de_tipos_MIME",
+    "slug": "Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types",
     "modified": "2019-03-24T01:19:32.581Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types",
     "tags": [
       "Archivos",
       "Audio",
@@ -263,17 +256,15 @@
     "summary": "HTTP est un protocole extensible. Il s'appuie sur quelques concepts basiques comme la notion de ressources et d'URI, une structure de messages simple et une structure client-serveur pour le flux de communication. En plus de ces concepts basiques, de nombreuses extensions du protocole sont apparues au fil des ans, ajoutant de nouvelles fonctionnalités et de nouvelle syntaxes en créant de nouvelles méthodes ou en-têtes HTTP.",
     "slug": "Web/HTTP/Basics_of_HTTP",
     "modified": "2019-03-24T01:24:52.804Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP",
     "tags": ["Aperçu", "HTTP"]
   },
-  "/fr/docs/web/http/basics_of_http/choisir_entre_les_urls_www_sans_www": {
-    "url": "/fr/docs/Web/HTTP/Basics_of_HTTP/Choisir_entre_les_URLs_www_sans_www",
+  "/fr/docs/web/http/basics_of_http/choosing_between_www_and_non-www_urls": {
+    "url": "/fr/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs",
     "title": "Choisir entre les URLs avec ou sans www",
     "locale": "fr",
     "summary": "Une question récurrente chez les propriétaires de sites web est de choisir entre utiliser des URLs qui débutent ou non par www. Cette page fournit quelques conseils sur la meilleure approche à envisager.",
-    "slug": "Web/HTTP/Basics_of_HTTP/Choisir_entre_les_URLs_www_sans_www",
+    "slug": "Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs",
     "modified": "2019-03-19T00:44:23.409Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs",
     "tags": ["Guide", "HTTP", "URL"]
   },
   "/fr/docs/web/http/basics_of_http/data_uris": {
@@ -283,7 +274,6 @@
     "summary": "Les URLs de données, les URLs préfixées par le schéma data:, permettent aux créateurs de contenu d'intégrer de petits fichiers dans des documents.",
     "slug": "Web/HTTP/Basics_of_HTTP/Data_URIs",
     "modified": "2020-01-10T03:30:13.621Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Data_URIs",
     "tags": ["Base64", "Guide", "HTTP", "Intermédiaire", "URL"]
   },
   "/fr/docs/web/http/basics_of_http/evolution_of_http": {
@@ -293,17 +283,15 @@
     "summary": "",
     "slug": "Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP",
     "modified": "2020-01-18T17:19:52.795Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP",
     "tags": ["Guide", "HTTP"]
   },
-  "/fr/docs/web/http/basics_of_http/identifier_des_ressources_sur_le_web": {
-    "url": "/fr/docs/Web/HTTP/Basics_of_HTTP/Identifier_des_ressources_sur_le_Web",
+  "/fr/docs/web/http/basics_of_http/identifying_resources_on_the_web": {
+    "url": "/fr/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web",
     "title": "Identifier des ressources sur le Web",
     "locale": "fr",
     "summary": "La cible d'une requête HTTP est appelée une \"ressource\", elle ne possède pas de type particulier. Il peut s'agir d'un document, d'une photo ou de n'importe quoi d'autre. Chaque ressource est identifiée à l'aide d'une Uniform Resource Identifier (URI) utilisé au sein de HTTP pour identifier les ressources.",
-    "slug": "Web/HTTP/Basics_of_HTTP/Identifier_des_ressources_sur_le_Web",
+    "slug": "Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web",
     "modified": "2019-03-19T00:41:54.222Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web",
     "tags": ["HTTP"]
   },
   "/fr/docs/web/http/basics_of_http/mime_types": {
@@ -313,7 +301,6 @@
     "summary": "Le type Multipurpose Internet Mail Extensions (type MIME) est un standard permettant d'indiquer la nature et le format d'un document. Il est défini au sein de la RFC 6838. L'Internet Assigned Numbers Authority (IANA) est l'organisme officiel responsable du suivi de l'ensemble des types MIME officiels existants. Une liste exhaustive et maintenue est consultable sur la page Media Types de l'IANA.",
     "slug": "Web/HTTP/Basics_of_HTTP/MIME_types",
     "modified": "2020-01-02T09:41:24.716Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/MIME_types",
     "tags": ["Content-Type", "Guide", "HTTP", "Types MIME"]
   },
   "/fr/docs/web/http/basics_of_http/mime_types/complete_list_of_mime_types": {
@@ -323,7 +310,6 @@
     "summary": "Voici une liste de types MIME, associés par type et ordonnée par extension.",
     "slug": "Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types",
     "modified": "2019-03-18T23:44:57.359Z",
-    "translation_of": "Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types",
     "tags": ["Audio", "HTTP", "Reference", "Types MIME", "Video"]
   }
 }

--- a/libs/types/document.ts
+++ b/libs/types/document.ts
@@ -134,7 +134,6 @@ export interface DocMetadata {
   modified: string;
   flaws: Flaws;
   other_translations?: Translation[];
-  translation_of?: string;
   parents?: DocParent[];
   source: Source;
   contributors: string[];

--- a/testing/translated-content/files/fr/web/foo/index.html
+++ b/testing/translated-content/files/fr/web/foo/index.html
@@ -1,7 +1,6 @@
 ---
 title: "<foo>: Une page de test"
 slug: Web/Foo
-translation_of: Web/Foo
 ---
 
 <p>Foë</p>

--- a/testing/translated-content/files/zh-cn/web/foo/index.md
+++ b/testing/translated-content/files/zh-cn/web/foo/index.md
@@ -1,7 +1,6 @@
 ---
 title: "<foo>: 测试网页"
 slug: Web/Foo
-translation_of: Web/Foo
 ---
 
 This is a test page for hreflang tag testing. When zh-TW locale is also

--- a/testing/translated-content/files/zh-tw/web/foo/index.html
+++ b/testing/translated-content/files/zh-tw/web/foo/index.html
@@ -1,7 +1,6 @@
 ---
 title: "<foo>: 測試網頁"
 slug: Web/Foo
-translation_of: Web/Foo
 ---
 
 <p>

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -806,67 +806,6 @@ program
     })
   )
 
-  .command("redundant-translations", "Find redundant translations")
-  .action(
-    tryOrExit(async () => {
-      if (!CONTENT_TRANSLATED_ROOT) {
-        throw new Error("CONTENT_TRANSLATED_ROOT not set");
-      }
-      if (!fs.existsSync(CONTENT_TRANSLATED_ROOT)) {
-        throw new Error(`${CONTENT_TRANSLATED_ROOT} does not exist`);
-      }
-      const documents = await Document.findAll();
-      if (!documents.count) {
-        throw new Error("No documents to analyze");
-      }
-      // Build up a map of translations by their `translation_of`
-      const map = new Map();
-      for (const document of documents.iterDocs()) {
-        if (!document.isTranslated) continue;
-        const { translation_of, locale } = document.metadata;
-        if (!map.has(translation_of)) {
-          map.set(translation_of, new Map());
-        }
-        if (!map.get(translation_of).has(locale)) {
-          map.get(translation_of).set(locale, []);
-        }
-        map
-          .get(translation_of)
-          .get(locale)
-          .push(
-            Object.assign(
-              { filePath: document.fileInfo.path },
-              document.metadata
-            )
-          );
-      }
-      // Now, let's investigate those with more than 1
-      let sumENUS = 0;
-      let sumTotal = 0;
-      for (const [translation_of, localeMap] of map) {
-        for (const [, metadatas] of localeMap) {
-          if (metadatas.length > 1) {
-            // console.log(translation_of, locale, metadatas);
-            sumENUS++;
-            sumTotal += metadatas.length;
-            console.log(
-              `https://developer.allizom.org/en-US/docs/${translation_of}`
-            );
-            for (const metadata of metadatas) {
-              console.log(metadata);
-            }
-          }
-        }
-      }
-      console.warn(
-        `${sumENUS} en-US documents have multiple translations with the same locale`
-      );
-      console.log(
-        `In total, ${sumTotal} translations that share the same translation_of`
-      );
-    })
-  )
-
   .command(
     "popularities",
     "Convert an AWS Athena log aggregation CSV into a popularities.json file"


### PR DESCRIPTION
## Summary

The "translation_of" metadata is used to present the en-US slug when we use a "localized" slug for a translated document. We have only used it in the past.

For now, we use the same slug for localized documents as for en-US documents, and we have removed the "translation_of" metadata from translated-content repo (check the [search result](https://github.com/search?q=repo%3Amdn%2Ftranslated-content+%22translation_of%22&type=code), finished in mdn/translated-content#7412). It's time to get rid of this metadata key.

### Solution

Search through the source code, and remove all the reference of this metadata key:

1. remove it from the type definition.
2. remove it from "documentData1.json", and update the urls/slugs (according to the "translation_of" fields).
3. remove it from testing raw documents (under "testing/translated-content/files/" tree)
4. remove the usage of it from "build/index.ts" (used to generate other_translation when the building document is from translation content and the slug is "localized" (the translations cannot be generated))
5. remove the "redundant-translations" tool, which is used to detect documents that have the same "translation_of" metadata key

---

## Screenshots

Check if the other translations can be generated without the translation_of metadata.

### Before

![image](https://github.com/mdn/yari/assets/15844309/a1de97c5-3d68-4e19-93f8-aabead05bce1)

### After

![image](https://github.com/mdn/yari/assets/15844309/64f619c6-b10d-4691-9b4f-f606e796200b)

---

## How did you test this change?


