### PR TITLE
fix(layout): avoid column breaks in index

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -524,6 +524,7 @@ pre {
     }
 
     li {
+      break-inside: avoid-column;
       margin: 0 0 0.5rem;
     }
   }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1102)

### Problem

In the multi-column index layout, some entries are split across columns.

### Solution

Avoid column-breaks.

---

## Screenshots

_Note_: The word-break in the en-US indicator will be fixed in https://github.com/mdn/yari/pull/11052.

### Before

<img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/eb15bdcf-ebbb-488a-9b58-933421f20789">

### After

<img width="1423" alt="image" src="https://github.com/mdn/yari/assets/495429/51ab7c25-8945-4ddf-bd67-5c1152e8ac61">


---

## How did you test this change?

Ran `yarn dev` and looked at http://localhost:3000/zh-CN/docs/Web/API#%E8%A7%84%E8%8C%83.