### PR TITLE
fix(workflows): cache `@vscode/ripgrep` bin in test job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -66,6 +66,12 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
+      - name: Cache @vscode/ripgrep bin
+        uses: actions/cache@v3
+        with:
+          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
+          path: node_modules/@vscode/ripgrep/bin/
+
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:


### PR DESCRIPTION
## Summary

Follow-up PR to https://github.com/mdn/yari/pull/10456.

### Problem

In https://github.com/mdn/yari/pull/10456, I added the caching step to every non-build workflow, but forgot to add it to the second job of the testing workflow.

### Solution

Add the missing step to the `test` job of the `testing` workflow.

## How did you test this change?

Verified that the [test job running on this PR](https://github.com/mdn/yari/actions/runs/7799228307/job/21269576614?pr=10471#step:4:11) executes the step.
