### PR TITLE
fix(callouts): reduce inner bottom spacing

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -213,10 +213,6 @@
   .section-content {
     p {
       font: var(--type-article-p);
-
-      &:last-child {
-        margin-bottom: 2rem;
-      }
     }
 
     figure {

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -18,7 +18,7 @@
 
   p {
     line-height: 2;
-    margin: 0 !important;
+    margin: 0;
   }
 
   &:before {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Callouts had an unnecessary spacing after the last paragraph, because a specific CSS rule for `p:last-child { margin-bottom: 2rem; }` rule was overriding the `p { margin: none }` rule for the callout. In fact, that `p:last-child` rule is unnecessary, because we already define `p { margin: 1rem 0 2rem; }` more generally (which includes `margin-bottom: 2rem;`).

### Solution

Remove the unnecessary CSS rule.

**Note**: At the same time, we can relax the `margin` for notecards, which was using the `!important` flag to workaround the issue.

---

## Screenshots

| Before | After |
| --- | --- |
| <img width="810" alt="image" src="https://github.com/mdn/yari/assets/495429/f7bcf287-1c7b-492d-86a6-052f8e32c32e"> | <img width="810" alt="image" src="https://github.com/mdn/yari/assets/495429/dc9fe2c5-459f-4fbd-ab4a-2fd7f02574a3"> |


---

## How did you test this change?

Ran `yarn && yarn dev` locally and looked at http://localhost:3000/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN#notes_warnings_and_callouts.