### PR TITLE
fix(macros/AccessibilitySidebar): remove deleted Annotations page

### DIFF
--- a/kumascript/macros/AccessibilitySidebar.ejs
+++ b/kumascript/macros/AccessibilitySidebar.ejs
@@ -72,7 +72,6 @@ const sections = [
       {
         name: "ARIA_guides",
         pages: [
-          "Web/Accessibility/ARIA/Annotations",
           "Web/Accessibility/ARIA/ARIA_Guides",
           "Web/Accessibility/ARIA/ARIA_Live_Regions",
           "Web/Accessibility/ARIA/ARIA_Screen_Reader_Implementors_Guide",


### PR DESCRIPTION
- related to https://github.com/mdn/content/pull/32593

## Summary

The macro throws a confusing flaw: `Error: wrong xref macro used (consider changing which macro you use)`

## Issue

The error is thrown by smartLink function because the document `Web/Accessibility/ARIA/Annotations` has been deleted and redirects to parent dir.

## Solution

Remove the deleted doc from the sidebar.

Also, the smartLink function should throw error with message related to the actual issue and not the cryptic one saying wrong macro usage. Changing smartLink function may break other macros and effort will be significant, so let's fix it another day.

## Testing

Tested using local dev before and after fix.