### PR TITLE
fix(featured-articles): improve how Blog articles are shown

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -21,7 +21,7 @@ import {
   BUILD_OUT_ROOT,
 } from "../libs/env/index.js";
 import { isValidLocale } from "../libs/locale-utils/index.js";
-import { DocFrontmatter, NewsItem } from "../libs/types/document.js";
+import { DocFrontmatter, DocParent, NewsItem } from "../libs/types/document.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { renderHTML } from "../ssr/dist/main.js";
@@ -317,6 +317,10 @@ export async function buildSPAs(options: {
                   mdn_url: `/${DEFAULT_LOCALE}/blog/${slug}/`,
                   summary: description,
                   title,
+                  tag: {
+                    uri: `/${DEFAULT_LOCALE}/blog/`,
+                    title: "Blog",
+                  } satisfies DocParent,
                 };
               }
             }

--- a/client/src/homepage/featured-articles/index.scss
+++ b/client/src/homepage/featured-articles/index.scss
@@ -45,7 +45,7 @@
     }
 
     .tile-title {
-      align-items: flex-end;
+      align-items: flex-start;
       display: flex;
       flex-grow: 1;
       font: var(--type-heading-h5);


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

In the "Featured articles" section on the homepage, Blog articles don't have a parent link, and short titles are aligned to the bottom.

### Solution

1. Add a "Blog" parent link for blog articles.
2. Align titles to the top.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="845" alt="image" src="https://github.com/mdn/yari/assets/495429/864a8ae1-c264-4fdb-8a3d-f53f1666e1a4">

### After

<img width="845" alt="image" src="https://github.com/mdn/yari/assets/495429/23a19733-4c29-47fb-98b5-596e396c7481">

---

## How did you test this change?

Ran `yarn dev` (which calls `yarn tool spas`) and opened http://localhost:3000/en-US/.