### PR TITLE
chore(macros/CSSRef): add missing media query guide

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -130,6 +130,7 @@ const text = mdn.localStringMap({
         'Using_media_queries': 'Using media queries',
         'Using_media_queries_for_accessibility': 'Using media queries for accessibility',
         'Testing_media_queries_programmatically': 'Testing media queries programmatically',
+        'Printing': 'Printing',
       'Nesting': 'Nesting style rules',
         'Using_CSS_nesting': 'Using CSS nesting',
         'Nesting_and_specificity': 'Nesting and specificity',
@@ -1369,6 +1370,7 @@ async function buildPropertylist(pages, title) {
             <li><%-smartLink(`${cssURL}CSS_Media_Queries/Using_media_queries`, null, text['Using_media_queries'], cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Media_Queries/Using_Media_Queries_for_Accessibility`, null, text['Using_media_queries_for_accessibility'], cssURL)%></li>
             <li><%-smartLink(`${cssURL}CSS_Media_Queries/Testing_media_queries`, null, text['Testing_media_queries_programmatically'], cssURL)%></li>
+            <li><%-smartLink(`${cssURL}CSS_Media_Queries/Printing`, null, text['Printing'], cssURL)%></li>
           </ol>
       </details>
   </li>


### PR DESCRIPTION

<img width="684" alt="Screenshot showing printing in sidebar" src="https://github.com/mdn/yari/assets/69888/8403c865-3aca-4388-8359-06dbc9e1c976">

## Summary

Media queries print guide is missing in the sidebar

### Problem

Media queries print guide is missing in the sidebar. 
This adds that guide to the sidebar in the correct location

