### PR TITLE
fix(baseline): checkmarks weren't reflecting mobile status

### DIFF
--- a/client/src/document/baseline-indicator.tsx
+++ b/client/src/document/baseline-indicator.tsx
@@ -7,12 +7,35 @@ import { useLocation } from "react-router";
 
 import "./baseline-indicator.scss";
 
-import type { SupportStatus } from "../../../libs/types/web-features";
+import type {
+  SupportStatus,
+  browserIdentifier,
+} from "../../../libs/types/web-features";
 
-const ENGINES = [
-  { name: "Blink", browsers: ["Chrome", "Edge"] },
-  { name: "Gecko", browsers: ["Firefox"] },
-  { name: "WebKit", browsers: ["Safari"] },
+interface BrowserGroup {
+  name: string;
+  ids: browserIdentifier[];
+}
+
+const ENGINES: {
+  name: string;
+  browsers: BrowserGroup[];
+}[] = [
+  {
+    name: "Blink",
+    browsers: [
+      { name: "Chrome", ids: ["chrome", "chrome_android"] },
+      { name: "Edge", ids: ["edge"] },
+    ],
+  },
+  {
+    name: "Gecko",
+    browsers: [{ name: "Firefox", ids: ["firefox", "firefox_android"] }],
+  },
+  {
+    name: "WebKit",
+    browsers: [{ name: "Safari", ids: ["safari", "safari_ios"] }],
+  },
 ];
 
 const LOCALIZED_BCD_IDS = {
@@ -52,25 +75,27 @@ export function BaselineIndicator({ status }: { status: SupportStatus }) {
     pathname
   )}&level=${level}`;
 
-  const supported = (browser: string) => {
-    const version: string | undefined = status.support?.[browser.toLowerCase()];
-    return Boolean(status.baseline || version);
+  const supported = (browser: BrowserGroup) => {
+    return browser.ids
+      .map((id) => status.support?.[id])
+      .every((version) => Boolean(version));
   };
 
-  const engineTitle = (browsers: string[]) =>
+  const engineTitle = (browsers: BrowserGroup[]) =>
     browsers
       .map((browser, index, array) => {
         const previous = index > 0 ? supported(array[index - 1]) : undefined;
         const current = supported(browser);
+        const name = browser.name;
         return typeof previous === "undefined"
           ? current
-            ? `Supported in ${browser}`
-            : `Not widely supported in ${browser}`
+            ? `Supported in ${name}`
+            : `Not widely supported in ${name}`
           : current === previous
-            ? ` and ${browser}`
+            ? ` and ${name}`
             : current
-              ? `, and supported in ${browser}`
-              : `, and not widely supported in ${browser}`;
+              ? `, and supported in ${name}`
+              : `, and not widely supported in ${name}`;
       })
       .join("");
 
@@ -105,12 +130,12 @@ export function BaselineIndicator({ status }: { status: SupportStatus }) {
             <span key={name} className="engine" title={engineTitle(browsers)}>
               {browsers.map((browser) => (
                 <span
-                  key={browser}
-                  className={`browser ${browser.toLowerCase()} ${
+                  key={browser.ids[0]}
+                  className={`browser ${browser.ids[0]} ${
                     supported(browser) ? "supported" : ""
                   }`}
                   role="img"
-                  aria-label={`${browser} ${
+                  aria-label={`${browser.name} ${
                     supported(browser) ? "check" : "cross"
                   }`}
                 />

--- a/libs/types/web-features.ts
+++ b/libs/types/web-features.ts
@@ -22,7 +22,7 @@ export interface FeatureData {
     | [usage_stats_url, usage_stats_url, ...usage_stats_url[]]; // A single URL or an array of two or more
 }
 
-type browserIdentifier =
+export type browserIdentifier =
   | "chrome"
   | "chrome_android"
   | "edge"


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Fixes https://github.com/mdn/yari/issues/10997

### Problem

We weren't taking mobile statuses into account when working out whether to display a checkmark next to a browser. For Safari we were only checking the `safari` key, we weren't also checking the `safari_ios` key, for instance.

### Solution

Check both desktop and mobile keys for Chrome, Firefox and Safari.

---

## Screenshots

### Before

![image](https://github.com/mdn/yari/assets/755354/614d5c5c-7af2-462d-8eed-a7d364ae0dcf)


### After

![image](https://github.com/mdn/yari/assets/755354/f7c4e66c-3414-43cd-9aa4-ba729257bfce)


---

## How did you test this change?

- `yarn dev`
- Visited http://localhost:3000/en-US/docs/Web/API/Fullscreen_API and a few other pages to verify checks/crosses worked as expected
- Looked at generated source to ensure titles and aria-lables were still being generated correctly, with no "[object Object]" strings within