### PR TITLE
fix(stage-build): trigger `next` version of workflow on schedule

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -65,12 +65,19 @@ permissions:
   id-token: write
 
 jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'mdn/yari' && github.event.schedule != '' }}
+    steps:
+      # The schedule runs the `main` version, but we want the `next` version.
+      - run: gh workflow run "${{ github.workflow }}" --ref "${{ env.DEFAULT_REF }}"
+
   build:
     environment: stage
     runs-on: ubuntu-latest
 
     # Only run the scheduled workflows on the main repo.
-    if: github.repository == 'mdn/yari'
+    if: ${{ github.repository == 'mdn/yari' && github.event.schedule == '' }}
 
     steps:
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/mdn/yari/pull/10930 (MP-1055).

### Problem

The scheduled workflow runs the workflow from `main`, but if we adjust the stage build in `next`, that's not what we want.

### Solution

When running on schedule, call the same workflow, but using an `workflow_dispatch` event (as if it was run manually).

---

## How did you test this change?

We won't know if it works until we merge this.