### PR TITLE
chore(macros/PreviousMenuNext): add zh translation

### DIFF
--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -33,6 +33,8 @@ var s_Menu = mdn.localString({
     "pt-BR": " Menu: ",
     "fr"   : " Aperçu&nbsp;: ",
     "ru"   : " Обзор: ",
+    "zh-CN": " 概述：",
+    "zh-TW": " 概述：",
 });
 
 if ($0) {


### PR DESCRIPTION
## Summary

add l10n-zh translation for PreviousMenuNext macro.

Part of: mdn/translated-content#13881.

---

## Screenshots

Checked slug: `Learn/Accessibility/WAI-ARIA_basics`

### Before

| local | screenshot |
| --- | --- |
| zh-CN | ![image](https://github.com/mdn/yari/assets/15844309/74c48c59-7cea-4eee-9d2e-e075eafeb46b) |
| zh-TW | ![image](https://github.com/mdn/yari/assets/15844309/c6f965d6-6000-4259-a076-7ccc17282572) |

### After

| local | screenshot |
| --- | --- |
| zh-CN | ![image](https://github.com/mdn/yari/assets/15844309/781ce359-4703-4a94-b7aa-6e3116b55630) |
| zh-TW | ![image](https://github.com/mdn/yari/assets/15844309/022722ed-0601-4b69-b1ff-2f96f258d4d8) |

---

## How did you test this change?

Run `yarn dev` and check those l10n-zh documents metioned above.
