### PR TITLE
fix(icon): fix the clipboard icon on safari ios

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -787,6 +787,7 @@ pre {
     mask-image: url("../assets/clippy.svg");
     mask-size: cover;
     width: 1rem;
+    padding: 0;
 
     &:hover,
     &:focus {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -786,8 +786,8 @@ pre {
     margin-top: -0.1rem;
     mask-image: url("../assets/clippy.svg");
     mask-size: cover;
-    width: 1rem;
     padding: 0;
+    width: 1rem;
 
     &:hover,
     &:focus {


### PR DESCRIPTION

## Summary


### Problem

The copy to clipboard icon for code examples is cur off when using Safari on iOS.


### Solution

Setting padding to 0 fixes the issue (seems to be a newly added default style).

---

## Screenshots

### Before

![safari_copy](https://github.com/mdn/yari/assets/3604775/4588cf85-557b-4d22-a5f3-a46c74ed4ad6)

### After

![safari_copy_fix](https://github.com/mdn/yari/assets/3604775/5e2e2244-e6f6-44bf-a69f-4016029b6413)


---

## How did you test this change?

Locally / remote debugging on my phone.
