### PR TITLE
fix(ai-help): remove decorative images from a11y tree

### DIFF
--- a/client/src/plus/ai-help/landing.tsx
+++ b/client/src/plus/ai-help/landing.tsx
@@ -34,21 +34,21 @@ export function AIHelpLanding() {
           <h2>New Additions</h2>
           <div className="ai-help-new-additions">
             <figure>
-              <HistorySVG />
+              <HistorySVG role="none" />
               <figcaption>
                 <h3>History</h3>
                 <p>Save your history to revisit your chats at anytime</p>
               </figcaption>
             </figure>
             <figure>
-              <ContextSVG />
+              <ContextSVG role="none" />
               <figcaption>
                 <h3>Enhanced Context</h3>
                 <p>Ask queries about browser compatibility data</p>
               </figcaption>
             </figure>
             <figure>
-              <GPT4SVG />
+              <GPT4SVG role="none" />
               <figcaption>
                 <h3>GPT-4-Powered</h3>
                 <p>Unlock GPT-4's potential with our paid subscriptions</p>


### PR DESCRIPTION
## Summary

(MP-707)

### Problem

We have decorative SVGs on the AI Help landing page, and the Developer Tools flagged that they did not have a text label.

### Solution

Specify their ARIA `role="none"` to remove them from the accessibility tree.

---

## How did you test this change?

Checked via the Firefox Developer Tools by opening the "Accessibility" tab, setting "Check for issues: all" and verifying that the SVGs no longer appear.