### PR TITLE
fix(l10n): improve position of en-US link indicators in sidebar

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -29,7 +29,7 @@
 
   a {
     color: var(--text-secondary);
-    display: inline-flex;
+    display: inline-block;
     hyphens: auto;
     padding: 0.25rem;
 


### PR DESCRIPTION
## Summary

This PR improves position of en-US link indicators in sidebar.

### Problem

Now en-US link indicators сan be positioned pushed to the right edge, resulting in a large gap of empty space.

### Solution

Change positioning from `inline-flex` to `inline-block`.

## Screenshots

### Before

![Screenshot from 2024-05-05 00-40-28](https://github.com/mdn/yari/assets/1682136/9dbaff6b-fbd1-440a-8977-abbf4d59a949)

### After

![Screenshot from 2024-05-05 00-40-59](https://github.com/mdn/yari/assets/1682136/49b3f46c-abd6-4825-b265-a9640fe0cf75)
