### PR TITLE
fix(curriculum): lazy load

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -34,12 +34,12 @@ import { HydrationData } from "../../libs/types/hydration";
 import { TopPlacement } from "./ui/organisms/placement";
 import { Blog } from "./blog";
 import { Newsletter } from "./newsletter";
-import { Curriculum } from "./curriculum";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
 const WritersHomepage = React.lazy(() => import("./writers-homepage"));
 const Sitemap = React.lazy(() => import("./sitemap"));
+const Curriculum = React.lazy(() => import("./curriculum"));
 const Playground = React.lazy(() => import("./playground"));
 
 function Layout({ pageType, children }) {

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -34,12 +34,12 @@ import { HydrationData } from "../../libs/types/hydration";
 import { TopPlacement } from "./ui/organisms/placement";
 import { Blog } from "./blog";
 import { Newsletter } from "./newsletter";
+import { Curriculum } from "./curriculum";
 
 const AllFlaws = React.lazy(() => import("./flaws"));
 const Translations = React.lazy(() => import("./translations"));
 const WritersHomepage = React.lazy(() => import("./writers-homepage"));
 const Sitemap = React.lazy(() => import("./sitemap"));
-const Curriculum = React.lazy(() => import("./curriculum"));
 const Playground = React.lazy(() => import("./playground"));
 
 function Layout({ pageType, children }) {

--- a/client/src/curriculum/about.tsx
+++ b/client/src/curriculum/about.tsx
@@ -7,7 +7,9 @@ import { CurriculumLayout } from "./layout";
 import "./index.scss";
 import "./about.scss";
 
-export function CurriculumAbout(props: HydrationData<any, CurriculumDoc>) {
+export default function CurriculumAbout(
+  props: HydrationData<any, CurriculumDoc>
+) {
   const doc = useCurriculumDoc(props);
   const [coloredTitle, ...restTitle] = doc?.title?.split(" ") || [];
   return (

--- a/client/src/curriculum/index.tsx
+++ b/client/src/curriculum/index.tsx
@@ -1,14 +1,16 @@
+import React from "react";
 import { Route, Routes } from "react-router-dom";
 
 import { HydrationData } from "../../../libs/types/hydration";
-import { CurriculumModuleOverview } from "./overview";
-import { CurriculumModule } from "./module";
-import { CurriculumAbout } from "./about";
-import { CurriculumLanding } from "./landing";
 
 import "./index.scss";
 
-export default function Curriculum(appProps: HydrationData) {
+const CurriculumModuleOverview = React.lazy(() => import("./overview"));
+const CurriculumModule = React.lazy(() => import("./module"));
+const CurriculumAbout = React.lazy(() => import("./about"));
+const CurriculumLanding = React.lazy(() => import("./landing"));
+
+export function Curriculum(appProps: HydrationData) {
   return (
     <Routes>
       <Route path="/" element={<CurriculumLanding {...appProps} />} />

--- a/client/src/curriculum/index.tsx
+++ b/client/src/curriculum/index.tsx
@@ -8,7 +8,7 @@ import { CurriculumLanding } from "./landing";
 
 import "./index.scss";
 
-export function Curriculum(appProps: HydrationData) {
+export default function Curriculum(appProps: HydrationData) {
   return (
     <Routes>
       <Route path="/" element={<CurriculumLanding {...appProps} />} />

--- a/client/src/curriculum/landing.tsx
+++ b/client/src/curriculum/landing.tsx
@@ -15,7 +15,9 @@ import "./index.scss";
 import "./landing.scss";
 import { ProseSection } from "../../../libs/types/document";
 
-export function CurriculumLanding(appProps: HydrationData<any, CurriculumDoc>) {
+export default function CurriculumLanding(
+  appProps: HydrationData<any, CurriculumDoc>
+) {
   const doc = useCurriculumDoc(appProps as CurriculumData);
   return (
     <CurriculumLayout

--- a/client/src/curriculum/module.tsx
+++ b/client/src/curriculum/module.tsx
@@ -9,7 +9,9 @@ import { topic2css, useCurriculumDoc } from "./utils";
 import "./index.scss";
 import "./module.scss";
 
-export function CurriculumModule(props: HydrationData<any, CurriculumDoc>) {
+export default function CurriculumModule(
+  props: HydrationData<any, CurriculumDoc>
+) {
   const doc = useCurriculumDoc(props as CurriculumData);
   return (
     <CurriculumLayout

--- a/client/src/curriculum/overview.tsx
+++ b/client/src/curriculum/overview.tsx
@@ -8,7 +8,7 @@ import { CurriculumLayout } from "./layout";
 
 import "./index.scss";
 
-export function CurriculumModuleOverview(
+export default function CurriculumModuleOverview(
   props: HydrationData<any, CurriculumDoc>
 ) {
   const doc = useCurriculumDoc(props as CurriculumData);


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When we launched Curriculum, our JavaScript main bundle increased by 13%, because we didn't lazy-load the Curriculum, so we loaded all Curriculum SVGs on all pages.

### Solution

Use `React.lazy()` to lazy-load the Curriculum.

---

## Screenshots

Ran `yarn client:build` once on `main` and once on this branch:

### Before

```
  412.42 kB  build/static/js/949.932cfa21.chunk.js
  185.62 kB  build/static/js/main.a07e1b52.js
  52.36 kB   build/static/js/149.b4d6ad35.chunk.js
  35.7 kB    build/static/css/main.83c12c32.css
  25.74 kB   build/static/js/453.0f49f04a.chunk.js
  16.37 kB   build/static/js/592.2e0c9764.chunk.js
  10.29 kB   build/static/js/79.ba38cf2a.chunk.js
  6.94 kB    build/static/js/345.7b57ad96.chunk.js
  6.01 kB    build/static/js/553.65e73d3d.chunk.js
  5.68 kB    build/static/js/browser-compatibility-table.190eea50.chunk.js
  5.11 kB    build/static/js/810.4d9def73.chunk.js
  4.7 kB     build/static/js/557.7ce8b7a9.chunk.js
  4.23 kB    build/static/css/592.ea41257b.chunk.css
  4.14 kB    build/static/js/277.d5b51ad7.chunk.js
  4.07 kB    build/static/js/920.da372a1f.chunk.js
  3.92 kB    build/static/js/405.ad88c8a1.chunk.js
  3.63 kB    build/static/js/220.100bbf2f.chunk.js
  3.46 kB    build/static/js/379.80713abc.chunk.js
  3.22 kB    build/static/js/326.640301ff.chunk.js
  2.65 kB    build/static/js/849.5831299a.chunk.js
  1.53 kB    build/static/css/79.8870f950.chunk.css
  1.45 kB    build/static/css/277.5291bc63.chunk.css
  1.44 kB    build/static/js/670.5db0e450.chunk.js
  1.3 kB     build/static/css/326.2e0c589c.chunk.css
  1.14 kB    build/static/css/319.35377965.chunk.css
  942 B      build/static/js/790.a4dc8d5a.chunk.js
  847 B      build/static/js/47.90466da6.chunk.js
  740 B      build/static/js/450.ea8dde84.chunk.js
  720 B      build/static/css/810.1705d41f.chunk.css
  647 B      build/static/css/345.ce762274.chunk.css
  645 B      build/static/css/557.d0c4e8c2.chunk.css
  539 B      build/static/js/338.33b295b9.chunk.js
  514 B      build/static/css/405.f77b0b94.chunk.css
  294 B      build/static/css/849.379bee48.chunk.css
  196 B      build/static/css/338.e54da6c2.chunk.css
  186 B      build/static/js/319.b1debb8c.chunk.js
  144 B      build/static/css/47.afeb9e7f.chunk.css
  133 B      build/static/css/450.aa0d597d.chunk.css
```

### After

```
File sizes after gzip:

  412.42 kB              build/static/js/949.932cfa21.chunk.js
  164.07 kB (-21.55 kB)  build/static/js/main.d9b6b429.js
  52.36 kB               build/static/js/149.b4d6ad35.chunk.js
  32.56 kB (-3.14 kB)    build/static/css/main.20bdaff8.css
  25.74 kB               build/static/js/453.0f49f04a.chunk.js
  22.76 kB               build/static/js/175.28733107.chunk.js
  16.37 kB               build/static/js/592.2e0c9764.chunk.js
  10.29 kB               build/static/js/79.ba38cf2a.chunk.js
  6.94 kB                build/static/js/345.7b57ad96.chunk.js
  6.01 kB                build/static/js/553.65e73d3d.chunk.js
  5.68 kB                build/static/js/browser-compatibility-table.190eea50.chunk.js
  5.11 kB                build/static/js/810.4d9def73.chunk.js
  4.7 kB                 build/static/js/557.7ce8b7a9.chunk.js
  4.47 kB                build/static/js/283.6b6ed477.chunk.js
  4.23 kB                build/static/css/592.ea41257b.chunk.css
  4.14 kB                build/static/js/277.d5b51ad7.chunk.js
  4.07 kB                build/static/js/920.da372a1f.chunk.js
  4.06 kB                build/static/js/246.e97cd37b.chunk.js
  3.92 kB                build/static/js/405.ad88c8a1.chunk.js
  3.63 kB                build/static/js/220.100bbf2f.chunk.js
  3.6 kB                 build/static/css/175.52325894.chunk.css
  3.46 kB                build/static/js/379.80713abc.chunk.js
  3.22 kB                build/static/js/326.640301ff.chunk.js
  2.65 kB                build/static/js/849.5831299a.chunk.js
  1.83 kB                build/static/css/283.93221190.chunk.css
  1.7 kB                 build/static/js/932.9aef6388.chunk.js
  1.53 kB                build/static/css/79.8870f950.chunk.css
  1.45 kB                build/static/css/277.5291bc63.chunk.css
  1.44 kB                build/static/js/670.5db0e450.chunk.js
  1.3 kB                 build/static/css/326.2e0c589c.chunk.css
  1.14 kB                build/static/css/319.35377965.chunk.css
  942 B                  build/static/js/790.a4dc8d5a.chunk.js
  847 B                  build/static/js/47.90466da6.chunk.js
  740 B                  build/static/js/450.ea8dde84.chunk.js
  731 B                  build/static/css/932.9d477ea6.chunk.css
  720 B                  build/static/css/810.1705d41f.chunk.css
  654 B                  build/static/css/246.5c0dc8f7.chunk.css
  647 B                  build/static/css/345.ce762274.chunk.css
  645 B                  build/static/css/557.d0c4e8c2.chunk.css
  539 B                  build/static/js/338.33b295b9.chunk.js
  514 B                  build/static/css/405.f77b0b94.chunk.css
  294 B                  build/static/css/849.379bee48.chunk.css
  196 B                  build/static/css/338.e54da6c2.chunk.css
  186 B                  build/static/js/319.b1debb8c.chunk.js
  144 B                  build/static/css/47.afeb9e7f.chunk.css
  133 B                  build/static/css/450.aa0d597d.chunk.css
```

---

## How did you test this change?

See above, and will deploy to stage first.
