### PR TITLE
fix: locale missing page - no data due to missing await

### DIFF
--- a/server/translations.ts
+++ b/server/translations.ts
@@ -621,7 +621,7 @@ router.get("/missing", async (req, res) => {
 
   const label = `Find all missing translations (${locale})`;
   console.time(label);
-  const found = gatherL10NstatsSection({ locale });
+  const found = await gatherL10NstatsSection({ locale });
   console.timeEnd(label);
   res.json(found);
 });


### PR DESCRIPTION
## Summary

An error occurred when accessing page http://localhost:3000/ko/_translations/missing.

While adding async to the `gatherL10NstatsSection` method, await seems to be missing.

### Problem

The browser is unable to receive data from the server because `await` is missing.

### Solution

`const found = gatherL10NstatsSection({ locale });` => `const found = await gatherL10NstatsSection({ locale });`

---

## Screenshots

### Before

<img width="490" alt="image" src="https://github.com/mdn/yari/assets/22424891/7b7a4d5a-e075-44e5-a088-5a57e9e8d0a3">

<img width="846" alt="image" src="https://github.com/mdn/yari/assets/22424891/066e2323-0b68-45c9-a0d8-73c64f3d57b6">

### After

<img width="1299" alt="image" src="https://github.com/mdn/yari/assets/22424891/2e565f9a-0258-4e79-921d-45bac44eaaa4">

<img width="1379" alt="image" src="https://github.com/mdn/yari/assets/22424891/5ab0844e-6fa4-43ce-aafe-133e69c68ca0">

