### PR TITLE
feat(ai-help): index short_title

### DIFF
--- a/scripts/ai-help.sql
+++ b/scripts/ai-help.sql
@@ -29,6 +29,7 @@ create table
     id bigserial,
     hash text null,
     title text not null,
+    title_short text not null,
     mdn_url text not null,
     html text null,
     markdown text null,


### PR DESCRIPTION
## Summary

(MP-671)

### Problem

MDN contains some pages with identical titles, and these may appear next to each other among the consulted MDN pages, only distinguishable by their corresponding URL.

### Solution

Index all pages' short_title so that we can show the parent page's `short_title` where necessary.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/495429/7b86554a-3087-4633-81d2-cf87c18cb164)

### After

![image](https://github.com/mdn/yari/assets/495429/6513f6f9-fb8a-400f-9938-d5bafa8d4ca5)

---

## How did you test this change?

Tested locally by asking `How can I redirect using HTTP?` with https://github.com/mdn/rumba/pull/428.

Notes:
- Added the `title_short` column to all three Supabase projects.
- Manually ran the script for the dev project.
- Copied `title` to `title_short` for stage and prod projects.
