### PR TITLE
fix(macro): update CSSRef macro

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -91,7 +91,6 @@ const text = mdn.localStringMap({
         'Controlling_flex_item_ratios': 'Controlling flex item ratios',
         'Mastering_wrapping_of_flex_items': 'Mastering wrapping of flex items',
         'Typical_use_cases_of_Flexbox': 'Typical use cases of Flexbox',
-        'Backwards_compatibility_of_Flexbox': 'Backwards compatibility of Flexbox',
       'Flow_layout': 'Flow layout',
         'Block_and_Inline_layout_in_normal_flow': 'Block and Inline layout in normal flow',
         'In_flow_and_Out_of_flow': 'In flow and Out of flow',
@@ -244,7 +243,6 @@ const text = mdn.localStringMap({
         'Controlling_flex_item_ratios': 'Contrôler les proportions des objets flexibles',
         'Mastering_wrapping_of_flex_items': 'Maîtriser le retour à la ligne des objets flexibles',
         'Typical_use_cases_of_Flexbox': 'Cas d\'usage caractéristiques des boîtes flexibles',
-        'Backwards_compatibility_of_Flexbox': 'Rétrocompatibilité des boîtes flexibles',
       'Flow_layout': 'Disposition de flux',
         'Block_and_Inline_layout_in_normal_flow': 'Disposition de bloc et en ligne avec le flux normal',
         'In_flow_and_Out_of_flow': 'Dans le flux et en dehors',
@@ -444,7 +442,6 @@ const text = mdn.localStringMap({
         'Controlling_flex_item_ratios': '항목 비율 설정하기',
         'Mastering_wrapping_of_flex_items': '항목 wrapping 정복하기',
         'Typical_use_cases_of_Flexbox': '플렉스박스 적용 사례',
-        'Backwards_compatibility_of_Flexbox': '플렉스박스의 하위 호환성',
       'Flow_layout': '플로 레이아웃',
         'Block_and_Inline_layout_in_normal_flow': '일반 대열 속 블록 및 인라인 레이아웃',
         'In_flow_and_Out_of_flow': '대열과 탈대열',
@@ -644,7 +641,6 @@ const text = mdn.localStringMap({
         'Controlling_flex_item_ratios': 'Управление соотношением элементов вдоль главной оси',
         'Mastering_wrapping_of_flex_items': 'Разбираемся с обёртыванием флекс-элементов',
         'Typical_use_cases_of_Flexbox': 'Типовые варианты использования флексбокса',
-        'Backwards_compatibility_of_Flexbox': 'Обратная совместимость флексбокс',
       'Flow_layout': 'Потоковая раскладка',
         'Block_and_Inline_layout_in_normal_flow': 'Блочная и последовательная раскладка в базовом потоке',
         'In_flow_and_Out_of_flow': 'В потоке и вне потока',
@@ -800,7 +796,6 @@ const text = mdn.localStringMap({
         'Controlling_flex_item_ratios': '控制弹性盒子元素在主轴上的比例',
         'Mastering_wrapping_of_flex_items': '包装弹性盒布局中的元素',
         'Typical_use_cases_of_Flexbox': '经典的弹性盒布局示例',
-        'Backwards_compatibility_of_Flexbox': '弹性盒布局的向下兼容性',
       'Flow_layout': '流式布局',
         'Block_and_Inline_layout_in_normal_flow': '一般的流式布局中的块式和行式布局',
         'In_flow_and_Out_of_flow': '应用或脱离流式布局',
@@ -1281,7 +1276,6 @@ async function buildPropertylist(pages, title) {
             <li><%-smartLink(`${cssURL}CSS_Flexible_Box_Layout/Controlling_ratios_of_flex_items_along_the_main_axis`, null, text['Controlling_flex_item_ratios'], cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items`, null, text['Mastering_wrapping_of_flex_items'], cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox`, null, text['Typical_use_cases_of_Flexbox'], cssURL)%></li>
-            <li><%-smartLink(`${cssURL}CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox`, null, text['Backwards_compatibility_of_Flexbox'], cssURL)%></li>
           </ol>
       </details>
   </li>


### PR DESCRIPTION
- completes https://github.com/mdn/content/pull/31630

`Backwards_compatibility_of_Flexbox` page has been removed from `mdn/content`.