### PR TITLE
chore(macros/EmbedLiveSample): deprecate screenshot URL parameter

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -5,7 +5,7 @@
 //  $0 - The ID of the header block containing the sample
 //  $1 - The width of the iframe (optional)
 //  $2 - The height of the iframe (optional)
-//  $3 - The url of a screenshot of the sample working as intended (optional)
+//  $3 - (Deprecated) The url of a screenshot of the sample working as intended (optional)
 //  $4 - (Deprecated) The slug from which to load the sample (optional; current page used if not provided)
 //  $5 - (Deprecated) The class name of the frame; defaults to "sample-code-frame". If you
 //       pass this parameter and give it a value other than "sample-code-frame",
@@ -15,12 +15,19 @@
 //
 // See also : LiveSampleLink
 
-// We have deprecated the use of the $4 to $6 parameters
-// If one of this parameter is not empty, we raise a MacroDeprecationError flaw
-// When there will be 0 use left on translated-content (May 2022: 203 occurrences for $4),
+// We have deprecated the $3, $4, and $5 parameters.
+// If a non-empty value is provided for a deprecated parameter, we raise a MacroDeprecationError flaw
+// When there are 0 uses in translated-content,
 // we will be able to simplify this macro (and likely the whole of MDN).
-if ($4 !== "" || $5 !== "") {
-  mdn.deprecatedParams("The fourth and fifth parameters of 'EmbedLiveSample' are deprecated");
+// (May 2022: 203 occurrences for $4)
+if ($3 !== "") {
+  mdn.deprecatedParams("'EmbedLiveSample' parameter $3 is deprecated (no screenshot URLs).");
+}
+if ($4 !== "") {
+  mdn.deprecatedParams("'EmbedLiveSample' parameter $4 is deprecated (no sample slug).");
+}
+if ($5 !== "") {
+  mdn.deprecatedParams("'EmbedLiveSample' parameter $5 is deprecated (no iframe classes).");
 }
 
 var sampleIdOrOffset = $0 || $token.location.start.offset;

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -19,7 +19,6 @@
 // If a non-empty value is provided for a deprecated parameter, we raise a MacroDeprecationError flaw
 // When there are 0 uses in translated-content,
 // we will be able to simplify this macro (and likely the whole of MDN).
-// (May 2022: 203 occurrences for $4)
 if ($3 !== "") {
   mdn.deprecatedParams("'EmbedLiveSample' parameter $3 is deprecated (no screenshot URLs).");
 }


### PR DESCRIPTION
## Summary

The EmbedLiveSample macro doesn't use the `$3` param (screenshot URL) in EN content.
Adding a `deprecatedParams` flaw for it

## Screenshots

![Screenshot 2024-03-13 at 11 55 49 AM](https://github.com/mdn/yari/assets/43580235/2842894f-1b5c-4e39-b900-387b71214b31)

## How did you test this change?

* yarn && yarn dev
* visit http://localhost:3000
* Added the updated macro to a document and visited on `http://localhost:3000/...#_flaws`


__Related issues and pull requests:__

Removals PRs:

- [x] https://github.com/mdn/content/pull/32588
- [x] https://github.com/mdn/content/pull/32505