### PR TITLE
enhance(ai-help): hash markdown to identify formatting updates

### DIFF
--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -28,7 +28,6 @@ interface IndexedDoc {
   id: number;
   mdn_url: string;
   title: string;
-  title_short: string;
   token_count: number | null;
   hash: string;
   markdown_hash: string;
@@ -514,7 +513,7 @@ export function isNotSupportedAtAll(support: SimpleSupportStatement) {
   return !support.version_added && !hasLimitation(support);
 }
 
-async function fetchAllExistingDocs(pgClient) {
+async function fetchAllExistingDocs(pgClient): Promise<IndexedDoc[]> {
   const PAGE_SIZE = 1000;
   const selectDocs = async (lastId) => {
     const query = {

--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -39,7 +39,6 @@ interface Doc {
   title: string;
   title_short: string;
   hash: string;
-  html: string;
   markdown: string;
   text?: string;
   text_hash?: string;
@@ -115,7 +114,6 @@ export async function updateEmbeddings(
     title,
     title_short,
     hash,
-    html,
     markdown,
     text,
   } of builtDocs(directory)) {
@@ -132,7 +130,6 @@ export async function updateEmbeddings(
         title,
         title_short,
         hash,
-        html,
         markdown,
         text,
         text_hash,
@@ -143,7 +140,6 @@ export async function updateEmbeddings(
         title,
         title_short,
         hash,
-        html,
         markdown,
       });
     }
@@ -166,7 +162,6 @@ export async function updateEmbeddings(
       title,
       title_short,
       hash,
-      html,
       markdown,
       text,
       text_hash,
@@ -186,30 +181,27 @@ export async function updateEmbeddings(
                     title,
                     title_short,
                     hash,
-                    html,
                     markdown,
                     token_count,
                     embedding,
                     text_hash
                 )
-            VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (mdn_url) DO
+            VALUES($1, $2, $3, $4, $5, $6, $7, $8) ON CONFLICT (mdn_url) DO
             UPDATE
             SET mdn_url = $1,
                 title = $2,
                 title_short = $3,
                 hash = $4,
-                html = $5,
-                markdown = $6,
-                token_count = $7,
-                embedding = $8,
-                text_hash = $9
+                markdown = $5,
+                token_count = $6,
+                embedding = $7,
+                text_hash = $8
           `,
           values: [
             mdn_url,
             title,
             title_short,
             hash,
-            html,
             markdown,
             total_tokens,
             pgvector.toSql(embedding),
@@ -230,7 +222,6 @@ export async function updateEmbeddings(
       title,
       title_short,
       hash,
-      html,
       markdown,
     } of formattingUpdates) {
       try {
@@ -242,17 +233,16 @@ export async function updateEmbeddings(
         const query = {
           name: "upsert-doc",
           text: `
-            INSERT INTO mdn_doc_macro(mdn_url, title, title_short, hash, html, markdown)
-            VALUES($1, $2, $3, $4, $5, $6) ON CONFLICT (mdn_url) DO
+            INSERT INTO mdn_doc_macro(mdn_url, title, title_short, hash, markdown)
+            VALUES($1, $2, $3, $4, $5) ON CONFLICT (mdn_url) DO
             UPDATE
             SET mdn_url = $1,
                 title = $2,
                 title_short = $3,
                 hash = $4,
-                html = $5,
-                markdown = $6
+                markdown = $5
           `,
-          values: [mdn_url, title, title_short, hash, html, markdown],
+          values: [mdn_url, title, title_short, hash, markdown],
           rowMode: "array",
         };
 
@@ -285,8 +275,8 @@ export async function updateEmbeddings(
 }
 
 async function formatDocs(directory: string) {
-  for await (const { html, markdown, text } of builtDocs(directory)) {
-    console.log(html, markdown, text);
+  for await (const { markdown, text } of builtDocs(directory)) {
+    console.log(markdown, text);
   }
 }
 
@@ -340,7 +330,6 @@ async function* builtDocs(directory: string) {
         title,
         title_short: short_title || title,
         hash,
-        html,
         markdown,
         text,
       };


### PR DESCRIPTION
## Summary

### Problem

The `scripts/ai-help-macros.ts` script updates the document content if the document hash changes, but this hash also changes when building the content from another yari branch (e.g. `next`), because the branch name is included in the `source` property:

<img width="702" alt="image" src="https://github.com/mdn/yari/assets/495429/ebbbe8ec-231e-462c-9d03-d04561b9bfd6">

### Solution

Use the hash of the markdown content to determine whether the content has changed.

_Note_: We still use the text content to determine whether the embedding needs to be regenerated.

---

## How did you test this change?

Ran the following query on the Supabase dev project to populate the new `markdown_hash` column:
```sql
update mdn_doc_macro set markdown_hash = encode(digest (markdown, 'sha256'), 'base64');
```

Then ran `yarn ai-help-macros update-index` locally. 