### PR TITLE
enhance(macros/PreviousMenuNext): use the actual title of the document by default

### DIFF
--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -42,7 +42,7 @@ function generateLink(pageSlug, linkText) {
 function generateMenuLink(pageSlug) {
   const url = `/${locale}/docs/${pageSlug}`;
   let aPage = info.getPageByURL(url);
-  if (!aPage.url) {
+  if (!aPage.url && locale !== defaultLocale) {
     const fallbackUrl = `/${defaultLocale}/docs/${pageSlug}`;
     aPage = info.getPageByURL(fallbackUrl);
   }

--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -11,12 +11,13 @@ Issue
 
 */
 
-var lang = env.locale;
-var strPrevious = "";
-var strNext = "";
-var strMenu = "";
+const locale = env.locale;
+const defaultLocale = "en-US";
+const prevPage = $0.replace(/ /g, '_');
+const nextPage = $1.replace(/ /g, '_');
+const mainMenu = $2.replace(/ /g, '_');
 
-var s_PreviousNext = mdn.localString({
+const previousNextStr = mdn.localString({
     "en-US": [" Previous ",          " Next  "],
     "es"   : [" Anterior ",     " Siguiente  "],
     "fr"   : [" Précédent ",      " Suivant  "],
@@ -28,7 +29,7 @@ var s_PreviousNext = mdn.localString({
     "zh-TW": [" 前頁 ",                              " 次頁  "]
 });
 
-var s_Menu = mdn.localString({
+const menuStr = mdn.localString({
     "en-US": " Overview: ",
     "pt-BR": " Menu: ",
     "fr"   : " Aperçu&nbsp;: ",
@@ -37,29 +38,34 @@ var s_Menu = mdn.localString({
     "zh-TW": " 概述：",
 });
 
-if ($0) {
-    strPrevious = '<li><a class="button secondary" href="/' + lang + '/docs/' + $0.replace(/ /g, '_') + '"><span class="button-wrap">' + s_PreviousNext[0] + '</span></a></li>';
+function generateLink(pageSlug, linkText) {
+  return `<li><a class="button secondary" href="/${locale}/docs/${pageSlug}"><span class="button-wrap">${linkText}</span></a></li>`;
 }
 
-if ($1) {
-    strNext = '<li><a class="button secondary" href="/' + lang + '/docs/' + $1.replace(/ /g, '_') + '"><span class="button-wrap">' + s_PreviousNext[1] + '</span></a></li>';
-}
-
-if ($2) {
-  var startString = $2;
-  var linkTextArray = startString.split('/');
-  var linkText = linkTextArray[linkTextArray.length-1];
-  var re = /_/gi;
-  var finalString = linkText.replace(re,' ');
-
-  if($0 && $1) {
-    strMenu = '<li><a class="button secondary" href="/' + lang + '/docs/' + $2.replace(/ /g, '_') + '"><span class="button-wrap">' + s_Menu + finalString + '</span></a></li>';
-  } else if($0) {
-    strMenu = '<li><a class="button secondary" href="/' + lang + '/docs/' + $2.replace(/ /g, '_') + '"><span class="button-wrap">' + s_Menu + finalString + '</span></a></li>';
-  } else if($1) {
-    strMenu = '<li><a class="button secondary" href="/' + lang + '/docs/' + $2.replace(/ /g, '_') + '"><span class="button-wrap">' + s_Menu + finalString + '</span></a></li>';
+function generateMenuLink(pageSlug) {
+  const url = `/${locale}/docs/${pageSlug}`;
+  let aPage = info.getPageByURL(url);
+  if (!aPage.url) {
+    const fallbackUrl = `/${defaultLocale}/docs/${pageSlug}`;
+    aPage = info.getPageByURL(fallbackUrl);
   }
+  
+  let title = "";
+  if (!aPage.url) {
+    // fallback to generate title from slug
+    title = pageSlug.split('/').at(-1).replace(/_/g, ' ');
+  } else {
+    title = aPage.title;
+  }
+  return generateLink(pageSlug, `${menuStr}${title}`);
 }
+
+
+// Output
+const strPrevious = prevPage ? generateLink(prevPage, previousNextStr[0]) : "";
+const strNext = nextPage ? generateLink(nextPage, previousNextStr[1]) : "";
+// If there is a main menu with a previous and/or a next page, generate a link to the main menu
+const strMenu = (mainMenu && (prevPage || nextPage)) ? generateMenuLink(mainMenu) : "";
 %>
 <ul class="prev-next">
     <%- strPrevious %>

--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -13,9 +13,9 @@ Issue
 
 const locale = env.locale;
 const defaultLocale = "en-US";
-const prevPage = $0.replace(/ /g, '_');
-const nextPage = $1.replace(/ /g, '_');
-const mainMenu = $2.replace(/ /g, '_');
+const prevPage = $0.replace(/ /g, "_");
+const nextPage = $1.replace(/ /g, "_");
+const mainMenu = $2.replace(/ /g, "_");
 
 const previousNextStr = mdn.localString({
     "en-US": [" Previous ",          " Next  "],
@@ -53,7 +53,7 @@ function generateMenuLink(pageSlug) {
   let title = "";
   if (!aPage.url) {
     // fallback to generate title from slug
-    title = pageSlug.split('/').at(-1).replace(/_/g, ' ');
+    title = pageSlug.split('/').at(-1).replace(/_/g, " ");
   } else {
     title = aPage.title;
   }

--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -6,16 +6,13 @@ Parameter
     $1 (second parameter): path of Next page
     $2 (third parameter): path to main menu of module
 
-Issue
-    * Problem of Apostrophe (https://developer.mozilla.org/fr/docs/JavaScript_Guide/Op%C3%A9rateurs/Op%C3%A9rateurs_sp%C3%A9ciaux)
-
 */
 
 const locale = env.locale;
 const defaultLocale = "en-US";
-const prevPage = $0.replace(/ /g, "_");
-const nextPage = $1.replace(/ /g, "_");
-const mainMenu = $2.replace(/ /g, "_");
+const prevPage = $0?.replace(/ /g, "_");
+const nextPage = $1?.replace(/ /g, "_");
+const mainMenu = $2?.replace(/ /g, "_");
 
 const previousNextStr = mdn.localString({
     "en-US": [" Previous ",          " Next  "],


### PR DESCRIPTION
## Summary

Fixes: #10274

### Problem

We used to use localized slugs, so we could generate localized titles through the slugs. But now we have used unified slugs across locales, which causes the `{{PreviousMenuNext}}` macro to be unable to display localized titles for the menu link.

### Solution

Solve this problem by retrieving the title of the page, if the page is not found:

- for translated documents: try to retrive the title from the default locale (`en-US`), if still not existed, fallback to generate it from the given slug.
- for en-US: fallback to generate it from the given slug.

---

## Screenshots

| path | Before | After |
| --- | --- | --- |
| /zh-CN/docs/Learn/Accessibility/CSS_and_JavaScript |  ![image](https://github.com/mdn/yari/assets/15844309/e5d6404d-a048-45bd-a255-9d2e93cf3bf3) | ![image](https://github.com/mdn/yari/assets/15844309/43d2e625-b021-4ad8-bc00-c8265551871e) |
| /zh-CN/docs/Learn/Accessibility/HTML | ![image](https://github.com/mdn/yari/assets/15844309/4a590fd9-a02c-4931-b361-03cdb2753c95) | ![image](https://github.com/mdn/yari/assets/15844309/aab660f4-8bec-4d71-b093-1f21d1caa6cf) |
| /fr/docs/Learn/Accessibility/HTML | ![image](https://github.com/mdn/yari/assets/15844309/0661e6ac-2913-4567-b2ef-a3469a786d91) | ![image](https://github.com/mdn/yari/assets/15844309/b5bc722b-2988-4888-9577-7363bb770867) |

### PreviousMenu macro

`{{PreviousMenu}}` macro reuses the `{{PreviousMenuNext}}` macro.

| path | Before | After |
| --- | --- | --- |
| /fr/docs/Learn/Accessibility/Accessibility_troubleshooting | ![image](https://github.com/mdn/yari/assets/15844309/c944784f-a151-4d1f-a554-cf8867b87789) | ![image](https://github.com/mdn/yari/assets/15844309/46bb5c02-fa17-4c39-a69a-8ef20b2e15e0) |
| /ja/docs/Learn/Accessibility/Accessibility_troubleshooting | ![image](https://github.com/mdn/yari/assets/15844309/bd383a89-adec-423d-ac4a-b32b56a4333e) | ![image](https://github.com/mdn/yari/assets/15844309/1b4d365c-dd88-45ea-b7ff-2bb87be0a9b2) |

---

## How did you test this change?

Run `yarn dev` and check the above pages.
