### PR TITLE
fix(macros/CSS_Ref): fix special cases

### DIFF
--- a/kumascript/macros/CSS_Ref.ejs
+++ b/kumascript/macros/CSS_Ref.ejs
@@ -394,6 +394,7 @@ for (let i in characters) {
         let item = index[characters[i]][j];
 
         switch (item.label) {
+            // Add alternate name for pseudo-elements (one colon)
             case "::after":
             case "::before":
             case "::first-letter":
@@ -401,8 +402,10 @@ for (let i in characters) {
                 item.label += ` (${item.label.replace(/^:/, "")})`;
                 break;
 
+            // Font-feature-values
             case "@annotation":
             case "@character-variant":
+            case "@historical-forms":
             case "@ornaments":
             case "@styleset":
             case "@stylistic":
@@ -410,6 +413,7 @@ for (let i in characters) {
                 item.urlPath = `@font-feature-values#${item.label}`;
                 break;
 
+            // Font-variant-alternates
             case "annotation()":
             case "character-variant()":
             case "ornaments()":
@@ -419,18 +423,17 @@ for (let i in characters) {
                 item.urlPath = `font-variant-alternates#${item.label}`;
                 break;
 
-            case "format()":
-                item.urlPath = "@font-face/src#format()";
-                break;
 
+            // Image
             case "image()":
                 item.urlPath = "image#The_image()_functional_notation";
                 break;
-
-            case "url()":
-                item.urlPath = "url#The_url()_functional_notation";
+            case "image-set()":
+            case "paint()":
+                item.urlPath = `image/${item.label.replace("()", "")}`;
                 break;
 
+            // Filter
             case "blur()":
             case "brightness()":
             case "contrast()":
@@ -444,6 +447,7 @@ for (let i in characters) {
                 item.urlPath = `filter-function/${item.label.replace("()", "")}`;
                 break;
 
+            // Transforms
             case "matrix()":
             case "matrix3d()":
             case "perspective()":
@@ -468,24 +472,46 @@ for (let i in characters) {
                 item.urlPath = `transform-function/${item.label.replace("()", "")}`;
                 break;
 
+            // Colors
+            case "rgba()": // Still valid but alternative name for rgb()
+                item.urlPath = "color_value/rgb";
+                break;
+            case "hsla()": // Still valid but alternative name for hsl()
+                item.urlPath = "color_value/hsl";
+                break;
             case "rgb()":
-            case "rgba()":
             case "hsl()":
-            case "hsla()":
-                item.urlPath = `color_value#${item.label}`;
+            case "hwb()":
+            case "lab()":
+            case "lch()":
+            case "light-dark()":
+            case "oklab()":
+            case "oklch()":
+                item.urlPath = `color_value/${item.label.replace("()", "")}`;
                 break;
 
+            // Gradients
+            case "conic-gradient()":
+            case "linear-gradient()":
+            case "radial-gradient()":
+            case "repeating-conic-gradient()":
+            case "repeating-linear-gradient()":
+            case "repeating-radial-gradient()":
+                item.urlPath = `gradient/${item.label.replace("()", "")}`;
+                break;
+
+            // Shapes
             case "inset()":
             case "polygon()":
             case "circle()":
             case "ellipse()":
                 item.urlPath = `basic-shape#${item.label}`;
                 break;
-
             case "rect()":
                 item.urlPath = `shape#${item.label}`;
                 break;
 
+            // @page
             case "@top-left-corner":
             case "@top-left":
             case "@top-center":
@@ -505,10 +531,37 @@ for (let i in characters) {
                 item.urlPath = "@page#page-margin-box-type";
                 break;
 
+            // Easing functions
             case "cubic-bezier()":
-            case "frames()":
+                item.urlPath = "easing-function#cubic_bézier_easing_function";
+                break;
+            case "linear()":
+                item.urlPath = "easing-function#linear_easing_function";
+                break;
             case "steps()":
-                item.urlPath = `single-transition-timing-function#${item.label}`;
+                item.urlPath = `easing-function#steps_easing_function`;
+                break;
+
+            // Alternate name
+            case "word-wrap":
+                item.urlPath = "overflow-wrap";
+                break;
+            case "line-clamp": // Nobody implements it under this name
+                item.urlPath = "-webkit-line-clamp"
+                break;
+
+            // Misc
+            case "view()":
+                item.urlPath = "animation-timeline/view";
+                break;
+            case ":host()":
+                item.urlPath = ":host_function"
+                break;
+            case "format()":
+                item.urlPath = "@font-face/src#format()";
+                break;
+            case "url()":
+                item.urlPath = "url#The_url()_functional_notation";
                 break;
         }
     }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
`{{CSS_Ref}}`  creates an index of CSS features at https://developer.mozilla.org/en-US/docs/Web/CSS/Reference. It takes data from mdn/data and has some hardcoded "exceptions".

Over the years, this list got outdated: some new exceptions are missing, and some old ones need to be updated.

### Problem

Links generated by CSS_Ref are sometimes incorrect. This PR fixes those that can be fixed. Note that mdn/data#697 removed abandoned values.

### Solution
Updated the exception list.

## Screenshots

No change in UI

### Before:
![Capture d’écran 2023-12-28 à 12 43 29](https://github.com/mdn/yari/assets/1466293/aa1f7db1-8e08-407d-b44b-5b86174d2a83)

### After
![Capture d’écran 2023-12-28 à 12 43 22](https://github.com/mdn/yari/assets/1466293/4e96a20f-27d6-4b8d-934b-15cafe519fc4)

**Note:** more message will be removed once mdn/data#697 is in prod. (the remaining ones are missing pages)

## How did you test this change?

Locally, clicking on the links I changed to test them.


Note: One day, we will sever the connection to mdn/data (and likely use `page-type:` to select an entry if we keep the macro at all.
