### PR TITLE
feat(stage-build): deploy next with main merged

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -13,6 +13,7 @@ env:
   DEFAULT_DEPLOYMENT_PREFIX: "main"
   DEFAULT_NOTES: ""
   DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
+  DEFAULT_REF: next
 
 on:
   schedule:
@@ -21,6 +22,10 @@ on:
 
   workflow_dispatch:
     inputs:
+      ref:
+        description: "Branch to deploy (default: next)"
+        required: false
+
       notes:
         description: "Notes"
         required: false
@@ -69,6 +74,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || env.DEFAULT_REF }}
+          fetch-depth: 0
+
+      - name: Merge main
+        if: ${{ (github.event.inputs.ref || env.DEFAULT_REF) != 'main' }}
+        run: |
+          git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
+          git config --global user.name "mdn-bot"
+          git status
+          git pull
+          git checkout main
+          git status
+          git checkout -
+          git merge main --no-edit
 
       - uses: actions/checkout@v4
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -73,6 +73,18 @@ jobs:
     if: github.repository == 'mdn/yari'
 
     steps:
+      # Our usecase is a bit complicated. When the cron schedule runs this workflow,
+      # we rely on the env vars defined at the top of the file. But if it's a manual
+      # trigger we rely on the inputs and only the inputs. That way, the user can
+      # opt to type in 'false'.
+      # It's not possible to express this with GitHub Workflow syntax, so we
+      # have a dedicate set that conveniently sets these as env vars which we
+      # can refer to later in `if: ....` lines or in bash with the `run: ...` blocks.
+      - name: Merge dispatch inputs with default env vars
+        run: |
+          echo "DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}" >> $GITHUB_ENV
+          echo "DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref || env.DEFAULT_REF }}
@@ -114,18 +126,6 @@ jobs:
         with:
           repository: mdn/curriculum
           path: mdn/curriculum
-
-      # Our usecase is a bit complicated. When the cron schedule runs this workflow,
-      # we rely on the env vars defined at the top of the file. But if it's a manual
-      # trigger we rely on the inputs and only the inputs. That way, the user can
-      # opt to type in 'false'.
-      # It's not possible to express this with GitHub Workflow syntax, so we
-      # have a dedicate set that conveniently sets these as env vars which we
-      # can refer to later in `if: ....` lines or in bash with the `run: ...` blocks.
-      - name: Merge dispatch inputs with default env vars
-        run: |
-          echo "DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}" >> $GITHUB_ENV
-          echo "DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -84,14 +84,15 @@ jobs:
         run: |
           echo "DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}" >> $GITHUB_ENV
           echo "DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}" >> $GITHUB_ENV
+          echo "REF=${{ github.event.inputs.ref || env.DEFAULT_REF }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.ref || env.DEFAULT_REF }}
+          ref: ${{ env.REF }}
           fetch-depth: 0
 
       - name: Merge main
-        if: ${{ (github.event.inputs.ref || env.DEFAULT_REF) != 'main' }}
+        if: ${{ env.REF != 'main' }}
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"


### PR DESCRIPTION
## Summary

(MP-1055)

### Problem

Our stage environment is regularly missing changes from `main`, because we currently deploy stage manually from the `next` branch and disabled the scheduled deployment from the `main` branch.

### Solution

Deploy stage from `next` by default, merging the latest changes from the `main` branch.

---

## How did you test this change?

Kicked off [a stage build from this branch](https://github.com/mdn/yari/actions/runs/8706806138/job/23880275396), and the "Merge main" step [executed successfully](https://github.com/mdn/yari/actions/runs/8706806138/job/23880275396). (It might fail though if there is a merge conflict.)