### PR TITLE
fix(curriculum): don't flag curriclum links

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -232,6 +232,7 @@ export function getBrokenLinksFlaws(
       // links in our content but that's a reality of MDN being 15+ years old.
     } else if (
       href.startsWith("https://developer.mozilla.org/") &&
+      !href.startsWith("https://developer.mozilla.org/en-US/curriculum/") &&
       !href.startsWith("https://developer.mozilla.org/en-US/blog/")
     ) {
       // It might be a working 200 OK link but the link just shouldn't
@@ -283,7 +284,7 @@ export function getBrokenLinksFlaws(
     } else if (
       href.startsWith("/") &&
       !href.startsWith("//") &&
-      !/^\/(discord|en-US\/blog)(\/|$)/.test(href)
+      !/^\/(discord|en-US\/(blog|curriculum))(\/|$)/.test(href)
     ) {
       // Got to fake the domain to sensible extract the .search and .hash
       const absoluteURL = new URL(href, "http://www.example.com");


### PR DESCRIPTION
## Summary

### Problem

Links to the curriculum within content render as invalid link.

### Solution

Stop flagging them.

---

## Screenshots


### Before

![image](https://github.com/mdn/yari/assets/3604775/5fa7df9b-8044-494a-9dd8-d87af3a44abf)


### After

![image](https://github.com/mdn/yari/assets/3604775/f042004e-6773-49aa-93c3-d58c315478af)

---

## How did you test this change?

Locally
