### PR TITLE
chore(macros): Deprecate no_tag_omission macro

### DIFF
--- a/kumascript/macros/no_tag_omission.ejs
+++ b/kumascript/macros/no_tag_omission.ejs
@@ -1,3 +1,4 @@
+<% mdn.deprecated(); %>
 <%
 /* This string will be extended in the future as there are discussion to apply animation-delay to non-animatable property */
 
@@ -9,6 +10,5 @@ var str = mdn.localString({
     "ru": "Нет, открывающий и закрывающий теги обязательны.",
     "zh-CN": "不允许，开始标签和结束标签都不能省略。"
 });
-
 
 %><%- str %>


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/10685

### Problem

This macro is being removed from EN content and can be deprecated.

## Screenshots

Added the updated macro to a document and visited on `http://localhost:3000/...#_flaws`

![image](https://github.com/mdn/yari/assets/43580235/32bf0314-a301-4355-8bf5-a91e42b329d9)


## How did you test this change?

* yarn && yarn dev
* visit http://localhost:3000

__Related issues and pull requests:__

- [x] https://github.com/mdn/content/pull/32675
- [x] https://github.com/mdn/content/pull/32394