### PR TITLE
fix(article-footer): reduce illustration size

### DIFF
--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -99,7 +99,7 @@
 
     .last-modified-date {
       margin-bottom: 0;
-      margin-top: 3rem;
+      margin-top: 2rem;
     }
   }
 }

--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -27,7 +27,7 @@
         position: absolute;
         right: 0;
         top: 0;
-        width: 25%;
+        width: 20%;
       }
     }
 


### PR DESCRIPTION
## Summary

(MP-931)

### Problem

The illustration in the article footer is to prominent.

### Solution

Reduce its size (by 1/4), and reduce the space below the contribute link accordingly.

---

## Screenshots

### Before

<img width="783" alt="image" src="https://github.com/mdn/yari/assets/495429/4df5cfbd-da95-4fb8-9568-1b10d0490b78">

### After

<img width="783" alt="image" src="https://github.com/mdn/yari/assets/495429/67d4de17-92fe-4db9-9fad-8d2123c7cd0f">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/docs/Web#developer_tools_documentation locally.