### PR TITLE
fix(auth-container): always show login/signup in row

### DIFF
--- a/client/src/ui/molecules/auth-container/index.scss
+++ b/client/src/ui/molecules/auth-container/index.scss
@@ -2,33 +2,40 @@
 
 .auth-container {
   display: flex;
-  flex-flow: column-reverse;
   flex-shrink: 0;
+  flex-wrap: nowrap;
   font-family: var(--font-body);
   font-size: var(--type-smaller-font-size);
   font-weight: var(--font-body-strong-weight);
-  gap: 0.5rem;
+  gap: 1rem;
   list-style: none;
-  margin-bottom: 0.5rem;
   padding: 0;
-  text-align: center;
 
   li {
     flex-shrink: 0;
   }
+}
 
-  @media screen and (min-width: $screen-lg) {
-    align-items: center;
-    flex-flow: row;
-    gap: 1rem;
-    justify-content: flex-end;
-    margin: 0;
-    text-align: initial;
-    width: min-content;
+/*.top-navigation-main {
+  .auth-container {
+    @media screen and (max-width: #{$screen-lg - 1}) {
+      align-items: center;
+      flex-flow: column-reverse;
+      gap: 0.5rem;
+      justify-content: flex-end;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
   }
+}*/
 
-  // override to fix layout in English.
-  @media screen and (min-width: 820px) {
-    width: unset;
+.top-navigation-main {
+  .auth-container {
+    @media screen and (max-width: #{$screen-lg - 1}) {
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 0.5rem;
+      text-align: center;
+    }
   }
 }

--- a/client/src/ui/molecules/auth-container/index.scss
+++ b/client/src/ui/molecules/auth-container/index.scss
@@ -16,19 +16,6 @@
   }
 }
 
-/*.top-navigation-main {
-  .auth-container {
-    @media screen and (max-width: #{$screen-lg - 1}) {
-      align-items: center;
-      flex-flow: column-reverse;
-      gap: 0.5rem;
-      justify-content: flex-end;
-      margin-bottom: 0.5rem;
-      text-align: center;
-    }
-  }
-}*/
-
 .top-navigation-main {
   .auth-container {
     @media screen and (max-width: #{$screen-lg - 1}) {

--- a/client/src/ui/molecules/auth-container/index.scss
+++ b/client/src/ui/molecules/auth-container/index.scss
@@ -21,7 +21,7 @@
     @media screen and (max-width: #{$screen-lg - 1}) {
       align-items: center;
       justify-content: center;
-      margin-bottom: 0.5rem;
+      margin-bottom: 1rem;
       text-align: center;
     }
   }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `AuthContainer` is shown as `column-reverse` on mobile, which is confusing and not desired in most contexts.

### Solution

Always show the "Log in" and "Sign up for free" buttons in a row.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="1133" alt="image" src="https://github.com/mdn/yari/assets/495429/760acbcb-c2eb-4a43-9282-fa28c534c0e6"> | <img width="1133" alt="image" src="https://github.com/mdn/yari/assets/495429/c5d45343-7937-43e2-862c-2f413aa5ff41"> |
| <img width="885" alt="image" src="https://github.com/mdn/yari/assets/495429/9282b33a-d4d9-4a8b-8581-709230fe9968"> | <img width="885" alt="image" src="https://github.com/mdn/yari/assets/495429/aaeae33b-3495-4fd1-a286-c8faf84b318b"> |
| <img width="486" alt="image" src="https://github.com/mdn/yari/assets/495429/08c8a6ea-a348-4445-99f5-cf1850e9be20"> | <img width="486" alt="image" src="https://github.com/mdn/yari/assets/495429/fccad1bc-0b34-4208-9f86-8964407a5a62"> | 

---

## How did you test this change?

Ran `yarn && yarn dev` and checked http://localhost:3000/en-US/plus/ai-help locally.