### PR TITLE
fix(search): use "noindex, follow" robots tag + remove robots.txt exclude

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -140,7 +140,7 @@ export async function buildSPAs(options: {
 
       const SPAs = [
         { prefix: "play", pageTitle: "Playground | MDN" },
-        { prefix: "search", pageTitle: "Search" },
+        { prefix: "search", pageTitle: "Search", onlyFollow: true },
         { prefix: "plus", pageTitle: MDN_PLUS_TITLE },
         {
           prefix: "plus/ai-help",
@@ -177,12 +177,13 @@ export async function buildSPAs(options: {
         },
       ];
       const locale = VALID_LOCALES.get(pathLocale) || pathLocale;
-      for (const { prefix, pageTitle, noIndexing } of SPAs) {
+      for (const { prefix, pageTitle, noIndexing, onlyFollow } of SPAs) {
         const url = `/${locale}/${prefix}`;
         const context = {
           pageTitle,
           locale,
           noIndexing,
+          onlyFollow,
         };
 
         const html = renderCanonicalHTML(url, context);

--- a/libs/types/hydration.ts
+++ b/libs/types/hydration.ts
@@ -8,7 +8,8 @@ interface HydrationData<T = any, S = any> {
   pageTitle?: any;
   possibleLocales?: any;
   locale?: any;
-  noIndexing?: any;
+  noIndexing?: boolean;
+  onlyFollow?: boolean;
   image?: string | null;
 }
 

--- a/ssr/render.ts
+++ b/ssr/render.ts
@@ -106,7 +106,8 @@ export default function render(
     pageTitle = null,
     possibleLocales = null,
     locale = null,
-    noIndexing = null,
+    noIndexing = false,
+    onlyFollow = false,
     image = null,
     blogMeta = null,
   }: HydrationData = {}
@@ -211,7 +212,9 @@ export default function render(
   const robotsContent =
     !ALWAYS_ALLOW_ROBOTS || (doc && doc.noIndexing) || noIndexing
       ? "noindex, nofollow"
-      : "";
+      : onlyFollow
+        ? "noindex, follow"
+        : "";
   const robotsMeta = robotsContent
     ? `<meta name="robots" content="${robotsContent}">`
     : "";

--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -24,12 +24,6 @@ Disallow: /
 `;
 
 export async function runBuildRobotsTxt(outfile: string) {
-  let content = ALWAYS_ALLOW_ROBOTS ? ALLOW_TEXT : DISALLOW_TEXT;
-  if (ALWAYS_ALLOW_ROBOTS) {
-    // Append extra lines specifically when we do allow robots.
-    for (const locale of VALID_LOCALES.values()) {
-      content += `Disallow: /${locale}/search\n`;
-    }
-  }
+  const content = ALWAYS_ALLOW_ROBOTS ? ALLOW_TEXT : DISALLOW_TEXT;
   fs.writeFileSync(outfile, `${content.trim()}\n`, "utf-8");
 }

--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -5,7 +5,6 @@
  */
 import fs from "node:fs";
 
-import { VALID_LOCALES } from "../libs/constants/index.js";
 import { ALWAYS_ALLOW_ROBOTS } from "../libs/env/index.js";
 
 const ALLOW_TEXT = `


### PR DESCRIPTION
## Summary

(MP-1108)

~~⚠️ Requires https://github.com/mdn/yari/pull/11139 to be merged first.~~

### Problem

The full-text search pages are excluded via `robots.txt`, but their robots tag still indicates `index, follow`. 

### Solution

Update the robots tag to `noindex, follow`, and remove the exclusion from the `robots.txt`.

---

## How did you test this change?

1. Added `BUILD_ALWAYS_ALLOW_ROBOTS=true` to my `.env` file.
2. Ran `yarn build:prepare`.
3. Verified that `client/build/en-us/search/index.html` has a robots tag with value `noindex, follow`.
4. Verified that `client/build/robots.txt` no longer has exclusion rules for `/*/search`.