### PR TITLE
fix(ai-help): show stopped message once + restore search animation

### DIFF
--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -477,7 +477,6 @@
 
       .stopped-message {
         color: var(--text-muted);
-        content: "■\00a0Stopped answering";
         display: block;
         margin-top: 1.7rem;
       }

--- a/client/src/plus/ai-help/index.scss
+++ b/client/src/plus/ai-help/index.scss
@@ -475,21 +475,11 @@
         }
       }
 
-      &.status-stopped .ai-help-message-content {
-        &.empty::after,
-        > :not(ol):not(ul):not(pre):last-child:after,
-        > ol:last-child li:last-child:after,
-        > pre:last-child code:after,
-        > ul:last-child li:last-child:after {
-          color: var(--text-muted);
-          content: "■\00a0Stopped answering";
-          display: block;
-          margin-top: 1.7rem;
-        }
-
-        &.empty::after {
-          margin-left: unset;
-        }
+      .stopped-message {
+        color: var(--text-muted);
+        content: "■\00a0Stopped answering";
+        display: block;
+        margin-top: 1.7rem;
       }
     }
 

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -541,7 +541,7 @@ function AIHelpAssistantResponseSources({
       <div
         className={[
           "ai-help-message-progress",
-          message.status !== MessageStatus.Pending && "complete",
+          message.status === MessageStatus.Pending ? "active" : "complete",
         ]
           .filter(Boolean)
           .join(" ")}

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -489,6 +489,11 @@ function AIHelpAssistantResponse({
           >
             {isOffTopic ? SORRY_FRONTEND : message.content}
           </ReactMarkdown>
+          {message.status === "stopped" && (
+            <section className="stopped-message">
+              {"■\u00a0Stopped answering"}
+            </section>
+          )}
           {(message.status === "complete" || isOffTopic) && (
             <>
               <section className="ai-help-feedback">


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Recent changes caused two regressions:

1. The "Stopped answering" message was potentially showing multiple times.
2. The icon next to "Searching for MDN content…" was no longer blinking.

### Solution

1. Move the "Stopped " message out of CSS into React.
2. Add the missing `active` class for the search status.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

https://github.com/mdn/yari/assets/495429/9c74180a-0c33-4185-b012-1cc480fefa68

---

## How did you test this change?

Asked a question locally and stopped when it was generating content in a nested list.