### PR TITLE
fix(seo): add rel="nofollow" on "Sign up for free" link

### DIFF
--- a/client/src/ui/atoms/signup-link/index.tsx
+++ b/client/src/ui/atoms/signup-link/index.tsx
@@ -11,6 +11,7 @@ export const SignUpLink = ({ toPlans = false, gleanContext = "" }) => {
 
   const href = toPlans ? plansUrl : loginUrl;
   const label = toPlans ? "Upgrade Now" : "Sign up for free";
+  const rel = toPlans ? undefined : "nofollow";
 
   return (
     <Button
@@ -18,6 +19,7 @@ export const SignUpLink = ({ toPlans = false, gleanContext = "" }) => {
       target="_self"
       extraClasses="mdn-plus-subscribe-link"
       onClickHandler={() => gleanContext && gleanClick(gleanContext)}
+      rel={rel}
     >
       {label}
     </Button>


### PR DESCRIPTION
## Summary

(MP-1165)

### Problem

Our “Sign up for free” link is missing `rel="nofollow"`, so Google is considering indexing and therefore crawling each of those `/users/fxa/login/authenticate/?next=...` URLs.

### Solution

Add `rel="nofollow"` for those `/users/fxa/login/authenticate/` links.

---

## How did you test this change?

Ran `yarn dev` locally and inspected the "Sign up for free" link at http://localhost:3000/en-US/. 