### PR TITLE
chore(deps): bump semver v5 from 5.7.1 to 5.7.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13426,9 +13426,9 @@ semver-truncate@^1.1.2:
     semver "^5.3.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.5.0, semver@^5.6.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"


### PR DESCRIPTION
## Summary

Bumps `semver` v5 (required by `bin-version`, `bin-version-check`, `imagemin-gifsicle`, `read-pkg` and `semver-truncate`) from 5.7.1 to 5.7.2.

_Note_: I had to manually update the `yarn.lock` file as `yarn upgrade semver` etc wouldn't work.

## How did you test this change?

See checks.
