### PR TITLE
fix(baseline): hide status from async-clipboard subfeatures

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -568,7 +568,28 @@ export async function buildDocument(
 
 function addBaseline(doc: Partial<Doc>) {
   if (doc.browserCompat) {
-    return getWebFeatureStatus(...doc.browserCompat);
+    const filteredBrowserCompat = doc.browserCompat.filter(
+      (query) =>
+        // temporary blocklist while we wait for per-key baseline statuses
+        // or another solution to the baseline/bcd table discrepancy problem
+        ![
+          "api.Clipboard.read",
+          "api.Clipboard.readText",
+          "api.Clipboard.write",
+          "api.Clipboard.writeText",
+          "api.ClipboardEvent",
+          "api.ClipboardEvent.ClipboardEvent",
+          "api.ClipboardEvent.clipboardData",
+          "api.ClipboardItem",
+          "api.ClipboardItem.ClipboardItem",
+          "api.ClipboardItem.getType",
+          "api.ClipboardItem.presentationStyle",
+          "api.ClipboardItem.types",
+          "api.Navigator.clipboard",
+          "api.Permissions.permission_clipboard-read",
+        ].includes(query)
+    );
+    return getWebFeatureStatus(...filteredBrowserCompat);
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

See: https://github.com/web-platform-dx/web-features/issues/495

### Problem

Showing the Baseline widget for the overall `async-clipboard` feature group on some pages that belong to that group has confused users, as there appears to be a discrepancy between the "not baseline" status, and an all-green bcd table, e.g. on https://developer.mozilla.org/en-US/docs/Web/API/ClipboardEvent/clipboardData

### Solution

While we find a solution to this wider problem upstream, hide the widget on the problematic pages. For now that's, all clipboard pages other than the overview pages:
- https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
- https://developer.mozilla.org/en-US/docs/Web/API/Clipboard

---

## Screenshots

As an example, there's many more pages affected:

### Before

![image](https://github.com/mdn/yari/assets/755354/5c218924-dbe9-4437-abd2-462e02d17f73)

### After

![image](https://github.com/mdn/yari/assets/755354/2aa4994a-193c-4f91-b2e9-6516e346fbb5)

---

## How did you test this change?

Visited, and still saw a "limited availability" status:
- http://localhost:3000/en-US/docs/Web/API/Clipboard_API
- http://localhost:3000/en-US/docs/Web/API/Clipboard

Visited, and now saw no status:
- http://localhost:3000/en-US/docs/Web/API/Clipboard/read
- http://localhost:3000/en-US/docs/Web/API/Clipboard/readText
- http://localhost:3000/en-US/docs/Web/API/Clipboard/write
- http://localhost:3000/en-US/docs/Web/API/Clipboard/writeText
- http://localhost:3000/en-US/docs/Web/API/ClipboardEvent
- http://localhost:3000/en-US/docs/Web/API/ClipboardEvent/ClipboardEvent
- http://localhost:3000/en-US/docs/Web/API/ClipboardEvent/clipboardData
- http://localhost:3000/en-US/docs/Web/API/Navigator/clipboard
- etc.
