### PR TITLE
fix(release-please): specify last-release-sha

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  ".": "2.38.4"
+  "last-release-sha": "79980295f3bc209d006d14c8555ac1cbf430edb4"
 }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Release-please adds more commits to the release notes, because it doesn't recognize the last release.

### Solution

Specify the last release as commit hash, see: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile

---

## How did you test this change?

We'll see when it's merged.