### PR TITLE
chore(curriculum): unify some spacing

### DIFF
--- a/client/src/curriculum/module.scss
+++ b/client/src/curriculum/module.scss
@@ -10,11 +10,6 @@
         "icon heading"
         "icon category";
       justify-content: flex-start;
-      @media screen and (min-width: $screen-md) {
-        grid-template-areas:
-          "icon heading group"
-          "icon category .";
-      }
 
       .topic-icon {
         --background-primary: var(--curriculum-bg-color-topic);

--- a/client/src/curriculum/modules-list.scss
+++ b/client/src/curriculum/modules-list.scss
@@ -65,6 +65,7 @@
         > label {
           color: var(--text-inactive);
           cursor: pointer;
+          width: max-content;
         }
 
         &#modules-0 {

--- a/client/src/curriculum/modules-list.scss
+++ b/client/src/curriculum/modules-list.scss
@@ -214,7 +214,7 @@
             font-size: var(--type-smaller-font-size);
             height: 11rem;
             justify-content: space-between;
-            padding: 1rem var(--spacing);
+            padding: var(--spacing);
 
             p {
               color: var(--text-secondary);

--- a/client/src/curriculum/modules-list.scss
+++ b/client/src/curriculum/modules-list.scss
@@ -146,6 +146,8 @@
       }
 
       li.module-list-item {
+        --spacing: 1rem;
+        --icon-size: 4rem;
         display: block;
 
         > a {
@@ -178,12 +180,15 @@
             background-color: var(--curriculum-bg-color-list-item-header);
             display: flex;
             flex-direction: column;
-            height: 10rem;
-            padding: 1rem;
+            font-weight: var(--font-body-strong-weight);
+            height: 10.5rem;
+            height: calc(3 * var(--spacing) + var(--icon-size) + 2lh);
+            padding: var(--spacing);
+            row-gap: var(--spacing);
 
             svg.topic-icon {
-              height: 4rem;
-              width: 4rem;
+              height: var(--icon-size);
+              width: var(--icon-size);
 
               circle {
                 fill: var(--curriculum-bg-color-list-item-icon);
@@ -196,8 +201,7 @@
 
             > span {
               color: var(--text-primary);
-              font-weight: var(--font-body-strong-weight);
-              margin: auto;
+              margin: 0 auto;
               text-align: center;
             }
           }
@@ -209,7 +213,7 @@
             font-size: var(--type-smaller-font-size);
             height: 11rem;
             justify-content: space-between;
-            padding: 1rem 1.5rem;
+            padding: 1rem var(--spacing);
 
             p {
               color: var(--text-secondary);


### PR DESCRIPTION
## Summary

- Adjust spacing for module cards. (1rem everywhere + spacing for a line warp in the title).
- Move group label on top of heading.
- Fix modules list list spacing.
---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### 
|Before|After|
|------|-----|
|![image](https://github.com/mdn/yari/assets/3604775/bd1fe668-66c4-478b-ac7f-e031f5d01352)|![image](https://github.com/mdn/yari/assets/3604775/31b4c943-1349-43d4-a5bb-13433da6cf56)|
|![image](https://github.com/mdn/yari/assets/3604775/41dfc48f-7dc0-4a90-bc22-eab578d633fe)|![image](https://github.com/mdn/yari/assets/3604775/b6e6dc5e-d440-476e-b616-87c251aa68b9)|
![image](https://github.com/mdn/yari/assets/3604775/06508ebf-458a-4c94-8411-f18c7332d953)|![image](https://github.com/mdn/yari/assets/3604775/d25240d3-e7f2-4e81-8863-15a0109c9912)|
---

## How did you test this change?

Locally and [stage](https://developer.allizom.org/en-US/curriculum/#modules)
