### PR TITLE
fix(cli): add popularities to "yarn start" script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "(husky || true) && yarn install:all && yarn install:all:npm",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",
-    "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
+    "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -f popuarities.json || yarn tool popularities) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
     "start:client": "cd client && cross-env NODE_ENV=development BABEL_ENV=development BROWSER=none PORT=3000 node scripts/start.js",
     "start:server": "node-dev --experimental-loader ts-node/esm server/index.ts",
     "start:static-server": "ts-node server/static.ts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "prepare": "(husky || true) && yarn install:all && yarn install:all:npm",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",
-    "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -f popuarities.json || yarn tool popularities) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
+    "start": "(test -f client/build/index.html || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -f popularities.json || yarn tool popularities) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
     "start:client": "cd client && cross-env NODE_ENV=development BABEL_ENV=development BROWSER=none PORT=3000 node scripts/start.js",
     "start:server": "node-dev --experimental-loader ts-node/esm server/index.ts",
     "start:static-server": "ts-node server/static.ts",


### PR DESCRIPTION
## Summary

Related to: https://github.com/mdn/yari/issues/10653#issuecomment-2003374829

### Problem

`yarn start` fails on a fresh checkout, with the following error:

```
error: ENOENT: no such file or directory, open '/path/to/yari/popularities.json'
```

### Solution

Run `yarn tool popularities` as part of `yarn start`, if the `popularities.json` doesn't exist.

---

## How did you test this change?

Ran `yarn start` on a fresh checkout, and I was able open http://localhost:3000/ afterwards.
