### PR TITLE
fix(cloud-function): skip next() on fundamental redirect

### DIFF
--- a/cloud-function/src/middlewares/redirect-fundamental.ts
+++ b/cloud-function/src/middlewares/redirect-fundamental.ts
@@ -22,7 +22,7 @@ export async function redirectFundamental(
         (fundamentalRedirect.url.includes("?") ? "&" : "?") +
         url.search.substring(1);
     }
-    redirect(res, fundamentalRedirect.url, {
+    return redirect(res, fundamentalRedirect.url, {
       status: fundamentalRedirect.status,
       cacheControlSeconds: THIRTY_DAYS,
     });


### PR DESCRIPTION
## Summary

(MP-1166)

### Problem

Our Cloud Function sometimes returns HTTP 5xx, if (a) a fundamental redirect is triggered, and (b) a subsequent middleware modifies the header.

### Solution

Skip subsequent middlewares if fundamental redirect is triggered, by not calling `next()` (like all other redirect middlewares already do).

---

## How did you test this change?

Ran `npm i && npm start` in `/cloud-function` and ran `watch curl -sI http://localhost:5100/en-US/profiles/test/` in a separate console.