### PR TITLE
fix(macros/EmbedLiveSample): un-deprecate the 6th parameter (allowed features)

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -10,7 +10,7 @@
 //  $5 - (Deprecated) The class name of the frame; defaults to "sample-code-frame". If you
 //       pass this parameter and give it a value other than "sample-code-frame",
 //       then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
-//  $6 - (Deprecated) Allowed features, separated by semicolons (optional)
+//  $6 - Allowed features, separated by semicolons (optional)
 //
 // See also : LiveSampleLink
 
@@ -18,8 +18,8 @@
 // If one of this parameter is not empty, we raise a MacroDeprecationError flaw
 // When there will be 0 use left on translated-content (May 2022: 203 occurrences for $4),
 // we will be able to simplify this macro (and likely the whole of MDN).
-if ($4 !== "" || $5 !== "" || $6 !== "") {
-  mdn.deprecatedParams("The fourth to sixth parameters of 'EmbedLiveSample' are deprecated");
+if ($4 !== "" || $5 !== "") {
+  mdn.deprecatedParams("The fourth and fifth parameters of 'EmbedLiveSample' are deprecated");
 }
 
 var sampleIdOrOffset = $0 || $token.location.start.offset;

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -10,7 +10,8 @@
 //  $5 - (Deprecated) The class name of the frame; defaults to "sample-code-frame". If you
 //       pass this parameter and give it a value other than "sample-code-frame",
 //       then the "Open in CodePen"/"Open in JSFiddle" buttons will not be displayed.
-//  $6 - Allowed features, separated by semicolons (optional)
+//  $6 - Allowed features (like geolocation, microphone), separated by semicolons (optional).
+//       Defaults to ''.
 //
 // See also : LiveSampleLink
 


### PR DESCRIPTION

## Summary

The 6th parameter of the macro is still in use, and we can't get rid of it.

### Problem

A flaw is added to the page when the 6th parameter is used

### Solution

Change the test to not generate a flaw when the 6th parameter is in use.

## Screenshots

No UI change

## How did you test this change?

I locally tested with an example page
