### PR TITLE
chore(tool): add "remove" alias to "tool delete"

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -334,6 +334,7 @@ program
   )
 
   .command("delete", "Delete content")
+  .alias("remove", "rm")
   .argument("<slug>", "Slug")
   .argument("[locale]", "Locale", {
     default: DEFAULT_LOCALE,


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This PR adds a `remove` (and `rm`) alias to the `yarn tool delete` command.

### Problem

I often accidentally type `yarn content remove ...` when attempting to remove and redirect a page in MDN content.  This is because `remove` is the more common phrase used in development.

### Solution

The solution is simple: to alias the `delete` command.  This will allow the use of `remove` (or `rm`), without impacting the workflow of existing users.

---

## How did you test this change?

Just ran `yarn tool remove` and `yarn tool rm` and made sure it outputs the same message as `yarn tool delete`.