### PR TITLE
feat(sidebar-filter): measure when user types in the filter

### DIFF
--- a/client/src/document/organisms/sidebar/filter.tsx
+++ b/client/src/document/organisms/sidebar/filter.tsx
@@ -4,10 +4,14 @@ import { Button } from "../../../ui/atoms/button";
 
 import "./filter.scss";
 import { useGleanClick } from "../../../telemetry/glean-context";
-import { SIDEBAR_FILTER_FOCUS } from "../../../telemetry/constants";
+import {
+  SIDEBAR_FILTER_FOCUS,
+  SIDEBAR_FILTER_TYPED,
+} from "../../../telemetry/constants";
 
 export function SidebarFilter() {
   const [isActive, setActive] = useState<Boolean>(false);
+  const [hasTyped, setTyped] = useState<Boolean>(false);
   const { query, setQuery, matchCount } = useSidebarFilter();
   const gleanClick = useGleanClick();
 
@@ -16,6 +20,24 @@ export function SidebarFilter() {
       gleanClick(SIDEBAR_FILTER_FOCUS);
     }
   }, [gleanClick, isActive]);
+
+  useEffect(() => {
+    if (hasTyped) {
+      gleanClick(SIDEBAR_FILTER_TYPED);
+    }
+  }, [gleanClick, hasTyped]);
+
+  useEffect(() => {
+    if (query) {
+      setTyped(true);
+    }
+  }, [query, setTyped]);
+
+  useEffect(() => {
+    if (!isActive) {
+      setTyped(false);
+    }
+  }, [isActive, setTyped]);
 
   return (
     <section className="sidebar-filter-container">

--- a/client/src/document/organisms/sidebar/filter.tsx
+++ b/client/src/document/organisms/sidebar/filter.tsx
@@ -22,16 +22,16 @@ export function SidebarFilter() {
   }, [gleanClick, isActive]);
 
   useEffect(() => {
-    if (hasTyped) {
-      gleanClick(SIDEBAR_FILTER_TYPED);
-    }
-  }, [gleanClick, hasTyped]);
-
-  useEffect(() => {
     if (query) {
       setTyped(true);
     }
   }, [query, setTyped]);
+
+  useEffect(() => {
+    if (hasTyped) {
+      gleanClick(SIDEBAR_FILTER_TYPED);
+    }
+  }, [gleanClick, hasTyped]);
 
   useEffect(() => {
     if (!isActive) {

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -4,6 +4,7 @@ export const OFFER_OVERVIEW_CLICK = "offer_overview_click";
 export const SIDEBAR_CLICK = "sidebar_click";
 export const SIDEBAR_CLICK_WITH_FILTER = "sidebar_click_with_filter";
 export const SIDEBAR_FILTER_FOCUS = "sidebar_filter_focus";
+export const SIDEBAR_FILTER_TYPED = "sidebar_filter_typed";
 export const TOC_CLICK = "toc_click";
 /** Replaced "top_nav_already_subscriber" in July 2023. */
 export const TOP_NAV_LOGIN = "top_nav: login";


### PR DESCRIPTION
## Summary

(MP-1007)

### Problem

We measure when users focus the sidebar filter, but we don't measure when users type in it.

### Solution

Add a measurement on the first type.

---

## How did you test this change?

Ran `yarn && yarn dev` with Glean debugging enabled (`REACT_APP_GLEAN_CHANNEL`, `REACT_APP_GLEAN_DEBUG` and `REACT_APP_GLEAN_ENABLED`).

1. Opened http://localhost:3000/en-US/docs/Learn/HTML
2. Focused the sidebar filter (and observed the `sidebar_filter_focus` measurement).
3. Started typing (and observed a single instance of the new `sidebar_filter_typed` measurement).
4. Unfocused, focused again and continued typing (without observing any measurement).
5. Cleared the sidebar filter, focused again (and observed another `sidebar_filter_focus` measurement).
6. Started typing again (and observed another `sidebar_filter_typed` measurement).