### PR TITLE
fix(macro): Fix two flaws in CSSRef.ejs

### DIFF
--- a/kumascript/macros/CSSRef.ejs
+++ b/kumascript/macros/CSSRef.ejs
@@ -1119,8 +1119,8 @@ async function buildPropertylist(pages, title) {
 
 <ol>
   <li class="section"><%-smartLink(`/${locale}/docs/Web/CSS`, null, 'CSS')%></li>
-  <li class="section"><%-smartLink(`${learnURL}/CSS`, null, text['Tutorials'])%></li>
-  <li><%-smartLink(`${learnURL}/Getting_started_with_the_web/CSS_basics`, null, text['CSS_basics'])%></li>
+  <li class="section"><%-smartLink(`${learnURL}CSS`, null, text['Tutorials'])%></li>
+  <li><%-smartLink(`${learnURL}Getting_started_with_the_web/CSS_basics`, null, text['CSS_basics'])%></li>
   <li class="toggle">
       <details>
           <summary><%=text['CSS_first_steps']%></summary>


### PR DESCRIPTION
- The https://github.com/mdn/yari/pull/11042 revealed a simple to fix flaw in CSSRef.ejs

> Wrong xref macro used (consider changing which macro you use). Error processing path /en-US/docs/Learn//CSS

> Wrong xref macro used (consider changing which macro you use). Error processing path /en-US/docs/Learn//Getting_started_with_the_web/CSS_basics

This fixes 1031 flaws!  :tada: 
