### PR TITLE
fix(language-menu): always render inter-locale links

### DIFF
--- a/client/src/app.scss
+++ b/client/src/app.scss
@@ -186,6 +186,10 @@ main {
   width: 1px !important;
 }
 
+.contents {
+  display: contents;
+}
+
 .hidden {
   display: none;
 }

--- a/client/src/ui/molecules/dropdown/index.tsx
+++ b/client/src/ui/molecules/dropdown/index.tsx
@@ -54,9 +54,11 @@ export function DropdownMenuWrapper({
 
 export function DropdownMenu({
   children,
+  alwaysRenderChildren = false,
   onClose = () => {},
 }: {
   children: React.ReactNode;
+  alwaysRenderChildren?: boolean;
   onClose?: (event?: Event) => void;
 }) {
   const { isOpen, wrapperRef, close, disableAutoClose } =
@@ -82,7 +84,12 @@ export function DropdownMenu({
       onClose(event);
     }
   });
-  if (!isOpen) return null;
+
+  if (alwaysRenderChildren) {
+    return <div className={isOpen ? "contents" : "hidden"}>{children}</div>;
+  } else if (!isOpen) {
+    return null;
+  }
 
   return <>{children}</>;
 }

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -95,7 +95,7 @@ export function LanguageMenu({
         {native}
       </Button>
 
-      <DropdownMenu>
+      <DropdownMenu alwaysRenderChildren>
         <Submenu menuEntry={menuEntry} />
       </DropdownMenu>
     </DropdownMenuWrapper>


### PR DESCRIPTION
## Summary

(MP-1092)

### Problem

The server-side rendered HTML doesn't contain links to the other locales, and these are only rendered on user interaction, so these are not visible to search engines.

### Solution

1. Add a `alwaysRenderChildren` option to the `Dropdown` component.
2. Set the option for the `LanguageMenu`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="923" alt="image" src="https://github.com/mdn/yari/assets/495429/61319e96-74f3-42c1-bf2a-63f6a87d9b51">

### After

<img width="923" alt="image" src="https://github.com/mdn/yari/assets/495429/71dfeb6d-f018-4a0c-bc91-c2cb5829b55a">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/docs/Web/HTML locally, inspecting the HTML using Firefox DevTools.
