### PR TITLE
fix(fonts): ensure italic looks like italic in Safari

### DIFF
--- a/client/src/about/index.scss
+++ b/client/src/about/index.scss
@@ -29,6 +29,7 @@
         font-family: var(--font-heading);
         font-size: 1.313rem;
         font-style: normal;
+        font-variation-settings: normal;
         font-weight: normal;
         line-height: 175%;
         margin: 0;

--- a/client/src/curriculum/index.scss
+++ b/client/src/curriculum/index.scss
@@ -101,6 +101,7 @@
       border-left: 2px solid var(--category-color);
       display: inline-block;
       font-style: normal;
+      font-variation-settings: normal;
       font-weight: 600;
       padding: 0.25rem 0.25rem 0.25rem 0.5rem;
       width: 100%;

--- a/client/src/document/ingredients/browser-compatibility-table/index.scss
+++ b/client/src/document/ingredients/browser-compatibility-table/index.scss
@@ -180,6 +180,7 @@
 .bc-legend-tip {
   font-size: var(--type-smaller-font-size);
   font-style: italic;
+  font-variation-settings: "slnt" -10;
   margin-bottom: 1rem;
   margin-top: 0;
 }

--- a/client/src/document/mathml-polyfill/mathml.css
+++ b/client/src/document/mathml-polyfill/mathml.css
@@ -193,6 +193,7 @@ mspace {
 }
 mi {
   font-style: italic;
+  font-variation-settings: "slnt" -10;
 }
 mo {
   margin-right: 0.2em;
@@ -233,6 +234,7 @@ ms[rquote]:after {
 [mathvariant="sans-serif-italic"],
 [mathvariant="sans-serif-bold-italic"] {
   font-style: italic;
+  font-variation-settings: "slnt" -10;
 }
 [mathvariant="normal"] {
   font-style: normal;

--- a/client/src/document/mathml-polyfill/mathml.css
+++ b/client/src/document/mathml-polyfill/mathml.css
@@ -217,10 +217,12 @@ ms[rquote]:after {
 [mathvariant="sans-serif-bold-italic"] {
   font-weight: var(--font-body-strong-weight);
   font-style: normal;
+  font-variation-settings: normal;
 }
 [mathvariant="monospace"] {
   font-family: monospace;
   font-style: normal;
+  font-variation-settings: normal;
 }
 [mathvariant="sans-serif"],
 [mathvariant="bold-sans-serif"],
@@ -228,6 +230,7 @@ ms[rquote]:after {
 [mathvariant="sans-serif-bold-italic"] {
   font-family: sans-serif;
   font-style: normal;
+  font-variation-settings: normal;
 }
 [mathvariant="italic"],
 [mathvariant="bold-italic"],
@@ -238,6 +241,7 @@ ms[rquote]:after {
 }
 [mathvariant="normal"] {
   font-style: normal;
+  font-variation-settings: normal;
 }
 
 /* mphantom */

--- a/client/src/document/mathml-polyfill/mathml.css
+++ b/client/src/document/mathml-polyfill/mathml.css
@@ -193,7 +193,6 @@ mspace {
 }
 mi {
   font-style: italic;
-  font-variation-settings: "slnt" -10;
 }
 mo {
   margin-right: 0.2em;
@@ -217,12 +216,10 @@ ms[rquote]:after {
 [mathvariant="sans-serif-bold-italic"] {
   font-weight: var(--font-body-strong-weight);
   font-style: normal;
-  font-variation-settings: normal;
 }
 [mathvariant="monospace"] {
   font-family: monospace;
   font-style: normal;
-  font-variation-settings: normal;
 }
 [mathvariant="sans-serif"],
 [mathvariant="bold-sans-serif"],
@@ -230,18 +227,15 @@ ms[rquote]:after {
 [mathvariant="sans-serif-bold-italic"] {
   font-family: sans-serif;
   font-style: normal;
-  font-variation-settings: normal;
 }
 [mathvariant="italic"],
 [mathvariant="bold-italic"],
 [mathvariant="sans-serif-italic"],
 [mathvariant="sans-serif-bold-italic"] {
   font-style: italic;
-  font-variation-settings: "slnt" -10;
 }
 [mathvariant="normal"] {
   font-style: normal;
-  font-variation-settings: normal;
 }
 
 /* mphantom */

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -19,6 +19,7 @@
     border-left: 2px solid var(--category-color);
     display: inline-block;
     font-style: normal;
+    font-variation-settings: normal;
     font-weight: 600;
     hyphens: auto;
     padding: 0.25rem;

--- a/client/src/homepage/contributor-spotlight/index.scss
+++ b/client/src/homepage/contributor-spotlight/index.scss
@@ -13,6 +13,7 @@
     border: 0;
     display: flex;
     font-style: italic;
+    font-variation-settings: "slnt" -10;
     margin: 0;
     padding: 0;
 

--- a/client/src/minimal-prism.scss
+++ b/client/src/minimal-prism.scss
@@ -72,6 +72,7 @@ don't use any of that, we can safely ignore it.
 
 .token.italic {
   font-style: italic;
+  font-variation-settings: "slnt" -10;
 }
 
 .token.entity {

--- a/client/src/plus/ai-help/landing.scss
+++ b/client/src/plus/ai-help/landing.scss
@@ -42,6 +42,7 @@
       em {
         color: var(--category-color);
         font-style: unset;
+        font-variation-settings: unset;
       }
     }
 
@@ -140,6 +141,7 @@
 
         em {
           font-style: unset;
+          font-variation-settings: unset;
           font-weight: 600;
         }
       }

--- a/client/src/plus/collections/collection.scss
+++ b/client/src/plus/collections/collection.scss
@@ -69,6 +69,7 @@
     .breadcrumbs {
       font-size: 0.6875rem;
       font-style: italic;
+      font-variation-settings: "slnt" -10;
       margin-top: -0.5rem;
     }
 
@@ -98,6 +99,7 @@
       font-size: 0.875rem;
 
       font-style: italic;
+      font-variation-settings: "slnt" -10;
       gap: 1rem;
       padding: 1rem;
 

--- a/client/src/plus/collections/collection.scss
+++ b/client/src/plus/collections/collection.scss
@@ -120,6 +120,7 @@
         &.code {
           font-family: var(--font-code);
           font-style: normal;
+          font-variation-settings: normal;
         }
       }
     }

--- a/client/src/plus/common/login-banner.scss
+++ b/client/src/plus/common/login-banner.scss
@@ -12,6 +12,7 @@
   .plus-link {
     color: var(--text-primary);
     font-style: normal;
+    font-variation-settings: normal;
     text-decoration: underline;
     text-decoration-thickness: 0.15rem;
     text-underline-offset: 0.1em;

--- a/client/src/plus/icon-card/index.scss
+++ b/client/src/plus/icon-card/index.scss
@@ -43,6 +43,7 @@
     display: flex;
     font-size: 0.75rem;
     font-style: italic;
+    font-variation-settings: "slnt" -10;
     height: 3rem;
     justify-content: center;
     padding: 0.5rem;

--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.scss
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.scss
@@ -16,6 +16,7 @@
       color: var(--text-primary);
       font-size: 24px;
       font-style: normal;
+      font-variation-settings: normal;
       font-weight: 650;
       line-height: 120%;
       margin-bottom: 2rem;
@@ -103,6 +104,7 @@
             .sub-price {
               font-size: 36px;
               font-style: normal;
+              font-variation-settings: normal;
               font-weight: 650;
               grid-column: 1/2;
               justify-self: right;
@@ -117,6 +119,7 @@
             .sub-length {
               font-size: 0.8rem;
               font-style: normal;
+              font-variation-settings: normal;
               grid-column: 2/3;
               justify-self: left;
               line-height: 120%;

--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.scss
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.scss
@@ -178,6 +178,7 @@
             color: var(--text-invert);
             font-size: 14px;
             font-style: italic;
+            font-variation-settings: "slnt" -10;
             margin-top: auto;
             text-decoration: underline;
 

--- a/client/src/plus/plus-docs/index.scss
+++ b/client/src/plus/plus-docs/index.scss
@@ -40,6 +40,7 @@
 
       p {
         font-style: italic;
+        font-variation-settings: "slnt" -10;
       }
     }
 

--- a/client/src/plus/plus-docs/index.scss
+++ b/client/src/plus/plus-docs/index.scss
@@ -8,6 +8,7 @@
   .main-page-content {
     em {
       font-style: normal;
+      font-variation-settings: normal;
       text-decoration: underline;
       text-decoration-color: var(--text-link);
       text-decoration-thickness: 0.15rem;

--- a/client/src/site-search/index.scss
+++ b/client/src/site-search/index.scss
@@ -2,6 +2,7 @@
 
 .query-string {
   font-style: italic;
+  font-variation-settings: "slnt" -10;
 }
 
 .site-search {

--- a/client/src/site-search/search-results.scss
+++ b/client/src/site-search/search-results.scss
@@ -11,6 +11,7 @@
 
   .highlight {
     font-style: italic;
+    font-variation-settings: "slnt" -10;
   }
 
   .nerd-data {
@@ -83,6 +84,7 @@
     border-radius: var(--elem-radius);
     color: var(--text-primary);
     font-style: italic;
+    font-variation-settings: "slnt" -10;
   }
 }
 

--- a/client/src/ui/base/_prism.scss
+++ b/client/src/ui/base/_prism.scss
@@ -53,6 +53,7 @@
 
 .token.italic {
   font-style: italic;
+  font-variation-settings: "slnt" -10;
 }
 
 .token.entity {

--- a/client/src/ui/base/_reset.scss
+++ b/client/src/ui/base/_reset.scss
@@ -62,6 +62,11 @@ picture {
   max-width: 100%;
 }
 
+/* Fix Inter font bug: 'em' not slanted in Safari. See issue: https://github.com/mdn/yari/issues/7203 */
+em {
+  font-variation-settings: "slnt" -10;
+}
+
 /* Inherit fonts for inputs and buttons */
 input,
 button,

--- a/client/src/ui/molecules/quote/index.scss
+++ b/client/src/ui/molecules/quote/index.scss
@@ -14,6 +14,7 @@ blockquote.quote {
   p {
     display: flex;
     font-style: italic;
+    font-variation-settings: "slnt" -10;
 
     .icon {
       margin-right: 1rem;

--- a/client/src/ui/molecules/search/index.scss
+++ b/client/src/ui/molecules/search/index.scss
@@ -140,6 +140,7 @@
 
     .nothing-found {
       font-style: italic;
+      font-variation-settings: "slnt" -10;
     }
 
     .result-item {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Text marked with `<em>` element is not slanted. Fixes #7203.

### Problem

A possible bug with Inter (italic) font requires extra styling to display slanted text in Safari.

### Solution

Added `font-variation-settings: "slnt" -10;` to `em` elements.
[See additional references here](https://fonts.google.com/knowledge/using_type/styling_type_on_the_web_with_variable_fonts#registered-axes-italic-and-slant).

---

## Screenshots

### Before

![](https://user-images.githubusercontent.com/55398995/191337958-e78e6b9c-ff4e-4717-999b-16839d944e2b.png)


### After

<img width="809" alt="safari-em" src="https://github.com/mdn/yari/assets/63248335/1b8c91f9-c898-49ea-8c84-788e5f37a0a3">

---

## How did you test this change?

Browsed the content in Safari 17.4 after adding the code above to [`_reset.scss`](https://github.com/ironnysh/yari/blob/fcabe3441d6e53e474b9b4ffdd7b1c1971b3acbf/client/src/ui/base/_reset.scss#L65-L69)