### PR TITLE
fix(spas): set canonical url

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -227,7 +227,8 @@ export async function buildSPAs(options: {
       const file = filepath.replace(dirpath, "");
       const page = file.split(".")[0];
 
-      const locale = DEFAULT_LOCALE.toLowerCase();
+      const locale = DEFAULT_LOCALE;
+      const pathLocale = locale.toLowerCase();
       const markdown = fs.readFileSync(filepath, "utf-8");
 
       const frontMatter = frontmatter<DocFrontmatter>(markdown);
@@ -250,7 +251,7 @@ export async function buildSPAs(options: {
       const html = renderPage(url, context);
       const outPath = path.join(
         BUILD_OUT_ROOT,
-        locale,
+        pathLocale,
         ...slug.split("/"),
         page
       );

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -114,10 +114,7 @@ export async function buildSPAs(options: {
   // The URL isn't very important as long as it triggers the right route in the <App/>
   const url = `/${DEFAULT_LOCALE}/404.html`;
   let html = renderHTML(url, { pageNotFound: true });
-  html = html.replace(
-    '<link rel="canonical" href="https://developer.mozilla.org"/>',
-    ""
-  );
+  html = setCanonical(html, null);
   const outPath = path.join(
     BUILD_OUT_ROOT,
     DEFAULT_LOCALE.toLowerCase(),
@@ -467,14 +464,21 @@ async function fetchLatestNews() {
 
 function renderPage(url: string, context: any) {
   let html = renderHTML(url, context);
+  html = setCanonical(html, url);
+  return html;
+}
+
+function setCanonical(html: string, url: string | null) {
   html = html.replace(
     `<link rel="canonical" href="${BASE_URL}"/>`,
-    `<link rel="canonical" href="${BASE_URL}${url}"/>`
+    url ? `<link rel="canonical" href="${BASE_URL}${url}"/>` : ""
   );
   // Better safe than sorry.
   html = html.replace(
     `<link rel="canonical" href="https://developer.mozilla.org"/>`,
-    `<link rel="canonical" href="https://developer.mozilla.org${url}"/>`
+    url
+      ? `<link rel="canonical" href="https://developer.mozilla.org${url}"/>`
+      : ""
   );
   return html;
 }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -113,8 +113,8 @@ export async function buildSPAs(options: {
 
   // The URL isn't very important as long as it triggers the right route in the <App/>
   const url = `/${DEFAULT_LOCALE}/404.html`;
-  const html = renderHTML(url, { pageNotFound: true });
-  html.replace(
+  let html = renderHTML(url, { pageNotFound: true });
+  html = html.replace(
     '<link rel="canonical" href="https://developer.mozilla.org"/>',
     ""
   );

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -19,6 +19,7 @@ import {
   CONTRIBUTOR_SPOTLIGHT_ROOT,
   BUILD_OUT_ROOT,
   DEV_MODE,
+  BASE_URL,
 } from "../libs/env/index.js";
 import { isValidLocale } from "../libs/locale-utils/index.js";
 import { DocFrontmatter, DocParent, NewsItem } from "../libs/types/document.js";
@@ -75,7 +76,7 @@ async function buildContributorSpotlight(
     };
     const context = { hyData };
 
-    const html = renderHTML(`/${locale}/${prefix}/${contributor}`, context);
+    const html = renderPage(`/${locale}/${prefix}/${contributor}`, context);
     const outPath = path.join(
       BUILD_OUT_ROOT,
       locale.toLowerCase(),
@@ -113,6 +114,10 @@ export async function buildSPAs(options: {
   // The URL isn't very important as long as it triggers the right route in the <App/>
   const url = `/${DEFAULT_LOCALE}/404.html`;
   const html = renderHTML(url, { pageNotFound: true });
+  html.replace(
+    '<link rel="canonical" href="https://developer.mozilla.org"/>',
+    ""
+  );
   const outPath = path.join(
     BUILD_OUT_ROOT,
     DEFAULT_LOCALE.toLowerCase(),
@@ -185,7 +190,7 @@ export async function buildSPAs(options: {
           noIndexing,
         };
 
-        const html = renderHTML(url, context);
+        const html = renderPage(url, context);
         const outPath = path.join(BUILD_OUT_ROOT, pathLocale, prefix);
         fs.mkdirSync(outPath, { recursive: true });
         const filePath = path.join(outPath, "index.html");
@@ -242,7 +247,7 @@ export async function buildSPAs(options: {
         pageTitle: `${frontMatter.attributes.title || ""} | ${title}`,
       };
 
-      const html = renderHTML(url, context);
+      const html = renderPage(url, context);
       const outPath = path.join(
         BUILD_OUT_ROOT,
         locale,
@@ -342,7 +347,7 @@ export async function buildSPAs(options: {
         featuredArticles,
       };
       const context = { hyData };
-      const html = renderHTML(url, context);
+      const html = renderPage(url, context);
       const outPath = path.join(BUILD_OUT_ROOT, localeLC);
       fs.mkdirSync(outPath, { recursive: true });
       const filePath = path.join(outPath, "index.html");
@@ -457,4 +462,13 @@ async function fetchLatestNews() {
   return {
     items,
   };
+}
+
+function renderPage(url: string, context: any) {
+  const html = renderHTML(url, context);
+  html.replace(
+    `<link rel="canonical" href="${BASE_URL}"/>`,
+    `<link rel="canonical" href="${BASE_URL}${url}"/>`
+  );
+  return html;
 }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -466,6 +466,11 @@ async function fetchLatestNews() {
 
 function renderPage(url: string, context: any) {
   const html = renderHTML(url, context);
+  // Better safe than sorry.
+  html.replace(
+    `<link rel="canonical" href="https://developer.mozilla.org"/>`,
+    `<link rel="canonical" href="https://developer.mozilla.org${url}"/>`
+  );
   html.replace(
     `<link rel="canonical" href="${BASE_URL}"/>`,
     `<link rel="canonical" href="${BASE_URL}${url}"/>`

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -465,15 +465,15 @@ async function fetchLatestNews() {
 }
 
 function renderPage(url: string, context: any) {
-  const html = renderHTML(url, context);
-  // Better safe than sorry.
-  html.replace(
-    `<link rel="canonical" href="https://developer.mozilla.org"/>`,
-    `<link rel="canonical" href="https://developer.mozilla.org${url}"/>`
-  );
-  html.replace(
+  let html = renderHTML(url, context);
+  html = html.replace(
     `<link rel="canonical" href="${BASE_URL}"/>`,
     `<link rel="canonical" href="${BASE_URL}${url}"/>`
+  );
+  // Better safe than sorry.
+  html = html.replace(
+    `<link rel="canonical" href="https://developer.mozilla.org"/>`,
+    `<link rel="canonical" href="https://developer.mozilla.org${url}"/>`
   );
   return html;
 }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -115,14 +115,11 @@ export async function buildSPAs(options: {
   let buildCount = 0;
 
   // The URL isn't very important as long as it triggers the right route in the <App/>
-  const url = `/${DEFAULT_LOCALE}/404.html`;
+  const locale = DEFAULT_LOCALE;
+  const url = `/${locale}/404.html`;
   let html = renderHTML(url, { pageNotFound: true });
   html = setCanonical(html, null);
-  const outPath = path.join(
-    BUILD_OUT_ROOT,
-    DEFAULT_LOCALE.toLowerCase(),
-    "_spas"
-  );
+  const outPath = path.join(BUILD_OUT_ROOT, locale.toLowerCase(), "_spas");
   fs.mkdirSync(outPath, { recursive: true });
   fs.writeFileSync(path.join(outPath, path.basename(url)), html);
   buildCount++;

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -76,7 +76,10 @@ async function buildContributorSpotlight(
     };
     const context = { hyData };
 
-    const html = renderPage(`/${locale}/${prefix}/${contributor}`, context);
+    const html = renderCanonicalHTML(
+      `/${locale}/${prefix}/${contributor}`,
+      context
+    );
     const outPath = path.join(
       BUILD_OUT_ROOT,
       locale.toLowerCase(),
@@ -187,7 +190,7 @@ export async function buildSPAs(options: {
           noIndexing,
         };
 
-        const html = renderPage(url, context);
+        const html = renderCanonicalHTML(url, context);
         const outPath = path.join(BUILD_OUT_ROOT, pathLocale, prefix);
         fs.mkdirSync(outPath, { recursive: true });
         const filePath = path.join(outPath, "index.html");
@@ -245,7 +248,7 @@ export async function buildSPAs(options: {
         pageTitle: `${frontMatter.attributes.title || ""} | ${title}`,
       };
 
-      const html = renderPage(url, context);
+      const html = renderCanonicalHTML(url, context);
       const outPath = path.join(
         BUILD_OUT_ROOT,
         pathLocale,
@@ -345,7 +348,7 @@ export async function buildSPAs(options: {
         featuredArticles,
       };
       const context = { hyData };
-      const html = renderPage(url, context);
+      const html = renderCanonicalHTML(url, context);
       const outPath = path.join(BUILD_OUT_ROOT, localeLC);
       fs.mkdirSync(outPath, { recursive: true });
       const filePath = path.join(outPath, "index.html");
@@ -462,7 +465,7 @@ async function fetchLatestNews() {
   };
 }
 
-function renderPage(url: string, context: any) {
+function renderCanonicalHTML(url: string, context: any) {
   let html = renderHTML(url, context);
   html = setCanonical(html, url);
   return html;


### PR DESCRIPTION
## Summary

(MP-1095)

### Problem

Our static pages incorrectly reference `https://developer.mozilla.org/` as their canonical URL.

### Solution

Correctly set the canonical URL on static pages.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

1. Ran `yarn tool spas` and verified the `index.html` in `client/build`.
1. Deployed to stage and verified these pages:
    - [x] https://developer.allizom.org/en-US/
    - [x] https://developer.allizom.org/fr/
    - [x] https://developer.allizom.org/es/advertising
    - [x] https://developer.allizom.org/en-US/plus/docs/faq
    - [x] https://developer.allizom.org/en-US/community/spotlight/yuji
    - [ ] https://developer.allizom.org/404