### PR TITLE
enhance(flaws-page): specify 'yarn build' usage in error message for clarity

### DIFF
--- a/client/src/flaws/index.tsx
+++ b/client/src/flaws/index.tsx
@@ -628,7 +628,7 @@ function DocumentsTable({
         )}
       </h3>
       {!counts.built ? (
-        <WarnAboutNothingBuilt />
+        <WarnAboutNothingBuilt locale={locale} />
       ) : (
         <h4 className="subheader">
           {counts.built.toLocaleString()} documents built ({locale})
@@ -735,13 +735,13 @@ function PageLink({
   );
 }
 
-function WarnAboutNothingBuilt() {
+function WarnAboutNothingBuilt({ locale }) {
   return (
     <div className="notecard warning document-warnings">
       <h4>No documents have been built, so no flaws can be found</h4>
       <p>
-        At the moment, you have to use the command line tools to build documents
-        that we can analyze.
+        Run <code>yarn build --locale {locale.toLowerCase()}</code> to build all
+        documents for the current locale.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

Specify 'yarn build' usage in error message for clarity.

Related #10653.

### Problem

Added detailed solution guidance for beginners.

### Solution

```diff
- At the moment, you have to use the command line tools to build documents that we can analyze.
+ Run <code>yarn build --locale {locale.toLowerCase()}</code> to build all documents for the current locale.
```

<img width="1408" alt="image" src="https://github.com/mdn/yari/assets/22424891/cecc20d2-7e5a-4294-8c69-2dc3b9efbe7d">
<img width="1397" alt="image" src="https://github.com/mdn/yari/assets/22424891/f7246459-93c1-4b81-8bd0-22da8b67dca0">
