### PR TITLE
chore(workflows): use default runners

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   build:
     environment: prod
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -62,7 +62,7 @@ permissions:
 jobs:
   build:
     environment: stage
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/xyz-build.yml
+++ b/.github/workflows/xyz-build.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   build:
     environment: xyz
-    runs-on: ubuntu-latest-4core
+    runs-on: ubuntu-latest
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/yari'


### PR DESCRIPTION
## Summary

Switch from [large runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners) back to the default GitHub runners.

### Problem

We have been using so-called large runners with 4 vCPUs, because the default runners used to have only 2 vCPUs, but now the default runners were upgraded, see: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

### Solution

Go back to using the default GitHub runners.

---

## How did you test this change?

I will kick off a build to see the impact on runtime.