### PR TITLE
fix(ssr): imported svg paths set wrong

### DIFF
--- a/ssr/webpack.config.js
+++ b/ssr/webpack.config.js
@@ -54,8 +54,18 @@ const config = {
               ref: true,
             },
           },
-          "file-loader?outputPath=/distimages/",
+          {
+            loader: "file-loader",
+            options: {
+              emitFile: false,
+              publicPath: "/",
+              name: "static/media/[name].[hash].[ext]",
+            },
+          },
         ],
+        issuer: {
+          and: [/\.(ts|tsx|js|jsx|md|mdx)$/],
+        },
       },
       {
         test: [/\.avif$/, /\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

follow up to https://github.com/mdn/yari/pull/10982 which fixes things for svgs too

### Problem

As in https://github.com/mdn/yari/pull/10982, importing svg files like `import pathToSVG from "foobar.svg"` fails when SSRing, with webpack setting the path to a local `file://` path, this is due to a misconfiguration in our SSR webpack config.

### Solution

Mirror [the svg config from our client webpack config](https://github.com/mdn/yari/blob/8fea595d181602c1aae9ec3b7b3f41364bd8132a/client/config/webpack.config.js#L361-L386), with some tweaks to ensure the output path is correct, and the svg doesn't actually get output (the client webpack run takes care of that).

Longer term we should replace `file-loader` with asset modules, but this'll require a change to how we import svgs as react modules, so deferring that for now to the wider webpack cleanup I'm working on.

---

## Screenshots

No change

---

## How did you test this change?

Before checking out this change, import an svg somewhere and add it to an `<img>`, let's say `client/src/homepage/index.tsx`:

```
...
import example from "../assets/mdn-logo.svg";
...
<img src={example} />
...
```
Run `yarn dev`
Open http://localhost:5042/en-US/ and observe an error in the console, along with a broken image:
`Security Error: Content at http://localhost:5042/en-US/ may not load or link to file:///workspace/yari/ssr/dist//distimages/0190b323502da5d19d9a1b6ced997386.svg.`

Check out this change (keeping the changes to `client/src/homepage/index.tsx`)
Run `yarn dev` again
Open http://localhost:5042/en-US/ and observe no error in the console, along with a loaded image!