### PR TITLE
fix(bcd): Fix tooltip for removed features

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -336,7 +336,7 @@ function getNotes(
             (otherItem) => otherItem.version_added === item.version_removed
           )
             ? {
-                iconName: "disabled",
+                iconName: "footnote",
                 label: (
                   <>
                     Removed in {labelFromString(item.version_removed, browser)}{" "}


### PR DESCRIPTION
## Summary

Fixes #8587

### Problem

It used to be that the "Removed in..." note used the footnote icon. After the redesign back in 2022, the icon was changed to the disabled icon, which if you didn't know the codebase would make perfect sense. However, the disabled icon has the tooltip "User must explicitly enable this feature."

### Solution

Switch back to the footnote tooltip.

## Screenshots

### Before

![Screenshot from 2024-03-12 11-22-23](https://github.com/mdn/yari/assets/29206584/390bdc50-edad-4ac6-a3e6-fd278f7121a6)

### After

![Screenshot from 2024-03-12 11-21-49](https://github.com/mdn/yari/assets/29206584/fdcf9042-c458-4c54-a6c7-fca306c86876)