### PR TITLE
fix(stage-build): provide GH_TOKEN + specify repo in trigger job

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -70,7 +70,7 @@ jobs:
     if: ${{ github.repository == 'mdn/yari' && github.event.schedule != '' }}
     steps:
       # The schedule runs the `main` version, but we want the `next` version.
-      - run: gh workflow run "${{ github.workflow }}" --ref "${{ env.DEFAULT_REF }}"
+      - run: gh workflow run "${{ github.workflow }}" --repo "${{ github.repository }}" --ref "${{ env.DEFAULT_REF }}"
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -71,6 +71,8 @@ jobs:
     steps:
       # The schedule runs the `main` version, but we want the `next` version.
       - run: gh workflow run "${{ github.workflow }}" --ref "${{ env.DEFAULT_REF }}"
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
 
   build:
     environment: stage


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Follow-up of https://github.com/mdn/yari/pull/10931 (MP-1055).

### Problem

The new `trigger` job of the `stage-build` workflow fails, because it doesn't have the permission to `gh workflow run` and the call doesn't specify the repo.

### Solution

1. Reuse the @mdn-bot personal access token to trigger the workflow run.
2. Specify the repo.

---

## How did you test this change?

Temporarily changed the condition to run only the trigger on non-main branches, and [it suceeded](https://github.com/mdn/yari/actions/runs/8719319320), triggering the actual [build from next](https://github.com/mdn/yari/actions/runs/8719320657).