### PR TITLE
fix(baseline): add custom elements group to blocklist

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -573,6 +573,7 @@ function addBaseline(doc: Partial<Doc>) {
         // temporary blocklist while we wait for per-key baseline statuses
         // or another solution to the baseline/bcd table discrepancy problem
         ![
+          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/async-clipboard.yml
           "api.Clipboard.read",
           "api.Clipboard.readText",
           "api.Clipboard.write",
@@ -587,6 +588,15 @@ function addBaseline(doc: Partial<Doc>) {
           "api.ClipboardItem.types",
           "api.Navigator.clipboard",
           "api.Permissions.permission_clipboard-read",
+          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/custom-elements.yml
+          "api.CustomElementRegistry",
+          "api.CustomElementRegistry.builtin_element_support",
+          "api.CustomElementRegistry.define",
+          "api.Window.customElements",
+          "css.selectors.defined",
+          "css.selectors.host",
+          "css.selectors.host-context",
+          "css.selectors.part",
         ].includes(query)
     );
     return getWebFeatureStatus(...filteredBrowserCompat);


### PR DESCRIPTION
## Summary

Fixes:
- https://github.com/mdn/content/issues/32138
- https://github.com/mdn/content/issues/32008
- https://github.com/mdn/content/issues/31932
- https://github.com/mdn/content/issues/31764
- https://github.com/mdn/content/issues/31566
- https://github.com/web-platform-dx/web-features/issues/562
- https://github.com/web-platform-dx/web-features/issues/561

See also:
- https://github.com/web-platform-dx/web-features/issues/571
- https://github.com/web-platform-dx/web-features/issues/495
- https://github.com/mdn/yari/issues/10297

### Problem

Much like https://github.com/mdn/yari/pull/10345, users are confused by the overall custom elements "not baseline" banner showing on pages describing elements of custom elements which *are* interoperable cross-browser.

### Solution

Hide these banners until we find a solution upstream.

## How did you test this change?

Visited:
- http://localhost:3000/en-US/docs/Web/API/CustomElementRegistry/define
- http://localhost:3000/en-US/docs/Web/CSS/::part
- http://localhost:3000/en-US/docs/Web/CSS/:defined
- etc.