### PR TITLE
fix(article-footer): reduce margin on small screens

### DIFF
--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -14,6 +14,11 @@
     margin-top: 0;
   }
 
+  @media screen and (max-width: $screen-sm) {
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
   .article-footer-inner {
     margin: 0 auto;
     max-width: 1440px;


### PR DESCRIPTION
## Summary

Fixes margins for the feedback form so the text won’t overflow.

### Problem

The feedback form doesn’t fit well on smaller screens (iPhone 15 with 375px viewport).

### Solution

Add `@media` condition for `$screen-sm` to make side margins smaller.

## Screenshots

### Before

![before](https://github.com/mdn/yari/assets/105274/b7b8cd9c-0387-45e0-8b46-325c74e021e5)

### After

![after](https://github.com/mdn/yari/assets/105274/87edcc52-7ffa-445d-8676-05d646445371)

---

## How did you test this change?

I couldn’t test it because the feedback form is not available when running the project locally. But it tested it in DevTools.