### PR TITLE
fix(logo): set width to width of largest logo

### DIFF
--- a/client/src/ui/atoms/logo/index.scss
+++ b/client/src/ui/atoms/logo/index.scss
@@ -3,6 +3,7 @@
 .logo {
   align-items: center;
   display: flex;
+  width: 160px;
 
   svg {
     height: 1.5rem;

--- a/client/src/ui/atoms/logo/index.scss
+++ b/client/src/ui/atoms/logo/index.scss
@@ -3,6 +3,7 @@
 .logo {
   align-items: center;
   display: flex;
+  // Width of largest logo ("mdn web docs").
   width: 160px;
 
   svg {


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-922)

### Problem

We have three logos: `mdn`, `mdn plus`, `mdn web docs`.

These have different width, which causes the menu to jump when navigating between these parts of MDN.

### Solution

By setting a fixed width, we avoid these jumps.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

https://github.com/mdn/yari/assets/495429/8b5e150b-9e2d-45e3-a54f-00620587d15b

### After

https://github.com/mdn/yari/assets/495429/2e11e124-588a-437c-9b40-e9e1a4707966

---

## How did you test this change?

Ran `yarn dev`, then opened http://localhost:5042/en-US/ locally, clicked on "References", "Plus" and "Curriculum" and verified that the menu no longer jumps (see screen recording above).