### PR TITLE
chore(macros/CSSRef): add Containment guides

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1264,7 +1264,7 @@ async function buildPropertylist(pages, title) {
       <details>
           <summary><%=text['Conditional_rules']%></summary>
           <ol>
-            <li><%-smartLink(`${cssURL}CSS_Conditional_Rules/Using_Feature_Queries`)%></li>
+            <li><%-smartLink(`${cssURL}CSS_Conditional_Rules/Using_Feature_Queries`, null, text['Using_feature_queries'], cssURL)%></li>
           </ol>
       </details>
   </li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -81,6 +81,10 @@ const text = mdn.localStringMap({
         'Content_breaks_in_Multicol': 'Content breaks in Multicol',
       'Conditional_rules': 'Conditional rules',
         'Using_feature_queries': 'Using feature queries',
+      'Containment' : 'Containment',
+        'Using_CSS_containment' : 'Using CSS containment',
+        'Container_queries' : 'CSS container queries',
+        'Container_size_and_style_queries' : 'Using container size and style queries',
       'CSSOM_view': 'CSSOM view',
         'Coordinate_systems': 'Coordinate systems',
       'Flexbox': 'Flexbox',
@@ -1263,6 +1267,16 @@ async function buildPropertylist(pages, title) {
             <li><%-smartLink(`${cssURL}CSS_Conditional_Rules/Using_Feature_Queries`, null, text['Using_feature_queries'], cssURL)%></li>
           </ol>
       </details>
+  </li>
+  <li class="toggle">
+    <details>
+        <summary><%=text['Containment']%></summary>
+        <ol>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null, text['Using_CSS_containment'], cssURL)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Container_queries`, null, text['Container_queries'], cssURL)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Container_size_and_style_queries`, null, text['Container_size_and_style_queries'], cssURL)%></li>
+        </ol>
+    </details>
   </li>
   <li class="toggle">
       <details>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1264,7 +1264,7 @@ async function buildPropertylist(pages, title) {
       <details>
           <summary><%=text['Conditional_rules']%></summary>
           <ol>
-            <li><%-smartLink(`${cssURL}CSS_Conditional_Rules/Using_Feature_Queries`, null, text['Using_feature_queries'], cssURL)%></li>
+            <li><%-smartLink(`${cssURL}CSS_Conditional_Rules/Using_Feature_Queries`)%></li>
           </ol>
       </details>
   </li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1272,9 +1272,9 @@ async function buildPropertylist(pages, title) {
     <details>
         <summary><%=text['Containment']%></summary>
         <ol>
-          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null, text['Using_CSS_containment'], cssURL)%></li>
-          <li><%-smartLink(`${cssURL}CSS_Containment/Container_queries`, null, text['Container_queries'], cssURL)%></li>
-          <li><%-smartLink(`${cssURL}CSS_Containment/Container_size_and_style_queries`, null, text['Container_size_and_style_queries'], cssURL)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Container_queries`)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Container_size_and_style_queries`)%></li>
         </ol>
     </details>
   </li>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1272,7 +1272,7 @@ async function buildPropertylist(pages, title) {
     <details>
         <summary><%=text['Containment']%></summary>
         <ol>
-          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null, text['Using_CSS_containment'], cssURL)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null,text['Using_CSS_containment'], cssURL)%></li>
           <li><%-smartLink(`${cssURL}CSS_Containment/Container_queries`, null, text['Container_queries'], cssURL)%></li>
           <li><%-smartLink(`${cssURL}CSS_Containment/Container_size_and_style_queries`, null, text['Container_size_and_style_queries'], cssURL)%></li>
         </ol>

--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1272,7 +1272,7 @@ async function buildPropertylist(pages, title) {
     <details>
         <summary><%=text['Containment']%></summary>
         <ol>
-          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null,text['Using_CSS_containment'], cssURL)%></li>
+          <li><%-smartLink(`${cssURL}CSS_Containment/Using_CSS_containment`, null, text['Using_CSS_containment'], cssURL)%></li>
           <li><%-smartLink(`${cssURL}CSS_Containment/Container_queries`, null, text['Container_queries'], cssURL)%></li>
           <li><%-smartLink(`${cssURL}CSS_Containment/Container_size_and_style_queries`, null, text['Container_size_and_style_queries'], cssURL)%></li>
         </ol>


### PR DESCRIPTION


## Summary

Adds the three containment guides to the CSS guides section of the CSS sidebar

### Problem

The containment guides are not listed in the CSS sidebar

### Solution

This adds the 3 guides

## Screenshots


### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<img width="344" alt="Screenshot showing 3 containment modules in the sidebar" src="https://github.com/mdn/yari/assets/69888/0c0c124b-a7cd-43ff-ab38-3ec2381527e1">


## How did you test this change?

localhost:3000
i clicked on all three links and the pages came up.
