### PR TITLE
fix(baseline): hide screen orientation lock banner

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -587,6 +587,10 @@ function addBaseline(doc: Partial<Doc>) {
           "api.InputEvent.dataTransfer",
           "api.InputEvent.getTargetRanges",
           "api.InputEvent.inputType",
+          // https://github.com/web-platform-dx/web-features/issues/1038
+          // https://github.com/web-platform-dx/web-features/blob/64d2cfd/features/screen-orientation-lock.dist.yml
+          "api.ScreenOrientation.lock",
+          "api.ScreenOrientation.unlock",
         ].includes(query)
     );
     return getWebFeatureStatus(...filteredBrowserCompat);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

https://github.com/web-platform-dx/web-features/issues/1038

### Problem

Screen orientation lock is a feature unlikely to be necessary beyond mobile devices, yet the current Baseline definition requires a feature be implemented across desktop and mobile to be considered supported.

### Solution

While the discussion is happening upstream, hide the banner to avoid any confusion.

---

## How did you test this change?

- `yarn dev`
- http://localhost:3000/en-US/docs/Web/API/ScreenOrientation/lock
- http://localhost:3000/en-US/docs/Web/API/ScreenOrientation/unlock