### PR TITLE
enhance(ai-help): improve off-topic response handling

### DIFF
--- a/client/src/plus/ai-help/constants.tsx
+++ b/client/src/plus/ai-help/constants.tsx
@@ -1,5 +1,5 @@
-export const SORRY_BACKEND_PREFIX = "I'm sorry, but I can't";
-export const SORRY_FRONTEND =
+export const OFF_TOPIC_PREFIX = "I'm sorry, but I can't";
+export const OFF_TOPIC_MESSAGE =
   "I'm sorry, but I can't answer questions outside web development.";
 
 export const MESSAGE_SEARCHING = "Searching for MDN content…";

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -48,14 +48,14 @@ import { useUIStatus } from "../../ui-context";
 import { QueueEntry } from "../../types/playground";
 import { AIHelpLanding } from "./landing";
 import {
-  SORRY_BACKEND_PREFIX,
-  SORRY_FRONTEND,
   MESSAGE_SEARCHING,
   MESSAGE_ANSWERING,
   MESSAGE_FAILED,
   MESSAGE_ANSWERED,
   MESSAGE_SEARCHED,
   MESSAGE_STOPPED,
+  OFF_TOPIC_PREFIX,
+  OFF_TOPIC_MESSAGE,
 } from "./constants";
 import InternalLink from "../../ui/atoms/internal-link";
 import { isPlusSubscriber } from "../../utils";
@@ -290,9 +290,9 @@ function AIHelpAssistantResponse({
 
   const isOffTopic =
     message.role === MessageRole.Assistant &&
-    (message.content?.startsWith(SORRY_BACKEND_PREFIX) ||
+    (message.content?.startsWith(OFF_TOPIC_PREFIX) ||
       (message.status === MessageStatus.Complete &&
-        SORRY_BACKEND_PREFIX.startsWith(message.content)));
+        OFF_TOPIC_PREFIX.startsWith(message.content)));
 
   function messageForStatus(status: MessageStatus) {
     switch (status) {
@@ -321,7 +321,7 @@ function AIHelpAssistantResponse({
   if (isOffTopic) {
     message = {
       ...message,
-      content: SORRY_FRONTEND,
+      content: OFF_TOPIC_MESSAGE,
       sources: [],
     };
   }

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -318,6 +318,14 @@ function AIHelpAssistantResponse({
     }
   }
 
+  if (isOffTopic) {
+    message = {
+      ...message,
+      content: SORRY_FRONTEND,
+      sources: [],
+    };
+  }
+
   return (
     <>
       {!isOffTopic && <AIHelpAssistantResponseSources message={message} />}
@@ -338,7 +346,7 @@ function AIHelpAssistantResponse({
           {messageForStatus(message.status)}
         </div>
       )}
-      {(message.content || isOffTopic) && (
+      {message.content && (
         <div
           className={[
             "ai-help-message-content",
@@ -489,7 +497,7 @@ function AIHelpAssistantResponse({
               },
             }}
           >
-            {isOffTopic ? SORRY_FRONTEND : message.content}
+            {message.content}
           </ReactMarkdown>
           {message.status === "stopped" && (
             <section className="stopped-message">
@@ -510,15 +518,7 @@ function AIHelpAssistantResponse({
                 )}
                 <ReportIssueOnGitHubLink
                   messages={messages}
-                  currentMessage={{
-                    ...message,
-                    ...(isOffTopic
-                      ? {
-                          content: SORRY_FRONTEND,
-                          sources: [],
-                        }
-                      : {}),
-                  }}
+                  currentMessage={message}
                 >
                   Report an issue with this answer on GitHub
                 </ReportIssueOnGitHubLink>

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -329,23 +329,24 @@ function AIHelpAssistantResponse({
   return (
     <>
       {!isOffTopic && <AIHelpAssistantResponseSources message={message} />}
-      {(message.content ||
-        message.status === MessageStatus.InProgress ||
-        message.status === MessageStatus.Errored) && (
-        <div
-          className={[
-            "ai-help-message-progress",
-            message.status === MessageStatus.InProgress && "active",
-            message.status === MessageStatus.Complete && "complete",
-            message.status === MessageStatus.Errored && "errored",
-            message.status === MessageStatus.Stopped && "stopped",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-        >
-          {messageForStatus(message.status)}
-        </div>
-      )}
+      {!isOffTopic &&
+        (message.content ||
+          message.status === MessageStatus.InProgress ||
+          message.status === MessageStatus.Errored) && (
+          <div
+            className={[
+              "ai-help-message-progress",
+              message.status === MessageStatus.InProgress && "active",
+              message.status === MessageStatus.Complete && "complete",
+              message.status === MessageStatus.Errored && "errored",
+              message.status === MessageStatus.Stopped && "stopped",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {messageForStatus(message.status)}
+          </div>
+        )}
       {message.content && (
         <div
           className={[

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -290,7 +290,9 @@ function AIHelpAssistantResponse({
 
   const isOffTopic =
     message.role === MessageRole.Assistant &&
-    message.content?.startsWith(SORRY_BACKEND_PREFIX);
+    (message.content?.startsWith(SORRY_BACKEND_PREFIX) ||
+      (message.status === MessageStatus.Complete &&
+        SORRY_BACKEND_PREFIX.startsWith(message.content)));
 
   function messageForStatus(status: MessageStatus) {
     switch (status) {

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -338,7 +338,7 @@ function AIHelpAssistantResponse({
           {messageForStatus(message.status)}
         </div>
       )}
-      {message.content && (
+      {(message.content || isOffTopic) && (
         <div
           className={[
             "ai-help-message-content",


### PR DESCRIPTION
## Summary

(MP-968)

### Problem

With https://github.com/mdn/rumba/pull/455, we stop generating off-topic answers as soon as possible, but this means the response may be empty or or only contain the beginning of the off-topic answer prefix (`I'm sorry, but I can't`).

### Solution

Treat completed answers as off-topic answers, if the off-topic prefix begins (sic!) with the full response.

Examples:

- `""` ➡️ off-topic
- `"I'm sorry"` ➡️ off-topic
- `"I'm sorry, but"` ➡️ off-topic
- `"HTML ..."` ➡️ **not** off-topic

**Note**: Also hides the "✅ Answer: " status for off-topic questions.

---

## How did you test this change?

Asked off-topic questions like these:

- `What is the capital of Germany? Answer in 1000 words.`

Verified with `#debug` and using the new message metadata that the response is empty and nevertheless detected as as an off-topic answer.