### PR TITLE
 fix(release-please): move release-type/changelog-sections to config file

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,8 +18,6 @@ jobs:
       - name: Release
         uses: google-github-actions/release-please-action@v4
         id: release
-        with:
-          release-type: node
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,3 @@
 {
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix", "section": "Bug Fixes", "hidden": false },
-    { "type": "enhance", "section": "Enhancements", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous", "hidden": false }
-  ]
+  ".": "2.38.4"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+  "packages": {
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "node",
+    "changelog-sections": [
+      { "type": "feat", "section": "Features", "hidden": false },
+      { "type": "fix", "section": "Bug Fixes", "hidden": false },
+      { "type": "enhance", "section": "Enhancements", "hidden": false },
+      { "type": "chore", "section": "Miscellaneous", "hidden": false }
+    ],
+    ".": {}
+  }
+}


### PR DESCRIPTION
This is an attempt to fix migration to release please v4. Document referred for this: [bootstrap manually](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#bootstrap-manually) and [config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json)

After merging this you'll need to create a new release-pr.

cc @caugner 