### PR TITLE
fix(curriculum): expand clickable area in module card

### DIFF
--- a/client/src/curriculum/modules-list.scss
+++ b/client/src/curriculum/modules-list.scss
@@ -160,6 +160,7 @@
         padding: 0;
         scroll-snap-align: center;
         width: 100%;
+        position: relative;
 
         @media screen and (min-width: $screen-md) {
           min-width: initial;
@@ -201,6 +202,12 @@
               font-weight: var(--font-body-strong-weight);
               margin: auto;
               text-align: center;
+            }
+
+            &::before {
+              content: "";
+              position: absolute;
+              inset: 0;
             }
           }
         }


### PR DESCRIPTION
Fixes https://github.com/mdn/yari/issues/10734.

### Problem

![image](https://github.com/mdn/yari/assets/25101758/4bc89500-6a09-4a95-94d3-57b8610ab59c)

Half of the card is not clickable. While it may look like a card (clickable element) - in fact it is not.

### Solution

In order to preserve the semantics and make entire card clickable - we make the card non-staticly positioned element and create a pseudo element inside the link that takes all the available space;

```
.parent {
  position: relative;
}

a::before {
  content: "";
  position: absolute;
  inset: 0;
}
```

