### PR TITLE
fix(macros/APIRef): skip duplicate entries in Related pages

### DIFF
--- a/kumascript/macros/APIRef.ejs
+++ b/kumascript/macros/APIRef.ejs
@@ -175,7 +175,7 @@ async function buildSublist(pages, title) {
     const title = getPageTitle(aPage);
 
     result += '<li>';
-    
+
     const pageBadges = (await page.badges(aPage)).join("");
 
     if (rtlLocales.indexOf(locale) != -1) {
@@ -205,8 +205,10 @@ function buildIFList(interfaces, title) {
   var result = '<li class="toggle"><details open><summary>' + title + '</summary><ol>';
 
   for (var i = 0; i < interfaces.length; i++) {
-    var url = interfaces[i].replace('()', '').replace('.', '/');
-    result += `<li>${web.smartLink(APIHref + '/' + url, null, `<code>${interfaces[i]}</code>`, APIHref, null, "APIRef")}</li>`;
+    var url = APIHref + '/' + interfaces[i].replace('()', '').replace('.', '/');
+    if (!url.endsWith(slug)) {
+      result += `<li>${web.smartLink(url, null, `<code>${interfaces[i]}</code>`, APIHref, null, "APIRef")}</li>`;
+    }
   }
 
   result += '</ol></details></li>';


### PR DESCRIPTION
## Summary

Fixes #10864

### Problem

Duplicate entries in the sidebar

### Solution

Filter them

---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/3604775/8c3dc606-c6fb-4b96-a6b8-b1a17cb0964e)

### After

![image](https://github.com/mdn/yari/assets/3604775/b3d76446-34ed-4784-beda-cae972e4e50d)

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
