### PR TITLE
fix(markdown): Fix GFM rendering if blank line right after magic keyword

### DIFF
--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -118,7 +118,7 @@ export function buildLocalizedHandlers(locale: string): Handlers {
         if (type.isGFM) {
           // Handle GFM proposed syntax
           node.children[0].children[0].value =
-            node.children[0].children[0].value.replace(/\[!\w+\]\n/, "");
+            node.children[0].children[0].value.replace(/\[!\w+\]\n?/, "");
 
           // If the type isn't a callout, add the magic keyword
           if (!isCallout) {
@@ -134,6 +134,14 @@ export function buildLocalizedHandlers(locale: string): Handlers {
             node.children[0].children[1].value =
               (["zh-CN", "zh-TW"].includes(locale) ? "" : " ") +
               node.children[0].children[1].value;
+          }
+
+          // Remove blank line if there is one
+          if (
+            node.children[0].children.length === 1 &&
+            node.children[0].children[0].value === ""
+          ) {
+            node.children.splice(0, 1);
           }
         } else {
           // Remove "Callout:" text


### PR DESCRIPTION
## Summary

This PR is a follow-up to #10168, which fixes the rendering of GFM noteblocks if there is a blank line after the magic keyword (which is required for callouts due to Prettier formatting).

### Problem

_See summary_

### Solution

The solution is simple: update the regex to remove the magic keyword from rendering to make the newline character afterwards optional, since a blank line in between the magic keyword and content generates multiple paragraphs instead of a newline character.  Afterwards, any preceding blank lines are stripped for pretty rendering.

---

## Screenshots

Test Markdown used:

```md
> [!NOTE]
> Hello!

> [!WARNING]
> Hello!

> [!CALLOUT]
> Hello!

---

> [!NOTE]
>
> Hello!

> [!WARNING]
>
> Hello!

> [!CALLOUT]
>
> Hello!
```

### Before

<img width="239" alt="Screenshot 2024-05-11 at 17 28 32" src="https://github.com/mdn/yari/assets/5179191/5a0933c0-362a-4dd8-8067-1b34e302b782">

### After

<img width="203" alt="Screenshot 2024-05-11 at 17 28 48" src="https://github.com/mdn/yari/assets/5179191/806a44e5-f0f6-445c-a0fc-0f0335c9d037">
