### PR TITLE
fix(bcd): re-surface "see bug xxxxx" notes

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -11,6 +11,7 @@ import {
   isTruthy,
   versionIsPreview,
   SupportStatementExtended,
+  bugURLToString,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
 import { DEFAULT_LOCALE } from "../../../../../libs/constants";
@@ -372,6 +373,19 @@ function getNotes(
             ? (Array.isArray(item.notes) ? item.notes : [item.notes]).map(
                 (note) => ({ iconName: "footnote", label: note })
               )
+            : null,
+          item.impl_url
+            ? (Array.isArray(item.impl_url)
+                ? item.impl_url
+                : [item.impl_url]
+              ).map((impl_url) => ({
+                iconName: "footnote",
+                label: (
+                  <>
+                    See <a href={impl_url}>{bugURLToString(impl_url)}</a>.
+                  </>
+                ),
+              }))
             : null,
           versionIsPreview(item.version_added, browser)
             ? {

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -116,14 +116,21 @@ export function versionIsPreview(
 
 export function hasNoteworthyNotes(support: BCD.SimpleSupportStatement) {
   return (
-    support.notes?.length &&
+    (support.notes?.length || support.impl_url?.length) &&
     !support.version_removed &&
     !support.partial_implementation
   );
 }
 
+export function bugURLToString(url: string) {
+  const bugNumber = url.match(
+    /^https:\/\/(?:crbug\.com|webkit\.org\/b|bugzil\.la)\/([0-9]+)/i
+  )?.[1];
+  return bugNumber ? `bug ${bugNumber}` : url;
+}
+
 function hasLimitation(support: BCD.SimpleSupportStatement) {
-  return hasMajorLimitation(support) || support.notes;
+  return hasMajorLimitation(support) || support.notes || support.impl_url;
 }
 
 function hasMajorLimitation(support: BCD.SimpleSupportStatement) {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/10522
Relates to https://github.com/web-platform-dx/web-features/issues/591

cc @queengooborg, @foolip 

### Problem

bcd migrated to using the `impl_url` field over the `notes` field in most cases: https://github.com/mdn/browser-compat-data/pull/20608

### Solution

this commit attempts to bring back the same functionality as before

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before https://github.com/mdn/browser-compat-data/pull/20608

![image](https://github.com/mdn/yari/assets/755354/b01201d3-df8f-44fa-bbcf-9da77b288470)


### Before

![image](https://github.com/mdn/yari/assets/755354/2c96297f-af12-427f-a4c3-19da7e501fc5)


### After

![image](https://github.com/mdn/yari/assets/755354/757cbdf1-6aaa-471a-af57-f96e8b3680c8)


---

## How did you test this change?

Set `REACT_APP_BCD_BASE_URL=""` in `.env` in order to use local bcd data, rather than stage data.

In `yari/node_modules/@mdn/browser-compat-data/data.json`, replaced
```
{"chrome":{"impl_url":"https://crbug.com/393466","version_added":false},"chrome_android":{"impl_url":"https://crbug.com/393466","version_added":false}
```
with
```
{"chrome":{"notes": "See <a href='https://crbug.com/393466'>bug 393466</a>.","version_added":false},"chrome_android":{"impl_url":"https://crbug.com/foobar/393466","version_added":false}
```
Visited http://localhost:3000/en-US/docs/Web/API/HTMLElement/accessKeyLabel#browser_compatibility to test that the display of the `notes` with Chrome was the same as the display of `impl_url` with Edge, and that the malformed url with Chrome for Android rendered without error.

Also installed the version of BCD prior to https://github.com/mdn/browser-compat-data/pull/20608 with `yarn add @mdn/browser-compat-data@v5.3.13`.