### PR TITLE
chore(pong): set forwardedip/useragent on click/view requests

### DIFF
--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -53,7 +53,11 @@ export async function proxyBSA(req: Request, res: Response) {
     }
     const params = new URLSearchParams(search);
     try {
-      const { status, location } = await handleClick(params);
+      const { status, location } = await handleClick(
+        params,
+        countryCode,
+        userAgent
+      );
       if (location && (status === 301 || status === 302)) {
         return res.redirect(location);
       } else {
@@ -68,7 +72,7 @@ export async function proxyBSA(req: Request, res: Response) {
     }
     const params = new URLSearchParams(search);
     try {
-      await handleViewed(params);
+      await handleViewed(params, countryCode, userAgent);
       return res.sendStatus(201).end();
     } catch (e) {
       console.error(e);

--- a/libs/pong/pong2.d.ts
+++ b/libs/pong/pong2.d.ts
@@ -15,7 +15,9 @@ export function createPong2GetHandler(
 }>;
 
 export function createPong2ClickHandler(coder: Coder): (
-  params: URLSearchParams
+  params: URLSearchParams,
+  countryCode: string,
+  userAgent: string
 ) => Promise<{
   status: number;
   location: string;
@@ -23,4 +25,8 @@ export function createPong2ClickHandler(coder: Coder): (
 
 export function createPong2ViewedHandler(
   coder: Coder
-): (params: URLSearchParams) => Promise<void>;
+): (
+  params: URLSearchParams,
+  countryCode: string,
+  userAgent: string
+) => Promise<void>;

--- a/libs/pong/pong2.js
+++ b/libs/pong/pong2.js
@@ -114,13 +114,21 @@ export function createPong2GetHandler(zoneKeys, coder) {
 }
 
 export function createPong2ClickHandler(coder) {
-  return async (params) => {
+  return async (params, countryCode, userAgent) => {
     const click = coder.decodeAndVerify(params.get("code"));
 
     if (!click) {
       return {};
     }
-    const res = await fetch(`https:${click}`, { redirect: "manual" });
+
+    const anonymousIp = anonymousIpByCC(countryCode);
+    const clickURL = new URL(`https:${click}`);
+    clickURL.searchParams.set("forwardedip", anonymousIp);
+    clickURL.searchParams.set("useragent", userAgent);
+
+    const res = await fetch(clickURL, {
+      redirect: "manual",
+    });
     const status = res.status;
     const location = res.headers.get("location");
     return { status, location };
@@ -128,10 +136,15 @@ export function createPong2ClickHandler(coder) {
 }
 
 export function createPong2ViewedHandler(coder) {
-  return async (params) => {
+  return async (params, countryCode, userAgent) => {
     const view = coder.decodeAndVerify(params.get("code"));
     if (view) {
-      await fetch(`https:${view}`, {
+      const anonymousIp = anonymousIpByCC(countryCode);
+      const viewURL = new URL(`https:${view}`);
+      viewURL.searchParams.set("forwardedip", anonymousIp);
+      viewURL.searchParams.set("useragent", userAgent);
+
+      await fetch(viewURL, {
         redirect: "manual",
       });
     }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We don't send the `forwardedip` (anonymous IP representing the user's country) and `useragent` parameters on click and view requests, but BSA requires this.

### Solution

Set the `forwardedip` and `useragent` parameters also on the click and view URLs.

---

## How did you test this change?

BSA will test this change on stage.
