### PR TITLE
chore(deps): resolve semver-regex to ^3.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   "resolutions": {
     "http-cache-semantics": ">=4.1.1",
     "lodash": ">=4.17.15",
-    "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3"
+    "react-dev-utils/fork-ts-checker-webpack-plugin": "^6.5.3",
+    "semver-regex": "^3.1.4"
   },
   "dependencies": {
     "@caporal/core": "^2.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13413,10 +13413,10 @@ selfsigned@^2.1.1:
   dependencies:
     node-forge "^1"
 
-semver-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
-  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
+semver-regex@^2.0.0, semver-regex@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
+  integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
 semver-truncate@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary

Bumps the indirect dependency `semver-regex` by defining a resolution `^3.1.4`, since `imagemin-{gifsicle,mozjpeg,pngquant}` depend on `semver-regex@^2.0.0` via `find-versions@3.2.0`.

_Note_: The only breaking change in v3 is the drop of Node.js 8 support: https://github.com/sindresorhus/semver-regex/releases/tag/v3.0.0

However, we cannot upgrade to v4, because [it is pure ESM](https://github.com/sindresorhus/semver-regex/releases/tag/v4.0.0).

## How did you test this change?

See checks.