### PR TITLE
fix(release-please): move release-type to manifest

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Release
         uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          release-type: node
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -4,5 +4,10 @@
     { "type": "fix", "section": "Bug Fixes", "hidden": false },
     { "type": "enhance", "section": "Enhancements", "hidden": false },
     { "type": "chore", "section": "Miscellaneous", "hidden": false }
-  ]
+  ],
+  "packages": {
+    ".": {
+      "release-type": "node"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

### Problem

We [migrated to release-please-action v4](https://github.com/mdn/yari/pull/10122) and [moved all removed workflow inputs to a manifest file](https://github.com/mdn/yari/pull/10122/commits/8475280396edbbea4720eb9fbf1cb57261a7bb97), but [it seems that specifying the `release-type` input causes the manifest file to be ignored](https://github.com/google-github-actions/release-please-action/issues/932), as per the documentation:

> Specifying a release-type configuration is the most straight-forward configuration option, but allows for no further customization.

### Solution

Move the `release-type` into the manifest file.

---

## How did you test this change?

Unfortunately, we won't know if this works until this PR is merged.