### PR TITLE
enhance(telemetry): enable Glean automatic page load events

### DIFF
--- a/client/src/telemetry/glean-context.tsx
+++ b/client/src/telemetry/glean-context.tsx
@@ -91,7 +91,7 @@ function glean(): GleanAnalytics {
   const uploadEnabled = !userIsOptedOut && GLEAN_ENABLED;
 
   Glean.initialize(GLEAN_APP_ID, uploadEnabled, {
-    maxEvents: 1,
+    enableAutoPageLoadEvents: true,
     channel: GLEAN_CHANNEL,
     migrateFromLegacyStorage: true,
     serverEndpoint: DEV_MODE
@@ -101,8 +101,8 @@ function glean(): GleanAnalytics {
 
   if (DEV_MODE) {
     Glean.setDebugViewTag("mdn-dev");
+    Glean.setLogPings(GLEAN_DEBUG);
   }
-  Glean.setLogPings(GLEAN_DEBUG);
 
   const gleanContext = {
     page: (page: PageProps) => {


### PR DESCRIPTION
## Summary

Duplicate of https://github.com/mdn/yari/pull/10983 (by @Dexterp37) targeting `main`.

### Problem

Glean supports automatic page load events, but we haven't enabled them yet.

### Solution

Enable them.

*Note*: Also removes an unnecessary option and fixes debug logging.

---

## How did you test this change?

Deployed to stage via https://github.com/mdn/yari/pull/10983.