### PR TITLE
fix(build): sort build.json content

### DIFF
--- a/build/cli.ts
+++ b/build/cli.ts
@@ -386,6 +386,13 @@ async function buildDocuments(
   );
 
   for (const [locale, meta] of Object.entries(buildMetadata)) {
+    if (meta.baseline) {
+      // Sort to avoid build difference.
+      meta.baseline.highPaths.sort();
+      meta.baseline.lowPaths.sort();
+      meta.baseline.notPaths.sort();
+    }
+
     // have to write per-locale because we build each locale concurrently
     fs.writeFileSync(
       path.join(BUILD_OUT_ROOT, locale.toLowerCase(), "build.json"),

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -54,7 +54,17 @@ interface GlobalMetadata {
 }
 
 interface BuildMetadata {
-  [locale: string]: any;
+  [locale: string]: {
+    baseline?: {
+      total: number;
+      high: number;
+      highPaths: string[];
+      low: number;
+      lowPaths: string[];
+      not: number;
+      notPaths: string[];
+    };
+  };
 }
 
 async function buildDocumentInteractive(


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `build.json` has different output on each build, because we don't build documents in a stable order.

### Solution

Sort the `build.json` content to avoid a build difference.

---

## How did you test this change?

Ran `yarn build --locale en-us` and looked at `client/build/en-us/build.json`. 