### PR TITLE
enhance(breadcrumbs): show current and parent (not root) on mobile + add padding

### DIFF
--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -6,7 +6,11 @@
   margin-right: auto;
 
   ol {
+    display: flex;
+    flex-wrap: wrap;
     line-height: 1.2;
+    padding: 0.25rem 0;
+    row-gap: 0.25rem;
   }
 
   li {

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -6,15 +6,11 @@
   margin-right: auto;
 
   ol {
-    display: flex;
-    flex-wrap: wrap;
     line-height: 1.2;
-    padding-top: 0.375rem;
   }
 
   li {
     display: none;
-    padding-bottom: 0.375rem;
     hyphens: auto;
     // only show last two items on small sizes (size < 426px)
     &:nth-last-child(-n + 2) {
@@ -66,7 +62,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-sm) {
+  @media screen and (min-width: $screen-xl) {
     li {
       display: inline-flex;
     }

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -9,12 +9,12 @@
     display: flex;
     flex-wrap: wrap;
     line-height: 1.2;
-    padding-top: 6px;
+    padding-top: 0.375rem;
   }
 
   li {
     display: none;
-    padding-bottom: 6px;
+    padding-bottom: 0.375rem;
     hyphens: auto;
     // only show last two items on small sizes (size < 426px)
     &:nth-last-child(-n + 2) {

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -12,6 +12,7 @@
   li {
     display: none;
     hyphens: auto;
+
     // only show last two items on small sizes (size < 426px)
     &:nth-last-child(-n + 2) {
       display: inline-flex;

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -6,11 +6,15 @@
   margin-right: auto;
 
   ol {
+    display: flex;
+    flex-wrap: wrap;
     line-height: 1.2;
+    padding-top: 6px;
   }
 
   li {
     display: none;
+    padding-bottom: 6px;
     // only show last two items on small sizes (size < 426px)
     &:nth-last-child(-n + 2) {
       display: inline-flex;

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -15,6 +15,7 @@
   li {
     display: none;
     padding-bottom: 6px;
+    hyphens: auto;
     // only show last two items on small sizes (size < 426px)
     &:nth-last-child(-n + 2) {
       display: inline-flex;

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -17,7 +17,7 @@
     display: none;
     hyphens: auto;
 
-    // only show last two items on small sizes (size < 426px)
+    // only show last two items on mobile
     &:nth-last-child(-n + 2) {
       display: inline-flex;
     }

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -11,11 +11,8 @@
 
   li {
     display: none;
-    hyphens: auto;
-
-    // only show first and last on mobile
-    &:first-child,
-    &:last-child {
+    // only show last two items on small sizes (size < 426px)
+    &:nth-last-child(-n + 2) {
       display: inline-flex;
     }
 

--- a/client/src/ui/molecules/breadcrumbs/index.scss
+++ b/client/src/ui/molecules/breadcrumbs/index.scss
@@ -61,7 +61,7 @@
     }
   }
 
-  @media screen and (min-width: $screen-xl) {
+  @media screen and (min-width: $screen-sm) {
     li {
       display: inline-flex;
     }


### PR DESCRIPTION
## Summary
Just a proposal from a user frequently using the app on mobile.
I found it better to show the previous nav item instead of the root for ex:
" Array> Array.prototype.slice() " instead of "References > Array.prototype.slice()"

Also, it handles breadcrumbs wrapped layout.

In addition to that, it shows the last two items only in small sizes.

Fixes #10385
(No longer fixes #8250,  #8627)

### Problem

Navbar shows 2 elements in small sizes ("root element", and "current page") and I just found the "root element" not needed by the user unlike the "parent of the current page"

Navbar not handling wrapped layouts.

Navbar shows 2 elements on a wide screen sizes where other items can be shown

### Solution

I suggest to replace the "root element" with the "parent of the current page"  so that we can provide the users with better experience in my opinion 

handle wrapped layouts by adding spaces between breadcrumbs items

show 2 elements only in small sizes 

## Screenshots

### Before

1- root and last items
![Screenshot 2024-01-25 105448](https://github.com/mdn/yari/assets/65634467/e97aefdd-1eb6-4430-8dae-acea7253ccb3)

2- wrapped layout with no space
![Screenshot 2024-01-27 064941](https://github.com/mdn/yari/assets/65634467/ceaa95e3-3990-4f90-9a21-8e5f64a721b8)

3- show 2 items even in wide screens
![Screenshot 2024-01-27 064819](https://github.com/mdn/yari/assets/65634467/f162d5fc-ecb3-4827-9716-75527b3edbf6)

### After

1-last two items
![image](https://github.com/mdn/yari/assets/65634467/f623dfe7-241a-4b74-837b-10bc3b9f3e72)

2-wrapped layout with space
![Screenshot 2024-01-27 064720](https://github.com/mdn/yari/assets/65634467/d8707c91-1bd7-4831-a7d6-680ae6e16c7c)

3-show 2 items in small screens only (size < 426px)
![Screenshot 2024-01-27 064751](https://github.com/mdn/yari/assets/65634467/5d813e2c-e74b-4e41-9406-0b6a4d97d476)
