### PR TITLE
fix(breadcrumbs): use short-title for parents

### DIFF
--- a/build/document-utils.ts
+++ b/build/document-utils.ts
@@ -56,7 +56,9 @@ export function addBreadcrumbData(url, document) {
     if (parentDoc) {
       parents.unshift({
         uri: parentURL,
-        title: transformTitle(parentDoc.metadata.title),
+        title:
+          parentDoc.metadata["short-title"] ||
+          transformTitle(parentDoc.metadata.title),
       });
     }
   }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The breadcrumbs are inconsistent in their usage of the `short-title` attribute, which is used for the current item, but not for the parent item:

<img width="1130" alt="image" src="https://github.com/mdn/yari/assets/495429/5f0d6559-e290-40a6-bf33-1788c450d976">
<img width="1130" alt="image" src="https://github.com/mdn/yari/assets/495429/bb88b9da-aa45-405a-bd4a-5aaa04cf91c3">

### Solution

Use the `short-title` for the breadcrumb parents, where available.

---

## Screenshots

| Before/After |
|--------|
| <img width="1130" style="border: 1px solid" alt="image" src="https://github.com/mdn/yari/assets/495429/bb88b9da-aa45-405a-bd4a-5aaa04cf91c3"> |
| <img width="1130" src="https://github.com/mdn/yari/assets/495429/4d0e0702-1086-43e0-b29b-15c5eba00c5e"> | 


---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/docs/Glossary/Abstraction locally.