### PR TITLE
fix(css): remove unused minmax function

### DIFF
--- a/client/src/settings/index.scss
+++ b/client/src/settings/index.scss
@@ -20,7 +20,7 @@ article.settings {
       li {
         display: grid;
         gap: 0 1rem;
-        grid-template-columns: 1fr minmax(5em);
+        grid-template-columns: 1fr 5em;
         margin: 2em 0;
 
         h3 {


### PR DESCRIPTION
## Summary

Fixes #10137

### Problem

[There’s a declaration](https://github.com/mdn/yari/blob/main/client/src/settings/index.scss#L23) with `minmax()` that’s not applied. That’s fair since it [requires two values](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax).

### Solution

Remove the function, per [suggestion](https://github.com/mdn/yari/issues/10137#issuecomment-1841228343).