### PR TITLE
fix(csp): allow GA via Tag Manager

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -64,7 +64,10 @@ export const CSP_SCRIPT_SRC_VALUES = [
   "'report-sample'",
   "'self'",
 
+  // UA.
   "www.google-analytics.com/analytics.js",
+  // GA4.
+  "https://www.googletagmanager.com/gtag/js",
 
   "assets.codepen.io",
   "production-assets.codepen.io",
@@ -104,7 +107,12 @@ export const CSP_DIRECTIVES = {
     "updates.developer.allizom.org",
     "updates.developer.mozilla.org",
 
+    // UA.
     "www.google-analytics.com",
+    // GA4.
+    "https://*.google-analytics.com",
+    "https://*.googletagmanager.com",
+
     "stats.g.doubleclick.net",
     "https://api.stripe.com",
   ],
@@ -146,7 +154,13 @@ export const CSP_DIRECTIVES = {
     "wikipedia.org",
     "upload.wikimedia.org",
 
+    // UA.
     "www.google-analytics.com",
+
+    // GA4.
+    "https://*.google-analytics.com",
+    "https://*.googletagmanager.com",
+
     "www.gstatic.com",
   ],
   "manifest-src": ["'self'"],


### PR DESCRIPTION
## Summary

(Extracted from https://github.com/mdn/yari/pull/10687.)

### Problem

We're migrating to GA4 and have connected our UA Property, which causes the `analytics.js` to load `gtag.js`, but that origin (as well as the origins used by `gtag.js` for measuring) are not in our CSP, so we're seeing very low numbers in GA4.

### Solution

Add the GA4-related origins to `script-src`, `connect-src` and `img-src` respectively.

Ref: https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics

---

## How did you test this change?

https://github.com/mdn/yari/pull/10687 is deployed on stage, and we don't get any CSP errors there.