### PR TITLE
chore(macros): Mark 'DOMAttributeMethods' as deprecated

### DIFF
--- a/kumascript/macros/DOMAttributeMethods.ejs
+++ b/kumascript/macros/DOMAttributeMethods.ejs
@@ -1,4 +1,7 @@
 <%
+// Removed from mdn/content in https://github.com/mdn/content/pull/32268
+mdn.deprecated();
+
 var tableTitle = 'DOM methods dealing with element\'s attributes:';
 var tableHead1 = 'Not namespace-aware, most commonly used methods';
 var tableHead2 = 'Namespace-aware variants (DOM Level 2)';


### PR DESCRIPTION
## Summary

This macro is removed from EN content and can be deprecated.

Fixes #10528

## Screenshots

![image](https://github.com/mdn/yari/assets/43580235/fc6919e0-3a1c-4328-8a23-412633d1ffe1)


## How did you test this change?

* yarn && yarn dev
* Add `{{DOMAttributeMethods}}` to a page
* visit http://localhost:3000/ and view results

