### PR TITLE
fix(seo): identify sponsored links

### DIFF
--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -327,7 +327,7 @@ function RenderSideOrTopBanner({
             click
           )}&version=${version}`}
           target="_blank"
-          rel="noreferrer"
+          rel="sponsored noreferrer"
         >
           <img
             src={`/pimg/${encodeURIComponent(image || "")}`}
@@ -346,7 +346,7 @@ function RenderSideOrTopBanner({
               click
             )}&version=${version}`}
             target="_blank"
-            rel="noreferrer"
+            rel="sponsored noreferrer"
           >
             {cta}
           </a>
@@ -405,7 +405,7 @@ function RenderHpPlacement({
           click
         )}&version=${version}`}
         target="_blank"
-        rel="noreferrer"
+        rel="sponsored noreferrer"
       >
         <img
           src={`/pimg/${encodeURIComponent(image || "")}`}
@@ -445,7 +445,7 @@ function RenderBottomBanner({
             click
           )}&version=${version}`}
           target="_blank"
-          rel="noreferrer"
+          rel="sponsored noreferrer"
         >
           <img
             src={`/pimg/${encodeURIComponent(image || "")}`}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1161)

### Problem

We don't identify our placement links as sponsored, but Google [recommends this](https://developers.google.com/search/blog/2019/09/evolving-nofollow-new-ways-to-identify).

### Solution

Update the `rel` attribute of those links to include `sponsored`.

---

## Screenshots

(No visible change.)

---

## How did you test this change?

Trivial change, not explicitly tested.
