### PR TITLE
feat(google-analytics): migrate to gtag.js with dual tagging

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -24,7 +24,7 @@ REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET=true
 
 # These are set to fake values just to make sure the paths that
 # injects the relevant script tags actually run in end-to-end testing.
-BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
+BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-00000000-0
 
 # The functional tests are done in a production'y way as if it had
 # to go into full production mode.

--- a/.env.testing
+++ b/.env.testing
@@ -24,7 +24,7 @@ REACT_APP_AUTOCOMPLETE_SEARCH_WIDGET=true
 
 # These are set to fake values just to make sure the paths that
 # injects the relevant script tags actually run in end-to-end testing.
-BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-00000000-0
+BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXX
 
 # The functional tests are done in a production'y way as if it had
 # to go into full production mode.

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -125,7 +125,7 @@ jobs:
 
           # This just makes sure the Google Analytics script gets used even if
           # it goes nowhere.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-00000000-0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-00000000-0
 
           # This removes the ability to sign in
           REACT_APP_DISABLE_AUTH: true

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -125,7 +125,7 @@ jobs:
 
           # This just makes sure the Google Analytics script gets used even if
           # it goes nowhere.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-00000000-0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-XXXXXXXX
 
           # This removes the ability to sign in
           REACT_APP_DISABLE_AUTH: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -50,7 +50,7 @@ jobs:
 
           # Make sure it's set to something so that the build uses the
           # Google Analytics tag which is most realistic.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-00000000-0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-XXXXXXXX
         run: |
           yarn build:prepare
           # BUILD_FOLDERSEARCH=mdn/kitchensink yarn build

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -50,7 +50,7 @@ jobs:
 
           # Make sure it's set to something so that the build uses the
           # Google Analytics tag which is most realistic.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-00000000-0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-00000000-0
         run: |
           yarn build:prepare
           # BUILD_FOLDERSEARCH=mdn/kitchensink yarn build

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -191,11 +191,11 @@ jobs:
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 
-          # This is the Google Analytics account ID for developer.mozilla.org
-          # If it's used on other domains (e.g. stage or dev builds), it's OK
-          # because ultimately Google Analytics will filter it out since the
-          # origin domain isn't what that account expects.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5
+          # These are the Google Analytics measurement IDs for:
+          # - developer.mozilla.org (UA)
+          # - developer.mozilla.org (GA4)
+          # Using measurement ids on other domains is okay, as GA will filter these events.
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5,G-PWTK27XVWP
 
           # This enables the MDN Plus
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -195,7 +195,7 @@ jobs:
           # If it's used on other domains (e.g. stage or dev builds), it's OK
           # because ultimately Google Analytics will filter it out since the
           # origin domain isn't what that account expects.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-36116321-5
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5
 
           # This enables the MDN Plus
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -194,11 +194,8 @@ jobs:
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 
-          # This is the Google Analytics account ID for developer.mozilla.org
-          # If it's used on other domains (e.g. stage or dev builds), it's OK
-          # because ultimately Google Analytics will filter it out since the
-          # origin domain isn't what that account expects.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-36116321-5
+          # This is the Google Analytics measurement ID for developer.allizom.org.
+          BUILD_GOOGLE_ANALYTICS_ACCOUNT: G-ZG5HNVZRY0
 
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -195,7 +195,7 @@ jobs:
           BUILD_FLAW_LEVELS: "*:ignore"
 
           # This is the Google Analytics measurement ID for developer.allizom.org.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: G-ZG5HNVZRY0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-ZG5HNVZRY0
 
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -194,8 +194,11 @@ jobs:
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 
-          # This is the Google Analytics measurement ID for developer.allizom.org.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-ZG5HNVZRY0
+          # These are the Google Analytics measurement IDs for:
+          # - developer.mozilla.org (UA)
+          # - developer.allizom.org (GA4)
+          # Using measurement ids on other domains is okay, as GA will filter these events.
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5,G-ZG5HNVZRY0
 
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/xyz-build.yml
+++ b/.github/workflows/xyz-build.yml
@@ -129,7 +129,7 @@ jobs:
           # If it's used on other domains (e.g. stage or dev builds), it's OK
           # because ultimately Google Analytics will filter it out since the
           # origin domain isn't what that account expects.
-          BUILD_GOOGLE_ANALYTICS_ACCOUNT: UA-36116321-5
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5
 
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -147,10 +147,9 @@ export function Document(props /* TODO: define a TS interface for this */) {
         // I.e. not the initial load but the location has now changed.
         // Note that in local development, where you use `localhost:3000`
         // this will always be true because it's always client-side navigation.
-        gtag("set", "dimension19", "Yes");
-        gtag("send", {
-          hitType: "pageview",
-          location,
+        gtag("event", "pageview", {
+          dimension19: "Yes",
+          page_location: location,
         });
         gleanClick(`${CLIENT_SIDE_NAVIGATION}: ${location}`);
       }

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -67,7 +67,7 @@ export class HTTPError extends Error {
 }
 
 export function Document(props /* TODO: define a TS interface for this */) {
-  const ga = useGA();
+  const { gtag } = useGA();
   const gleanClick = useGleanClick();
   const isServer = useIsServer();
 
@@ -147,8 +147,8 @@ export function Document(props /* TODO: define a TS interface for this */) {
         // I.e. not the initial load but the location has now changed.
         // Note that in local development, where you use `localhost:3000`
         // this will always be true because it's always client-side navigation.
-        ga("set", "dimension19", "Yes");
-        ga("send", {
+        gtag("set", "dimension19", "Yes");
+        gtag("send", {
           hitType: "pageview",
           location,
         });
@@ -159,7 +159,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
       // a client-side navigation happened.
       mountCounter.current++;
     }
-  }, [ga, gleanClick, doc, error]);
+  }, [gtag, gleanClick, doc, error]);
 
   React.useEffect(() => {
     const location = document.location;

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 
 export interface GAData {
   gtag: GAFunction;
@@ -37,20 +37,6 @@ export function GAProvider(props: { children: React.ReactNode }) {
   return (
     <GAContext.Provider value={{ gtag }}>{props.children}</GAContext.Provider>
   );
-}
-
-// This is a custom hook to return the GA client id. It returns the
-// empty string until (and unless) it can determine that id from the GA object.
-export function useClientId() {
-  const [clientId, setClientId] = useState<string>("");
-  const { gtag } = useContext(GAContext);
-  useEffect(() => {
-    gtag((tracker) => {
-      setClientId(tracker.get("clientId"));
-    });
-  }, [gtag]);
-
-  return clientId;
 }
 
 export function useGA() {

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { useContext, useEffect, useState } from "react";
 
+export interface GAData {
+  gtag: GAFunction;
+}
 export type GAFunction = (...any) => void;
 
 const GA_SESSION_STORAGE_KEY = "ga";
@@ -34,25 +37,25 @@ export function gaSendOnNextPage(newEvents: any[]) {
 
 declare global {
   interface Window {
-    ga?: Function;
+    gtag?: Function;
   }
 }
 
-function ga(...args) {
-  if (typeof window === "object" && typeof window.ga === "function") {
-    window.ga(...args);
+function gtag(...args) {
+  if (typeof window === "object" && typeof window.gtag === "function") {
+    window.gtag(...args);
   }
 }
 
-const GAContext = React.createContext<GAFunction>(ga);
+const GAContext = React.createContext<GAData>({ gtag });
 
 /**
  * If we're running in the browser (not being server-side rendered)
  * and if the HTML document includes the Google Analytics snippet that
- * defines the ga() function, then this provider component makes that
- * ga() function available to any component via:
+ * defines the gtag() function, then this provider component makes that
+ * gtag() function available to any component via:
  *
- *    let ga = useContext(GAProvider.context)
+ *    const { gtag } = useContext(GAProvider.context)
  *
  * If we're not in a browser or if google analytics is not enabled,
  * then we provide a dummy function that ignores its arguments and
@@ -72,23 +75,25 @@ export function GAProvider(props: { children: React.ReactNode }) {
       // No sessionStorage support
     }
     for (const event of events) {
-      ga("send", event);
+      gtag("send", event);
     }
   }, []);
 
-  return <GAContext.Provider value={ga}>{props.children}</GAContext.Provider>;
+  return (
+    <GAContext.Provider value={{ gtag }}>{props.children}</GAContext.Provider>
+  );
 }
 
 // This is a custom hook to return the GA client id. It returns the
 // empty string until (and unless) it can determine that id from the GA object.
 export function useClientId() {
   const [clientId, setClientId] = useState<string>("");
-  const ga = useContext(GAContext);
+  const { gtag } = useContext(GAContext);
   useEffect(() => {
-    ga((tracker) => {
+    gtag((tracker) => {
       setClientId(tracker.get("clientId"));
     });
-  }, [ga]);
+  }, [gtag]);
 
   return clientId;
 }

--- a/client/src/ga-context.tsx
+++ b/client/src/ga-context.tsx
@@ -6,35 +6,6 @@ export interface GAData {
 }
 export type GAFunction = (...any) => void;
 
-const GA_SESSION_STORAGE_KEY = "ga";
-
-function getPostponedEvents() {
-  let value;
-  try {
-    value = sessionStorage.getItem(GA_SESSION_STORAGE_KEY);
-  } catch (e) {
-    // No sessionStorage support
-    return [];
-  }
-  return JSON.parse(value || JSON.stringify([]));
-}
-
-/**
- * Saves given events into sessionStorage so that they are sent once the next
- * page has loaded. This should be used for events that need to be sent without
- * delaying navigation to a new page (which would cancel pending network
- * requests).
- */
-export function gaSendOnNextPage(newEvents: any[]) {
-  const events = getPostponedEvents();
-  const value = JSON.stringify(events.concat(newEvents));
-  try {
-    sessionStorage.setItem(GA_SESSION_STORAGE_KEY, value);
-  } catch (e) {
-    // No sessionStorage support
-  }
-}
-
 declare global {
   interface Window {
     gtag?: Function;
@@ -63,22 +34,6 @@ const GAContext = React.createContext<GAData>({ gtag });
  * the function provided by this component.
  */
 export function GAProvider(props: { children: React.ReactNode }) {
-  /**
-   * Checks for the existence of postponed analytics events, which we store
-   * in sessionStorage. It also clears them so that they aren't sent again.
-   */
-  useEffect(() => {
-    const events = getPostponedEvents();
-    try {
-      sessionStorage.removeItem(GA_SESSION_STORAGE_KEY);
-    } catch (e) {
-      // No sessionStorage support
-    }
-    for (const event of events) {
-      gtag("send", event);
-    }
-  }, []);
-
   return (
     <GAContext.Provider value={{ gtag }}>{props.children}</GAContext.Provider>
   );

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -41,10 +41,9 @@ export function SiteSearch() {
         // I.e. not the initial load but the location has now changed.
         // Note that in local development, where you use `localhost:3000`
         // this will always be true because it's always client-side navigation.
-        gtag("set", "dimension19", "Yes");
-        gtag("send", {
-          hitType: "pageview",
-          location,
+        gtag("event", "pageview", {
+          dimension19: "Yes",
+          page_location: location,
         });
         gleanClick(`${CLIENT_SIDE_NAVIGATION}: ${location}`);
       }

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -14,7 +14,7 @@ const SearchResults = React.lazy(() => import("./search-results"));
 
 export function SiteSearch() {
   const isServer = useIsServer();
-  const ga = useGA();
+  const { gtag } = useGA();
   const gleanClick = useGleanClick();
   const [searchParams] = useSearchParams();
 
@@ -34,15 +34,15 @@ export function SiteSearch() {
 
   const mountCounter = React.useRef(0);
   React.useEffect(() => {
-    if (ga) {
+    if (gtag) {
       if (mountCounter.current > 0) {
         const location = window.location.toString();
         // 'dimension19' means it's a client-side navigation.
         // I.e. not the initial load but the location has now changed.
         // Note that in local development, where you use `localhost:3000`
         // this will always be true because it's always client-side navigation.
-        ga("set", "dimension19", "Yes");
-        ga("send", {
+        gtag("set", "dimension19", "Yes");
+        gtag("send", {
           hitType: "pageview",
           location,
         });
@@ -52,7 +52,7 @@ export function SiteSearch() {
       // a client-side navigation happened.
       mountCounter.current++;
     }
-  }, [query, page, ga, gleanClick]);
+  }, [query, page, gtag, gleanClick]);
 
   return (
     <div className="main-wrapper site-search">

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -151,6 +151,12 @@ If set, the rendered HTML will have a Google Analytics snippet. For example, to
 test use: `export BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXX`. By default
 it's disabled (empty string).
 
+For dual tagging (UA + GA4), multiple IDs can be separated by a comma:
+
+```env
+export BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-00000000-0,G-XXXXXXXX
+```
+
 ### `BUILD_ALWAYS_ALLOW_ROBOTS`
 
 **Default: `false`**

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -148,8 +148,8 @@ The base URL used in the Interactive Example iframes.
 **Default: `''`**
 
 If set, the rendered HTML will have a Google Analytics snippet. For example, to
-test use: `export BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-00000000-0`. By
-default it's disabled (empty string).
+test use: `export BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXX`. By default
+it's disabled (empty string).
 
 ### `BUILD_ALWAYS_ALLOW_ROBOTS`
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -143,13 +143,13 @@ Used to serve legacy lives samples that do not support playground rendering.
 
 The base URL used in the Interactive Example iframes.
 
-### `BUILD_GOOGLE_ANALYTICS_ACCOUNT`
+### `BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID`
 
 **Default: `''`**
 
 If set, the rendered HTML will have a Google Analytics snippet. For example, to
-test use: `export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0`. By default it's
-disabled (empty string).
+test use: `export BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-00000000-0`. By
+default it's disabled (empty string).
 
 ### `BUILD_ALWAYS_ALLOW_ROBOTS`
 

--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -151,16 +151,6 @@ If set, the rendered HTML will have a Google Analytics snippet. For example, to
 test use: `export BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0`. By default it's
 disabled (empty string).
 
-### `BUILD_GOOGLE_ANALYTICS_DEBUG`
-
-**Default: `false`**
-
-If true, and when `BUILD_GOOGLE_ANALYTICS_ACCOUNT` is truthy, when it injects
-the Google Analytics script tag it will use
-`<script src="https://www.google-analytics.com/analytics_debug.js"></script>`
-instead which triggers additional console logging which is useful for
-developers.
-
 ### `BUILD_ALWAYS_ALLOW_ROBOTS`
 
 **Default: `false`**

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -28,11 +28,11 @@ See:
 You can send individual arbitrary events in the client-side code. The best way
 to describe how this works is to look a existing code.
 
-Look for code that uses the `const ga = useGA()` hook and things that start
-with...:
+Look for code that uses the `const { gtag } = useGA()` hook and things that
+start with...:
 
 ```javascript
-ga("send", {
+gtag("event", {
   ...
 ```
 

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -5,7 +5,7 @@ from the client-side code. The way it works is that you have to send an
 environment variable, like:
 
 ```bash
-BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-1234678-0
+BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-1234678-0
 ```
 
 and that gets included in the build by more or less code-generating the snippet

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -13,10 +13,10 @@ we use to set up Google Analytics.
 
 By default, it's not set and that means no Google Analytics JavaScript code
 inside the rendered final HTML. By setting the environment variable, a
-build-step will generate a `/static/js/ga.js` file that configures how we enable
-Google Analytics. And the server-side rendering will inject a
-`<script defer src=/static/js/ga.js>` in the HTML of every page, including home
-page, site-search, `404.html` and article pages.
+build-step will generate a `/static/js/gtag.js` file that configures how we
+enable Google Analytics. And the server-side rendering will inject a
+`<script defer src=/static/js/gtag.js>` in the HTML of every page, including
+home page, site-search, `404.html` and article pages.
 
 ## Debugging
 
@@ -55,7 +55,7 @@ to wrap you send events with a conditional statement.
 
 ## Client-side navigation
 
-By default, we send a `pageview` event as soon as the `ga.js` and the
+By default, we send a `pageview` event as soon as the `gtag.js` and the
 `https://www.google-analytics.com/analytics.js` code have both loaded. This
 should happen as early as possible. Even before the `DOMContentLoaded` DOM
 event. But we do use some client-side navigation and that will trigger a new

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -5,7 +5,7 @@ from the client-side code. The way it works is that you have to send an
 environment variable, like:
 
 ```bash
-BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=UA-1234678-0
+BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=G-XXXXXXXX
 ```
 
 and that gets included in the build by more or less code-generating the snippet

--- a/docs/google-analytics.md
+++ b/docs/google-analytics.md
@@ -20,21 +20,8 @@ home page, site-search, `404.html` and article pages.
 
 ## Debugging
 
-The best way to debugging it is to set two environment variables in your `.env`.
-
-```bash
-BUILD_GOOGLE_ANALYTICS_ACCOUNT=UA-00000000-0
-BUILD_GOOGLE_ANALYTICS_DEBUG=true
-```
-
-That will ensure that the `https://www.google-analytics.com/analytics_debug.js`
-file is used which uses `console.log()` to print out all sorts of information
-about what it's sending to Google Analytics.
-
-But note, when you use the `webpack` server (from `create-react-app`) that runs
-on <http://localhost:3000> this will not be present. It's only present on pages
-that are fully server-side rendered. So to test out what Google Analytics does,
-make sure you use <http://localhost:5042>.
+See:
+[Troubleshooting with Tag Assistant](https://support.google.com/tagassistant/answer/10039345)
 
 ## Sending events
 

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -64,8 +64,6 @@ export const CSP_SCRIPT_SRC_VALUES = [
   "'report-sample'",
   "'self'",
 
-  // UA.
-  "www.google-analytics.com/analytics.js",
   // GA4.
   "https://www.googletagmanager.com/gtag/js",
 
@@ -107,8 +105,6 @@ export const CSP_DIRECTIVES = {
     "updates.developer.allizom.org",
     "updates.developer.mozilla.org",
 
-    // UA.
-    "www.google-analytics.com",
     // GA4.
     "https://*.google-analytics.com",
     "https://*.analytics.google.com",
@@ -154,9 +150,6 @@ export const CSP_DIRECTIVES = {
 
     "wikipedia.org",
     "upload.wikimedia.org",
-
-    // UA.
-    "www.google-analytics.com",
 
     // GA4.
     "https://*.google-analytics.com",

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -4,7 +4,6 @@ export const BASE_URL: string;
 export const FILES: string;
 export const FOLDERSEARCH: string;
 export const GOOGLE_ANALYTICS_ACCOUNT: string;
-export const GOOGLE_ANALYTICS_DEBUG: boolean;
 export const NO_PROGRESSBAR: boolean;
 export const FIX_FLAWS: boolean;
 export const FIX_FLAWS_DRY_RUN: boolean;

--- a/libs/env/index.d.ts
+++ b/libs/env/index.d.ts
@@ -3,7 +3,7 @@ export const DEFAULT_FLAW_LEVELS: string;
 export const BASE_URL: string;
 export const FILES: string;
 export const FOLDERSEARCH: string;
-export const GOOGLE_ANALYTICS_ACCOUNT: string;
+export const GOOGLE_ANALYTICS_MEASUREMENT_ID: string;
 export const NO_PROGRESSBAR: boolean;
 export const FIX_FLAWS: boolean;
 export const FIX_FLAWS_DRY_RUN: boolean;

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -28,8 +28,8 @@ export const DEFAULT_FLAW_LEVELS = process.env.BUILD_FLAW_LEVELS || "*:warn";
 
 export const FILES = process.env.BUILD_FILES || "";
 export const FOLDERSEARCH = process.env.BUILD_FOLDERSEARCH || "";
-export const GOOGLE_ANALYTICS_ACCOUNT =
-  process.env.BUILD_GOOGLE_ANALYTICS_ACCOUNT || "";
+export const GOOGLE_ANALYTICS_MEASUREMENT_ID =
+  process.env.BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID || "";
 export const NO_PROGRESSBAR = Boolean(
   JSON.parse(process.env.BUILD_NO_PROGRESSBAR || process.env.CI || "false")
 );

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -30,9 +30,6 @@ export const FILES = process.env.BUILD_FILES || "";
 export const FOLDERSEARCH = process.env.BUILD_FOLDERSEARCH || "";
 export const GOOGLE_ANALYTICS_ACCOUNT =
   process.env.BUILD_GOOGLE_ANALYTICS_ACCOUNT || "";
-export const GOOGLE_ANALYTICS_DEBUG = JSON.parse(
-  process.env.BUILD_GOOGLE_ANALYTICS_DEBUG || "false"
-);
 export const NO_PROGRESSBAR = Boolean(
   JSON.parse(process.env.BUILD_NO_PROGRESSBAR || process.env.CI || "false")
 );

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -94,8 +94,8 @@ const readBuildHTML = lazy(() => {
   return html;
 });
 
-const getGAScriptPathName = lazy((relPath = "/static/js/ga.js") => {
-  // Return the relative path if there exists a `BUILD_ROOT/static/js/ga.js`.
+const getGAScriptPathName = lazy((relPath = "/static/js/gtag.js") => {
+  // Return the relative path if there exists a `BUILD_ROOT/static/js/gtag.js`.
   // If the file doesn't exist, return falsy.
   // Remember, unless explicitly set, the BUILD_OUT_ROOT defaults to a path
   // based on `dirname` but that's wrong when compared as a source and as

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -123,7 +123,7 @@ test("content built foo page", () => {
 
   // The HTML should contain the Google Analytics snippet.
   // The ID should match what's set in `.env.testing`.
-  expect($('script[src="/static/js/ga.js"]')).toHaveLength(1);
+  expect($('script[src="/static/js/gtag.js"]')).toHaveLength(1);
 
   // Because this en-US page has a French translation
   expect($('link[rel="alternate"]')).toHaveLength(5);

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -29,7 +29,6 @@ import {
   CONTENT_ROOT,
   CONTENT_TRANSLATED_ROOT,
   GOOGLE_ANALYTICS_ACCOUNT,
-  GOOGLE_ANALYTICS_DEBUG,
 } from "../libs/env/index.js";
 import { runMakePopularitiesFile } from "./popularities.js";
 import { runOptimizeClientBuild } from "./optimize-client-build.js";


### PR DESCRIPTION
## Summary

(MP-951)

### Problem

We have been using `analytics.js`, which is being deprecated (see [here](https://support.google.com/analytics/answer/4457764)), and we want to smoothly transition from UA to GA4 using dual tagging (see [here](https://support.google.com/analytics/answer/10271001#analyticsjs-aboutgtagjs&zippy=%2Cin-this-article)).

### Solution

Migrate to `gtag.js`, and support multiple measurement ids.

---

## How did you test this change?

Kicked off a [stage deployment](https://github.com/mdn/yari/actions/runs/8264408752/job/22607948222).

Ran `BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID=foo,bar yarn tool google-analytics-code` and manually checked the result in `client/build/static/js/gtag.js`:

```js
// ...
if (Mozilla && !Mozilla.dntEnabled()) {
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'foo', { 'anonymize_ip': true });
  gtag('config', 'bar', { 'anonymize_ip': true });

  var gaScript = document.createElement('script');
  gaScript.async = true;
  gaScript.src = 'https://www.googletagmanager.com/gtag/js?id=foo';
  document.head.appendChild(gaScript);
}

```
