### PR TITLE
feat(ai-help): index text-embedding-3-model embeddings

### DIFF
--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -22,6 +22,9 @@ import {
 } from "@mdn/browser-compat-data/types";
 import { h2mSync } from "../markdown/index.js";
 
+const EMBEDDING_MODEL_NEXT = "text-embedding-3-small";
+const EMBEDDING_MODEL = "text-embedding-ada-002";
+
 const { program } = caporal;
 
 interface IndexedDoc {
@@ -172,11 +175,11 @@ export async function updateEmbeddings(
         // Embedding for full document.
         const { total_tokens, embedding } = await createEmbedding(
           text,
-          "text-embedding-ada-002"
+          EMBEDDING_MODEL
         );
         const { embedding: embedding_next } = await createEmbedding(
           text,
-          "text-embedding-3-model-small"
+          EMBEDDING_MODEL_NEXT
         );
 
         // Create/update document record.

--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -211,13 +211,16 @@ export async function updateEmbeddings(
         console.log(`-> [${mdn_url}] Updating document...`);
 
         // Embedding for full document.
-        const { total_tokens, embedding } = await createEmbedding(
-          text,
-          EMBEDDING_MODEL
+        const [{ total_tokens, embedding }, embedding_next] = await Promise.all(
+          [
+            createEmbedding(text, EMBEDDING_MODEL),
+            EMBEDDING_MODEL_NEXT
+              ? createEmbedding(text, EMBEDDING_MODEL_NEXT).then(
+                  ({ embedding }) => embedding
+                )
+              : null,
+          ]
         );
-        const embedding_next = EMBEDDING_MODEL_NEXT
-          ? (await createEmbedding(text, EMBEDDING_MODEL_NEXT)).embedding
-          : null;
 
         // Create/update document record.
         const query = {

--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -138,6 +138,7 @@ export async function updateEmbeddings(
       .digest("base64");
 
     if (existingDoc?.text_hash !== text_hash) {
+      // Document added or content changed => (re)generate embeddings.
       updates.push({
         mdn_url,
         title,
@@ -147,28 +148,31 @@ export async function updateEmbeddings(
         text,
         text_hash,
       });
-    } else if (
-      updateFormatting ||
-      existingDoc?.markdown_hash !== markdown_hash
-    ) {
-      formattingUpdates.push({
-        mdn_url,
-        title,
-        title_short,
-        markdown,
-        markdown_hash,
-      });
-    } else if (
-      !existingDoc.has_embedding ||
-      !existingDoc.has_embedding_next !== !EMBEDDING_MODEL_NEXT
-    ) {
-      const { has_embedding, has_embedding_next } = existingDoc;
-      embeddingUpdates.push({
-        mdn_url,
-        text,
-        has_embedding,
-        has_embedding_next,
-      });
+    } else {
+      if (updateFormatting || existingDoc?.markdown_hash !== markdown_hash) {
+        // Document formatting changed => update markdown.
+        formattingUpdates.push({
+          mdn_url,
+          title,
+          title_short,
+          markdown,
+          markdown_hash,
+        });
+      }
+
+      if (
+        !existingDoc.has_embedding ||
+        !existingDoc.has_embedding_next !== !EMBEDDING_MODEL_NEXT
+      ) {
+        // Embedding missing => add embeddings.
+        const { has_embedding, has_embedding_next } = existingDoc;
+        embeddingUpdates.push({
+          mdn_url,
+          text,
+          has_embedding,
+          has_embedding_next,
+        });
+      }
     }
   }
 

--- a/scripts/ai-help-macros.ts
+++ b/scripts/ai-help-macros.ts
@@ -22,8 +22,8 @@ import {
 } from "@mdn/browser-compat-data/types";
 import { h2mSync } from "../markdown/index.js";
 
-const EMBEDDING_MODEL_NEXT = "text-embedding-3-small";
 const EMBEDDING_MODEL = "text-embedding-ada-002";
+const EMBEDDING_MODEL_NEXT = "text-embedding-3-small";
 
 const { program } = caporal;
 

--- a/scripts/ai-help.sql
+++ b/scripts/ai-help.sql
@@ -34,7 +34,8 @@ create table
     html text null,
     markdown text null,
     token_count integer null,
-    embedding extensions.vector null,
+    embedding extensions.vector(1536) null,
+    embedding_next extensions.vector(1536) null,
     text_hash text null,
     constraint mdn_doc_macro_pkey primary key (id),
     constraint mdn_doc_macro_url_key unique (mdn_url)


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We want to upgrade our embeddings to the `text-embedding-3-model` model.

### Solution

Index all documents in parallel using both the current and the new model.

---

## How did you test this change?

Ran `yarn ai-help-macros update-index` locally, and it populated the `embedding_next` column in the Supabase dev project (the column also exists in the stage/prod projects). 
