### PR TITLE
fix(playground): only show for js,css,html

### DIFF
--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -137,6 +137,13 @@ export function addCollectButton(
     return;
   }
   if (!element || element.querySelector(".play-button")) return;
+  if (
+    [...(element.nextElementSibling?.classList.values() || [])].filter((c) =>
+      ["js", "javascript", "css", "html"].includes(c)
+    ).length === 0
+  ) {
+    return;
+  }
   const checkId = crypto.randomUUID();
   const playlist = document.createElement("div");
   playlist.classList.add("playlist");


### PR DESCRIPTION
## Summary

Only add the play and queue button to js, css and html code blocks.


### Problem

Button appear on bash code blocks.

### Solution

Restrict them to JS, CSS and HTML

---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/3604775/6fd35a9b-34b2-4479-b45b-0a3c131eb6e6)

### After

![image](https://github.com/mdn/yari/assets/3604775/87b7ad1c-6b1c-4d86-92f2-b3b9331ba8ef)


