### PR TITLE
fix(document): do not break the line of the metadata

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -147,6 +147,7 @@ export function saveFile(
   fs.mkdirSync(folderPath, { recursive: true });
 
   const combined = `---\n${yaml.dump(saveMetadata, {
+    lineWidth: -1, // do not break lines
     quotingType: '"',
   })}---\n\n${rawBody.trim()}\n`;
   fs.writeFileSync(filePath, combined);


### PR DESCRIPTION
## Summary

The content sync tool will finally call the `saveFile()` function to update the metadata of documents. And it would break the line of the key/value pair in the front-matter. This default behavior [conflicts with our front-matter-linter](https://github.com/mdn/content/blob/c3be131cfd2c33822cb36b21cb4fca78980a6b4e/front-matter-config.json#L2).

> see: mdn/translated-content#17266.

### Solution

Adding the [`lineWidth`](https://www.npmjs.com/package/js-yaml#dump-object---options-) option to resolve this.

---

## How did you test this change?

Using the following script to test the option:

```js
import yaml from "js-yaml";

const options = {
  lineWidth: -1,
  quotingType: '"',
}

console.log(yaml.dump({
  // test long line which breaks into two lines in mdn/translated-content#17266
  "slug": "Web/Media/Audio_and_video_delivery/Adding_captions_and_subtitles_to_HTML5_video",
  "browser-compat": [ // test array
    "api.MessageChannel",
    "api.MessagePort"
  ]
}, options))
```
