### PR TITLE
chore(macros/LearnSidebar): add Japanese translation for Games section

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -284,6 +284,8 @@ const l10nStrings = mdn.localStringMap({
     'Accessibility_—_Make_the_web_usable_by_everyone' : 'Accessibility — Make the web usable by everyone',
       'Accessibility_guides' : 'Accessibility guides',
       'Accessibility_assessment' : 'Accessibility assessment',
+    'Games_Developing_for_web' : 'ゲーム — ウェブ用ゲームの開発',
+      'Guides_and_tutorials': 'ガイドとチュートリアル',
     'Tools_and_testing' : 'ツールとテスト',
       'Cross_browser_testing' : 'ブラウザー横断テスト',
       'Git_and_GitHub' : 'Git と GitHub',


### PR DESCRIPTION
## Summary
@hmatrjp @potappo , mdn-yari-ja

please review for this pull request

- issue:  [ サイドメニュー の翻訳（Games — Developing games for the web, Guides and tutorials） #760 ](https://github.com/mozilla-japan/translation/issues/760) 

### Problem
still en-us only

#### English pages
![スクリーンショット 2024-05-18 13 26 31](https://github.com/mdn/yari/assets/7631567/2dbcd15d-c29e-432b-bb9b-121003adb160)

#### Japanese pages
![スクリーンショット 2024-05-18 13 26 58](https://github.com/mdn/yari/assets/7631567/3e20144b-9b78-48d6-ba92-72d64a78aaf1)


### Solution

translate japanese for LearnSidebar.ejs

### NOTICE

@caugner, @wbamberg , @schalkneethling 

Please merge once mdn-yari-ja is approved.

### Before

still en-us only

### After

add tranlate japanese for LearnSidebar.ejs
