### PR TITLE
enhance(stage-build): always build from next + trigger from main

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -62,9 +62,10 @@ permissions:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'mdn/yari' && github.event.schedule != '' }}
+
+    # When run from `main` branch (schedule or manual), trigger workflow on `next` branch instead.
+    if: ${{ github.repository == 'mdn/yari' && github.ref_name == 'main'  }}
     steps:
-      # The schedule runs the `main` version, but we want the `next` version.
       - run: gh workflow run "${{ github.workflow }}" --repo "${{ github.repository }}" --ref "next"
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
@@ -73,8 +74,8 @@ jobs:
     environment: stage
     runs-on: ubuntu-latest
 
-    # Only run the scheduled workflows on the main repo.
-    if: ${{ github.repository == 'mdn/yari' && github.event.schedule == '' }}
+    # We only ever want to deploy the `next` branch to stage.
+    if: ${{ github.repository == 'mdn/yari' && github.ref_name == 'next' }}
 
     steps:
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,
@@ -94,7 +95,6 @@ jobs:
           fetch-depth: 0
 
       - name: Merge main
-        if: ${{ github.ref_name != 'main' }}
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -13,7 +13,6 @@ env:
   DEFAULT_DEPLOYMENT_PREFIX: "main"
   DEFAULT_NOTES: ""
   DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD: "false"
-  DEFAULT_REF: next
 
 on:
   schedule:
@@ -22,10 +21,6 @@ on:
 
   workflow_dispatch:
     inputs:
-      ref:
-        description: "Branch to deploy (default: next)"
-        required: false
-
       notes:
         description: "Notes"
         required: false
@@ -70,7 +65,7 @@ jobs:
     if: ${{ github.repository == 'mdn/yari' && github.event.schedule != '' }}
     steps:
       # The schedule runs the `main` version, but we want the `next` version.
-      - run: gh workflow run "${{ github.workflow }}" --repo "${{ github.repository }}" --ref "${{ env.DEFAULT_REF }}"
+      - run: gh workflow run "${{ github.workflow }}" --repo "${{ github.repository }}" --ref "next"
         env:
           GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
 
@@ -93,15 +88,13 @@ jobs:
         run: |
           echo "DEPLOYER_BUCKET_PREFIX=${{ github.event.inputs.deployment_prefix || env.DEFAULT_DEPLOYMENT_PREFIX }}" >> $GITHUB_ENV
           echo "DEPLOYER_LOG_EACH_SUCCESSFUL_UPLOAD=${{ github.event.inputs.log_each_successful_upload || env.DEFAULT_LOG_EACH_SUCCESSFUL_UPLOAD }}" >> $GITHUB_ENV
-          echo "REF=${{ github.event.inputs.ref || env.DEFAULT_REF }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.REF }}
           fetch-depth: 0
 
       - name: Merge main
-        if: ${{ env.REF != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

In https://github.com/mdn/yari/pull/10930, we introduced a `ref` input for our stage-build workflow to choose the branch to build, but building a branch using the workflow version from another branch is dangerous.

### Solution

Remove the `ref` input again, and always build from `next` and always trigger from `main`.

---

## How did you test this change?

Will trigger the stage-build on this branch and it should skip both jobs.