### PR TITLE
chore(readme): remove ngrok section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,35 +185,6 @@ manually upgrade them you can use:
 
     yarn upgrade-interactive --latest
 
-### Sharing your dev environment with `ngrok`
-
-[`ngrok`](https://ngrok.com/) allows you to start an HTTP proxy server from the
-web into your Yari server. This can be useful for testing your current build
-using external tools like BrowserStack, WebPageTest, or Google Translate, or to
-simply show a friend what you're up to. Obviously it'll never be faster than
-your uplink Internet connection but it should be fairly feature-complete.
-
-1. [Create in account on Ngrok.com](https://dashboard.ngrok.com/signup)
-2. [Download the executable](https://ngrok.com/download)
-3. Start your Yari server with `yarn start` in one terminal
-4. Start the `ngrok` executable with: `/path/to/your/ngrok http 5042`
-
-This will display something like this:
-
-    Session Status                online
-    Account                       (Plan: Free)
-    Version                       2.3.35
-    Region                        United States (us)
-    Web Interface                 http://127.0.0.1:4040
-    Forwarding                    http://920ba2108da8.ngrok.io -> http://localhost:5042
-    Forwarding                    https://920ba2108da8.ngrok.io -> http://localhost:5042
-
-    Connections                   ttl     opn     rt1     rt5     p50     p90
-                                  0       0       0.00    0.00    0.00    0.00
-
-Now, take that "Forwarding" URL (`https://920ba2108da8.ngrok.io` in this
-example) and share it.
-
 ## Building
 
 The `server` builds content automatically (on-the-fly) when you're viewing


### PR DESCRIPTION
## Summary

Replaces https://github.com/mdn/yari/pull/11136.

### Problem

The README recommends ngrok, but we haven't been using it, and don't need to feature it.

### Solution

Remove the section.

---

## How did you test this change?

Looked at https://github.com/mdn/yari/blob/10154d677ef9d903d5d07bd4589fd965f4159487/README.md.