### PR TITLE
chore(deps): bump fast-xml-parser from 4.1.3 to 4.3.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6861,9 +6861,9 @@ fast-xml-parser@^3.19.0:
     strnum "^1.0.4"
 
 fast-xml-parser@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.1.3.tgz#0254ad0d4d27f07e6b48254b068c0c137488dd97"
-  integrity sha512-LsNDahCiCcJPe8NO7HijcnukHB24tKbfDDA5IILx9dmW3Frb52lhbeX6MPNUSvyGNfav2VTYpJ/OqkRoVLrh2Q==
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz#385cc256ad7bbc57b91515a38a22502a9e1fca0d"
+  integrity sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==
   dependencies:
     strnum "^1.0.5"
 


### PR DESCRIPTION
## Summary

Bumps the indirect dependency `fast-xml-parser`.

## How did you test this change?

See checks.
