### PR TITLE
fix(ai-help): example header highlighting

### DIFF
--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -126,11 +126,14 @@ export function collectCode(input?: HTMLInputElement): EditorContent {
   };
 }
 
-export function highlight(header: Element, highlightedExample: string | null) {
-  // highlight the header if it's the one we're mouse-overing
-  // on the corresponding item in the queue
+export function highlight(
+  header: Element,
+  highlightedQueueExample: string | null
+) {
+  // Highlight the header if it's the one we're mouse-overing
+  // on the corresponding item in the queue.
   const id = header.querySelector('[type="checkbox"]')?.id;
-  if (highlightedExample === id) {
+  if (highlightedQueueExample === id) {
     header.classList.add("active");
   } else {
     header.classList.remove("active");

--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -126,6 +126,20 @@ export function collectCode(input?: HTMLInputElement): EditorContent {
   };
 }
 
+export function highlight(
+  header: Element,
+  highlightedExample: string | null
+) {
+  // highlight the header if it's the one we're mouse-overing 
+  // on the corresponding item in the queue
+  const id = header.querySelector('[type="checkbox"]')?.id;
+  if (highlightedExample === id) {
+    header.classList.add("active");
+  } else {
+    header.classList.remove("active");
+  }
+}
+
 export function addCollectButton(
   element: Element | null,
   id: string,

--- a/client/src/document/code/playground.ts
+++ b/client/src/document/code/playground.ts
@@ -126,11 +126,8 @@ export function collectCode(input?: HTMLInputElement): EditorContent {
   };
 }
 
-export function highlight(
-  header: Element,
-  highlightedExample: string | null
-) {
-  // highlight the header if it's the one we're mouse-overing 
+export function highlight(header: Element, highlightedExample: string | null) {
+  // highlight the header if it's the one we're mouse-overing
   // on the corresponding item in the queue
   const id = header.querySelector('[type="checkbox"]')?.id;
   if (highlightedExample === id) {

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -9,8 +9,10 @@ import {
   addCollectButton,
   getCodeAndNodesForIframe,
   getCodeAndNodesForIframeBySampleClass,
+  highlight,
 } from "./code/playground";
 import { addCopyToClipboardButton } from "./code/copy";
+import { useUIStatus } from "../ui-context";
 
 export function useDocumentURL() {
   const locale = useLocale();
@@ -25,6 +27,8 @@ export function useDocumentURL() {
 export function useCollectSample(doc: any) {
   const isServer = useIsServer();
   const locale = useLocale();
+  const { highlightedExample } = useUIStatus();
+
 
   useEffect(() => {
     if (isServer) {
@@ -40,8 +44,9 @@ export function useCollectSample(doc: any) {
       )
       .forEach((header) => {
         addCollectButton(header, "collect", locale);
+        highlight(header, highlightedExample);
       });
-  }, [doc, isServer, locale]);
+  }, [doc, isServer, locale, highlightedExample]);
 }
 
 export function useRunSample(doc: Doc | undefined) {

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -29,7 +29,6 @@ export function useCollectSample(doc: any) {
   const locale = useLocale();
   const { highlightedExample } = useUIStatus();
 
-
   useEffect(() => {
     if (isServer) {
       return;

--- a/client/src/document/hooks.ts
+++ b/client/src/document/hooks.ts
@@ -27,7 +27,7 @@ export function useDocumentURL() {
 export function useCollectSample(doc: any) {
   const isServer = useIsServer();
   const locale = useLocale();
-  const { highlightedExample } = useUIStatus();
+  const { highlightedQueueExample } = useUIStatus();
 
   useEffect(() => {
     if (isServer) {
@@ -43,9 +43,9 @@ export function useCollectSample(doc: any) {
       )
       .forEach((header) => {
         addCollectButton(header, "collect", locale);
-        highlight(header, highlightedExample);
+        highlight(header, highlightedQueueExample);
       });
-  }, [doc, isServer, locale, highlightedExample]);
+  }, [doc, isServer, locale, highlightedQueueExample]);
 }
 
 export function useRunSample(doc: Doc | undefined) {

--- a/client/src/playground/queue/index.tsx
+++ b/client/src/playground/queue/index.tsx
@@ -19,14 +19,18 @@ function PQEntry({
   unqueue: () => void;
 }) {
   const gleanClick = useGleanClick();
+  const { setHighlightedExample } = useUIStatus();
   const getHeader = () => {
     const element = document.getElementById(id);
     return element?.parentElement?.parentElement;
   };
   const setActive = (value: boolean) => {
-    const header = getHeader();
-    if (header instanceof HTMLElement) {
-      header.classList.toggle("active", value);
+    if (setHighlightedExample) {
+      if (value) {
+        setHighlightedExample(id);
+      } else {
+        setHighlightedExample(null);
+      }
     }
   };
   const intoView = () => {
@@ -39,8 +43,8 @@ function PQEntry({
   return (
     <li
       key={key}
-      onMouseOver={() => setActive(true)}
-      onMouseOut={() => setActive(false)}
+      onMouseEnter={() => setActive(true)}
+      onMouseLeave={() => setActive(false)}
     >
       <button
         className="queue-ref"

--- a/client/src/playground/queue/index.tsx
+++ b/client/src/playground/queue/index.tsx
@@ -19,17 +19,17 @@ function PQEntry({
   unqueue: () => void;
 }) {
   const gleanClick = useGleanClick();
-  const { setHighlightedExample } = useUIStatus();
+  const { setHighlightedQueueExample } = useUIStatus();
   const getHeader = () => {
     const element = document.getElementById(id);
     return element?.parentElement?.parentElement;
   };
   const setActive = (value: boolean) => {
-    if (setHighlightedExample) {
+    if (setHighlightedQueueExample) {
       if (value) {
-        setHighlightedExample(id);
+        setHighlightedQueueExample(id);
       } else {
-        setHighlightedExample(null);
+        setHighlightedQueueExample(null);
       }
     }
   };

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -401,7 +401,11 @@ function AIHelpAssistantResponse({
                 sample += 1;
                 return (
                   <div className="code-example">
-                    <div className={`example-header play-collect ${highlightedExample === id ? 'active' : ''}`}>
+                    <div
+                      className={`example-header play-collect ${
+                        highlightedExample === id ? "active" : ""
+                      }`}
+                    >
                       <span className="language-name">{code}</span>
                       {message.status === MessageStatus.Complete &&
                         ["html", "js", "javascript", "css"].includes(

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -284,6 +284,7 @@ function AIHelpAssistantResponse({
 }) {
   const gleanClick = useGleanClick();
   const locale = useLocale();
+  const { highlightedExample } = useUIStatus();
 
   let sample = 0;
 
@@ -400,7 +401,7 @@ function AIHelpAssistantResponse({
                 sample += 1;
                 return (
                   <div className="code-example">
-                    <div className="example-header play-collect">
+                    <div className={`example-header play-collect ${highlightedExample === id ? 'active' : ''}`}>
                       <span className="language-name">{code}</span>
                       {message.status === MessageStatus.Complete &&
                         ["html", "js", "javascript", "css"].includes(
@@ -517,7 +518,7 @@ export function AIHelpInner() {
   const footerRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState("");
   const [showDisclaimer, setShowDisclaimer] = useState(false);
-  const { queuedExamples, setQueue } = useUIStatus();
+  const { queuedExamples, setQueue, setHighlightedExample } = useUIStatus();
   const { hash } = useLocation();
   const gleanClick = useGleanClick();
   const user = useUserData();
@@ -718,6 +719,7 @@ export function AIHelpInner() {
                           gleanClick(`${AI_HELP}: topic new`);
                           setQuery("");
                           setQueue([]);
+                          setHighlightedExample(null);
                           reset();
                           window.setTimeout(() => window.scrollTo(0, 0));
                         }}

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -284,7 +284,7 @@ function AIHelpAssistantResponse({
 }) {
   const gleanClick = useGleanClick();
   const locale = useLocale();
-  const { highlightedExample } = useUIStatus();
+  const { highlightedQueueExample } = useUIStatus();
 
   let sample = 0;
 
@@ -403,7 +403,7 @@ function AIHelpAssistantResponse({
                   <div className="code-example">
                     <div
                       className={`example-header play-collect ${
-                        highlightedExample === id ? "active" : ""
+                        highlightedQueueExample === id ? "active" : ""
                       }`}
                     >
                       <span className="language-name">{code}</span>
@@ -522,7 +522,8 @@ export function AIHelpInner() {
   const footerRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState("");
   const [showDisclaimer, setShowDisclaimer] = useState(false);
-  const { queuedExamples, setQueue, setHighlightedExample } = useUIStatus();
+  const { queuedExamples, setQueue, setHighlightedQueueExample } =
+    useUIStatus();
   const { hash } = useLocation();
   const gleanClick = useGleanClick();
   const user = useUserData();
@@ -723,7 +724,7 @@ export function AIHelpInner() {
                           gleanClick(`${AI_HELP}: topic new`);
                           setQuery("");
                           setQueue([]);
-                          setHighlightedExample(null);
+                          setHighlightedQueueExample(null);
                           reset();
                           window.setTimeout(() => window.scrollTo(0, 0));
                         }}

--- a/client/src/ui-context.tsx
+++ b/client/src/ui-context.tsx
@@ -13,8 +13,8 @@ interface UIStatus {
   queuedExamples: Set<string>;
   queue: QueueEntry[];
   setQueue: React.Dispatch<React.SetStateAction<QueueEntry[]>>;
-  highlightedExample: null | string;
-  setHighlightedExample: (value: string | null) => void;
+  highlightedQueueExample: null | string;
+  setHighlightedQueueExample: (value: string | null) => void;
 }
 
 export enum Overlay {
@@ -34,8 +34,8 @@ const UIContext = React.createContext<UIStatus>({
   queuedExamples: new Set<string>(),
   queue: [],
   setQueue: () => {},
-  highlightedExample: null,
-  setHighlightedExample: () => {},
+  highlightedQueueExample: null,
+  setHighlightedQueueExample: () => {},
 });
 
 export function UIProvider(props: any) {
@@ -48,9 +48,9 @@ export function UIProvider(props: any) {
   );
   const [queuedExamples, setQueuedExamples] = useState<Set<string>>(new Set());
   const [queue, setQueue] = useState<QueueEntry[]>([]);
-  const [highlightedExample, setHighlightedExample] = useState<string | null>(
-    null
-  );
+  const [highlightedQueueExample, setHighlightedQueueExample] = useState<
+    string | null
+  >(null);
 
   const toggleMobileOverlay = useCallback(
     (overlay: Overlay, shown?: boolean) => {
@@ -124,8 +124,8 @@ export function UIProvider(props: any) {
         queuedExamples,
         queue,
         setQueue,
-        highlightedExample,
-        setHighlightedExample,
+        highlightedQueueExample: highlightedQueueExample,
+        setHighlightedQueueExample: setHighlightedQueueExample,
       }}
     >
       {props.children}

--- a/client/src/ui-context.tsx
+++ b/client/src/ui-context.tsx
@@ -13,8 +13,8 @@ interface UIStatus {
   queuedExamples: Set<string>;
   queue: QueueEntry[];
   setQueue: React.Dispatch<React.SetStateAction<QueueEntry[]>>;
-  highlightedExample: null | string,
-  setHighlightedExample: (value: string | null) => void,
+  highlightedExample: null | string;
+  setHighlightedExample: (value: string | null) => void;
 }
 
 export enum Overlay {
@@ -33,9 +33,9 @@ const UIContext = React.createContext<UIStatus>({
   setColorScheme: () => {},
   queuedExamples: new Set<string>(),
   queue: [],
-  setQueue: () => { },
+  setQueue: () => {},
   highlightedExample: null,
-  setHighlightedExample: () => { },
+  setHighlightedExample: () => {},
 });
 
 export function UIProvider(props: any) {
@@ -48,7 +48,9 @@ export function UIProvider(props: any) {
   );
   const [queuedExamples, setQueuedExamples] = useState<Set<string>>(new Set());
   const [queue, setQueue] = useState<QueueEntry[]>([]);
-  const [highlightedExample, setHighlightedExample] = useState<string | null>(null);
+  const [highlightedExample, setHighlightedExample] = useState<string | null>(
+    null
+  );
 
   const toggleMobileOverlay = useCallback(
     (overlay: Overlay, shown?: boolean) => {
@@ -123,7 +125,7 @@ export function UIProvider(props: any) {
         queue,
         setQueue,
         highlightedExample,
-        setHighlightedExample
+        setHighlightedExample,
       }}
     >
       {props.children}

--- a/client/src/ui-context.tsx
+++ b/client/src/ui-context.tsx
@@ -13,6 +13,8 @@ interface UIStatus {
   queuedExamples: Set<string>;
   queue: QueueEntry[];
   setQueue: React.Dispatch<React.SetStateAction<QueueEntry[]>>;
+  highlightedExample: null | string,
+  setHighlightedExample: (value: string | null) => void,
 }
 
 export enum Overlay {
@@ -31,7 +33,9 @@ const UIContext = React.createContext<UIStatus>({
   setColorScheme: () => {},
   queuedExamples: new Set<string>(),
   queue: [],
-  setQueue: () => {},
+  setQueue: () => { },
+  highlightedExample: null,
+  setHighlightedExample: () => { },
 });
 
 export function UIProvider(props: any) {
@@ -44,6 +48,7 @@ export function UIProvider(props: any) {
   );
   const [queuedExamples, setQueuedExamples] = useState<Set<string>>(new Set());
   const [queue, setQueue] = useState<QueueEntry[]>([]);
+  const [highlightedExample, setHighlightedExample] = useState<string | null>(null);
 
   const toggleMobileOverlay = useCallback(
     (overlay: Overlay, shown?: boolean) => {
@@ -117,6 +122,8 @@ export function UIProvider(props: any) {
         queuedExamples,
         queue,
         setQueue,
+        highlightedExample,
+        setHighlightedExample
       }}
     >
       {props.children}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This fixes an issue on example queues from either the AI help section or the blog section. In some situations, the mouse-over highlight of the example, triggered from the playground queue did not survive a scroll-into-view.

### Problem

The highlight css attribute got set directly on the element from the mouse event handler. Therefore it did not survive a react re-render of the component. A render is sometimes triggered by the autmatic viewport scrolling.

### Solution

Refactored the highlighting into a react state variable that is part of the UI context and properly tracked. The playground queue is currently used in the AI-help section and in the Blog section (to my knowledge).


## How did you test this change?

Manually, locally