### PR TITLE
chore(macros): Mark 'unimplemented_inline' as deprecated

### DIFF
--- a/kumascript/macros/unimplemented_inline.ejs
+++ b/kumascript/macros/unimplemented_inline.ejs
@@ -1,1 +1,2 @@
-<%- await template("unimplementedGeneric", ["inline",$0]) %>
+<% mdn.deprecated(); %> <%- await template("unimplementedGeneric",
+["inline",$0])%>

--- a/kumascript/macros/unimplemented_inline.ejs
+++ b/kumascript/macros/unimplemented_inline.ejs
@@ -1,2 +1,1 @@
-<% mdn.deprecated(); %> <%- await template("unimplementedGeneric",
-["inline",$0])%>
+<% mdn.deprecated(); %> <%- await template("unimplementedGeneric",["inline",$0])%>

--- a/kumascript/macros/unimplemented_inline.ejs
+++ b/kumascript/macros/unimplemented_inline.ejs
@@ -1,1 +1,1 @@
-<% mdn.deprecated(); %> <%- await template("unimplementedGeneric",["inline",$0])%>
+<% mdn.deprecated(); %> <%- await template("unimplementedGeneric", ["inline",$0]) %>


### PR DESCRIPTION
## Summary

Fixes #10485.

### Problem

This macro is removed from EN content and can be deprecated.

## Screenshots

Added the updated macro to a document and visited on http://localhost:3000/en-US/docs/Web/CSS/CSS_nesting/Nesting_at-rules#_flaws

![image](https://github.com/mdn/yari/assets/43580235/b40b2340-01d9-4aa9-87a0-966aafc30b7c)

## How did you test this change?

* yarn && yarn dev
* visit http://localhost:3000

## Open questions

The formatting looks messed up, is Prettier config picking up the wrong file type?

__Related issues and pull requests:__

- [x] https://github.com/mdn/yari/issues/10485
- [x] https://github.com/mdn/content/pull/32158
- [x] https://github.com/mdn/content/pull/25039
- Discussion: https://github.com/orgs/mdn/discussions/637