### PR TITLE
fix(baseline): bcd link not localized

### DIFF
--- a/client/src/document/baseline-indicator.tsx
+++ b/client/src/document/baseline-indicator.tsx
@@ -1,3 +1,4 @@
+import { DEFAULT_LOCALE } from "../../../libs/constants";
 import { WebFeatureStatus } from "../../../libs/types/document";
 import { useLocale } from "../hooks";
 import { BASELINE } from "../telemetry/constants";
@@ -27,7 +28,9 @@ export function BaselineIndicator({ status }: { status: WebFeatureStatus }) {
   const gleanClick = useGleanClick();
   const locale = useLocale();
 
-  const bcdLink = `#${LOCALIZED_BCD_IDS[locale] || LOCALIZED_BCD_IDS["en-US"]}`;
+  const bcdLink = `#${
+    LOCALIZED_BCD_IDS[locale] || LOCALIZED_BCD_IDS[DEFAULT_LOCALE]
+  }`;
 
   const supported = (browser: string) => {
     const version: string | boolean | undefined =

--- a/client/src/document/baseline-indicator.tsx
+++ b/client/src/document/baseline-indicator.tsx
@@ -1,4 +1,5 @@
 import { WebFeatureStatus } from "../../../libs/types/document";
+import { useLocale } from "../hooks";
 import { BASELINE } from "../telemetry/constants";
 import { useGleanClick } from "../telemetry/glean-context";
 import { Icon } from "../ui/atoms/icon";
@@ -10,8 +11,23 @@ const ENGINES = [
   { name: "WebKit", browsers: ["Safari"] },
 ];
 
+const LOCALIZED_BCD_IDS = {
+  "en-US": "browser_compatibility",
+  es: "compatibilidad_con_navegadores",
+  fr: "compatibilité_des_navigateurs",
+  ja: "ブラウザーの互換性",
+  ko: "브라우저_호환성",
+  "pt-BR": "compatibilidade_com_navegadores",
+  ru: "совместимость_с_браузерами",
+  "zh-CN": "浏览器兼容性",
+  "zh-TW": "瀏覽器相容性",
+};
+
 export function BaselineIndicator({ status }: { status: WebFeatureStatus }) {
   const gleanClick = useGleanClick();
+  const locale = useLocale();
+
+  const bcdLink = `#${LOCALIZED_BCD_IDS[locale] || LOCALIZED_BCD_IDS["en-US"]}`;
 
   const supported = (browser: string) => {
     const version: string | boolean | undefined =
@@ -90,10 +106,7 @@ export function BaselineIndicator({ status }: { status: WebFeatureStatus }) {
             </a>
           </li>
           <li>
-            <a
-              href="#browser_compatibility"
-              data-glean={BASELINE.LINK_BCD_TABLE}
-            >
+            <a href={bcdLink} data-glean={BASELINE.LINK_BCD_TABLE}>
               See full compatibility
             </a>
           </li>


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/MP-668
https://github.com/mdn/yari/issues/9848

This isn't a complete fix: some Portuguese pages need `#compatibilidade_com_navegadores` others need `#compatibilidade_de_navegadores`, I chose the former because more pages used that. This fix does at least reduce the number of pages on which the link doesn't work.

Backported from the `baseline-next` work, so already in QA.