### PR TITLE
fix(l10n): improve style of en-US links

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -943,15 +943,11 @@ kbd {
   }
 }
 
-html a.only-in-en-us {
-  opacity: 0.775;
-
-  &:after {
-    content: "(en-US)";
-    display: inline-block;
-    font-size: var(--type-tiny-font-size);
-    vertical-align: super;
-  }
+html a.only-in-en-us:after {
+  content: "(en-US)";
+  display: inline-block;
+  font-size: var(--type-tiny-font-size);
+  vertical-align: super;
 }
 
 html[lang="es"] a.only-in-en-us:after {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -949,7 +949,7 @@ html a.only-in-en-us {
   &:after {
     content: "(en-US)";
     display: inline-block;
-    font-size: smaller;
+    font-size: var(--type-tiny-font-size);
     vertical-align: super;
   }
 }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -943,10 +943,14 @@ kbd {
   }
 }
 
-html a.only-in-en-us:after {
-  content: "(en-US)";
-  font-size: smaller;
-  vertical-align: super;
+html a.only-in-en-us {
+  opacity: 0.775;
+
+  &:after {
+    content: "(en-US)";
+    font-size: smaller;
+    vertical-align: super;
+  }
 }
 
 html[lang="es"] a.only-in-en-us:after {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -948,6 +948,7 @@ html a.only-in-en-us {
 
   &:after {
     content: "(en-US)";
+    display: inline-block;
     font-size: smaller;
     vertical-align: super;
   }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1101)

### Problem

The en-US link indicators (e.g. "(angl.)") are very prominent and underlined, and they sometimes break over one line.

### Solution

Reduce the font-size, stop underlining the indicator, and avoid the line break.

---

## Screenshots

_Note_: The column-breaks in the index layout will be fixed in https://github.com/mdn/yari/pull/11053.

| | fr | zh-CN |
|--------|--------|--------|
| Before | <img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/8f61420b-8485-4bbd-9882-ac71c024a54b"> | <img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/b1ba81be-37a5-44d6-84df-07ba98883113"> |
| After | <img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/fd726374-0ae4-4a06-8516-129f4d706b58"> | <img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/0cdf0efe-5e9c-4d9e-8385-56d029924760"> |

---

## How did you test this change?

Ran `yarn dev` locally and checked the Web/API page in [fr](http://localhost:3000/fr/docs/Web/API#sp%C3%A9cifications) and [zh-CN](http://localhost:3000/zh-CN/docs/Web/API#%E8%A7%84%E8%8C%83).
