### PR TITLE
chore(macros/secureContext_inline): replace notecard with badge

### DIFF
--- a/kumascript/macros/secureContext_inline.ejs
+++ b/kumascript/macros/secureContext_inline.ejs
@@ -22,4 +22,4 @@ var str_tooltip = mdn.localString({
 });
 %>
 
-<span class="notecard inline secure" title="<%-str_tooltip%>"><%-str_title%></span>
+<span class="badge inline secure" title="<%-str_tooltip%>"><%-str_title%></span>

--- a/kumascript/macros/secureContext_inline.ejs
+++ b/kumascript/macros/secureContext_inline.ejs
@@ -20,4 +20,4 @@ var str_tooltip = mdn.localString({
 });
 %>
 
-<span class="badge inline secure" title="<%-str_tooltip%>"><%-str_title%></span>
+<span class="badge inline secure" title="<%= str_tooltip %>"><%= str_title %></span>

--- a/kumascript/macros/secureContext_inline.ejs
+++ b/kumascript/macros/secureContext_inline.ejs
@@ -1,9 +1,7 @@
 <%
 // Macro for inserting an inline secure context notice, i.e. to mark a
-// feature as only available on secure contexts. See the following page:
+// feature as only available in secure contexts. See the following page:
 // https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
-
-var lang = env.locale;
 
 var str_title = mdn.localString({
   "en-US": "Secure context",


### PR DESCRIPTION
## Summary
`{{securecontext_inline}}` uses an ugly notecard class. As we decided to continue using it in the foreseeable future, in https://github.com/orgs/mdn/discussions/482#discussioncomment-7825014., we need to get it more standard.

### Problem

The `notecard` class is not suitable for a badge.

### Solution

Switch to use the already existing `badge`class.
## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->
![Capture d’écran 2023-12-21 à 09 49 23](https://github.com/mdn/yari/assets/1466293/6add8c8d-b0b4-41e6-a877-f798c4e1a18a)

### After

<!-- Replace this line with your screenshot (or video). -->
![Capture d’écran 2023-12-21 à 09 51 06](https://github.com/mdn/yari/assets/1466293/a464f5ca-1341-4076-b99d-edd8e3244740)

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
Locally (and I needed it for the screenshots)
