### PR TITLE
fix(release-please): specify last-release-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "296a3bd7d8afa00c655d70ce19d4b52410328277",
   "release-type": "node",
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },


### PR DESCRIPTION
## Summary

This should prevent release-please from including more commits than necessary in the next release.

---

## How did you test this change?

Merge and see.