### PR TITLE
fix(workflows): cache `@vscode/ripgrep` bin

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -21,6 +21,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,6 +31,13 @@ jobs:
           cache: yarn
           registry-url: "https://registry.npmjs.org"
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        if: steps.release.outputs.release_created
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install
         if: steps.release.outputs.release_created
         run: yarn --frozen-lockfile

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         if: steps.release.outputs.release_created
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         if: steps.release.outputs.release_created
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -26,6 +26,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "yarn"
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,6 +30,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -31,6 +31,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,12 @@ jobs:
             client/pwa/yarn.lock
             libs/**/*.js
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages (ROOT)
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages (ROOT)

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache @vscode/ripgrep bin
         uses: actions/cache@v3
         with:
-          key: ripgrep-${{ hashFiles('yarn.lock') }}
+          key: vscode-ripgrep-bin-${{ hashFiles('yarn.lock') }}
           path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages (ROOT)


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This should reduce the number of failed workflow runs, caused by `yarn install` failing to download ripgrep with the following error message:

```
[5/5] Building fresh packages...
error /home/runner/work/yari/yari/node_modules/@vscode/ripgrep: Command failed.
Exit code: 1
Command: node ./lib/postinstall.js
Arguments: 
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Directory: /home/runner/work/yari/yari/node_modules/@vscode/ripgrep
Output:
Finding release for v13.0.0-10
GET https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/v13.0.0-10
Deleting invalid download cache
Downloading ripgrep failed: Error: Request failed: 403
    at ClientRequest.<anonymous> (/home/runner/work/yari/yari/node_modules/@vscode/ripgrep/lib/download.js:109:24)
    at Object.onceWrapper (node:events:629:26)
    at ClientRequest.emit (node:events:514:28)
    at HTTPParser.parserOnIncomingClient (node:_http_client:700:27)
    at HTTPParser.parserOnHeadersComplete (node:_http_common:119:17)
    at TLSSocket.socketOnData (node:_http_client:541:22)
    at TLSSocket.emit (node:events:514:28)
    at addChunk (node:internal/streams/readable:324:12)
    at readableAddChunk (node:internal/streams/readable:297:9)
    at Readable.push (node:internal/streams/readable:234:10)
```

### Problem

We use the `@vscode/ripgrep` npm package, which downloads a ripgrep (`rg`) binary, and unfortunately this download regularly fails (see above), although we're already following [the recommendation](https://github.com/microsoft/vscode-ripgrep?tab=readme-ov-file#github-api-limit-note) of passing `GITHUB_TOKEN` to the step.

### Solution

Use the `@actions/cache` GitHub Action to explicitly cache the ripgrep binary (`rg`).

---

## How did you test this change?

The checks on this PR passed, and created a [new cache](https://github.com/mdn/yari/actions/caches?query=sort%3Acreated-desc) `vscode-ripgrep-bin-...`:
<img width="1288" alt="image" src="https://github.com/mdn/yari/assets/495429/91ee99d6-a8be-4df8-a361-4ecd9521b8c7">
