### PR TITLE
fix(google-analytics): allow analytics.js in CSP

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -65,6 +65,7 @@ export const CSP_SCRIPT_SRC_VALUES = [
   "'self'",
 
   // GA4.
+  "https://www.google-analytics.com/analytics.js",
   "https://www.googletagmanager.com/gtag/js",
 
   "assets.codepen.io",


### PR DESCRIPTION
## Summary

(MP-951)

### Problem

We're getting these errors:

```
Content-Security-Policy: The page’s settings blocked a script (script-src-elem) at https://www.google-analytics.com/analytics.js from being executed because it violates the following directive: “script-src-elem 'report-sample' 'self' https://www.googletagmanager.com/gtag/js https://assets.codepen.io/ https://production-assets.codepen.io/ https://js.stripe.com/ 'sha256-uogddBLIKmJa413dyT0iPejBg3VFcO+4x6B+vw3jng0=' 'sha256-EehWlTYp7Bqy57gDeQttaWKp0ukTTEUKGP44h8GVeik='”
```

### Solution

Allow `https://www.google-analytics.com/analytics.js` as `script-src-elem`.

---

## How did you test this change?

Will deploy to stage.