### PR TITLE
fix(release-please): use bootstrap-sha instead of last-release-sha

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,3 @@
 {
-  "last-release-sha": "79980295f3bc209d006d14c8555ac1cbf430edb4"
+  "bootstrap-sha": "79980295f3bc209d006d14c8555ac1cbf430edb4"
 }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Release-please couldn't use `last-release-sha` on its own:

```
Error: release-please failed: unable to parse version string: 79980295f3bc209d006d14c8555ac1cbf430edb4
```

### Solution

Use `bootstrap-sha` instead.

---

## How did you test this change?

We cannot easily test without merging.