### PR TITLE
fix(playground): remove redundant vertical scroll bar

### DIFF
--- a/client/src/playground/index.scss
+++ b/client/src/playground/index.scss
@@ -191,10 +191,10 @@ main.play {
               var(--editor-header-padding) - var(--editor-header-border-width)
           );
           margin: 0.5rem 0 0;
-          overflow: scroll;
+          overflow-y: scroll;
 
           .cm-editor {
-            height: 100%;
+            min-height: 100%;
             width: 100%;
 
             @media screen and (max-width: $screen-sm) {


### PR DESCRIPTION
- fixes https://github.com/mdn/yari/issues/10732

## Summary

Seeing two y-scrollbars in editors when code is long.

The playground doesn't work in internet archive so it's hard to know when and where the issue appeared. Looking at the current code. Parent wrapper `.editor` [has `overflow: scroll` set](https://github.com/mdn/yari/blob/56dbe78ae713bf7d9082f7b44c8600621afb31c8/client/src/playground/index.scss#L194) so both x and y scrollbars are always visible. And child wrapper `.cm-editor` also [has height `100%`](https://github.com/mdn/yari/blob/56dbe78ae713bf7d9082f7b44c8600621afb31c8/client/src/playground/index.scss#L197) set. As the child has fixed height so when code is long the child also get y-scrollbar.

## Solution

Instead of limiting the child `.cm-editor` height to `100%` set `min-height: 100%`. So the child becomes long and the parent's `.editor`'s scrollbar becomes usable.

### Bonus

The code is actually being wrapped so there is no need of x-scrollbar on `.editor`. So instead of `overflow: scroll` we could use `overflow-y: scroll`.

## Screenshot

### Before

![before](https://github.com/mdn/yari/assets/87750369/cc2f0b3a-f1e2-46e6-84bc-2c07d1884d1e)


### After

![after](https://github.com/mdn/yari/assets/87750369/ff43562a-831d-4a6c-baf5-5c25f2e554e5)

## Testing

Ran `yarn dev` and tried on Chrome, Edge, and Brave browsers on Linux Mint.

