### PR TITLE
chore(deps): bump http-proxy-middleware from 2.0.6 to 3.0.0 in /cloud-function

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -20,7 +20,7 @@
         "accept-language-parser": "^1.5.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
-        "http-proxy-middleware": "^2.0.6",
+        "http-proxy-middleware": "^3.0.0",
         "sanitize-filename": "^1.6.3"
       },
       "devDependencies": {
@@ -1646,27 +1646,41 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.0.tgz",
+      "integrity": "sha512-36AV1fIaI2cWRzHo+rbcxhe3M3jUDCNzc4D5zRl57sEWRAxdXYtw7FSQKYY6PDKssiAKjLYypbssHk+xs/kMXw==",
       "dependencies": {
-        "@types/http-proxy": "^1.17.8",
+        "@types/http-proxy": "^1.17.10",
+        "debug": "^4.3.4",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
         "is-plain-obj": "^3.0.0",
-        "micromatch": "^4.0.2"
+        "micromatch": "^4.0.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
       },
-      "peerDependencies": {
-        "@types/express": "^4.17.13"
+      "engines": {
+        "node": ">=6.0"
       },
       "peerDependenciesMeta": {
-        "@types/express": {
+        "supports-color": {
           "optional": true
         }
       }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/http-server": {
       "version": "14.1.1",

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -37,7 +37,7 @@
     "accept-language-parser": "^1.5.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "http-proxy-middleware": "^2.0.6",
+    "http-proxy-middleware": "^3.0.0",
     "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {

--- a/cloud-function/src/handlers/proxy-api.ts
+++ b/cloud-function/src/handlers/proxy-api.ts
@@ -9,5 +9,7 @@ export const proxyApi = createProxyMiddleware({
   autoRewrite: true,
   proxyTimeout: PROXY_TIMEOUT,
   xfwd: true,
-  onProxyReq: fixRequestBody,
+  on: {
+    proxyReq: fixRequestBody,
+  },
 });

--- a/cloud-function/src/handlers/proxy-content.ts
+++ b/cloud-function/src/handlers/proxy-content.ts
@@ -22,25 +22,29 @@ export const proxyContent = createProxyMiddleware({
   proxyTimeout: PROXY_TIMEOUT,
   xfwd: true,
   selfHandleResponse: true,
-  onProxyReq: fixRequestBody,
-  onProxyRes: responseInterceptor(
-    async (responseBuffer, proxyRes, req, res) => {
-      withContentResponseHeaders(proxyRes, req, res);
-      if (proxyRes.statusCode === 404 && !isLiveSampleURL(req.url ?? "")) {
-        const tryHtml = await fetch(`${target}${req.url?.slice(1)}/index.html`);
-        if (tryHtml.ok) {
-          res.statusCode = 200;
+  on: {
+    proxyReq: fixRequestBody,
+    proxyRes: responseInterceptor(
+      async (responseBuffer, proxyRes, req, res) => {
+        withContentResponseHeaders(proxyRes, req, res);
+        if (proxyRes.statusCode === 404 && !isLiveSampleURL(req.url ?? "")) {
+          const tryHtml = await fetch(
+            `${target}${req.url?.slice(1)}/index.html`
+          );
+          if (tryHtml.ok) {
+            res.statusCode = 200;
+            res.setHeader("Content-Type", "text/html");
+            return Buffer.from(await tryHtml.arrayBuffer());
+          } else if (!notFoundBuffer) {
+            const response = await fetch(`${target}${NOT_FOUND_PATH}`);
+            notFoundBuffer = await response.arrayBuffer();
+          }
           res.setHeader("Content-Type", "text/html");
-          return Buffer.from(await tryHtml.arrayBuffer());
-        } else if (!notFoundBuffer) {
-          const response = await fetch(`${target}${NOT_FOUND_PATH}`);
-          notFoundBuffer = await response.arrayBuffer();
+          return Buffer.from(notFoundBuffer);
         }
-        res.setHeader("Content-Type", "text/html");
-        return Buffer.from(notFoundBuffer);
-      }
 
-      return responseBuffer;
-    }
-  ),
+        return responseBuffer;
+      }
+    ),
+  },
 });

--- a/cloud-function/src/handlers/proxy-runner.ts
+++ b/cloud-function/src/handlers/proxy-runner.ts
@@ -17,11 +17,13 @@ export const proxyRunner = createProxyMiddleware({
   proxyTimeout: PROXY_TIMEOUT,
   xfwd: true,
   selfHandleResponse: true,
-  onProxyReq: fixRequestBody,
-  onProxyRes: responseInterceptor(
-    async (responseBuffer, proxyRes, req, res) => {
-      withRunnerResponseHeaders(proxyRes, req, res);
-      return responseBuffer;
-    }
-  ),
+  on: {
+    proxyReq: fixRequestBody,
+    proxyRes: responseInterceptor(
+      async (responseBuffer, proxyRes, req, res) => {
+        withRunnerResponseHeaders(proxyRes, req, res);
+        return responseBuffer;
+      }
+    ),
+  },
 });

--- a/cloud-function/src/handlers/proxy-telemetry.ts
+++ b/cloud-function/src/handlers/proxy-telemetry.ts
@@ -8,5 +8,7 @@ export const proxyTelemetry = createProxyMiddleware({
   autoRewrite: true,
   proxyTimeout: PROXY_TIMEOUT,
   xfwd: true,
-  onProxyReq: fixRequestBody,
+  on: {
+    proxyReq: fixRequestBody,
+  },
 });


### PR DESCRIPTION
## Summary

Like https://github.com/mdn/yari/pull/10829, but for `/cloud-function` (for which Dependabot doesn't work reliably).

---

## How did you test this change?

@mirunacurtean has tested our stage system and found not regressions.
