### PR TITLE
feat(build): add Macro render report

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -31,6 +31,7 @@ import SearchIndex from "./search-index.js";
 import { makeSitemapXML, makeSitemapIndexXML } from "./sitemaps.js";
 import { humanFileSize } from "./utils.js";
 import { initSentry } from "./sentry.js";
+import { macroRenderTimes } from "../kumascript/src/render.js";
 
 const { program } = caporal;
 const { prompt } = inquirer;
@@ -402,6 +403,42 @@ function formatTotalFlaws(flawsCountMap, header = "Total_Flaws_Count") {
   return out.join("\n");
 }
 
+function nsToMs(bigint: bigint) {
+  return Number(bigint / BigInt(1_000)) / 1_000;
+}
+
+function formatMacroRenderReport(header = "Macro render report") {
+  const out = ["\n"];
+  out.push(header);
+
+  // Prepare data.
+  const stats = Object.entries(macroRenderTimes).map(([name, times]) => {
+    const sortedTimes = times.slice().sort(compareBigInt);
+    return {
+      name,
+      min: sortedTimes.at(0),
+      max: sortedTimes.at(-1),
+      count: times.length,
+      sum: times.reduce((acc, value) => acc + value, BigInt(0)),
+    };
+  });
+
+  // Sort by total render time.
+  stats.sort(({ sum: a }, { sum: b }) => Number(b - a));
+
+  // Format data.
+  out.push(
+    ["name", "count", "min (ms)", "avg (ms)", "max (ms)", "sum (ms)"].join(",")
+  );
+  for (const { name, min, max, count, sum } of stats) {
+    const avg = sum / BigInt(count);
+    out.push([name, count, ...[min, avg, max, sum].map(nsToMs)].join(","));
+  }
+
+  out.push("\n");
+  return out.join("\n");
+}
+
 interface BuildArgsAndOptions {
   args: {
     files?: string[];
@@ -560,6 +597,7 @@ program
         }
         console.log(`Peak heap memory usage: ${humanFileSize(peakHeapBytes)}`);
         console.log(formatTotalFlaws(totalFlaws));
+        console.log(formatMacroRenderReport());
       }
     } catch (error) {
       // So you get a stacktrace in the CLI output
@@ -570,3 +608,12 @@ program
   });
 
 program.run();
+function compareBigInt(a: bigint, b: bigint): number {
+  if (a < b) {
+    return -1;
+  } else if (a > b) {
+    return 1;
+  } else {
+    return 0;
+  }
+}

--- a/kumascript/src/render.ts
+++ b/kumascript/src/render.ts
@@ -60,6 +60,8 @@ export function normalizeMacroName(name) {
   return name.replace(/:/g, "-").toLowerCase();
 }
 
+export const macroRenderTimes: Record<string, bigint[]> = {};
+
 export async function render(
   source: string,
   pageEnvironment,
@@ -166,6 +168,7 @@ export async function render(
     }
 
     const macroName = normalizeMacroName(token.name);
+    const startTime = process.hrtime.bigint();
 
     if (selectiveMode) {
       if (selectMacros.includes(macroName)) {
@@ -267,6 +270,9 @@ export async function render(
         errors.push(error);
       }
     }
+    const elapsedTime = process.hrtime.bigint() - startTime;
+    macroRenderTimes[macroName] ??= [];
+    macroRenderTimes[macroName].push(elapsedTime);
   }
   return [output, errors];
 }


### PR DESCRIPTION
## Summary

Extracted from https://github.com/mdn/yari/pull/10225.

Counts how much each macro contributes to the total build time and provides a report at the end of the build with these metrics:
- Count: Number of invocations.
- Min: Minimal render time.
- Avg: Average render time.
- Max: Maximal render time.
- Sum: Total render time.

### Problem

We don't know how much time each macro contributes to the build time.

### Solution

Measure the render time of each macro and print a report.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
$ yarn build --locale en-us
...
Total_Flaws_Count
bad_bcd_queries  74
broken_links     627
macros           1,721
```

### After

```
$ yarn build --locale en-us
...
Total_Flaws_Count
bad_bcd_queries  74
broken_links     627
macros           1,721




Macro render report
name,count,min (ms),avg (ms),max (ms),sum (ms)
csssyntax,560,327.038,1869.509,2219.525,1046925.129
cssref,1045,0,19.536,587.678,20415.738
apiref,6078,0.419,2.142,73.987,13021.285
learnsidebar,328,0,14.745,462.421,4836.649
domxref,50772,0,0.085,10.001,4351.434
jsxref,12037,0,0.216,390.168,2604.518
addonsidebar,703,1.225,3.023,109.741,2125.493
jssidebar,281,1.919,5.632,188.365,1582.837
glossarysidebar,570,1.771,2.593,99.959,1478.547
jsref,693,0.591,1.963,33.665,1360.447
subpageswithsummaries,9,3.358,146.081,825.333,1314.737
cssxref,13411,0,0.095,2.719,1284.689
svgref,359,0,3.566,150.543,1280.253
httpsidebar,333,1.273,3.492,105.468,1162.876
htmlelement,7806,0,0.146,9.664,1142.935
landingpagelistsubpages,11,0.16,95.701,276.006,1052.711
htmlsidebar,231,1.379,4.497,153.748,1038.842
defaultapisidebar,428,0.043,1.46,29.504,625.174
embedlivesample,2862,0.06,0.191,2.188,546.688
apilistalpha,1,425.427,425.427,425.427,425.427
quicklinkswithsubpages,186,0.039,1.982,55.475,368.716
glossary,3858,0,0.092,3.188,358.235
webextallexamples,1,337.542,337.542,337.542,337.542
listsubpagesforsidebar,178,0.063,1.878,63.66,334.402
listsubpages,12,0.049,13.713,120.632,164.563
svgelement,2884,0,0.046,1.931,133.667
xsltsidebar,99,0.523,1.348,19.575,133.462
pwasidebar,31,0.524,4.247,32.069,131.663
cssinfo,489,0.065,0.207,8.613,101.443
listgroups,1,98.674,98.674,98.674,98.674
webextallcompattables,1,91.471,91.471,91.471,91.471
specifications,8617,0.005,0.009,1.767,78.909
compat,9394,0.005,0.008,0.365,77.698
mathmlref,46,0.381,1.557,18.522,71.652
css_ref,1,60.584,60.584,60.584,60.584
glossarydisambiguation,10,0.043,3.977,7.664,39.77
embedinteractiveexample,1247,0.012,0.023,1.432,29.656
inheritancediagram,845,0.007,0.027,0.384,22.91
seecompattable,1422,0,0.014,0.319,20.328
svginfo,75,0.048,0.219,2.584,16.441
securecontext_header,629,0.006,0.025,0.491,15.783
webextexamples,580,0.011,0.023,1.644,13.697
webextapiref,2193,0,0.005,0.256,13.142
svgattr,2709,0,0.004,1.165,12.92
optional_inline,2741,0,0.004,0.48,11.754
gamessidebar,67,0.099,0.16,1.995,10.75
experimental_inline,1542,0,0.006,1.995,10.374
readonlyinline,3258,0,0.003,0.321,10.287
firefoxsidebar,162,0.04,0.059,0.57,9.57
webassemblysidebar,116,0.052,0.082,1.795,9.567
firefox_for_developers,121,0.019,0.071,0.851,8.625
deprecated_header,595,0.006,0.014,0.202,8.583
previousmenunext,380,0,0.019,0.595,7.479
httpheader,1723,0,0.004,0.255,7.41
mdnsidebar,79,0.062,0.089,0.847,7.053
embedghlivesample,586,0.001,0.009,0.283,5.507
non-standard_header,372,0.005,0.014,0.309,5.254
domattributemethods,13,0.253,0.354,1.102,4.604
availableinworkers,365,0.003,0.011,0.221,4.263
deprecated_inline,1276,0,0.003,0.103,3.88
non-standard_inline,567,0,0.006,0.113,3.714
rfc,232,0,0.013,0.428,3.016
livesamplelink,12,0.063,0.227,0.866,2.724
previousnext,179,0,0.014,0.504,2.507
js_property_attributes,52,0.014,0.038,0.741,1.986
nextmenu,54,0,0.034,0.514,1.845
previousmenu,52,0,0.034,0.495,1.804
httpstatus,327,0,0.005,0.427,1.732
unimplemented_inline,1,1.421,1.421,1.421,1.421
httpmethod,227,0,0.006,0.391,1.403
mathmlelement,228,0,0.005,0.483,1.341
xsltref,23,0.029,0.057,0.509,1.318
csp,194,0,0.006,0.349,1.18
no_tag_omission,71,0.005,0.015,0.358,1.08
jsfiddleembed,34,0.003,0.026,0.513,0.891
securecontext_inline,109,0,0.006,0.414,0.757
next,10,0,0.066,0.424,0.663
previous,10,0,0.065,0.429,0.655
embedyoutube,18,0.003,0.035,0.497,0.63
addonsidebarmain,1,0.603,0.603,0.603,0.603
xref_csscomputed,1,0.011,0.011,0.011,0.011
xref_cssinitial,1,0.011,0.011,0.011,0.011
nonstandardbadge,1,0.009,0.009,0.009,0.009
xref_cssinherited,1,0.005,0.005,0.005,0.005
```

---

## How did you test this change?

Ran `yarn build --locale en-us` locally
