### PR TITLE
chore(telemetry): measure theme switcher clicks

### DIFF
--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -78,3 +78,4 @@ export const BASELINE = Object.freeze({
 
 export const CLIENT_SIDE_NAVIGATION = "client_side_nav";
 export const LANGUAGE = "language";
+export const THEME_SWITCHER = "theme_switcher";

--- a/client/src/ui/molecules/theme-switcher/index.tsx
+++ b/client/src/ui/molecules/theme-switcher/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "../../atoms/button";
 import { Submenu } from "../submenu";

--- a/client/src/ui/molecules/theme-switcher/index.tsx
+++ b/client/src/ui/molecules/theme-switcher/index.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "../../atoms/button";
 import { Submenu } from "../submenu";
@@ -9,6 +9,8 @@ import "./index.scss";
 import { switchTheme } from "../../../utils";
 import { Theme } from "../../../types/theme";
 import { useUIStatus } from "../../../ui-context";
+import { useGleanClick } from "../../../telemetry/glean-context";
+import { THEME_SWITCHER } from "../../../telemetry/constants";
 
 type ThemeButton = {
   id: Theme;
@@ -19,6 +21,7 @@ export const ThemeSwitcher = () => {
   const menuId = "themes-menu";
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  const gleanClick = useGleanClick();
   const { setColorScheme } = useUIStatus();
   const [activeTheme, setActiveTheme] = React.useState<Theme>("os-default");
 
@@ -30,6 +33,7 @@ export const ThemeSwitcher = () => {
         `}
         icon={`theme-${id}`}
         onClickHandler={() => {
+          gleanClick(`${THEME_SWITCHER}: switch -> ${id}`);
           setColorScheme(id);
           switchTheme(id, setActiveTheme);
           setIsOpen(false);
@@ -74,6 +78,7 @@ export const ThemeSwitcher = () => {
         icon={`theme-${activeTheme}`}
         extraClasses="theme-switcher-menu small"
         onClickHandler={() => {
+          gleanClick(`${THEME_SWITCHER}: ${isOpen ? "close" : "open"}`);
           setIsOpen(!isOpen);
         }}
       >


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-937)

### Problem

We don't know how many users use the theme switcher, but this is important to know in order to evaluate its placement.

### Solution

Start measuring how often the theme switcher is opened/closed and how often each theme is chosen.

---

## How did you test this change?

Ran `yarn dev` locally with Glean debugging enabled, and verified that the events show up in the Debug Ping Viewer.