### PR TITLE
fix(l10n): localize translation banner in Spanish

### DIFF
--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -13,6 +13,11 @@ export function LocalizedContentNote({
         "This page was translated from English by the community. Learn more and join the MDN Web Docs community.",
       url: "/en-US/docs/MDN/Community/Contributing/Translated_content#active_locales",
     },
+    es: {
+      linkText:
+        "Esta página ha sido traducida del inglés por la comunidad. Aprende más y únete a la comunidad de MDN Web Docs.",
+      url: "/es/docs/MDN/Community/Contributing/Translated_content#locales_activos",
+    },
     fr: {
       linkText:
         "Cette page a été traduite à partir de l'anglais par la communauté. Vous pouvez également contribuer en rejoignant la communauté francophone sur MDN Web Docs.",
@@ -41,10 +46,6 @@ export function LocalizedContentNote({
     "en-US": {
       linkText:
         "This page was translated from English by the community, but it's not maintained and may be out-of-date. To help maintain it, learn how to activate locales.",
-    },
-    es: {
-      linkText:
-        "Esta página fue traducida del inglés por la comunidad, pero no se mantiene activamente, por lo que puede estar desactualizada. Si desea ayudar a mantenerlo, descubra cómo activar las configuraciones regionales inactivas.",
     },
   };
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Translated locales have a banner at the top, and it is usually localized in the current locale, but the Spanish locale shows the banner in English.

### Solution

Add a Spanish translation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/88fb8421-f92b-4757-b7ff-4675bf119eaf">

### After

<img width="1417" alt="image" src="https://github.com/mdn/yari/assets/495429/4935a211-7e59-40d0-83ca-ca62bf89b407">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/es/docs/Learn locally.