### PR TITLE
fix(ai-help): don't allow empty questions

### DIFF
--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -167,7 +167,7 @@ function AIHelpUserQuestion({
         onKeyDown={(event) => {
           if (event.key === "Enter" && !event.shiftKey) {
             event.preventDefault();
-            if (canEdit && question) {
+            if (canEdit && question?.trim()) {
               gleanClick(`${AI_HELP}: edit submit`);
               setEditing(false);
               submit(

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -154,7 +154,7 @@ function AIHelpUserQuestion({
       className="ai-help-input-form"
       onSubmit={(event) => {
         event.preventDefault();
-        if (canEdit && question) {
+        if (canEdit && question?.trim()) {
           gleanClick(`${AI_HELP}: edit submit`);
           setEditing(false);
           submit(question, message.chatId, message.parentId, message.messageId);
@@ -205,7 +205,7 @@ function AIHelpUserQuestion({
               icon="send"
               buttonType="submit"
               title="Submit question"
-              isDisabled={!question}
+              isDisabled={!question.trim()}
             >
               <span className="visually-hidden">Submit question</span>
             </Button>
@@ -803,7 +803,7 @@ export function AIHelpInner() {
                           icon="send"
                           buttonType="submit"
                           title="Submit question"
-                          isDisabled={!query}
+                          isDisabled={!query.trim()}
                         >
                           <span className="visually-hidden">
                             Submit question


### PR DESCRIPTION
## Summary

Don't allow empty (or only white space) questions when editing a question and disable the submit button if empty / only white space. 

