### PR TITLE
enhance(ai-help): disable top banner if quota banner is visible

### DIFF
--- a/client/src/plus/ai-help/banners.tsx
+++ b/client/src/plus/ai-help/banners.tsx
@@ -6,13 +6,15 @@ import { useUserData } from "../../user-context";
 import { PlusLoginBanner } from "../common/login-banner";
 import { isPlusSubscriber } from "../../utils";
 
-export function AiHelpBanner() {
+export function AiHelpBanner({
+  isDisabled = false,
+}: { isDisabled?: boolean } = {}) {
   const user = useUserData();
 
   const isSubscriber = useMemo(() => isPlusSubscriber(user), [user]);
 
   return (
-    <div className="ai-help-banner">
+    <div className={`ai-help-banner ${isDisabled ? "disabled" : ""}`}>
       <p>
         <Icon name="bell-ring" />
         <strong>

--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -152,6 +152,16 @@
     .auth-container {
       margin-top: 1rem;
     }
+
+    &.disabled {
+      background-color: var(--background-secondary);
+
+      margin-bottom: 2.25rem;
+
+      .button {
+        display: none;
+      }
+    }
   }
 
   .ai-help-inner {

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -622,7 +622,7 @@ export function AIHelpInner() {
         messageId={messages.length === 2 ? messages[0]?.messageId : undefined}
       />
       <Container>
-        <AiHelpBanner />
+        <AiHelpBanner isDisabled={isQuotaExceeded(quota)} />
         {isQuotaLoading || isHistoryLoading ? (
           <Loading />
         ) : (

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -124,9 +124,6 @@ function AIHelpAuthenticated() {
           </a>
         </p>
       </Container>
-      <Container>
-        <AiHelpBanner />
-      </Container>
       <AIHelpInner />
     </div>
   );
@@ -625,6 +622,7 @@ export function AIHelpInner() {
         messageId={messages.length === 2 ? messages[0]?.messageId : undefined}
       />
       <Container>
+        <AiHelpBanner />
         {isQuotaLoading || isHistoryLoading ? (
           <Loading />
         ) : (


### PR DESCRIPTION
## Summary

(MP-700)

### Problem

When a user has reached their quota, we show two banners with an "Upgrade Now" button at the top and at the bottom.

### Solution

"Disable" the top banner if the user reached their quota:

1. Change the background-color to gray.
2. Hide the "Upgrade Now" button.
3. Add a margin equivalent to the height of the button to avoid layout shift.

---

## Screenshots

### Before/After:

https://github.com/mdn/yari/assets/495429/9b77bb27-2c05-4c2e-82c7-0c57f47091d1

---

## How did you test this change?

Opened http://localhost:3000/en-US/plus/ai-help locally, asked 5 questions, then manually toggled the "disabled" class on the banner. (For the screen recording, I temporarily changed `&.disabled` to `&:hover`.)