### PR TITLE
fix(curriculum): highlight "Getting started" in module overview

### DIFF
--- a/client/src/curriculum/about.tsx
+++ b/client/src/curriculum/about.tsx
@@ -9,6 +9,7 @@ import "./about.scss";
 
 export function CurriculumAbout(props: HydrationData<any, CurriculumDoc>) {
   const doc = useCurriculumDoc(props);
+  // [["About"], ["the", "MDN", "Curriculum"]]
   const [coloredTitle, ...restTitle] = doc?.title?.split(" ") || [];
   return (
     <CurriculumLayout

--- a/client/src/curriculum/overview.tsx
+++ b/client/src/curriculum/overview.tsx
@@ -12,7 +12,12 @@ export function CurriculumModuleOverview(
   props: HydrationData<any, CurriculumDoc>
 ) {
   const doc = useCurriculumDoc(props as CurriculumData);
-  const [coloredTitle, ...restTitle] = doc?.title?.split(" ") || [];
+  // ["Getting", "started", "modules"]
+  const titleParts = doc?.title?.split(" ") || [];
+  // "Getting started"
+  const coloredTitle = titleParts.slice(0, -1).join(" ");
+  // "modules"
+  const restTitle = titleParts.at(-1);
   return (
     <CurriculumLayout
       doc={doc}
@@ -20,7 +25,7 @@ export function CurriculumModuleOverview(
     >
       <header>
         <h1>
-          <span>{coloredTitle}</span> {restTitle.join(" ")}
+          <span>{coloredTitle}</span> {restTitle}
         </h1>
       </header>
       <RenderCurriculumBody doc={doc} />


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1107)

### Problem

On the "Getting started modules" overview page, only "Getting" is highlighted in the title.

### Solution

Highlight "Getting started", i.e. everything except the trailing "modules" part.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="843" alt="image" src="https://github.com/mdn/yari/assets/495429/92f3e24f-06fe-4039-b231-547f847ba061">

### After

<img width="843" alt="image" src="https://github.com/mdn/yari/assets/495429/db438da9-0186-4c41-b015-b4de407a3273">

---

## How did you test this change?

Ran `yarn dev` locally, and then `yarn build:curriculum` concurrently.
