### PR TITLE
fix(ssr): imported image paths set wrong

### DIFF
--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -50,11 +50,22 @@ const config = {
               ref: true,
             },
           },
+          "file-loader?outputPath=/distimages/",
         ],
       },
       {
-        test: /\.(png|svg|jpg|gif)$/,
-        use: ["file-loader?outputPath=/distimages/"],
+        test: [/\.avif$/, /\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+        type: "asset",
+        parser: {
+          dataUrlCondition: {
+            maxSize: 0,
+          },
+        },
+        generator: {
+          emit: false,
+          publicPath: "/",
+          filename: "static/media/[name].[hash][ext]",
+        },
       },
       { test: /\.(css|scss)$/, loader: "ignore-loader" },
     ],


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://mozilla-hub.atlassian.net/browse/MP-1088

### Problem

On https://developer.mozilla.org/en-US/plus this error appears in the browser console:
> Security Error: Content at https://developer.mozilla.org/en-US/plus may not load or link to file:///home/runner/work/yari/yari/ssr/dist//distimages/7023cc01db35a3cf8c89371f0e78da61.png. 

This is because our ssr webpack config is improperly configured.

### Solution

Copied [the relevant lines from the client webpack config](https://github.com/mdn/yari/blob/1d0445d50ddd84313e2795057c39b23d0dd6c667/client/config/webpack.config.js#L339-L360), in-lining the value for `dataUrlCondition.maxSize` (0) and adding the appropriate `generator` options to ensure the ssr doesn't output these assets and sets the appropriate asset url in the generated html.

The previous rule also set an svg rule, so moved that rule above into the svg config to maintain that behaviour (which in itself seems far from ideal, but seems to work - removing the rule breaks things).

This is still far from ideal but kept the change minimal to fix this specific issue, and I've tabled a discussion for the next engineering sync to discuss further fixes to the webpack config vs just switching to a different bundler.

---

## Screenshots

No change

---

## How did you test this change?

- `yarn dev`
- Loaded http://localhost:5042/en-US/plus/ with javascript disabled
- Verified the first image (ai help) loaded, and the path matched the one added once javascript kicks in
