### PR TITLE
fix(bcd): link to pages in same locale

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -13,6 +13,7 @@ import {
   SupportStatementExtended,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
+import { DEFAULT_LOCALE } from "../../../../../libs/constants";
 
 function getSupportClassName(
   support: SupportStatementExtended | undefined,
@@ -525,8 +526,12 @@ export const FeatureRow = React.memo(
     let titleNode: string | React.ReactNode;
 
     if (compat.mdn_url && depth > 0) {
+      const href = compat.mdn_url.replace(
+        `/${DEFAULT_LOCALE}/docs`,
+        `/${locale}/docs`
+      );
       titleNode = (
-        <a href={compat.mdn_url} className="bc-table-row-header">
+        <a href={href} className="bc-table-row-header">
           {title}
           {compat.status && <StatusIcons status={compat.status} />}
         </a>


### PR DESCRIPTION
## Summary

Supersedes https://github.com/mdn/bcd-utils/pull/26.

### Problem

The BCD table in non-English locales links to English pages, because the `mdn_url` in the BCD data contains the canonical English URL.

### Solution

Replace the locale in the links.

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/ja/docs/Web/API/URL#%E3%83%96%E3%83%A9%E3%82%A6%E3%82%B6%E3%83%BC%E3%81%AE%E4%BA%92%E6%8F%9B%E6%80%A7 locally. Also verified that http://localhost:3000/en-US/docs/Web/API/URL#browser_compatibility still links to `en-US`.