### PR TITLE
chore(deps): bump follow-redirects from 1.15.2 to 1.15.5 in /cloud-function

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -1341,9 +1341,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Summary

Bumps the indirect dependency `follow-redirects` from 1.15.2 to 1.15.5 in `/cloud-function`, because Dependabot fails to do so.

Note: It shouldn't cause any issue, because it's a patch bump (see [changes](https://github.com/follow-redirects/follow-redirects/compare/v1.15.2...v1.15.5)).

## How did you test this change?

See checks.