### PR TITLE
chore(deps): bump web-specs from 2.79.0 to 3.0.0

### DIFF
--- a/build/web-specs.ts
+++ b/build/web-specs.ts
@@ -10,9 +10,9 @@ interface WebSpec {
     currentSpecification: string;
     title: string;
     shortTitle: string;
-    nightlyUrl: string;
+    nightlyUrl?: string;
   };
-  nightly: {
+  nightly?: {
     url: string;
     status: string;
     sourcePath: string;
@@ -49,10 +49,11 @@ export async function getWebSpec(url: string): Promise<WebSpec | undefined> {
   return specs.find(
     (spec) =>
       url.startsWith(spec.url) ||
-      url.startsWith(spec.nightly.url) ||
-      spec.nightly.alternateUrls.some((s) => url.startsWith(s)) ||
-      // When grabbing series nightly, make sure we're grabbing the latest spec version
-      (spec.shortname === spec.series.currentSpecification &&
-        url.startsWith(spec.series.nightlyUrl))
+      (spec.nightly &&
+        (url.startsWith(spec.nightly.url) ||
+          spec.nightly.alternateUrls.some((s) => url.startsWith(s)) ||
+          // When grabbing series nightly, make sure we're grabbing the latest spec version
+          (spec.shortname === spec.series.currentSpecification &&
+            url.startsWith(spec.series.nightlyUrl))))
   );
 }

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0",
     "web-features": "^0.5.1",
-    "web-specs": "^2.79.0"
+    "web-specs": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15446,10 +15446,10 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
-web-specs@^2.79.0:
-  version "2.79.0"
-  resolved "https://registry.yarnpkg.com/web-specs/-/web-specs-2.79.0.tgz#c6db408943387cc1a95608ba77a0fae51f131f25"
-  integrity sha512-364IxMgYLUjWDeTPrfNtO/+zZxIJ2ZzV4STzbOdVn6DANptLBo3aNTEJ0SS2Qe2P331apSfnU0b4K6wxl6cuew==
+web-specs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/web-specs/-/web-specs-3.0.0.tgz#b564c3f1e3f935f78c2a055e6390f48662fee8f8"
+  integrity sha512-iFIqX1Zu13dJ9slgPlnxs0ndb1v/oB3WilmTAQRIm/RxyuAdjghoxWWnG6ypYOKdr+zv9lX+q/p9JLMZ1gi1GQ==
 
 web-streams-polyfill@4.0.0-beta.3:
   version "4.0.0-beta.3"


### PR DESCRIPTION
## Summary

In the new major version of web-specs, spec entries are no longer guaranteed to have a `nightly` property. This change was made to include specs that do not have a public URL, such as ISO specs. The logic that processed web-specs needed to be adjusted accordingly.

### Problem

The code assumed that all spec entries from web-specs had a `nightly` property and a `series.nightlyUrl` property.

### Solution

The code now only looks under the `nightly` property when it is set.
Worth noting: if `nightly` is set in web-specs, then `series.nightlyUrl` is set.


