### PR TITLE
fix(sync-translated-content): preserve l10n frontmatter

### DIFF
--- a/content/document.ts
+++ b/content/document.ts
@@ -114,6 +114,7 @@ export function saveFile(
     "tags",
     "original_slug",
     "browser-compat",
+    "l10n",
   ];
 
   const saveMetadata = {};


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes an issue with sync-translated-content encountered in https://github.com/mdn/translated-content/pull/21044#issuecomment-2141093997.

### Problem

Our `sync-translated-content` tool removes the `l10n` frontmatter key.

### Solution

Add `l10n` to the list of optional front matter keys.

---

## How did you test this change?

- Checked out mdn/content @ b68d6456477c19b1fed8fc6bc99eff8972b1af29
- Checked out mdn/translated-content @ f5db1f7163d985ff55b90d11f1efe2fc34ad3445
- Ran `yarn tool sync-translated-content ko`
- Verified the diff of `files/ko/glossary/gzip_compression/index.md`:

### Before

```diff
diff --git a/files/ko/glossary/gzip_compression/index.md b/files/ko/glossary/gzip_compression/index.md
index 2662038da6..087779623b 100644
--- a/files/ko/glossary/gzip_compression/index.md
+++ b/files/ko/glossary/gzip_compression/index.md
@@ -1,8 +1,6 @@
 ---
 title: GZip 압축 (GZip compression)
-slug: Glossary/GZip_compression
-l10n:
-  sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
+slug: Glossary/gzip_compression
 ---
 
 {{GlossarySidebar}}
```

### After

```diff
diff --git a/files/ko/glossary/gzip_compression/index.md b/files/ko/glossary/gzip_compression/index.md
index 2662038da6..0e12e51c7a 100644
--- a/files/ko/glossary/gzip_compression/index.md
+++ b/files/ko/glossary/gzip_compression/index.md
@@ -1,6 +1,6 @@
 ---
 title: GZip 압축 (GZip compression)
-slug: Glossary/GZip_compression
+slug: Glossary/gzip_compression
 l10n:
   sourceCommit: ada5fa5ef15eadd44b549ecf906423b4a2092f34
 ---
``` 