### PR TITLE
fix(l10n): localize translation banner in zh-TW

### DIFF
--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -41,6 +41,11 @@ export function LocalizedContentNote({
         "此页面由社区从英文翻译而来。了解更多并加入 MDN Web Docs 社区。",
       url: "/zh-CN/docs/MDN/Community/Contributing/Translated_content#活跃语言",
     },
+    "zh-TW": {
+      linkText:
+        "此頁面由社群從英文翻譯而來。了解更多並加入 MDN Web Docs 社群。",
+      url: "/zh-TW/docs/MDN/Community/Contributing/Translated_content#活躍的語言",
+    },
   };
   const inactiveLocaleNoteContent = {
     "en-US": {


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/mdn/yari/pull/11004.

### Problem

The translation banner is not translated into `zh-TW`.

### Solution

Add the translation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
