### PR TITLE
enhance(build/spas): allow yarn dev without internet if DEV_MODE is enabled

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -19,6 +19,7 @@ import {
   CONTENT_TRANSLATED_ROOT,
   CONTRIBUTOR_SPOTLIGHT_ROOT,
   BUILD_OUT_ROOT,
+  DEV_MODE,
 } from "../libs/env/index.js";
 import { isValidLocale } from "../libs/locale-utils/index.js";
 import { DocFrontmatter, NewsItem } from "../libs/types/document.js";
@@ -368,14 +369,25 @@ async function fetchGitHubPRs(repo, count = 5) {
     "sort:updated",
   ].join("+");
   const pullRequestUrl = `https://api.github.com/search/issues?q=${pullRequestsQuery}&per_page=${count}`;
-  const pullRequestsData = (await got(pullRequestUrl).json()) as {
-    items: any[];
-  };
-  const prDataRepo = pullRequestsData.items.map((item) => ({
-    ...item,
-    repo: { name: repo, url: `https://github.com/${repo}` },
-  }));
-  return prDataRepo;
+  try {
+    const pullRequestsData = (await got(pullRequestUrl).json()) as {
+      items: any[];
+    };
+    const prDataRepo = pullRequestsData.items.map((item) => ({
+      ...item,
+      repo: { name: repo, url: `https://github.com/${repo}` },
+    }));
+    return prDataRepo;
+  } catch (e) {
+    const msg = `Couldn't fetch recent GitHub contributions for repo ${repo}!`;
+    if (!DEV_MODE) {
+      console.error(`Error: ${msg}`);
+      throw e;
+    }
+
+    console.warn(`Warning: ${msg}`);
+    return [];
+  }
 }
 
 async function fetchRecentContributions() {

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -415,10 +415,6 @@ async function fetchRecentContributions() {
 }
 
 async function fetchLatestNews() {
-  const xml = await got("https://hacks.mozilla.org/category/mdn/feed/").text();
-
-  const $ = cheerio.load(xml, { xmlMode: true });
-
   const items: NewsItem[] = [];
 
   items.push(
@@ -461,9 +457,21 @@ async function fetchLatestNews() {
         name: "developer.mozilla.org",
         url: `/${DEFAULT_LOCALE}/blog/`,
       },
-    }
+    },
+    ...(await fetchHacksNews())
   );
 
+  return {
+    items,
+  };
+}
+
+async function fetchHacksNews(): Promise<NewsItem[]> {
+  const xml = await got("https://hacks.mozilla.org/category/mdn/feed/").text();
+
+  const $ = cheerio.load(xml, { xmlMode: true });
+
+  const items: NewsItem[] = [];
   $("item").each((i, item) => {
     const $item = $(item);
 
@@ -479,7 +487,5 @@ async function fetchLatestNews() {
     });
   });
 
-  return {
-    items,
-  };
+  return items;
 }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -467,25 +467,38 @@ async function fetchLatestNews() {
 }
 
 async function fetchHacksNews(): Promise<NewsItem[]> {
-  const xml = await got("https://hacks.mozilla.org/category/mdn/feed/").text();
+  try {
+    const xml = await got(
+      "https://hacks.mozilla.org/category/mdn/feed/"
+    ).text();
 
-  const $ = cheerio.load(xml, { xmlMode: true });
+    const $ = cheerio.load(xml, { xmlMode: true });
 
-  const items: NewsItem[] = [];
-  $("item").each((i, item) => {
-    const $item = $(item);
+    const items: NewsItem[] = [];
+    $("item").each((i, item) => {
+      const $item = $(item);
 
-    items.push({
-      title: $item.find("title").text(),
-      url: $item.find("guid").text(),
-      author: $item.find("dc\\:creator").text(),
-      published_at: $item.find("pubDate").text(),
-      source: {
-        name: "hacks.mozilla.org",
-        url: "https://hacks.mozilla.org/category/mdn/",
-      },
+      items.push({
+        title: $item.find("title").text(),
+        url: $item.find("guid").text(),
+        author: $item.find("dc\\:creator").text(),
+        published_at: $item.find("pubDate").text(),
+        source: {
+          name: "hacks.mozilla.org",
+          url: "https://hacks.mozilla.org/category/mdn/",
+        },
+      });
     });
-  });
 
-  return items;
+    return items;
+  } catch (e) {
+    const msg = "Couldn't fetch hacks.mozilla.org feed!";
+    if (!DEV_MODE) {
+      console.error(`Error: ${msg}`);
+      throw e;
+    }
+
+    console.warn(`Warning: ${msg}`);
+    return [];
+  }
 }

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -32,3 +32,4 @@ export const SENTRY_DSN_BUILD: string;
 export const OPENAI_KEY: string;
 export const PG_URI: string;
 export const SAMPLE_SIGN_KEY: Buffer;
+export const DEV_MODE: boolean;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -173,3 +173,15 @@ export const PG_URI = process.env.PG_URI || "";
 export const SAMPLE_SIGN_KEY = process.env.BUILD_SAMPLE_SIGN_KEY
   ? Buffer.from(process.env.BUILD_SAMPLE_SIGN_KEY, "base64")
   : null;
+
+const CRUD_MODE =
+  process.env.REACT_APP_WRITER_MODE || process.env.REACT_APP_DEV_MODE
+    ? false
+    : Boolean(
+        JSON.parse(
+          process.env.REACT_APP_CRUD_MODE ||
+            JSON.stringify(process.env.NODE_ENV === "development")
+        )
+      );
+export const DEV_MODE =
+  CRUD_MODE || Boolean(JSON.parse(process.env.REACT_APP_DEV_MODE || "false"));


### PR DESCRIPTION
## Summary

(MP-899)

### Problem

When working on a train or a plane without internet, you cannot run `yarn dev`, because it fails when building the SPA.

### Solution

Convert the errors to warnings if `DEV_MODE` is enabled (via setting `REACT_APP_DEV_MODE=true` in the `.env`).

*Note*: Technically, `yarn tool popularities` is also affected, but the command defaults to not downloading the popularities again if they already exist (unless `--refresh` is provided), so this PR doesn't cover that case (just don't delete your `popularities.json` when you're on a plane 🙂).

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% yarn tool spas
yarn run v1.22.21
$ NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts spas

error: getaddrinfo ENOTFOUND api.github.com

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After

```
% yarn tool spas
yarn run v1.22.21
$ NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts spas
Warning: Couldn't fetch recent GitHub contributions for repo mdn/translated-content!
Warning: Couldn't fetch recent GitHub contributions for repo mdn/content!
Warning: Couldn't fetch hacks.mozilla.org feed!
Built 146 SPA related files
✨  Done in 17.81s.
```

---

## How did you test this change?

Ran `yarn tool spas` with wifi disabled (see above).