### PR TITLE
enhance(notecards,callouts): reduce borders

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -544,7 +544,6 @@ pre {
 
 .callout {
   background: var(--background-secondary);
-  border: 1px solid var(--border-primary);
   border-radius: var(--elem-radius);
   box-shadow: var(--shadow-01);
   display: flex;

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -2,7 +2,7 @@
   --note-background: var(--background-information);
   --note-theme: var(--icon-information);
   background-color: var(--note-background);
-  border-left: 4px solid var(--note-theme);
+  border-left: 2px solid var(--note-theme);
   border-radius: var(--elem-radius);
   box-shadow: var(--shadow-01);
   margin: 1rem 0;

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -2,7 +2,6 @@
   --note-background: var(--background-information);
   --note-theme: var(--icon-information);
   background-color: var(--note-background);
-  border: 1px solid var(--border-secondary);
   border-left: 4px solid var(--note-theme);
   border-radius: var(--elem-radius);
   box-shadow: var(--shadow-01);


### PR DESCRIPTION
## Summary

(MP-1060)

### Problem

The notecards and callouts still have grey border, which is inconsistent to other parts of MDN where we removed them (e.g. code blocks).

### Solution

Remove the border from notecards and callouts, and reduce the left emphasis border.

---

## Screenshots


### Before

<img width="1390" alt="image" src="https://github.com/mdn/yari/assets/495429/8800487c-f6d2-473f-bae9-30009bed6761">

### After

<img width="1390" alt="image" src="https://github.com/mdn/yari/assets/495429/4cb92a9c-b2d7-43b6-92cf-b6cb7ea826e6">


---

## How did you test this change?

Ran `yarn && yarn dev` locally and looked at these pages/sections:

- http://localhost:3000/en-US/docs/Learn#where_to_start
- http://localhost:3000/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts
