### PR TITLE
fix(modal): make close button visible

### DIFF
--- a/client/src/ui/atoms/modal/index.scss
+++ b/client/src/ui/atoms/modal/index.scss
@@ -40,6 +40,12 @@ body.ReactModal__Body--open {
   padding-bottom: 1.5rem;
 
   .button.has-icon {
+    --button-color: var(--icon-secondary);
+
+    &:hover {
+      --button-color: var(--icon-primary);
+    }
+
     .button-wrap {
       height: auto;
       margin: -0.5rem;
@@ -49,7 +55,6 @@ body.ReactModal__Body--open {
   }
 
   .icon {
-    background-color: #000;
     height: 1.25rem;
     margin: 0;
     width: 1.25rem;


### PR DESCRIPTION
## Summary

(MP-909)

### Problem

The close button in the AI Help usage guidance modal is not visible in the dark theme.

### Solution

Use `--icon-secondary` and `--icon-primary` for the icon, instead of `#000`.

---

## Screenshots

| | Before | After |
|--------|--------|--------|
| Light | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/7089737d-11dc-4e6c-96aa-a2e1e73dd2d3"> | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/96147ff6-6250-45ac-b666-e77b5999365b"> |
| Light Hover | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/7dd050c1-f781-45fd-912a-74132ffd90e9">  | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/977bcc91-20ac-43f1-bffe-612f99aff56f"> |
| Dark | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/1d55d58f-7494-4b31-bb48-e3980dd038f0"> | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/8c90f0ed-b707-4b0a-be54-02fd67d6d391"> |
| Dark Hover | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/33c2c4b7-1dc3-4872-ac78-5098f7c05005"> | <img width="819" alt="image" src="https://github.com/mdn/yari/assets/495429/90b375c8-099b-410c-94cf-57b6cb17d4b5"> |

---

## How did you test this change?

Opened http://localhost:3000/en-US/plus/ai-help locally and clicked on the "full guidance" link in the footer below the question field.