### PR TITLE
feat(macros/MDNSidebar): add Feature status page

### DIFF
--- a/kumascript/macros/MDNSidebar.ejs
+++ b/kumascript/macros/MDNSidebar.ejs
@@ -146,7 +146,8 @@ const sections = [
             "Writing_guidelines/Page_structures/Sidebars",
             "Writing_guidelines/Page_structures/Specification_tables",
             "Writing_guidelines/Page_structures/Syntax_sections",
-            "Writing_guidelines/Page_structures/Macros"
+            "Writing_guidelines/Page_structures/Macros",
+            "Writing_guidelines/Page_structures/Feature_status",
           ]
         },
         "Writing_guidelines/Attrib_copyright_license",


### PR DESCRIPTION
- related to https://github.com/mdn/content/pull/31941

Adds a new page `Feature_status` to the MDNSidebar macro.