### PR TITLE
fix(release-please): disable include-component-in-tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "79980295f3bc209d006d14c8555ac1cbf430edb4",
   "release-type": "node",
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },
@@ -8,6 +7,7 @@
     { "type": "enhance", "section": "Enhancements", "hidden": false },
     { "type": "chore", "section": "Miscellaneous", "hidden": false }
   ],
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Release-please v4 started prefixing releases and tags with `yari-`.

### Solution

Explicitly disable the corresponding option.

---

## How did you test this change?

Merge and see.