### PR TITLE
refactor(macros): use smartLink() in sidebars (cont'd)

### DIFF
--- a/kumascript/macros/Firefox_for_developers.ejs
+++ b/kumascript/macros/Firefox_for_developers.ejs
@@ -43,7 +43,7 @@ if (minVersion < 4) {
 const releaseLinks = [];
 
 function generateReleaseLink(version) {
-  return `<li><a href="/${locale}/docs/Mozilla/Firefox/Releases/${version}">${str[0]}${version}${str[1]}</a></li>`;
+  return `<li>${web.smartLink(`/${locale}/docs/Mozilla/Firefox/Releases/${version}`, `${str[0]}${version}${str[1]}`)}</li>`;
 }
 
 // for newer version

--- a/kumascript/macros/Firefox_for_developers.ejs
+++ b/kumascript/macros/Firefox_for_developers.ejs
@@ -43,7 +43,7 @@ if (minVersion < 4) {
 const releaseLinks = [];
 
 function generateReleaseLink(version) {
-  return `<li>${web.smartLink(`/${locale}/docs/Mozilla/Firefox/Releases/${version}`, `${str[0]}${version}${str[1]}`)}</li>`;
+  return `<li>${web.smartLink(`/${locale}/docs/Mozilla/Firefox/Releases/${version}`, null, `${str[0]}${version}${str[1]}`)}</li>`;
 }
 
 // for newer version

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -315,7 +315,7 @@ var text = mdn.localStringMap({
 %>
 <section id="Quick_links" data-macro="HTMLSidebar">
  <ol>
-  <li class="section"><a href="/<%=locale%>/docs/Web/HTML">HTML</a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/HTML`, null, "HTML")%></li>
   <li class="section"><%-web.smartLink(`${learnBaseURL}HTML`, null, text['Tutorials'])%></li>
   <li><%-web.smartLink(`${learnBaseURL}Getting_started_with_the_web/HTML_basics`, null, text['HTML_basics'])%></li>
   <li class="toggle">
@@ -360,7 +360,7 @@ var text = mdn.localStringMap({
       </ol>
     </details>
   </li>
-  <li class="section"><a href="/<%=locale%>/docs/Web/HTML/Reference"><%=text['Reference']%></a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/HTML/Reference`, null, text['Reference'])%></li>
   <li class="toggle">
     <details <%=state('HTML_Elements')%>>
       <summary><%=text['HTML_Elements']%></summary>
@@ -403,16 +403,16 @@ var text = mdn.localStringMap({
   <li class="section no-link"><%=text['Guides']%></li>
   <li>
     <ol>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Content_categories"><%=text["Content_categories"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Block-level_elements"><%=text["Block-level_elements"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Inline_elements"><%=text["Inline_elements"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Quirks_Mode_and_Standards_Mode"><%=text["Quirks_Mode_and_Standards_Mode"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Date_and_time_formats"><%=text["Date_and_time_formats"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Constraint_validation"><%=text["Constraint_validation"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Microdata"><%=text["Microdata"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/microformats"><%=text["Microformats"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/Viewport_meta_tag"><%=text["Viewport_meta_tag"]%></a></li>
-      <li><a href="/<%=locale%>/docs/Web/HTML/CORS_enabled_image"><%=text["Allowing_cross-origin_images_and_canvas"]%></a></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Content_categories`, null, text["Content_categories"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Block-level_elements`, null, text["Block-level_elements"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Inline_elements`, null, text["Inline_elements"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Quirks_Mode_and_Standards_Mode`, null, text["Quirks_Mode_and_Standards_Mode"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Date_and_time_formats`, null, text["Date_and_time_formats"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Constraint_validation`, null, text["Constraint_validation"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Microdata`, null, text["Microdata"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/microformats`, null, text["Microformats"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Viewport_meta_tag`, null, text["Viewport_meta_tag"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/CORS_enabled_image`, null, text["Allowing_cross-origin_images_and_canvas"])%></li>
     </ol>
   </li>
  </ol>

--- a/kumascript/macros/HTMLSidebar.ejs
+++ b/kumascript/macros/HTMLSidebar.ejs
@@ -404,8 +404,8 @@ var text = mdn.localStringMap({
   <li>
     <ol>
       <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Content_categories`, null, text["Content_categories"])%></li>
-      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Block-level_elements`, null, text["Block-level_elements"])%></li>
-      <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Inline_elements`, null, text["Inline_elements"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Glossary/Block-level_content`, null, text["Block-level_elements"])%></li>
+      <li><%-web.smartLink(`/${locale}/docs/Glossary/Inline-level_content`, null, text["Inline_elements"])%></li>
       <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Quirks_Mode_and_Standards_Mode`, null, text["Quirks_Mode_and_Standards_Mode"])%></li>
       <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Date_and_time_formats`, null, text["Date_and_time_formats"])%></li>
       <li><%-web.smartLink(`/${locale}/docs/Web/HTML/Constraint_validation`, null, text["Constraint_validation"])%></li>

--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -288,17 +288,17 @@ var text = mdn.localStringMap({
 
 <section id="Quick_links" data-macro="HTTPSidebar">
   <ol>
-    <li class="section"><a href="/<%=locale%>/docs/Web/HTTP"><%=text['HTTP']%></a></li>
+    <li class="section"><%-web.smartLink(`/${locale}/docs/Web/HTTP`, null, text['HTTP'])%></li>
     <li class="section no-link"><%=text['Guides']%></li>
     <li class="toggle">
         <details>
             <summary><%=text['ResourcesURI']%></summary>
             <ol>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web"><%=text['Identifying']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/Data_URLs"><%=text['DataURLs']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/MIME_Types"><%=text['MIMETypes']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types"><%=text['ListMIMETypes']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs"><%=text['WWWorNotWWW']%></a></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web`, null, text['Identifying'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Data_URLs`, null, text['DataURLs'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_Types`, null, text['MIMETypes'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types`, null, text['ListMIMETypes'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs`, null, text['WWWorNotWWW'])%></li>
             </ol>
         </details>
     </li>
@@ -306,13 +306,13 @@ var text = mdn.localStringMap({
         <details>
             <summary><%=text['HTTPGuide']%></summary>
             <ol>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP"><%=text['Basics']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Overview"><%=text['Overview']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP"><%=text['Evolution']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Messages"><%=text['Messages']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Session"><%=text['Session']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Connection_management_in_HTTP_1.x"><%=text['Connection1x']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Protocol_upgrade_mechanism"><%=text['ProtocolUpgradeMech']%></a></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP`, null, text['Basics'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Overview`, null, text['Overview'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Evolution_of_HTTP`, null, text['Evolution'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Messages`, null, text['Messages'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Session`, null, text['Session'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Connection_management_in_HTTP_1.x`, null, text['Connection1x'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Protocol_upgrade_mechanism`, null, text['ProtocolUpgradeMech'])%></li>
             </ol>
         </details>
     </li>
@@ -320,28 +320,28 @@ var text = mdn.localStringMap({
         <details>
             <summary><%=text['Security']%></summary>
             <ol>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/CSP"><%=text['CSP']%></a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/Strict-Transport-Security">HTTP Strict Transport Security (HSTS)</a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/X-Content-Type-Options">X-Content-Type-Options</a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/X-Frame-Options">X-Frame-Options</a></li>
-                <li><a href="/<%=locale%>/docs/Web/HTTP/Headers/X-XSS-Protection">X-XSS-Protection</a></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/CSP`, null, text['CSP'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/Strict-Transport-Security`, null, "HTTP Strict Transport Security (HSTS)")%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/X-Content-Type-Options`, null, "X-Content-Type-Options")%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/X-Frame-Options`, null, "X-Frame-Options")%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/X-XSS-Protection`, null, "X-XSS-Protection")%></li>
                 <li><a href="https://wiki.mozilla.org/Security/Guidelines/Web_Security">Mozilla web security guidelines</a></li>
                 <li><a href="https://observatory.mozilla.org/">Mozilla Observatory</a></li>
             </ol>
         </details>
     </li>
 
-    <li><a href="/<%=locale%>/docs/Web/HTTP/CORS"><%=text['CORS']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Authentication"><%=text['Authentication']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Caching"><%=text['Caching']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Compression"><%=text['Compression']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Conditional_requests"><%=text['Conditionals']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Content_negotiation"><%=text['ContentNego']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Cookies"><%=text['Cookies']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Range_requests"><%=text['Ranges']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Redirections"><%=text['Redirects']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Resources_and_specifications"><%=text['Resources']%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/HTTP/Permissions_Policy"><%=text['Permissions_Policy']%></a></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/CORS`, null, text['CORS'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Authentication`, null, text['Authentication'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Caching`, null, text['Caching'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Compression`, null, text['Compression'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Conditional_requests`, null, text['Conditionals'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Content_negotiation`, null, text['ContentNego'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Cookies`, null, text['Cookies'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Range_requests`, null, text['Ranges'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Redirections`, null, text['Redirects'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Resources_and_specifications`, null, text['Resources'])%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Permissions_Policy`, null, text['Permissions_Policy'])%></li>
     <li class="section no-link"><%=text['Reference']%></li>
     <li class="toggle">
         <details <%=state('Web/HTTP/Headers')%>>

--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -296,7 +296,7 @@ var text = mdn.localStringMap({
             <ol>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web`, null, text['Identifying'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Data_URLs`, null, text['DataURLs'])%></li>
-                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_Types`, null, text['MIMETypes'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types`, null, text['MIMETypes'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types`, null, text['ListMIMETypes'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs`, null, text['WWWorNotWWW'])%></li>
             </ol>

--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -399,16 +399,16 @@ var text = mdn.localStringMap({
 %>
 <section id="Quick_links" data-macro="JsSidebar">
  <ol>
-  <li class="section"><a href="/<%=locale%>/docs/Web/JavaScript">JavaScript</a></li>
-  <li class="section"><a href="/<%=locale%>/docs/Web/JavaScript/Tutorials"><%=text['Tutorials']%></a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/JavaScript`, null, "JavaScript")%></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Tutorials`, null, text['Tutorials'])%></li>
   <li class="toggle">
     <details <%=state('Complete_beginners')%>>
       <summary><%=text['Complete_beginners']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Learn/Getting_started_with_the_web/JavaScript_basics"><%=text['Basics']%></a></li>
-        <li><a href="/<%=locale%>/docs/Learn/JavaScript/First_steps"><%=text['First_steps']%></a></li>
-        <li><a href="/<%=locale%>/docs/Learn/JavaScript/Building_blocks"><%=text['Building_blocks']%></a></li>
-        <li><a href="/<%=locale%>/docs/Learn/JavaScript/Objects"><%=text['Introducing_objects']%></a></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/Getting_started_with_the_web/JavaScript_basics`, null, text['Basics'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/JavaScript/First_steps`, null, text['First_steps'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/JavaScript/Building_blocks`, null, text['Building_blocks'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/JavaScript/Objects`, null, text['Introducing_objects'])%></li>
       </ol>
     </details>
   </li>
@@ -416,24 +416,24 @@ var text = mdn.localStringMap({
     <details <%=state('JavaScript Guide')%>>
       <summary><%=text['Guide']%></summary>
       <ol>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Introduction"><%=text['Guide_Introduction']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Grammar_and_types"><%=text['Guide_Grammar']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Control_flow_and_error_handling"><%=text['Guide_Control_flow']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Loops_and_iteration"><%=text['Guide_Loops']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Functions"><%=text['Guide_Functions']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Expressions_and_operators"><%=text['Guide_Expressions']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Numbers_and_dates"><%=text['Guide_Numbers']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Text_formatting"><%=text['Guide_Text']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Regular_expressions"><%=text['Guide_RegExp']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Indexed_collections"><%=text['Guide_Indexed_collections']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Keyed_collections"><%=text['Guide_keyed_collections']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Working_with_objects"><%=text['Guide_Objects']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Using_classes"><%=text['Guide_Classes']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Using_promises"><%=text['Guide_Promises']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Typed_arrays"><%=text['Guide_Typed_arrays']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Iterators_and_generators"><%=text['Guide_Iterators_generators']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Meta_programming"><%=text['Guide_Meta']%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/JavaScript/Guide/Modules"><%=text['Guide_Modules']%></a></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Introduction`, null, text['Guide_Introduction'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Grammar_and_types`, null, text['Guide_Grammar'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Control_flow_and_error_handling`, null, text['Guide_Control_flow'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Loops_and_iteration`, null, text['Guide_Loops'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Functions`, null, text['Guide_Functions'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Expressions_and_operators`, null, text['Guide_Expressions'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Numbers_and_dates`, null, text['Guide_Numbers'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Text_formatting`, null, text['Guide_Text'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Regular_expressions`, null, text['Guide_RegExp'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Indexed_collections`, null, text['Guide_Indexed_collections'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Keyed_collections`, null, text['Guide_keyed_collections'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Working_with_objects`, null, text['Guide_Objects'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Using_classes`, null, text['Guide_Classes'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Using_promises`, null, text['Guide_Promises'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Typed_arrays`, null, text['Guide_Typed_arrays'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Iterators_and_generators`, null, text['Guide_Iterators_generators'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Meta_programming`, null, text['Guide_Meta'])%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Guide/Modules`, null, text['Guide_Modules'])%></li>
         </ol>
     </details>
   </li>
@@ -441,13 +441,13 @@ var text = mdn.localStringMap({
     <details <%=state('Intermediate')%>>
       <summary><%=text['Intermediate']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks"><%=text['Frameworks']%></a></li>
-        <li><a href="/<%=locale%>/docs/Learn/JavaScript/Client-side_web_APIs"><%=text['Client-side_APIs']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Language_overview"><%=text['Language_overview']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Data_structures"><%=text['Data_structures']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Equality_comparisons_and_sameness"><%=text['Equality']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Enumerability_and_ownership_of_properties"><%=text['Enumerability']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Closures"><%=text['Closures']%></a></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks`, null, text['Frameworks'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Learn/JavaScript/Client-side_web_APIs`, null, text['Client-side_APIs'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Language_overview`, null, text['Language_overview'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Data_structures`, null, text['Data_structures'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Equality_comparisons_and_sameness`, null, text['Equality'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Enumerability_and_ownership_of_properties`, null, text['Enumerability'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Closures`, null, text['Closures'])%></li>
       </ol>
     </details>
   </li>
@@ -455,13 +455,13 @@ var text = mdn.localStringMap({
     <details <%=state('Advanced')%>>
       <summary><%=text['Advanced']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Inheritance_and_the_prototype_chain"><%=text['Inheritance']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Memory_management"><%=text['Memory_management']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Event_loop"><%=text['Event_loop']%></a></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Inheritance_and_the_prototype_chain`, null, text['Inheritance'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Memory_management`, null, text['Memory_management'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Event_loop`, null, text['Event_loop'])%></li>
       </ol>
     </details>
   </li>
-  <li class="section"><a href="/<%=locale%>/docs/Web/JavaScript/Reference"><%=text['Reference']%></a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference`, null, text['Reference'])%></li>
   <li class="toggle">
     <details <%=state('Objects')%>>
        <summary><%=text['Global_Objects']%></summary>
@@ -508,13 +508,13 @@ var text = mdn.localStringMap({
     <details <%=state('More')%>>
       <summary><%=text['More']%></summary>
       <ol>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/JavaScript_technologies_overview"><%=text['Overview']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Lexical_grammar"><%=text['Lexical_grammar']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Iteration_protocols"><%=text['Iteration_protocols']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Strict_mode"><%=text['Strict_mode']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Template_literals"><%=text['Template_strings']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Trailing_commas"><%=text['Trailing_commas']%></a></li>
-        <li><a href="/<%=locale%>/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features"><%=text['Deprecated_features']%></a></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/JavaScript_technologies_overview`, null, text['Overview'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Lexical_grammar`, null, text['Lexical_grammar'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Iteration_protocols`, null, text['Iteration_protocols'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Strict_mode`, null, text['Strict_mode'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Template_literals`, null, text['Template_strings'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Trailing_commas`, null, text['Trailing_commas'])%></li>
+        <li><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features`, null, text['Deprecated_features'])%></li>
       </ol>
     </details>
   </li>

--- a/kumascript/macros/JsSidebar.ejs
+++ b/kumascript/macros/JsSidebar.ejs
@@ -400,7 +400,7 @@ var text = mdn.localStringMap({
 <section id="Quick_links" data-macro="JsSidebar">
  <ol>
   <li class="section"><%-web.smartLink(`/${locale}/docs/Web/JavaScript`, null, "JavaScript")%></li>
-  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/JavaScript/Tutorials`, null, text['Tutorials'])%></li>
+  <li class="section"><%=text['Tutorials']%></li>
   <li class="toggle">
     <details <%=state('Complete_beginners')%>>
       <summary><%=text['Complete_beginners']%></summary>

--- a/kumascript/macros/MathMLRef.ejs
+++ b/kumascript/macros/MathMLRef.ejs
@@ -42,27 +42,16 @@ const text = mdn.localStringMap({
   },
 });
 
-const sidebarURL = `/docs/Web/MathML/`;
-const baseURL = `/${env.locale}${sidebarURL}`;
-
-async function getTitle(pageSlug) {
-  let page = await wiki.getPage(`${baseURL}${pageSlug}`);
-  if (!page.title) {
-    page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
-  }
-  return mdn.htmlEscape(page.title);
-}
-
 %>
 <section id="Quick_links" data-macro="MathMLRef">
  <ol>
-  <li class="section"><a href="/<%=locale%>/docs/Web/MathML">MathML</a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/MathML`)%></li>
   <li class="section no-link"><%=text['Guides']%></li>
   <li>
     <ol>
-    <li><a href="/<%=locale%>/docs/Web/MathML/Authoring"><%=await getTitle("Authoring")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/MathML/Fonts"><%=await getTitle("Fonts")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/MathML/Values"><%=await getTitle("Values")%></a></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Authoring`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Fonts`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Values`)%></li>
     </ol>
   </li>
   <li class="section no-link"><%=text['Reference']%></li>
@@ -78,12 +67,12 @@ async function getTitle(pageSlug) {
       <%-await template("ListSubpagesForSidebar", ['/en-US/docs/Web/MathML/Global_attributes'])%>
     </details>
   </li>
-  <li><a href="/<%=locale%>/docs/Web/MathML/Attribute"><%=await getTitle("Attribute")%></a></li>
+  <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Attribute`)%></li>
   <li class="section no-link"><%=text['Examples']%></li>
   <li>
     <ol>
-    <li><a href="/<%=locale%>/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula"><%=await getTitle("Examples/Deriving_the_Quadratic_Formula")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/MathML/Examples/MathML_Pythagorean_Theorem"><%=await getTitle("Examples/MathML_Pythagorean_Theorem")%></a></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Examples/Deriving_the_Quadratic_Formula`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/MathML/Examples/MathML_Pythagorean_Theorem`)%></li>
     </ol>
   </li>
  </ol>

--- a/kumascript/macros/SVGRef.ejs
+++ b/kumascript/macros/SVGRef.ejs
@@ -53,43 +53,32 @@ const text = mdn.localStringMap({
   },
 });
 
-const sidebarURL = `/docs/Web/SVG/`;
-const baseURL = `/${env.locale}${sidebarURL}`;
-
-async function getTitle(pageSlug) {
-  let page = await wiki.getPage(`${baseURL}${pageSlug}`);
-  if (!page.title) {
-    page = await wiki.getPage(`/en-US${sidebarURL}${pageSlug}`);
-  }
-  return mdn.htmlEscape(page.title);
-}
-
 %>
 <section id="Quick_links" data-macro="SVGRef">
  <ol>
-  <li class="section"><a href="/<%=locale%>/docs/Web/SVG">SVG</a></li>
+  <li class="section"><%-web.smartLink(`/${locale}/docs/Web/SVG`)%></li>
   <li class="section no-link"><%=text['Tutorials']%></li>
   <li class="toggle">
     <details>
       <summary><%=text['Introducing SVG from scratch']%></summary>
       <ol>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Introduction"><%=await getTitle("Tutorial/Introduction")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Getting_Started"><%=await getTitle("Tutorial/Getting_Started")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Positions"><%=await getTitle("Tutorial/Positions")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Basic_Shapes"><%=await getTitle("Tutorial/Basic_Shapes")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Paths"><%=await getTitle("Tutorial/Paths")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Fills_and_Strokes"><%=await getTitle("Tutorial/Fills_and_Strokes")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Gradients"><%=await getTitle("Tutorial/Gradients")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Patterns"><%=await getTitle("Tutorial/Patterns")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Texts"><%=await getTitle("Tutorial/Texts")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Basic_Transformations"><%=await getTitle("Tutorial/Basic_Transformations")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Clipping_and_masking"><%=await getTitle("Tutorial/Clipping_and_masking")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Other_content_in_SVG"><%=await getTitle("Tutorial/Other_content_in_SVG")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Filter_effects"><%=await getTitle("Tutorial/Filter_effects")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/SVG_fonts"><%=await getTitle("Tutorial/SVG_fonts")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/SVG_Image_Tag"><%=await getTitle("Tutorial/SVG_Image_Tag")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/Tools_for_SVG"><%=await getTitle("Tutorial/Tools_for_SVG")%></a></li>
-          <li><a href="/<%=locale%>/docs/Web/SVG/Tutorial/SVG_and_CSS"><%=await getTitle("Tutorial/SVG_and_CSS")%></a></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Introduction`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Getting_Started`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Positions`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Basic_Shapes`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Paths`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Fills_and_Strokes`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Gradients`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Patterns`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Texts`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Basic_Transformations`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Clipping_and_masking`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Other_content_in_SVG`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Filter_effects`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/SVG_fonts`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/SVG_Image_Tag`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/Tools_for_SVG`)%></li>
+          <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Tutorial/SVG_and_CSS`)%></li>
       </ol>
     </details>
   </li>
@@ -109,11 +98,11 @@ async function getTitle(pageSlug) {
   <li class="section no-link"><%=text['Guides']%></li>
   <li>
     <ol>
-    <li><a href="/<%=locale%>/docs/Web/SVG/Applying_SVG_effects_to_HTML_content"><%=await getTitle("Applying_SVG_effects_to_HTML_content")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/SVG/Content_type"><%=await getTitle("Content_type")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/SVG/Namespaces_Crash_Course"><%=await getTitle("Namespaces_Crash_Course")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/SVG/SVG_animation_with_SMIL"><%=await getTitle("SVG_animation_with_SMIL")%></a></li>
-    <li><a href="/<%=locale%>/docs/Web/SVG/SVG_as_an_Image"><%=await getTitle("SVG_as_an_Image")%></a></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Applying_SVG_effects_to_HTML_content`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Content_type`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/SVG/Namespaces_Crash_Course`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/SVG/SVG_animation_with_SMIL`)%></li>
+    <li><%-web.smartLink(`/${locale}/docs/Web/SVG/SVG_as_an_Image`)%></li>
     </ol>
   </li>
  </ol>

--- a/kumascript/macros/xref_csscomputed.ejs
+++ b/kumascript/macros/xref_csscomputed.ejs
@@ -9,4 +9,4 @@ let linkText = mdn.localString({
     "zh-CN": "计算值"
 });
 %>
-<%- `<a href="/${env.locale}/docs/Web/CSS/computed_value">${linkText}</a>` %>
+<%- web.smartLink(`/${env.locale}/docs/Web/CSS/computed_value`, null, linkText) %>

--- a/kumascript/macros/xref_cssinherited.ejs
+++ b/kumascript/macros/xref_cssinherited.ejs
@@ -10,4 +10,4 @@ let linkText = mdn.localString({
     "zh-TW": "繼承與否"
 });
 %>
-<%- `<a href="/${env.locale}/docs/Web/CSS/inheritance">${linkText}</a>` %>
+<%- web.smartLink(`/${env.locale}/docs/Web/CSS/inheritance`, null, linkText) %>

--- a/kumascript/macros/xref_cssinitial.ejs
+++ b/kumascript/macros/xref_cssinitial.ejs
@@ -11,4 +11,4 @@ let linkText = mdn.localString({
     
 });
 %>
-<%- `<a href="/${env.locale}/docs/Web/CSS/initial_value">${linkText}</a>` %>
+<%- web.smartLink(`${env.locale}/docs/Web/CSS/initial_value`, linkText) %>

--- a/kumascript/macros/xref_cssinitial.ejs
+++ b/kumascript/macros/xref_cssinitial.ejs
@@ -11,4 +11,4 @@ let linkText = mdn.localString({
     
 });
 %>
-<%- web.smartLink(`${env.locale}/docs/Web/CSS/initial_value`, linkText) %>
+<%- web.smartLink(`${env.locale}/docs/Web/CSS/initial_value`, null, linkText) %>

--- a/kumascript/tests/macros/HTTPSidebar.test.ts
+++ b/kumascript/tests/macros/HTTPSidebar.test.ts
@@ -74,6 +74,12 @@ function checkSidebarDom(dom, locale) {
 describeMacro("HTTPSidebar", function () {
   beforeEachMacro(function (macro) {
     macro.ctx.env.url = "/en-US/docs/Web/HTTP/Overview";
+    // Mock calls to env.recordNonFatalError, called from web.smartLink().
+    macro.ctx.env.recordNonFatalError = () => {
+      return {
+        macroSource: "foo",
+      };
+    };
   });
 
   itMacro("Creates a sidebar object for en-US", function (macro) {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Continuation of https://github.com/mdn/yari/pull/11014.

### Problem

We still have several raw links to MDN pages in sidebars, and this has some disadvantages over using `smartLink()`:

1. We don't get a warning (neither in the build nor on the page) if the page doesn't exist.
1. We get a link to a 404, if the page doesn't exist, and no fallback to en-US with the corresponding indicator.
1. We cannot use the translated page title (unless we pass it as a parameter). 

### Solution

Use `web.smartLink()` systematically for all remaining raw links in MDN sidebars.

---

## Screenshots


(omitted, because most sidebars are too long to compare them side-by-side)

Visual changes are:

1. Some pages now show up with an `(en-US)` indicator.
2. Some pages may show up with squiggly lines, if they don't exist.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
