### PR TITLE
chore(macros/LearnSidebar): add Games Developing section

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -29,6 +29,8 @@ const l10nStrings = mdn.localStringMap({
       'Performance_guides' : 'Performance guides',
     'MathML_Writing_mathematics' : 'MathML — Writing mathematics with MathML',
       'MathML_first_steps': 'MathML first steps',
+    'Games_Developing_for_web' : 'Games — Developing games for the web',
+      'Guides_and_tutorials': 'Guides and tutorials',
     'Tools_and_testing' : 'Tools and testing',
       'Cross_browser_testing' : 'Cross browser testing',
       'Git_and_GitHub' : 'Git and GitHub',
@@ -634,6 +636,20 @@ const sections = [
           "MathML/First_steps/Scripts",
           "MathML/First_steps/Tables",
           "MathML/First_steps/Three_famous_mathematical_formulas",
+        ]
+      }
+    ]
+  },
+  {
+    name: "Games_Developing_for_web",
+    link: "../Games",
+    subsections: [
+      {
+        name: "Guides_and_tutorials",
+        pages: [
+          "../Games/Introduction",
+          "../Games/Tutorials",
+          "../Games/Publishing_games",
         ]
       }
     ]

--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -648,6 +648,7 @@ const sections = [
         name: "Guides_and_tutorials",
         pages: [
           "../Games/Introduction",
+          "../Games/Techniques",
           "../Games/Tutorials",
           "../Games/Publishing_games",
         ]


### PR DESCRIPTION
## Summary

Features the Games section and a few articles in the Learn sidebar.

Fixes #8948

### Problem

Low visibility of the Games section.

### Solution

- The title goes to the main game dev landing
- There are three key articles under the toggler (debatable)

---

## Screenshots

<img width="353" alt="image" src="https://github.com/mdn/yari/assets/105274/96755597-e345-4281-8236-e65235e0ce45">