### PR TITLE
fix(macro): make smartLink() error message more informative

### DIFF
--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -117,7 +117,8 @@ const web = {
         } else {
           flaw = this.env.recordNonFatalError(
             "wrong-xref-macro",
-            "wrong xref macro used (consider changing which macro you use)",
+            "Wrong xref macro used (consider changing which macro you use). " +
+              `Error processing path ${href}`,
             {
               current: subpath,
             }


### PR DESCRIPTION
- related to https://github.com/mdn/yari/pull/11040

## Summary

For sidebar macros, if there is a bad URL used, then the `smartLink` function throws a confusing flaw: `Error: wrong xref macro used (consider changing which macro you use)`. This doesn't give much information about the buggy URL.

Also, the printed stack trace doesn't help in this situation to narrow down the location. Stack trace code line numbers are not the same because `.ts` file gets converted to `.js`.
```log
Error: Wrong xref macro used (consider changing which macro you use).
    at Object.recordNonFatalError (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/src/render.js:90:23)
    at Object.smartLink (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/src/api/web.js:93:37)
    at renderSubsection ("/home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/macros/AccessibilitySidebar.ejs":101:26)
    at renderSection ("/home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/macros/AccessibilitySidebar.ejs":130:21)
    at renderSidebar ("/home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/macros/AccessibilitySidebar.ejs":140:21)
    at async eval ("/home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/macros/AccessibilitySidebar.ejs":148:16)
    at async Templates.render (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/src/templates.js:94:30)
    at async render (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/src/render.js:192:40)
    at async Module.render (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/kumascript/index.js:58:36)
    at async buildDocument (file:///home/onkar/GitHub/mdn/content/node_modules/@mdn/yari/build/index.js:160:42)
```

### Solution

In the error message log path sent to the smartLink function. This will help sidebar macro maintainers to quickly figure out erroneous paths.

---

### Before

```text
The macro throws a confusing flaw: Error: wrong xref macro used (consider changing which macro you use)
```

### After

```text
Explanation: Wrong xref macro used (consider changing which macro you use). Error processing path /en-US/docs/Web/Accessibility/ARIA/Annotations
```

---

## How did you test this change?

In local dev environment reproduced https://github.com/mdn/yari/pull/11040 issue and tested output before and after the fix.