### PR TITLE
Make sure long words break onto the next line instead of overflowing for recent contributions list

### DIFF
--- a/client/src/homepage/recent-contributions/index.scss
+++ b/client/src/homepage/recent-contributions/index.scss
@@ -50,6 +50,7 @@
     gap: 0.125rem;
     line-height: var(--base-line-height);
     margin: 0;
+    overflow-wrap: break-word;
 
     a {
       color: var(--text-primary);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Fixes #10276 

Closing this as I forgot to sign the commit due to an expired GPG key, rather than rebasing and signing the old commit here. I submitted a new PR to avoid any history conflicts.

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
Long words overflow the content box for the recent contributions list on the homepage.

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution
Add a CSS declaration `overflow-wrap: break-word` to ensure that long words which would overflow its content box, instead break onto the next line.

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![Screen Shot 2024-02-11 at 6 11 43 PM](https://github.com/mdn/yari/assets/48612525/f94f68ba-7619-42ba-9177-9d1834a421eb)


### After

<!-- Replace this line with your screenshot (or video). -->
![Screen Shot 2024-02-11 at 6 11 56 PM](https://github.com/mdn/yari/assets/48612525/3e20e8b6-1715-44f9-9db1-56e19dd451a0)


---
