### PR TITLE
fix(article-footer): show red heart emoji in Chrome/Edge

### DIFF
--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -101,5 +101,10 @@
       margin-bottom: 0;
       margin-top: 3rem;
     }
+
+    .emoji {
+      // Ensure emojis are shown in color.
+      font-family: initial;
+    }
   }
 }

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -121,7 +121,9 @@ export function ArticleFooter({ doc, locale }) {
               </div>
             </>
           ) : (
-            <span className="thank-you">Thank you for your feedback! ❤️</span>
+            <span className="thank-you">
+              Thank you for your feedback! <span className="emoji">❤️</span>
+            </span>
           )}
         </fieldset>
 


### PR DESCRIPTION
## Summary

(MP-927)

### Problem

The heart emoji in the article footer (when submitting feedback) is shown in black in Chrome/Edge, because there seems to be [a compatibility issue](https://github.com/rsms/inter/issues/238) affecting the Inter fonts in Chromium.

### Solution

Avoid the Inter font for the emoji by wrapping it in a `<span>` and using the browser's default font.

---

## Screenshots

(Chrome:)

### Before

<img width="780" alt="image" src="https://github.com/mdn/yari/assets/495429/6d235908-9d6e-4980-9113-95b1479492ea">

### After

<img width="780" alt="image" src="https://github.com/mdn/yari/assets/495429/b57b454c-8e94-4d17-bdad-c71a3e9d608d">

---

## How did you test this change?

Ran `yarn dev`, then opened http://localhost:3000/en-US/docs/Web#developer_tools_documentation in Chrome 122.