### PR TITLE
fix(playground): rename reset to clear

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -158,7 +158,7 @@ export default function Playground() {
       window.removeEventListener("message", messageListener);
     };
   }, [messageListener]);
-  const reset = async () => {
+  const clear = async () => {
     setSearchParams([], { replace: true });
     setCodeSrc(undefined);
     htmlRef.current?.setContent(HTML_DEFAULT);
@@ -167,10 +167,10 @@ export default function Playground() {
 
     updateWithEditorContent();
   };
-  const resetConfirm = async () => {
-    if (window.confirm("Do you really want to reset everything?")) {
+  const clearConfirm = async () => {
+    if (window.confirm("Do you really want to clear everything?")) {
       gleanClick(`${PLAYGROUND}: reset-click`);
-      await reset();
+      await clear();
     }
   };
 
@@ -287,11 +287,11 @@ export default function Playground() {
               </Button>
               <Button
                 type="secondary"
-                id="reset"
+                id="clear"
                 extraClasses="red"
-                onClickHandler={resetConfirm}
+                onClickHandler={clearConfirm}
               >
-                reset
+                clear
               </Button>
             </menu>
           </aside>


### PR DESCRIPTION
## Summary
Reset is confusing when coming from a live sample. So we rename it to clear for now.

Resolves  #10733

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/3604775/dbade9c3-cf99-4fa3-a6b2-3694202f81ab)

### After

![image](https://github.com/mdn/yari/assets/3604775/76d71938-8e12-45a3-9952-cfd322cf7382)

---

## How did you test this change?
Locally
