### PR TITLE
fix(l10n): localize translation banner in pt-BR

### DIFF
--- a/client/src/document/molecules/localized-content-note/index.tsx
+++ b/client/src/document/molecules/localized-content-note/index.tsx
@@ -32,6 +32,11 @@ export function LocalizedContentNote({
       linkText:
         "이 페이지는 영어로부터 커뮤니티에 의하여 번역되었습니다. MDN Web Docs에서 한국 커뮤니티에 가입하여 자세히 알아보세요.",
     },
+    "pt-BR": {
+      linkText:
+        "Esta página foi traduzida do inglês pela comunidade. Saiba mais e junte-se à comunidade MDN Web Docs.",
+      url: "/pt-BR/docs/MDN/Community/Contributing/Translated_content#locais_ativos",
+    },
     ru: {
       linkText:
         "Эта страница была переведена с английского языка силами сообщества. Вы тоже можете внести свой вклад, присоединившись к русскоязычному сообществу MDN Web Docs.",


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Translated locales have a banner at the top, and it is usually localized in the current locale, but the `pt-BR` locale shows the banner in English.

### Solution

Add the `pt-BR` translation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1033" alt="image" src="https://github.com/mdn/yari/assets/495429/aa42eb36-3e50-44dd-8432-9a0dad953248">

### After

<img width="1033" alt="image" src="https://github.com/mdn/yari/assets/495429/568c9da9-4d2e-4eac-b131-50d01a6e3f4c">


---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/pt-BR/docs/Learn locally.