### PR TITLE
fix(playground): validate console messages

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -123,8 +123,19 @@ export default function Playground() {
       if (typ === "console") {
         if (prop === "clear") {
           setVConsole([]);
-        } else {
+        } else if (
+          (prop === "log" || prop === "error" || prop === "warn") &&
+          typeof message === "string"
+        ) {
           setVConsole((vConsole) => [...vConsole, { prop, message }]);
+        } else {
+          setVConsole((vConsole) => [
+            ...vConsole,
+            {
+              prop: "warn",
+              message: `[Playground] Unsupported console message: ${JSON.stringify({ prop, message }, null, 2)}`,
+            },
+          ]);
         }
       } else if (typ === "ready") {
         updatePlayIframe(iframe.current, getEditorContent());


### PR DESCRIPTION
## Summary

(MP-1063)

### Problem

The Playground crashes when it receives an invalid console message.

### Solution

Validate the received console messages.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1425" alt="image" src="https://github.com/mdn/yari/assets/495429/dc644b87-6dbb-4fbf-b013-10046f3e6334">

### After

<img width="1425" alt="image" src="https://github.com/mdn/yari/assets/495429/c0448eb2-17ac-48c0-8120-67576da65d7b">

---

## How did you test this change?

Created a Playground with the following JavaScript:

```js
parent.postMessage({typ:'console',prop:'log',message:{}},'*')
```