### PR TITLE
chore(macros/WebExtAllCompatTables): replace {{Compat}} call

### DIFF
--- a/kumascript/macros/WebExtAllCompatTables.ejs
+++ b/kumascript/macros/WebExtAllCompatTables.ejs
@@ -21,8 +21,10 @@ var featureList = Object.keys(features).sort();
 var output = '';
 
 for (featureName of featureList) {
-  output += `<h2>${featureName}</h2>`;
-  output += await template("compat", [`webextensions.api.${featureName}`, 2, true]);
+  output += `<h2>${featureName}</h2>
+  <div class="bc-data" data-query="webextensions.api.${featureName}" data-depth="2" data-multiple="false">
+    If you're able to see this, something went wrong on this page.
+  </div>`;
 }
 
 %>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

We deprecated the parameter of `{{Compat}}` years ago.

To actually remove it and simplify the codebase, we need to get rid of its only call (with a parameter) from yari. 
### Problem

We cannot remove the (almost dead) code in `{{Compat}}`

### Solution

Hardcode (two lines) the generation of the HTML directly into `{{WebExtAllCompatTables}}`.
---

## Screenshots

No Change (Verified locally)
---

## How did you test this change?
Tested locally.
