### PR TITLE
fix(playground): dispatch readystatechange + bubble DOMContentLoaded on document

### DIFF
--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -122,7 +122,7 @@
         document.body.appendChild(script);
 
         ["DOMContentLoaded", "readystatechange", "load"].forEach((type) => {
-          dispatchEvent(new Event(type));
+          document.dispatchEvent(new Event(type, { bubbles: true }));
         });
         initialized = true;
       }

--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -121,9 +121,12 @@
         script.textContent = state.js;
         document.body.appendChild(script);
 
-        ["DOMContentLoaded", "readystatechange", "load"].forEach((type) => {
-          document.dispatchEvent(new Event(type, { bubbles: true }));
-        });
+        document.dispatchEvent(
+          new Event("DOMContentLoaded", { bubbles: true })
+        );
+        document.dispatchEvent(new Event("readystatechange"));
+        window.dispatchEvent(new Event("load"));
+
         initialized = true;
       }
       window.addEventListener("message", (event) => {

--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -121,8 +121,9 @@
         script.textContent = state.js;
         document.body.appendChild(script);
 
-        dispatchEvent(new Event("DOMContentLoaded"));
-        dispatchEvent(new Event("load"));
+        ["DOMContentLoaded", "readystatechange", "load"].forEach((type) => {
+          dispatchEvent(new Event(type));
+        });
         initialized = true;
       }
       window.addEventListener("message", (event) => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/10766.
Fixes https://github.com/mdn/yari/issues/10771.

### Problem

The Playground doesn't dispatch a `readystatechange` event, and only dispatches the `DOMContentLoaded` on the `window`, not on the `document`, so event listeners on the `document` aren't called.

### Solution

1. Also dispatch a `readystatechange` event (once between `DOMContentLoaded` and `load`, because `document.readyState` will already be `completed`.)
2. Dispatch the `DOMContentLoaded` on `document` and let it bubble.

(Kudos to @Kaiido for the proposing this solution.)

---

## Screenshots

### Before

<img width="829" alt="image" src="https://github.com/mdn/yari/assets/495429/6779d4cc-ee7c-4e78-9748-e5084b7edf68">

### After

<img width="829" alt="image" src="https://github.com/mdn/yari/assets/495429/f50b6ce1-a4e3-47ee-9268-d7938c21db13">

---

## How did you test this change?

Deployed to stage and verified that it works as expected on https://developer.allizom.org/en-US/docs/web/api/document/readystatechange_event#result.