### PR TITLE
fix(playground): avoid stringifying invalid console messages

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -138,13 +138,15 @@ export default function Playground() {
         ) {
           setVConsole((vConsole) => [...vConsole, { prop, message }]);
         } else {
+          const warning = "[Playground] Unsupported console message";
           setVConsole((vConsole) => [
             ...vConsole,
             {
               prop: "warn",
-              message: `[Playground] Unsupported console message: ${JSON.stringify({ prop, message }, null, 2)}`,
+              message: `${warning} (see browser console)`,
             },
           ]);
+          console.warn(warning, { prop, message });
         }
       } else if (typ === "ready") {
         updatePlayIframe(iframe.current, getEditorContent());


### PR DESCRIPTION
## Summary

(MP-1063)

Follow-up to https://github.com/mdn/yari/pull/10962.

### Problem

Invalid console messages can crash the Playground.

### Solution

Avoid stringifying invalid console messages.

---

## How did you test this change?

1. Ran `yarn && yarn dev` and opened http://localhost:3000/en-US/play
2. Pasted in the following JavaScript:
    ```js
    var o = {};
    o.x = o;
    parent.postMessage({typ:'console',prop:'log',message:o}, '*');
    ```
3. Verified that the Playground doesn't crash and the Playground console shows:
    > _[Playground] Unsupported console message (see browser console)_