### PR TITLE
chore(fundamental-redirects): add more /docs/ prefix redirects

### DIFF
--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1162,7 +1162,7 @@ const MISC_REDIRECT_PATTERNS = [
   // redirects often take over from there, so let's only insert "/docs/"
   // and let any other redirect rules work from that point onwards.
   localeRedirect(
-    /^(?<prefix>AJAX|CSS|DOM|DragDrop|ECMAScript_DontEnum_attribute|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_audio_and_video_in_Firefox|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
+    /^(?<prefix>AJAX|CSS|DOM|DragDrop|ECMAScript_DontEnum_attribute|HTML|JavaScript|JavaScript_typed_arrays|Media_formats_supported_by_the_audio_and_video_elements|SVG|Tools|Using_audio_and_video_in_Firefox|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
     ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
     { permanent: true }
   ),

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1162,7 +1162,7 @@ const MISC_REDIRECT_PATTERNS = [
   // redirects often take over from there, so let's only insert "/docs/"
   // and let any other redirect rules work from that point onwards.
   localeRedirect(
-    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_audio_and_video_in_Firefox|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
+    /^(?<prefix>AJAX|CSS|DOM|DragDrop|ECMAScript_DontEnum_attribute|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_audio_and_video_in_Firefox|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
     ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
     { permanent: true }
   ),

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1162,7 +1162,7 @@ const MISC_REDIRECT_PATTERNS = [
   // redirects often take over from there, so let's only insert "/docs/"
   // and let any other redirect rules work from that point onwards.
   localeRedirect(
-    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|SVG|Tools|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
+    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
     ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
     { permanent: true }
   ),

--- a/libs/fundamental-redirects/index.js
+++ b/libs/fundamental-redirects/index.js
@@ -1162,7 +1162,7 @@ const MISC_REDIRECT_PATTERNS = [
   // redirects often take over from there, so let's only insert "/docs/"
   // and let any other redirect rules work from that point onwards.
   localeRedirect(
-    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
+    /^(?<prefix>AJAX|CSS|DOM|DragDrop|HTML|JavaScript|JavaScript_typed_arrays|SVG|Tools|Using_audio_and_video_in_Firefox|Using_files_from_web_applications|Web|XMLHttpRequest|Security)(?<subPath>\/.+?)?\/?$/i,
     ({ prefix, subPath = "" }) => `/docs/${prefix}${subPath}`,
     { permanent: true }
   ),

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -1222,6 +1222,10 @@ const MISC_REDIRECT_URLS = [].concat(
     "/en-US/DragDrop/Drag_and_Drop/",
     "/en-US/docs/DragDrop/Drag_and_Drop"
   ),
+  url_test(
+    "/en-US/ECMAScript_DontEnum_attribute",
+    "/en-US/docs/ECMAScript_DontEnum_attribute"
+  ),
   url_test("/en-US/HTML", "/en-US/docs/HTML"),
   url_test("/en-US/HTML/", "/en-US/docs/HTML"),
   url_test("/en-US/HTML/Canvas/", "/en-US/docs/HTML/Canvas"),

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -1245,6 +1245,10 @@ const MISC_REDIRECT_URLS = [].concat(
     "/en-US/docs/Tools/Memory/Treemap_view"
   ),
   url_test(
+    "/en-US/Using_audio_and_video_in_Firefox",
+    "/en-US/docs/Using_audio_and_video_in_Firefox"
+  ),
+  url_test(
     "/en-US/Using_files_from_web_applications",
     "/en-US/docs/Using_files_from_web_applications"
   ),

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -1228,6 +1228,10 @@ const MISC_REDIRECT_URLS = [].concat(
   url_test("/en-US/JavaScript", "/en-US/docs/JavaScript"),
   url_test("/en-US/JavaScript/", "/en-US/docs/JavaScript"),
   url_test(
+    "/en-US/JavaScript_typed_arrays/ArrayBuffer",
+    "/en-US/docs/JavaScript_typed_arrays/ArrayBuffer"
+  ),
+  url_test(
     "/en-US/JavaScript/Reference/About/",
     "/en-US/docs/JavaScript/Reference/About"
   ),

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -1239,6 +1239,10 @@ const MISC_REDIRECT_URLS = [].concat(
     "/en-US/JavaScript/Reference/About/",
     "/en-US/docs/JavaScript/Reference/About"
   ),
+  url_test(
+    "/en-US/Media_formats_supported_by_the_audio_and_video_elements",
+    "/en-US/docs/Media_formats_supported_by_the_audio_and_video_elements"
+  ),
   url_test("/en-US/SVG", "/en-US/docs/SVG"),
   url_test("/en-US/SVG/", "/en-US/docs/SVG"),
   url_test("/en-US/SVG/Element/font/", "/en-US/docs/SVG/Element/font"),


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We see a couple of page URLs without `/docs/` in our top 404s list:

| page | monthly users |
|:----- | ------:|
| /en-US/Media_formats_supported_by_the_audio_and_video_elements | 2,853 |
| /en-US/JavaScript_typed_arrays/ArrayBuffer | 1,099 |
| /en-US/JavaScript_typed_arrays/Uint8Array | 1,091 |
| /en-US/ECMAScript_DontEnum_attribute | 760 |
| /en-US/Using_audio_and_video_in_Firefox | 460 |

For each of these pages, content redirects exists for the `/docs/`-prefixed URL.

### Solution

Add `/docs/` redirect.

---

## How did you test this change?

Added a test case.