### PR TITLE
fix(article-footer): add missing space

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -5,7 +5,7 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
     <div id="on-github" className="on-github">
       <SourceOnGitHubLink doc={doc}>
         View this page on GitHub
-      </SourceOnGitHubLink>
+      </SourceOnGitHubLink>{" "}
       •{" "}
       <NewIssueOnGitHubLink doc={doc}>
         Report a problem with this content


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-907)

### Problem

The new article footer (https://github.com/mdn/yari/pull/10625) is missing a space left to the separator dot, which got lost in https://github.com/mdn/yari/pull/10625/commits/952c91fe8f53efc4767e4a7dcc01ccf9bfbf470d.

### Solution

Add the missing space.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="780" alt="image" src="https://github.com/mdn/yari/assets/495429/3feddb8d-02a8-471a-9d64-92bbd7b4f0a8">

### After

<img width="780" alt="image" src="https://github.com/mdn/yari/assets/495429/1467839f-3fca-4afe-93a5-c3bff8f9da8c">

---

## How did you test this change?

Ran `yarn dev` and visited http://localhost:3000/en-US/docs/Web#developer_tools_documentation locally.