### PR TITLE
fix(playground): dispatch DOMContentLoaded event manually

### DIFF
--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -121,6 +121,7 @@
         script.textContent = state.js;
         document.body.appendChild(script);
 
+        dispatchEvent(new Event("DOMContentLoaded"));
         dispatchEvent(new Event("load"));
         initialized = true;
       }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/9324.
Fixes https://github.com/mdn/yari/issues/9409.
Fixes https://github.com/mdn/yari/issues/10310.
Fixes https://github.com/mdn/yari/issues/10766.
Fixes https://github.com/mdn/yari/issues/10771.
Fixes https://github.com/mdn/yari/issues/10772.

### Problem

The `DOMContentLoaded` wasn't fired in the Playground, because the HTML is inserted only after the original `DOMContentLoaded` event is fired.

### Solution

Manually fire a `DOMContenLoaded` event, just like we manually fire a `load` event.

---

## Screenshots

### Before

Prod: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example

<img width="778" alt="image" src="https://github.com/mdn/yari/assets/495429/9d79752a-1cd3-4f37-a8b4-9d7add706908">

### After

Stage: https://developer.allizom.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example

<img width="778" alt="image" src="https://github.com/mdn/yari/assets/495429/972b8bc3-74d5-4f1d-816e-574ada27cba8">

---

## How did you test this change?

Deployed this to change and tested the live sample at https://developer.allizom.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example, mentioned in https://github.com/mdn/yari/issues/9324.