### PR TITLE
fix(baseline): blocklist some bcd keys from input-event

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -597,6 +597,13 @@ function addBaseline(doc: Partial<Doc>) {
           "css.selectors.host",
           "css.selectors.host-context",
           "css.selectors.part",
+          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/input-event.yml
+          "api.Element.input_event",
+          "api.InputEvent.InputEvent",
+          "api.InputEvent.data",
+          "api.InputEvent.dataTransfer",
+          "api.InputEvent.getTargetRanges",
+          "api.InputEvent.inputType",
         ].includes(query)
     );
     return getWebFeatureStatus(...filteredBrowserCompat);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/10487

See also https://github.com/web-platform-dx/web-features/issues/590

### Problem

Baseline banner and BCD table on some pages within the input-event group don't match.

### Solution

Hide the banners on those pages where they don't match, until we have a solution upstream, like https://github.com/mdn/yari/pull/10479 and https://github.com/mdn/yari/pull/10345.

---

## How did you test this change?

Verified banner is hidden on:
- http://localhost:3000/en-US/docs/Web/API/Element/input_event
- http://localhost:3000/en-US/docs/Web/API/InputEvent/data
- http://localhost:3000/en-US/docs/Web/API/InputEvent/dataTransfer
- http://localhost:3000/en-US/docs/Web/API/InputEvent/inputType

And still shown on (since the BCD table "matches" the banner):
- http://localhost:3000/en-US/docs/Web/API/InputEvent
- http://localhost:3000/en-US/docs/Web/API/InputEvent/isComposing
