### PR TITLE
chore(deps): resolve http-cache-semantics to >=4.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "resolutions": {
+    "http-cache-semantics": ">=4.1.1",
     "lodash": ">=4.17.15",
     "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8132,12 +8132,7 @@ htmlparser2@^8.0.1:
     domutils "^3.0.1"
     entities "^4.3.0"
 
-http-cache-semantics@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
-  integrity sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==
-
-http-cache-semantics@^4.1.1:
+http-cache-semantics@3.8.1, http-cache-semantics@>=4.1.1, http-cache-semantics@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==


### PR DESCRIPTION
## Summary

Bumps the indirect dependency `http-cache-semantics` by defining a resolution `>=4.1.1`, since `imagemin-{gifsicle,mozjpeg,pngquant}` depend on `http-cache-semantics@3.8.1` via `cacheable-request@2.1.4`.

_Note_: The only breaking change of `http-cache-semantics` v4 is the drop of Node.js 4 support, see: https://github.com/kornelski/http-cache-semantics/compare/v3.8.1...v4.0.0 

## How did you test this change?

See checks.