### PR TITLE
feat(blog): remove playground queue

### DIFF
--- a/client/src/blog/post.tsx
+++ b/client/src/blog/post.tsx
@@ -15,7 +15,6 @@ import {
   AuthorMetadata,
 } from "../../../libs/types/blog";
 import {
-  useCollectSample,
   useCopyExamplesToClipboardAndAIExplain,
   useRunSample,
 } from "../document/hooks";
@@ -191,7 +190,6 @@ export function BlogPost(props: HydrationData) {
   );
   const { doc, blogMeta } = data || props || {};
   useRunSample(doc);
-  useCollectSample(doc);
   useCopyExamplesToClipboardAndAIExplain(doc);
   return (
     <>


### PR DESCRIPTION
## Summary

Stop showing a queue and play button on non-live-sample code snippets.

Note: for now we keep the now unused hook around.


---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/3604775/d4eebe87-7a43-42ae-84d6-c0a9a3579dff)

### After

![image](https://github.com/mdn/yari/assets/3604775/43ca52b5-82fb-4e14-9283-b133cbd2966f)

---

## How did you test this change?

locally using http://localhost:3000/en-US/blog/leveraging-bun-on-vultr-a-superior-node-js-alternative/