### PR TITLE
Revert "chore(deps-dev): bump husky from 9.0.10 to 9.0.11 (#10518)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "history": "^5.2.0",
     "html-validate": "^8.9.1",
     "html-webpack-plugin": "^5.6.0",
-    "husky": "^9.0.11",
+    "husky": "^9.0.10",
     "identity-obj-proxy": "^3.0.0",
     "ignore-loader": "^0.1.2",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8182,10 +8182,10 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^9.0.11:
-  version "9.0.11"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
-  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+husky@^9.0.10:
+  version "9.0.10"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.10.tgz#ddca8908deb5f244e9286865ebc80b54387672c2"
+  integrity sha512-TQGNknoiy6bURzIO77pPRu+XHi6zI7T93rX+QnJsoYFf3xdjKOur+IlfqzJGMHIK/wXrLg+GsvMs8Op7vI2jVA==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"


### PR DESCRIPTION
Update seems to break our CI

This reverts commit 02d1832d8e43456f6d949b7aa961a63a2a093087.