### PR TITLE
fix(curriculum): remove forbidden hr from ol

### DIFF
--- a/client/src/curriculum/modules-list.scss
+++ b/client/src/curriculum/modules-list.scss
@@ -33,9 +33,10 @@
         grid-template-columns: auto auto auto 1fr;
       }
 
-      hr {
+      &::before {
         border: none;
         border-top: 1px solid var(--text-inactive);
+        content: "";
         grid-area: hr;
         margin: 0 0 1.5rem;
         width: 100%;

--- a/client/src/curriculum/modules-list.tsx
+++ b/client/src/curriculum/modules-list.tsx
@@ -14,7 +14,6 @@ export function ModulesListList({
   const [tab, setTab] = useState(1);
   return (
     <ol className="modules-list-list">
-      <hr />
       {modules.map((modulesList, i) => {
         return (
           <li


### PR DESCRIPTION
## Summary

This resolves #10777

### Problem

`<hr>` is not allowed in an `<ol>`

### Solution

replace with `:before`.

---

## Screenshots


### Before

![image](https://github.com/mdn/yari/assets/3604775/85f609fb-1d28-41ca-8ac6-d72ef96dbc85)

### After

![image](https://github.com/mdn/yari/assets/3604775/3096b9b3-0c0b-45fb-95c6-5452b9c05db8)

---

## How did you test this change?

locally
