### PR TITLE
fix(ad-free): show minimal muted top-banner fallback

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -35,7 +35,6 @@ import { TopPlacement } from "./ui/organisms/placement";
 import { Blog } from "./blog";
 import { Newsletter } from "./newsletter";
 import { Curriculum } from "./curriculum";
-import { useUserData } from "./user-context";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
@@ -45,7 +44,6 @@ const Playground = React.lazy(() => import("./playground"));
 
 function Layout({ pageType, children }) {
   const { pathname } = useLocation();
-  const user = useUserData();
   const [category, setCategory] = React.useState<string | null>(
     getCategoryByPathname(pathname)
   );
@@ -62,7 +60,7 @@ function Layout({ pageType, children }) {
           category ? `category-${category}` : ""
         } ${pageType}`}
       >
-        {user?.settings?.noAds || <TopPlacement />}
+        <TopPlacement />
         {pageType !== "document-page" && pageType !== "curriculum" && (
           <div className="sticky-header-container without-actions">
             <TopNavigation />

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -35,6 +35,7 @@ import { TopPlacement } from "./ui/organisms/placement";
 import { Blog } from "./blog";
 import { Newsletter } from "./newsletter";
 import { Curriculum } from "./curriculum";
+import { useUserData } from "./user-context";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
@@ -44,6 +45,7 @@ const Playground = React.lazy(() => import("./playground"));
 
 function Layout({ pageType, children }) {
   const { pathname } = useLocation();
+  const user = useUserData();
   const [category, setCategory] = React.useState<string | null>(
     getCategoryByPathname(pathname)
   );
@@ -60,7 +62,7 @@ function Layout({ pageType, children }) {
           category ? `category-${category}` : ""
         } ${pageType}`}
       >
-        <TopPlacement />
+        {user?.settings?.noAds || <TopPlacement />}
         {pageType !== "document-page" && pageType !== "curriculum" && (
           <div className="sticky-header-container without-actions">
             <TopNavigation />

--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -210,6 +210,11 @@ section.place.hp-main {
         text-decoration: underline;
       }
     }
+
+    &.ad-free {
+      color: var(--text-muted);
+      text-decoration: line-through;
+    }
   }
 }
 

--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -211,7 +211,7 @@ section.place.hp-main {
       }
     }
 
-    &.ad-free {
+    .ad-free {
       color: var(--text-muted);
       text-decoration: line-through;
     }

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -70,9 +70,12 @@ function TopPlacementFallbackContent() {
   const gleanClick = useGleanClick();
 
   return (
-    <p className={`fallback-copy ${user?.settings?.noAds ? "ad-free" : ""}`}>
+    <p className="fallback-copy">
       {user?.settings?.noAds ? (
-        <span title="Thank you for supporting MDN with your subscription. Enjoy MDN ads-free!">
+        <span
+          className="ad-free"
+          title="Thank you for supporting MDN with your subscription. Enjoy MDN ads-free!"
+        >
           {"Ads."}
         </span>
       ) : (

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -65,20 +65,30 @@ export function SidePlacement() {
 }
 
 function TopPlacementFallbackContent() {
+  const user = useUserData();
+
   const gleanClick = useGleanClick();
 
   return (
-    <p className="fallback-copy">
-      Get real-time assistance with your coding queries. Try{" "}
-      <a
-        href="/en-US/plus/ai-help"
-        onClick={() => {
-          gleanClick(BANNER_AI_HELP_CLICK);
-        }}
-      >
-        AI Help
-      </a>{" "}
-      now!
+    <p className={`fallback-copy ${user?.settings?.noAds ? "ad-free" : ""}`}>
+      {user?.settings?.noAds ? (
+        <span title="Thank you for supporting MDN with your subscription. Enjoy MDN ads-free!">
+          {"Ads."}
+        </span>
+      ) : (
+        <>
+          Get real-time assistance with your coding queries. Try{" "}
+          <a
+            href="/en-US/plus/ai-help"
+            onClick={() => {
+              gleanClick(BANNER_AI_HELP_CLICK);
+            }}
+          >
+            AI Help
+          </a>{" "}
+          now!
+        </>
+      )}
     </p>
   );
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We’re showing the

> _Get real-time assistance with your coding queries. Try [AI Help](https://developer.mozilla.org/en-US/plus/ai-help) now!_

top-banner fallback, even if paying subscribers have enabled the Ad-Free Experience.

### Solution

Show a minimal top-banner fallback copy instead if the Ad-Free Experience is enabled.

**Note**: We cannot currently hide the top-banner entirely, because this would cause a layout shift.

---

## Screenshots

### Before

<img width="1424" alt="image" src="https://github.com/mdn/yari/assets/495429/f83b3d43-7546-4dfb-b14b-015fea792af8">

### After

<img width="1424" alt="image" src="https://github.com/mdn/yari/assets/495429/d313b82e-6bc7-4075-ac1b-919db5ba3fac">

---

## How did you test this change?

Ran `yarn && yarn dev` locally with running rumba, logging in as a paying subscriber and enabling the Ad-Free Experience in the user settings.
