### PR TITLE
fix(history): show outline on focus-visible

### DIFF
--- a/client/src/plus/ai-help/history.scss
+++ b/client/src/plus/ai-help/history.scss
@@ -106,6 +106,11 @@
             overflow: hidden;
             white-space: nowrap;
             width: 100%;
+
+            &:focus-visible {
+              mask-image: initial;
+              text-overflow: ellipsis;
+            }
           }
 
           &.ai-help-history-active {


### PR DESCRIPTION
## Summary

The mask-image was hiding the outline.
Let's use ellipsis instead when focus-visible.

---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/3604775/c02ffa8e-8e12-498f-8886-31effe56a101)


### After

![image](https://github.com/mdn/yari/assets/3604775/e4edfe0b-b32c-4bf1-8c24-f163985c0abc)

---

## How did you test this change?

Locally
