### PR TITLE
fix(article-footer): link to translated-content for other locales

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -271,7 +271,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
             <DocumentSurvey doc={doc} />
             <RenderDocumentBody doc={doc} />
           </article>
-          <ArticleFooter doc={doc} locale={locale} />
+          <ArticleFooter doc={doc} />
         </MainContentContainer>
         {false && <PlayQueue standalone={true} />}
       </div>

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -140,17 +140,17 @@ export function ArticleFooter({ doc, locale }) {
 }
 
 function Contribute({ locale }) {
-  const contributeHref = [...VALID_LOCALES.keys()]
+  const contributeRepo = [...VALID_LOCALES.keys()]
     .filter((language) => language !== "en-us")
     .includes(locale)
-    ? "https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md"
-    : "https://github.com/mdn/content/blob/main/CONTRIBUTING.md";
+    ? "translated-content"
+    : "content";
 
   return (
     <>
       <a
         className="contribute"
-        href={contributeHref}
+        href={`https://github.com/mdn/${contributeRepo}/blob/main/CONTRIBUTING.md`}
         title="This will take you to our contribution guidelines on GitHub."
         target="_blank"
         rel="noopener noreferrer"

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -140,14 +140,13 @@ export function ArticleFooter({ doc }) {
 }
 
 function Contribute({ locale }) {
-  const contributeRepo =
-    locale === DEFAULT_LOCALE ? "content" : "translated-content";
+  const repo = locale === DEFAULT_LOCALE ? "content" : "translated-content";
 
   return (
     <>
       <a
         className="contribute"
-        href={`https://github.com/mdn/${contributeRepo}/blob/main/CONTRIBUTING.md`}
+        href={`https://github.com/mdn/${repo}/blob/main/CONTRIBUTING.md`}
         title="This will take you to our contribution guidelines on GitHub."
         target="_blank"
         rel="noopener noreferrer"

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -5,7 +5,7 @@ import { ReactComponent as ArticleFooterSVG } from "../../../assets/article-foot
 import "./index.scss";
 import { useGleanClick } from "../../../telemetry/glean-context";
 import { ARTICLE_FOOTER, THUMBS } from "../../../telemetry/constants";
-import { VALID_LOCALES } from "../../../constants";
+import { DEFAULT_LOCALE } from "../../../../../libs/constants";
 
 export function LastModified({ value, locale }) {
   if (!value) {
@@ -47,7 +47,7 @@ const FEEDBACK_REASONS: Required<Record<FeedbackReason, string>> = {
   other: "Other",
 };
 
-export function ArticleFooter({ doc, locale }) {
+export function ArticleFooter({ doc }) {
   const [view, setView] = useState<ArticleFooterView>(ArticleFooterView.Vote);
   const [reason, setReason] = useState<FeedbackReason>();
 
@@ -128,9 +128,9 @@ export function ArticleFooter({ doc, locale }) {
           )}
         </fieldset>
 
-        <Contribute locale={locale} />
+        <Contribute locale={doc.locale} />
         <p className="last-modified-date">
-          <LastModified value={doc.modified} locale={locale} /> by{" "}
+          <LastModified value={doc.modified} locale={doc.locale} /> by{" "}
           <Authors url={doc.mdn_url} />.
         </p>
         {doc.isActive && <OnGitHubLink doc={doc} />}
@@ -140,11 +140,8 @@ export function ArticleFooter({ doc, locale }) {
 }
 
 function Contribute({ locale }) {
-  const contributeRepo = [...VALID_LOCALES.keys()]
-    .filter((language) => language !== "en-us")
-    .includes(locale)
-    ? "translated-content"
-    : "content";
+  const contributeRepo =
+    locale === DEFAULT_LOCALE ? "content" : "translated-content";
 
   return (
     <>

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -5,6 +5,7 @@ import { ReactComponent as ArticleFooterSVG } from "../../../assets/article-foot
 import "./index.scss";
 import { useGleanClick } from "../../../telemetry/glean-context";
 import { ARTICLE_FOOTER, THUMBS } from "../../../telemetry/constants";
+import { VALID_LOCALES } from "../../../constants";
 
 export function LastModified({ value, locale }) {
   if (!value) {
@@ -127,7 +128,7 @@ export function ArticleFooter({ doc, locale }) {
           )}
         </fieldset>
 
-        <Contribute />
+        <Contribute locale={locale} />
         <p className="last-modified-date">
           <LastModified value={doc.modified} locale={locale} /> by{" "}
           <Authors url={doc.mdn_url} />.
@@ -138,13 +139,19 @@ export function ArticleFooter({ doc, locale }) {
   );
 }
 
-function Contribute() {
+function Contribute({ locale }) {
+  const contributeHref = [...VALID_LOCALES.keys()]
+    .filter((language) => language !== "en-us")
+    .includes(locale)
+    ? "https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md"
+    : "https://github.com/mdn/content/blob/main/CONTRIBUTING.md";
+
   return (
     <>
       <a
         className="contribute"
-        href="https://github.com/mdn/content/blob/main/CONTRIBUTING.md"
-        title={`This will take you to our contribution guidelines on GitHub.`}
+        href={contributeHref}
+        title="This will take you to our contribution guidelines on GitHub."
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
## Summary

Improve learn how to contribute footer for locales.

In the issue below, a contributor suggested linking a locale to the "Learn how to contribute" link.

- issue: https://github.com/mdn/translated-content/issues/827#issuecomment-2005808889

### Problem

Even if it is a locale page, it always links to "https://github.com/mdn/content/blob/main/CONTRIBUTING.md".

- https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array

### Solution

link "https://github.com/mdn/translated-content/blob/main/CONTRIBUTING.md" for locale.
