### PR TITLE
fix(csp): add *.analytics.google.com

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -111,6 +111,7 @@ export const CSP_DIRECTIVES = {
     "www.google-analytics.com",
     // GA4.
     "https://*.google-analytics.com",
+    "https://*.analytics.google.com",
     "https://*.googletagmanager.com",
 
     "stats.g.doubleclick.net",


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/mdn/yari/pull/10715.

### Problem

GA4 numbers are still not matching with UA, and one explanation could be the omission of `*.analytics.google.com` in the CSP `connect-src` directive (although [bedrock doesn't have this one](https://github.com/mozilla/bedrock/blob/bb7623799f96930161804ac147a837ad85e65aca/bedrock/settings/__init__.py#L209-L211)).

See: https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics

<img width="951" alt="image" src="https://github.com/mdn/yari/assets/495429/dec59d73-ea92-4097-a393-96d9006a07d8">

### Solution

Add `*.analytics.google.com` to the `connect-src.

---

## How did you test this change?

We will need to deploy to production to see the effect.