### PR TITLE
feat(kumascript): add mdn.cache() utility

### DIFF
--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -1,6 +1,7 @@
 <%
+mdn.cache();
+
 var locale = env.locale;
-var slug = env.slug;
 var baseURL = '/' + locale + '/docs/Mozilla/Add-ons/';
 
 var text = mdn.localStringMap({

--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -1,5 +1,4 @@
 <%
-mdn.cache();
 
 var locale = env.locale;
 var baseURL = '/' + locale + '/docs/Mozilla/Add-ons/';

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1,5 +1,7 @@
 <%
 
+mdn.cache();
+
 const text = mdn.localStringMap({
   'en-US': {
     'Tutorials': 'Tutorials',

--- a/kumascript/macros/GlossarySidebar.ejs
+++ b/kumascript/macros/GlossarySidebar.ejs
@@ -1,4 +1,6 @@
 <%
+mdn.cache();
+
 async function renderRootItem(slug) {
   const [link, title] = await getPageLinkAndTitle(slug);
   return `<li><a href="${link}"><strong>${title}</strong></a></li>`

--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -1,4 +1,6 @@
 <%
+mdn.cache();
+
 var currentSection = $0;
 var locale = env.locale;
 

--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -1,4 +1,5 @@
 <%
+mdn.cache();
 
 const l10nStrings = mdn.localStringMap({
   'en-US': {

--- a/kumascript/macros/SubpagesWithSummaries.ejs
+++ b/kumascript/macros/SubpagesWithSummaries.ejs
@@ -6,7 +6,6 @@
 //
 //  $0  A list of pages to output instead of the subpages of the current page;
 //      OPTIONAL.
-
 function pageSorter(a, b) {
     return a.title.localeCompare(b.title);
 }
@@ -15,6 +14,7 @@ var termList;
 var html = "";
 
 if ($0 && ($0 != undefined)) {
+    mdn.cache();
     termList = JSON.parse($0);
 } else {
     termList = await page.subpagesExpand();

--- a/kumascript/src/api/mdn.ts
+++ b/kumascript/src/api/mdn.ts
@@ -1,6 +1,7 @@
 import got from "got";
 import { KumaThis } from "../environment.js";
 import * as util from "./util.js";
+import { toggleRenderCache } from "../templates.js";
 
 // Module level caching for repeat calls to fetchWebExtExamples().
 let webExtExamples: any = null;
@@ -120,6 +121,10 @@ const mdn = {
    * Given a string, escapes all quotes within it.
    */
   escapeQuotes: util.escapeQuotes,
+
+  cache(this: KumaThis) {
+    toggleRenderCache(true);
+  },
 
   /**
    * Throw a deprecation error.

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -27,10 +27,19 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ejs from "ejs";
+import { LRUCache } from "lru-cache";
 
 const DEFAULT_MACROS_DIRECTORY = path.normalize(
   fileURLToPath(new URL("../macros", import.meta.url))
 );
+
+const RENDER_CACHE = new LRUCache<string, string>({ max: 100 });
+
+export let isRenderCacheEnabled = false;
+
+export function toggleRenderCache(value: boolean) {
+  isRenderCacheEnabled = value;
+}
 
 export default class Templates {
   private macroDirectory: string;
@@ -102,11 +111,24 @@ export default class Templates {
       throw new ReferenceError(`Unknown macro ${name}`);
     }
     try {
-      const rendered = await ejs.renderFile(path, args, {
-        async: true,
-        cache: args.cache || process.env.NODE_ENV === "production",
-      });
-      return rendered.trim();
+      const cacheKey = `${args.env.locale}:${name}:${JSON.stringify(args.$$)}`;
+
+      let output = RENDER_CACHE.get(cacheKey);
+
+      if (!output) {
+        output = await ejs.renderFile(path, args, {
+          async: true,
+          cache: args.cache || process.env.NODE_ENV === "production",
+        });
+        output = output.trim();
+      }
+
+      if (isRenderCacheEnabled) {
+        RENDER_CACHE.set(cacheKey, output);
+        toggleRenderCache(false);
+      }
+
+      return output;
     } catch (error) {
       console.error(
         `The ${name} macro on ${args.env.url} failed to render.`,

--- a/kumascript/src/templates.ts
+++ b/kumascript/src/templates.ts
@@ -111,7 +111,7 @@ export default class Templates {
       throw new ReferenceError(`Unknown macro ${name}`);
     }
     try {
-      const cacheKey = `${args.env.locale}:${name}:${JSON.stringify(args.$$)}`;
+      const cacheKey = `${args?.env?.locale}:${name}:${JSON.stringify(args.$$)}`;
 
       let output = RENDER_CACHE.get(cacheKey);
 
@@ -131,7 +131,7 @@ export default class Templates {
       return output;
     } catch (error) {
       console.error(
-        `The ${name} macro on ${args.env.url} failed to render.`,
+        `The ${name} macro on ${args?.env?.url} failed to render.`,
         error
       );
       throw error;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

Allows to cache the output of macros if it only depends on locale and args.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
Macro render report
name,count,min (ms),avg (ms),max (ms),sum (ms)
cssref,1050,0,18.604,561.208,19535.198
apiref,6173,0.414,2.092,68.581,12916.156
domxref,51473,0,0.083,10.326,4316.739
learnsidebar,328,0,12.921,446.038,4238.359
jsxref,12107,0,0.21,386.962,2551.605
addonsidebar,704,1.164,2.782,102.897,1959.104
jssidebar,282,1.851,5.253,180.012,1481.627
glossarysidebar,574,1.772,2.52,105.08,1447.039
jsref,693,0.568,1.94,40.298,1344.832
svgref,359,0,3.413,150.705,1225.618
subpageswithsummaries,9,3.271,135.332,752.703,1217.993
cssxref,13552,0,0.087,2.859,1181.436
landingpagelistsubpages,8,15.695,142.368,302.913,1138.948
htmlelement,8118,0,0.134,7.778,1093.663
httpsidebar,334,1.233,3.266,103.729,1091.158
htmlsidebar,231,1.293,4.418,150.304,1020.709
csssyntax,562,0.013,1.125,554.927,632.653
defaultapisidebar,432,0.042,1.411,30.301,609.705
embedlivesample,2916,0.061,0.161,3.958,471.384
apilistalpha,1,444.882,444.882,444.882,444.882
quicklinkswithsubpages,184,0.037,1.933,50.205,355.743
listsubpagesforsidebar,175,0.137,1.8,63.947,315.161
mdnsidebar,73,1.094,4.014,49.028,293.031
glossary,4007,0,0.073,2.296,292.529
listsubpages,12,0.053,14.091,125.773,169.103
xsltsidebar,99,0.487,1.267,20.616,125.508
pwasidebar,31,0.524,3.82,27.947,118.441
svgelement,2898,0,0.039,1.7,115.396
webextallcompattables,1,91.772,91.772,91.772,91.772
listgroups,1,84.783,84.783,84.783,84.783
compat,9495,0.005,0.008,2.114,77.796
cssinfo,488,0.038,0.155,7.95,76.024
webextallexamples,1,74.03,74.03,74.03,74.03
specifications,8724,0.005,0.007,1.486,69.028
mathmlref,46,0.349,1.432,19.765,65.882
css_ref,1,52.552,52.552,52.552,52.552
glossarydisambiguation,10,0.08,3.99,7.479,39.902
embedinteractiveexample,1250,0.011,0.023,1.671,29.291
inheritancediagram,850,0.007,0.028,1.835,23.874
securecontext_header,1343,0.005,0.017,0.581,23.039
seecompattable,1438,0,0.013,0.301,18.953
svginfo,75,0.047,0.239,3.096,17.935
webextexamples,581,0.01,0.025,1.916,14.785
webextapiref,2194,0,0.006,1.914,14.77
optional_inline,2830,0,0.004,0.476,12.218
svgattr,2715,0,0.004,0.237,11.915
gamessidebar,67,0.091,0.162,2.098,10.856
readonlyinline,3299,0,0.002,0.316,9.846
firefoxsidebar,164,0.038,0.057,0.611,9.428
webassemblysidebar,118,0.048,0.073,1.042,8.624
firefox_for_developers,123,0.019,0.066,0.757,8.225
deprecated_header,595,0.005,0.013,0.293,8.219
experimental_inline,1585,0,0.004,0.156,7.54
previousmenunext,380,0,0.018,0.752,6.871
httpheader,1744,0,0.003,0.219,6.76
embedghlivesample,579,0,0.011,1.96,6.384
availableinworkers,420,0.004,0.014,1.484,5.957
non-standard_header,369,0.004,0.012,0.312,4.556
deprecated_inline,1276,0,0.003,0.048,3.918
js_property_attributes,52,0.013,0.07,2.453,3.688
non-standard_inline,571,0,0.006,0.102,3.484
rfc,233,0,0.012,0.409,3.02
previousnext,179,0,0.012,0.386,2.302
livesamplelink,12,0.068,0.188,0.82,2.263
nextmenu,54,0,0.035,0.6,1.91
httpstatus,327,0,0.005,0.44,1.653
previousmenu,52,0,0.031,0.511,1.641
mathmlelement,228,0,0.006,0.533,1.472
httpmethod,231,0,0.006,0.339,1.444
csp,195,0,0.006,0.457,1.308
xsltref,23,0.022,0.048,0.485,1.118
no_tag_omission,71,0.005,0.015,0.342,1.088
jsfiddleembed,24,0.003,0.033,0.498,0.8
previous,10,0,0.068,0.461,0.68
next,10,0,0.066,0.451,0.664
addonsidebarmain,1,0.64,0.64,0.64,0.64
securecontext_inline,27,0,0.021,0.431,0.589
embedyoutube,18,0.003,0.032,0.442,0.587


✨  Done in 244.53s.
```

### After

```
Macro render report
name,count,min (ms),avg (ms),max (ms),sum (ms)
apiref,6173,0.408,2.25,68.395,13891.088
domxref,51473,0,0.086,10.888,4434.964
jsxref,12107,0,0.213,384.318,2585.122
addonsidebar,704,1.193,2.689,94.493,1893.122
cssxref,13552,0,0.125,3.881,1695.433
jsref,693,0.562,1.914,25.95,1326.641
svgref,359,0,3.361,146.847,1206.652
subpageswithsummaries,9,3.04,134.04,747.951,1206.363
jssidebar,282,1.563,4.181,138.675,1179.236
httpsidebar,334,1.269,3.36,89.465,1122.468
htmlelement,8118,0,0.129,8.022,1048.698
landingpagelistsubpages,8,13.713,127.048,270.037,1016.388
htmlsidebar,231,1.348,4.399,139.446,1016.229
defaultapisidebar,432,0.041,1.478,40.15,638.766
csssyntax,562,0.016,1.069,524.295,601.201
embedlivesample,2916,0.06,0.164,2.129,478.582
learnsidebar,328,0,1.365,439.972,447.962
cssref,1050,0,0.422,419.065,444.107
apilistalpha,1,423.756,423.756,423.756,423.756
quicklinkswithsubpages,184,0.04,1.819,50.219,334.853
glossary,4007,0,0.081,1.755,327.773
listsubpagesforsidebar,175,0.102,1.86,58.259,325.575
mdnsidebar,73,1.107,3.8,45.414,277.453
webextallexamples,1,215.143,215.143,215.143,215.143
glossarysidebar,574,0.057,0.335,130.956,192.342
listsubpages,12,0.09,13.519,123.641,162.233
xsltsidebar,99,0.512,1.25,24.591,123.752
pwasidebar,31,0.525,3.855,32.945,119.521
svgelement,2898,0,0.037,1.114,109.214
compat,9495,0.005,0.009,1.784,92.98
css_ref,1,91.04,91.04,91.04,91.04
webextallcompattables,1,85.979,85.979,85.979,85.979
listgroups,1,81.86,81.86,81.86,81.86
specifications,8724,0.005,0.008,1.783,75.783
cssinfo,488,0.032,0.15,7.729,73.444
mathmlref,46,0.377,1.414,19.884,65.075
glossarydisambiguation,10,0.055,4.335,8.15,43.355
embedinteractiveexample,1250,0.012,0.025,1.599,31.291
securecontext_header,1343,0.006,0.019,0.668,25.613
inheritancediagram,850,0.008,0.029,1.847,25.334
seecompattable,1438,0,0.014,0.312,20.898
webextexamples,581,0.011,0.035,2.668,20.73
svginfo,75,0.048,0.203,2.683,15.283
webextapiref,2194,0,0.006,0.262,13.861
svgattr,2715,0,0.004,0.248,12.441
optional_inline,2830,0,0.004,0.548,12.396
gamessidebar,67,0.1,0.163,2.094,10.959
readonlyinline,3299,0,0.003,0.327,10.613
firefoxsidebar,164,0.037,0.062,0.773,10.279
previousmenunext,380,0,0.024,0.566,9.15
deprecated_header,595,0.005,0.015,0.281,9.047
webassemblysidebar,118,0.047,0.073,1.034,8.71
firefox_for_developers,123,0.019,0.07,0.815,8.651
httpheader,1744,0,0.004,0.461,8.202
experimental_inline,1585,0,0.003,0.05,6.171
embedghlivesample,579,0.001,0.009,0.263,5.23
non-standard_header,369,0.005,0.013,0.326,5.155
availableinworkers,420,0.003,0.011,0.301,4.957
deprecated_inline,1276,0,0.003,0.049,4.013
non-standard_inline,571,0,0.006,0.049,3.55
rfc,233,0,0.013,0.493,3.183
previousnext,179,0,0.013,0.229,2.36
livesamplelink,12,0.067,0.181,0.731,2.179
nextmenu,54,0,0.035,0.504,1.915
previousmenu,52,0,0.036,0.495,1.884
httpstatus,327,0,0.005,0.291,1.717
js_property_attributes,52,0.014,0.031,0.443,1.65
httpmethod,231,0,0.006,0.427,1.591
mathmlelement,228,0,0.006,0.498,1.562
csp,195,0,0.006,0.384,1.363
xsltref,23,0.023,0.053,0.425,1.232
no_tag_omission,71,0.009,0.017,0.358,1.225
next,10,0,0.08,0.55,0.8
previous,10,0,0.069,0.465,0.695
addonsidebarmain,1,0.672,0.672,0.672,0.672
jsfiddleembed,24,0.004,0.027,0.429,0.666
embedyoutube,18,0.003,0.034,0.468,0.618
securecontext_inline,27,0,0.021,0.425,0.574


✨  Done in 228.71s.
```

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
