### PR TITLE
fix(spas): index AI Help + Updates

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -145,7 +145,6 @@ export async function buildSPAs(options: {
         {
           prefix: "plus/ai-help",
           pageTitle: `AI Help | ${MDN_PLUS_TITLE}`,
-          noIndexing: true,
         },
         {
           prefix: "plus/collections",
@@ -160,7 +159,6 @@ export async function buildSPAs(options: {
         {
           prefix: "plus/updates",
           pageTitle: `Updates | ${MDN_PLUS_TITLE}`,
-          noIndexing: true,
         },
         {
           prefix: "plus/settings",


### PR DESCRIPTION
## Summary

(MP-1113)

### Problem

We currently exclude [AI Help](https://developer.mozilla.org/en-US/plus/ai-help) and [Updates](https://developer.mozilla.org/en-US/plus/updates) from being indexed by search engines.

### Solution

Remove the exclusion, so that they can be indexed.

---

## How did you test this change?

1. Added `BUILD_ALWAYS_ALLOW_ROBOTS=true` to my `.env` file.
2. Ran `yarn build:prepare`.
3. Checked the meta robots tag in `client/build/en-us/plus/ai-help/index.html`.