### PR TITLE
enhance(l10n): localize "(en-US)" indicator

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -54,7 +54,6 @@ function mutateLink(
     // As we still suggest the translated version even if we only
     // have an English (US) version.
     $element.attr("href", enUSFallback);
-    $element.append(` <small>(${DEFAULT_LOCALE})<small>`);
     $element.addClass("only-in-en-us");
     $element.attr("title", "Currently only available in English (US)");
   } else if (suggestion) {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -975,8 +975,10 @@ html[lang="pt-BR"] a.only-in-en-us:after {
 
 html[lang="zh-CN"] a.only-in-en-us:after {
   content: "（英语）";
+  vertical-align: baseline;
 }
 
 html[lang="zh-TW"] a.only-in-en-us:after {
   content: "（英語）";
+  vertical-align: baseline;
 }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -942,3 +942,41 @@ kbd {
     opacity: 0.4;
   }
 }
+
+html a.only-in-en-us:after {
+  content: "(en-US)";
+  font-size: smaller;
+  vertical-align: super;
+}
+
+html[lang="es"] a.only-in-en-us:after {
+  content: "(inglés)";
+}
+
+html[lang="fr"] a.only-in-en-us:after {
+  content: "(angl.)";
+}
+
+html[lang="ja"] a.only-in-en-us:after {
+  content: "(英語)";
+}
+
+html[lang="ko"] a.only-in-en-us:after {
+  content: "(영어)";
+}
+
+html[lang="ru"] a.only-in-en-us:after {
+  content: "(англ.)";
+}
+
+html[lang="pt-BR"] a.only-in-en-us:after {
+  content: "(inglês)";
+}
+
+html[lang="zh-CN"] a.only-in-en-us:after {
+  content: "(英语)";
+}
+
+html[lang="zh-TW"] a.only-in-en-us:after {
+  content: "(英語)";
+}

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -974,9 +974,9 @@ html[lang="pt-BR"] a.only-in-en-us:after {
 }
 
 html[lang="zh-CN"] a.only-in-en-us:after {
-  content: "(英语)";
+  content: "（英语）";
 }
 
 html[lang="zh-TW"] a.only-in-en-us:after {
-  content: "(英語)";
+  content: "（英語）";
 }

--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -155,7 +155,7 @@ const web = {
         return (
           '<a class="only-in-en-us" ' +
           'title="Currently only available in English (US)" ' +
-          `href="${enUSPage.url}"${flawAttribute}>${content} <small>(en-US)</small></a>`
+          `href="${enUSPage.url}"${flawAttribute}>${content}</a>`
         );
       }
     }


### PR DESCRIPTION
## Summary

(MP-1091)

### Problem

1. Links in other locales that point to the English locale often have a trailing indicator "(en-US)", but this is rather technical and not ideal from a user experience point of view.
2. Not all links to the English locale have this indicator.

### Solution

1. Replace the hardcoded "(en-US)" indicator by a localized one (e.g. "(angl.)" in French), via CSS.
2. Use a CSS attribute selector targeting links that start with `/en-US/` to catch all (?) occurrences.

(Note: I will add the `hreflang` attribute in a subsequent PR.)

---

## Screenshots

| Locale | Before | After |
|--------|--------|--------|
| es | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/2a0d547a-dcd3-450f-9922-f93c5e30d6ae"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/5d492b84-8c0c-4f5f-99cd-7dca18c3b896">  |
| fr | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/faad6b95-41bb-4fdd-9751-ec1e1bd2e769"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/33159831-f9dd-4d5c-9779-d638645bb294"> |
| ja | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/2096eb70-172a-48d7-a39d-6f0670d45054"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/c0469d65-bcdb-4da2-beef-b40e86bfe19f"> |
| ko | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/43611b2f-7c6f-445a-bf75-717184a72546"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/193ae98d-3f4c-40f6-a494-71de6d55d30f"> |
| pt-BR | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/18febde8-0a8c-4b2f-9d9c-aa6ff25488c9"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/1d6fc26c-860b-4520-b885-b3d62314e252"> | 
| ru | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/74a5dba5-98fb-412e-89a4-800ef114b86b"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/d5f306cb-cb4f-4be0-94cb-d21f6fa92d10"> | 
| zh-CN | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/cc401ddc-9e77-4958-961e-a87e8b6e693e"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/23e6f18b-db80-4a20-95c9-d1b363fa9242"> | 
| zh-TW | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/382dfc17-713e-48b9-b348-cf982cb99484"> | <img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/331babdf-cb9e-4d37-abd5-ed031f9387ae"> | 

---

## How did you test this change?

Ran `yarn dev` locally and looked at http://localhost:3000/en-US/docs/Web/API in different locales.

## Approvals

- [x] es
- [x] fr
- [x] ja
- [x] ko
- [ ] pt-BR
- [x] ru
- [x] zh-CN
- [x] zh-TW