### PR TITLE
fix(seo): prevent contributors.txt from indexing and crawling

### DIFF
--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -29,7 +29,11 @@ export function LastModified({ value, locale }) {
 }
 
 export function Authors({ url }) {
-  return <a href={`${url}/contributors.txt`}>MDN contributors</a>;
+  return (
+    <a href={`${url}/contributors.txt`} rel="nofollow">
+      MDN contributors
+    </a>
+  );
 }
 
 enum ArticleFooterView {

--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -38,6 +38,10 @@ export function withContentResponseHeaders(
     xFrame: !isLiveSample,
   });
 
+  if (req.url?.endsWith("/contributors.txt")) {
+    res.setHeader("X-Robots-Tag", "noindex, nofollow");
+  }
+
   if (req.url?.endsWith("/sitemap.xml.gz")) {
     res.setHeader("Content-Type", "application/xml");
     res.setHeader("Content-Encoding", "gzip");

--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -13,6 +13,7 @@ User-agent: *
 Sitemap: https://developer.mozilla.org/sitemap.xml
 
 Disallow: /api/
+Disallow: /*/contributors.txt
 Disallow: /*/files/
 Disallow: /media
 `;


### PR DESCRIPTION
## Summary

(MP-1094)

### Problem

We link to our `/contributors.txt` without indicating to search engines that these files shouldn't be crawled or indexed.

### Solution

1. Mark them with `rel="nofollow"`.
2. Return an [X-Robots-Tag](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#xrobotstag) header.
3. Disallow `/*/contributors.txt` via `robots.txt`.

---

## How did you test this change?

1. Ran `yarn && yarn dev` and verified the HTML of http://localhost:3000/en-US/docs/Web/HTML#related_topics
2. Ran `cd cloud-function && npm i && npm start` and verified the HTTP headers of http://localhost:5100/en-US/docs/Web/HTML/contributors.txt