### PR TITLE
fix(cloud-function): redirect blog/curriculum/play without locale

### DIFF
--- a/cloud-function/src/middlewares/redirect-locale.ts
+++ b/cloud-function/src/middlewares/redirect-locale.ts
@@ -4,7 +4,8 @@ import { getLocale } from "../internal/locale-utils/index.js";
 import { VALID_LOCALES } from "../internal/constants/index.js";
 import { redirect } from "../utils.js";
 
-const NEEDS_LOCALE = /^\/(?:docs|search|settings|signin|signup|plus)(?:$|\/)/;
+const NEEDS_LOCALE =
+  /^\/(?:blog|curriculum|docs|play|search|settings|plus)(?:$|\/)/;
 
 export async function redirectLocale(
   req: Request,


### PR DESCRIPTION


## Summary

### Problem

We usually redirect if the locale is missing from the url, e.g. https://developer.mozilla.org/plus to https://developer.mozilla.org/en-US/plus.

However, this doesn't work for:

- https://developer.mozilla.org/blog
- https://developer.mozilla.org/curriculum
- https://developer.mozilla.org/play

### Solution

Update the responsible regex to include blog/curriculum/play.

_Note_: Blog and Curriculum aren't available in locales other than `en-US`, but that is a separate issue.

---

## How did you test this change?

Ran `npm i && npm run server:watch` in `/cloud-function` and verified that http://localhost:8080/blog, http://localhost:8080/curriculum and http://localhost:8080/play redirect.
