### PR TITLE
enhance(ai-help): add model to issue reports

### DIFF
--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -1083,6 +1083,9 @@ function ReportIssueOnGitHubLink({
   currentMessage: Message;
   children: React.ReactNode;
 }) {
+  const user = useUserData();
+  const isSubscriber = useMemo(() => isPlusSubscriber(user), [user]);
+
   const gleanClick = useGleanClick();
   const currentMessageIndex = messages.indexOf(currentMessage);
   const questions = messages
@@ -1107,6 +1110,8 @@ function ReportIssueOnGitHubLink({
       )
       .join("\n") ?? "(None)"
   );
+  // TODO Persist model in messages and read it from there.
+  sp.set("model", isSubscriber ? "gpt-4" : "gpt-3.5");
   sp.set("template", "ai-help-answer.yml");
 
   url.search = sp.toString();

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -1108,7 +1108,7 @@ function ReportIssueOnGitHubLink({
         (source) =>
           `- [${source.title}](https://developer.mozilla.org${source.url})`
       )
-      .join("\n") ?? "(None)"
+      .join("\n") || "(None)"
   );
   // TODO Persist model in messages and read it from there.
   sp.set("model", isSubscriber ? "gpt-4" : "gpt-3.5");


### PR DESCRIPTION
## Summary

(MP-1037)

### Problem

When users report issues with AI Help answers, we don't know if these answers were generated by GPT-3.5 or GPT-4.

### Solution

Add a parameter to the issue template links to record the used model.

---

## How did you test this change?

Verified locally by running yari alongside rumba and clicking on the issue report link, both with a free user and a paying subscriber, and observed the field to be pre-filled with "gpt-3.5" and "gpt-4" respectively.
