### PR TITLE
chore(fundamental-redirects): remove where target no longer exists

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -117,44 +117,6 @@ const LOCALE_PATTERNS = [
 
 // Redirects/rewrites/aliases migrated from SCL3 httpd config
 const SCL3_REDIRECT_PATTERNS = [
-  // RewriteRule ^/media/(redesign/)?css/(.*)-min.css$
-  // /static/build/styles/$2.css [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?css\/(?<doc>.*)-min.css$/i,
-    ({ doc }) => `/static/build/styles/${doc}.css`,
-    { permanent: true }
-  ),
-  // RewriteRule ^/media/(redesign/)?js/(.*)-min.js$ /static/build/js/$2.js
-  // [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?js\/(?<doc>.*)-min.js$/i,
-    ({ doc }) => `/static/build/js/${doc}.js`,
-    { permanent: true }
-  ),
-  // RewriteRule ^/media/(redesign/)?img(.*) /static/img$2 [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?img(?<suffix>.*)$/i,
-    ({ suffix }) => `/static/img${suffix}`,
-    { permanent: true }
-  ),
-  // RewriteRule ^/media/(redesign/)?css(.*) /static/styles$2 [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?css(?<suffix>.*)$/i,
-    ({ suffix }) => `/static/styles${suffix}`,
-    { permanent: true }
-  ),
-  // RewriteRule ^/media/(redesign/)?js(.*) /static/js$2 [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?js(?<suffix>.*)$/i,
-    ({ suffix }) => `/static/js${suffix}`,
-    { permanent: true }
-  ),
-  // RewriteRule ^/media/(redesign/)?fonts(.*) /static/fonts$2 [L,R=301]
-  redirect(
-    /^media\/(?:redesign\/)?fonts(?<suffix>.*)$/i,
-    ({ suffix }) => `/static/fonts${suffix}`,
-    { permanent: true }
-  ),
   // RedirectMatch 302 /media/uploads/demos/(.*)$
   // https://developer.mozilla.org/docs/Web/Demos_of_open_web_technologies/
   // Django will then redirect based on Accept-Language

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -323,291 +323,6 @@ const SCL3_REDIRECT_PATTERNS = [
     "/docs/Web/API/HTMLCanvasElement.mozGetAsFile",
     { permanent: true }
   ),
-  //##################################
-  // MDN.GITHUB.IO
-  //##################################
-  // canvas raycaster
-  redirect(
-    /^samples\/raycaster\/input.js$/i,
-    "http://mdn.github.io/canvas-raycaster/input.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/Level.js$/i,
-    "http://mdn.github.io/canvas-raycaster/Level.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/Player.js$/i,
-    "http://mdn.github.io/canvas-raycaster/Player.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/RayCaster.html$/i,
-    "http://mdn.github.io/canvas-raycaster/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/RayCaster.js$/i,
-    "http://mdn.github.io/canvas-raycaster/RayCaster.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/trace.css$/i,
-    "http://mdn.github.io/canvas-raycaster/trace.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/raycaster\/trace.js$/i,
-    "http://mdn.github.io/canvas-raycaster/trace.js",
-    { permanent: true }
-  ),
-  // Bug 1215255 - Redirect static WebGL examples
-  redirect(
-    /^samples\/webgl\/sample1$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample1",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample1\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample1/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample1\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample1/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample1\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample2",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample2/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample2/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample2\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample3",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample3/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample3/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample3\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample4",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample4/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample4/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample4\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample5",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample5/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample5/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample5\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample6",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/cubetexture.png$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/cubetexture.png",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample6\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample7",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/cubetexture.png$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/cubetexture.png",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample7\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample8",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/Firefox.ogv$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/Firefox.ogv",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/glUtils.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/index.html$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/index.html",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/sylvester.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/webgl-demo.js$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/webgl-demo.js",
-    { permanent: true }
-  ),
-  redirect(
-    /^samples\/webgl\/sample8\/webgl.css$/i,
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css",
-    { permanent: true }
-  ),
   // All of the remaining "samples/" URL's are redirected to the
   // the media domain (ATTACHMENTS_AWS_S3_CUSTOM_DOMAIN).
   redirect(
@@ -709,13 +424,6 @@ const SCL3_REDIRECT_PATTERNS = [
   localeRedirect(
     /^demos\/detail\/bananabread$/i,
     "https://github.com/kripken/BananaBread/",
-    { prependLocale: false, permanent: true }
-  ),
-  // RewriteRule ^(\w{2,3}(?:-\w{2})?/)?demos/detail/bananabread/launch$
-  // https://kripken.github.io/BananaBread/cube2/index.html [R=301,L]
-  localeRedirect(
-    /^demos\/detail\/bananabread\/launch$/i,
-    "https://kripken.github.io/BananaBread/cube2/index.html",
     { prependLocale: false, permanent: true }
   ),
   // All other Demo Studio and Dev Derby paths (bug 1238037)
@@ -865,8 +573,6 @@ for (const [zoneRoot, wikiSlug, locales] of zoneRedirects) {
   }
 }
 
-const MARIONETTE_CLIENT_DOCS_URL =
-  "https://marionette-client.readthedocs.io/en/latest/";
 const MARIONETTE_DOCS_ROOT_URL =
   "https://firefox-source-docs.mozilla.org/testing/marionette/marionette/";
 
@@ -878,14 +584,6 @@ const MARIONETTE_REDIRECT_PATTERNS = [
   externalRedirect(
     /docs\/(?:Mozilla\/QA\/)?Marionette\/Builds$/i,
     () => `${MARIONETTE_DOCS_ROOT_URL}Building.html`
-  ),
-  externalRedirect(
-    /docs\/(?:Mozilla\/QA\/)?Marionette\/Client$/i,
-    () => MARIONETTE_CLIENT_DOCS_URL
-  ),
-  externalRedirect(
-    /docs\/Mozilla\/QA\/Marionette\/Python_Client$/i,
-    () => MARIONETTE_CLIENT_DOCS_URL
   ),
   externalRedirect(
     /docs\/(?:Mozilla\/QA\/)?Marionette\/Developer_setup$/i,
@@ -1063,21 +761,6 @@ for (const [aoPath, ewPath] of [
   );
 }
 
-const FIREFOX_ACCOUNTS_REDIRECT_PATTERNS = [
-  externalRedirect(
-    /(?:docs\/)?Mozilla\/Firefox_Accounts_OAuth_Dashboard(?:\/|$)/i,
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
-  ),
-  externalRedirect(
-    /(?:docs\/)?Mozilla\/(?:Tech\/)?Firefox_Accounts(?:\/|$)/i,
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
-  ),
-  externalRedirect(
-    /(?:docs\/)?Archive\/Mozilla\/Firefox\/Accounts(?:\/|$)/i,
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
-  ),
-];
-
 const FIREFOX_SOURCE_DOCS_ROOT_URL = "https://firefox-source-docs.mozilla.org";
 const FIREFOX_SOURCE_DOCS_REDIRECT_PATTERNS = [];
 for (const [pattern, path] of [
@@ -1182,21 +865,8 @@ const REDIRECT_PATTERNS = [].concat(
   ZONE_REDIRECT_PATTERNS,
   MARIONETTE_REDIRECT_PATTERNS,
   WEBEXTENSIONS_REDIRECT_PATTERNS,
-  FIREFOX_ACCOUNTS_REDIRECT_PATTERNS,
   FIREFOX_SOURCE_DOCS_REDIRECT_PATTERNS,
   [
-    localeRedirect(
-      /^fellowship.*/i,
-      "/docs/Archive/2015_MDN_Fellowship_Program",
-      {
-        permanent: true,
-      }
-    ),
-    localeRedirect(
-      /^docs\/(ServerJS|CommonJS)(?<subPath>$|\/.+)/i,
-      ({ subPath }) => `https://wiki.mozilla.org/docs/ServerJS${subPath}`,
-      { prependLocale: false, permanent: true }
-    ),
     localeRedirect(/advertising\/with_us/i, "/advertising", {
       permanent: true,
     }),

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -27,18 +27,6 @@ function url_test(from, to, { statusCode = 301 } = {}) {
 }
 
 const SCL3_REDIRECT_URLS = [].concat(
-  url_test("/media/redesign/css/foo-min.css", "/static/build/styles/foo.css"),
-  url_test("/media/css/foo-min.css", "/static/build/styles/foo.css"),
-  url_test("/media/redesign/js/foo-min.js", "/static/build/js/foo.js"),
-  url_test("/media/js/foo-min.js", "/static/build/js/foo.js"),
-  url_test("/media/redesign/img.foo", "/static/img.foo"),
-  url_test("/media/img.foo", "/static/img.foo"),
-  url_test("/media/redesign/css.foo", "/static/styles.foo"),
-  url_test("/media/css.foo", "/static/styles.foo"),
-  url_test("/media/redesign/js.foo", "/static/js.foo"),
-  url_test("/media/js.foo", "/static/js.foo"),
-  url_test("/media/redesign/fonts.foo", "/static/fonts.foo"),
-  url_test("/media/fonts.foo", "/static/fonts.foo"),
   url_test(
     "/media/uploads/demos/foobar123",
     "/docs/Web/Demos_of_open_web_technologies/",
@@ -234,14 +222,6 @@ const SCL3_REDIRECT_URLS = [].concat(
     "/en/demos/detail/bananabread",
     "https://github.com/kripken/BananaBread/"
   ),
-  url_test(
-    "/en-US/demos/detail/bananabread/launch",
-    "https://kripken.github.io/BananaBread/cube2/index.html"
-  ),
-  url_test(
-    "/en/demos/detail/bananabread/launch",
-    "https://kripken.github.io/BananaBread/cube2/index.html"
-  ),
   url_test("/en-US/demos", "/en-US/docs/Web/Demos_of_open_web_technologies"),
   url_test("/en/demos", "/en/docs/Web/Demos_of_open_web_technologies"),
   url_test(
@@ -258,233 +238,6 @@ const SCL3_REDIRECT_URLS = [].concat(
   url_test(
     "/Web/JavaScript/Reference/Global_Objects/Array/from",
     "/docs/Web/JavaScript/Reference/Global_Objects/Array/from"
-  )
-);
-
-const GITHUB_IO_URLS = [].concat(
-  url_test(
-    "/samples/raycaster/input.js",
-    "http://mdn.github.io/canvas-raycaster/input.js"
-  ),
-  url_test(
-    "/samples/raycaster/Level.js",
-    "http://mdn.github.io/canvas-raycaster/Level.js"
-  ),
-  url_test(
-    "/samples/raycaster/Player.js",
-    "http://mdn.github.io/canvas-raycaster/Player.js"
-  ),
-  url_test(
-    "/samples/raycaster/RayCaster.html",
-    "http://mdn.github.io/canvas-raycaster/index.html"
-  ),
-  url_test(
-    "/samples/raycaster/RayCaster.js",
-    "http://mdn.github.io/canvas-raycaster/RayCaster.js"
-  ),
-  url_test(
-    "/samples/raycaster/trace.css",
-    "http://mdn.github.io/canvas-raycaster/trace.css"
-  ),
-  url_test(
-    "/samples/raycaster/trace.js",
-    "http://mdn.github.io/canvas-raycaster/trace.js"
-  ),
-  url_test(
-    "/samples/webgl/sample1",
-    "http://mdn.github.io/webgl-examples/tutorial/sample1"
-  ),
-  url_test(
-    "/samples/webgl/sample1/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample1/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample1/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample1/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample1/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample2",
-    "http://mdn.github.io/webgl-examples/tutorial/sample2"
-  ),
-  url_test(
-    "/samples/webgl/sample2/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample2/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample2/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample2/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample2/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample2/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample2/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample3",
-    "http://mdn.github.io/webgl-examples/tutorial/sample3"
-  ),
-  url_test(
-    "/samples/webgl/sample3/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample3/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample3/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample3/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample3/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample3/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample3/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample4",
-    "http://mdn.github.io/webgl-examples/tutorial/sample4"
-  ),
-  url_test(
-    "/samples/webgl/sample4/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample4/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample4/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample4/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample4/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample4/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample4/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample5",
-    "http://mdn.github.io/webgl-examples/tutorial/sample5"
-  ),
-  url_test(
-    "/samples/webgl/sample5/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample5/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample5/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample5/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample5/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample5/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample5/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample6",
-    "http://mdn.github.io/webgl-examples/tutorial/sample6"
-  ),
-  url_test(
-    "/samples/webgl/sample6/cubetexture.png",
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/cubetexture.png"
-  ),
-  url_test(
-    "/samples/webgl/sample6/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample6/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample6/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample6/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample6/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample6/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample7",
-    "http://mdn.github.io/webgl-examples/tutorial/sample7"
-  ),
-  url_test(
-    "/samples/webgl/sample7/cubetexture.png",
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/cubetexture.png"
-  ),
-  url_test(
-    "/samples/webgl/sample7/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample7/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample7/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample7/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample7/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample7/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
-  ),
-  url_test(
-    "/samples/webgl/sample8",
-    "http://mdn.github.io/webgl-examples/tutorial/sample8"
-  ),
-  url_test(
-    "/samples/webgl/sample8/Firefox.ogv",
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/Firefox.ogv"
-  ),
-  url_test(
-    "/samples/webgl/sample8/glUtils.js",
-    "http://mdn.github.io/webgl-examples/tutorial/glUtils.js"
-  ),
-  url_test(
-    "/samples/webgl/sample8/index.html",
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/index.html"
-  ),
-  url_test(
-    "/samples/webgl/sample8/sylvester.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sylvester.js"
-  ),
-  url_test(
-    "/samples/webgl/sample8/webgl-demo.js",
-    "http://mdn.github.io/webgl-examples/tutorial/sample8/webgl-demo.js"
-  ),
-  url_test(
-    "/samples/webgl/sample8/webgl.css",
-    "http://mdn.github.io/webgl-examples/tutorial/webgl.css"
   )
 );
 
@@ -681,15 +434,6 @@ for (const [zoneRoot, wikiSlug, childPath, locales] of ZONE_REDIRECTS) {
   }
 }
 
-const REDIRECT_URLS = [].concat(
-  url_test(
-    "/en-US/fellowship",
-    "/en-US/docs/Archive/2015_MDN_Fellowship_Program"
-  )
-);
-
-const marionette_client_docs_url =
-  "https://marionette-client.readthedocs.io/en/latest/";
 const marionette_docs_root_url =
   "https://firefox-source-docs.mozilla.org/testing/marionette/marionette/";
 const marionette_locales = "{/en-US,/fr,/ja,/pl,/pt-BR,/ru,/zh-CN,}";
@@ -704,7 +448,6 @@ const MARIONETTE_URLS = [].concat(
     `${marionette_multi_base}/Builds`,
     `${marionette_docs_root_url}Building.html`
   ),
-  url_test(`${marionette_multi_base}/Client`, marionette_client_docs_url),
   url_test(
     `${marionette_multi_base}/Developer_setup`,
     `${marionette_docs_root_url}Contributing.html`
@@ -725,7 +468,6 @@ const MARIONETTE_URLS = [].concat(
     `${marionette_base}/Protocol`,
     `${marionette_docs_root_url}Protocol.html`
   ),
-  url_test(`${marionette_base}/Python_Client`, marionette_client_docs_url),
   url_test(
     `${marionette_base}/WebDriver/status`,
     "https://bugzilla.mozilla.org/showdependencytree.cgi?id=721859&hide_resolved=1"
@@ -883,21 +625,6 @@ const WEBEXT_URLS = [].concat(
       `{/en-US,/fr,}/docs/Mozilla/Add-ons/${aoPath}`,
       `https://extensionworkshop.com/documentation/${ewPath}`
     )
-  )
-);
-
-const FIREFOX_ACCOUNTS_URLS = [].concat(
-  url_test(
-    "{/en-US,}/{docs/,}Mozilla/Firefox_Accounts_OAuth_Dashboard{/,}",
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
-  ),
-  url_test(
-    "{/en-US,/pl,}/{docs/,}Mozilla/{Tech/,}Firefox_Accounts{/Introduction,/Atttached_APIs,/WebExtensions,}",
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
-  ),
-  url_test(
-    "{/en-US,/pl,}/{docs/,}Archive/Mozilla/Firefox/Accounts{/Introduction,/Atttached_APIs,/WebExtensions,}",
-    "https://mozilla.github.io/ecosystem-platform/docs/welcome"
   )
 );
 
@@ -1265,12 +992,6 @@ describe("scl3 redirects", () => {
   }
 });
 
-describe("github io redirects", () => {
-  for (const [url, t] of GITHUB_IO_URLS) {
-    it(url, t);
-  }
-});
-
 describe("default samples redirects", () => {
   for (const [url, t] of DEFAULT_SAMPLES_URLS) {
     it(url, t);
@@ -1289,12 +1010,6 @@ describe("zone redirects", () => {
   }
 });
 
-describe("one off redirects", () => {
-  for (const [url, t] of REDIRECT_URLS) {
-    it(url, t);
-  }
-});
-
 describe("marionette redirects", () => {
   for (const [url, t] of MARIONETTE_URLS) {
     it(url, t);
@@ -1303,12 +1018,6 @@ describe("marionette redirects", () => {
 
 describe("webext redirects", () => {
   for (const [url, t] of WEBEXT_URLS) {
-    it(url, t);
-  }
-});
-
-describe("firefox accounts redirects", () => {
-  for (const [url, t] of FIREFOX_ACCOUNTS_URLS) {
     it(url, t);
   }
 });


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We have a lot of "fundamental" redirects where the target no longer exists.

### Solution

Remove those redirects.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
