### PR TITLE
fix(css-syntax): explicitly order specs

### DIFF
--- a/kumascript/src/lib/css-syntax.ts
+++ b/kumascript/src/lib/css-syntax.ts
@@ -560,21 +560,42 @@ export async function getCSSSyntax(
 let parsedWebRefCache: null | Promise<WebRefObjectData> = null;
 async function getParsedWebRef(): Promise<WebRefObjectData> {
   if (!parsedWebRefCache) {
-    parsedWebRefCache = getRawWebRefData().then((rawItems) =>
-      Object.fromEntries(
-        Object.entries(rawItems).map(
-          ([name, { spec, properties, atrules, values }]) => [
-            name,
-            {
-              spec,
-              properties: byName(properties),
-              atrules: byName(atrules),
-              values: byName(values),
-            },
-          ]
-        )
-      )
-    );
+    parsedWebRefCache = getRawWebRefData().then((rawItems) => {
+      const sortedRawItems = [...Object.entries(rawItems)];
+      sortedRawItems.sort(([a], [b]) => {
+        if (a === b) {
+          return 0;
+        }
+        if (/-\d+$/.test(a)) {
+          if (a.replace(/-\d+$/, "") === b) {
+            return -1;
+          }
+        }
+        if (/-\d+$/.test(b)) {
+          if (b.replace(/-\d+$/, "") === a) {
+            return 1;
+          }
+        }
+        if (a < b) {
+          return -1;
+        }
+        if (a > b) {
+          return 1;
+        }
+        return 0;
+      });
+      return Object.fromEntries(
+        sortedRawItems.map(([name, { spec, properties, atrules, values }]) => [
+          name,
+          {
+            spec,
+            properties: byName(properties),
+            atrules: byName(atrules),
+            values: byName(values),
+          },
+        ])
+      );
+    });
   }
 
   return parsedWebRefCache;

--- a/kumascript/src/lib/css-syntax.ts
+++ b/kumascript/src/lib/css-syntax.ts
@@ -566,15 +566,11 @@ async function getParsedWebRef(): Promise<WebRefObjectData> {
         if (a === b) {
           return 0;
         }
-        if (/-\d+$/.test(a)) {
-          if (a.replace(/-\d+$/, "") === b) {
-            return -1;
-          }
+        if (/-\d+$/.test(a) && a.replace(/-\d+$/, "") === b) {
+          return -1;
         }
-        if (/-\d+$/.test(b)) {
-          if (b.replace(/-\d+$/, "") === a) {
-            return 1;
-          }
+        if (/-\d+$/.test(b) && b.replace(/-\d+$/, "") === a) {
+          return 1;
         }
         if (a < b) {
           return -1;


### PR DESCRIPTION
## Summary

Right now we rely on somewhat predictable ordering from readdir in webref/css. Let's make this explicit for now.

### Problem

```
       The order in which filenames are read by successive calls to
       readdir() depends on the filesystem implementation; it is
       unlikely that the names will be sorted in any fashion.
```

### Solution

Explicitly sort the spec names, preserving the current behavior. 

---

## How did you test this change?

No difference vs a build using main.