### PR TITLE
fix(ai-help): limit input to 25k characters

### DIFF
--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -161,6 +161,7 @@ function AIHelpUserQuestion({
     >
       <ExpandingTextarea
         ref={inputRef}
+        maxLength={25_000}
         enterKeyHint="send"
         onKeyDown={(event) => {
           if (event.key === "Enter" && !event.shiftKey) {
@@ -799,6 +800,7 @@ export function AIHelpInner() {
                     >
                       <ExpandingTextarea
                         ref={inputRef}
+                        maxLength={25_000}
                         autoFocus={true}
                         disabled={isLoading || isResponding}
                         enterKeyHint="send"


### PR DESCRIPTION
## Summary

(MP-967)

### Problem

We don't limit the length of the questions, and questions equivalent to more than 8192 tokens result in an API error, because this is the limit of our embedding model (`text-embedding-ada-002`, see https://platform.openai.com/docs/guides/embeddings/embedding-models).

### Solution

Limit the input to 25k characters, which should always be within the token limits.

---

## How did you test this change?

Generated a long text (99999 characters) with [this lorem ipsum generator](https://www.blindtextgenerator.com/lorem-ipsum), then pasted it in and checked that the request succeeds.
