### PR TITLE
fix(scripts): use cross-env for tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test:libs": "yarn jest --rootDir libs --env=node",
     "test:prepare": "yarn build:prepare && yarn build && yarn start:static-server",
     "test:testing": "yarn jest --rootDir testing",
-    "tool": "NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts",
+    "tool": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts",
     "watch:ssr": "cd ssr && webpack --mode=production --watch"
   },
   "resolutions": {


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We're using `cross-env` for most scripts that set environment variables, except for `tool`.

### Solution

Use `cross-env` for `tool` as well.

---

## How did you test this change?

Didn't test, but this just aligns the script with other scripts.