### PR TITLE
chore(build): remove the redirection of legacy images that start with `/@api/deki/`

### DIFF
--- a/build/check-images.ts
+++ b/build/check-images.ts
@@ -89,11 +89,10 @@ export function checkImageReferences(
 
     // These two lines is to simulate what a browser would do.
     const baseURL = `http://yari.placeholder${url}/`;
-    // Make a special exception for the legacy images that start with `/@api/deki...`
+    // Make a special exception for the legacy images that start with `/files/...`
     // If you just pretend their existing URL is static external domain, it
     // will be recognized as an external image (which is fixable).
-    // Also any `<img src="/files/1234/foo.png">` should match.
-    const absoluteURL = /^\/(@api\/deki\/|files\/\d+)/.test(src)
+    const absoluteURL = /^\/files\/\d+/.test(src)
       ? new URL(`https://mdn.mozillademos.org${src}`)
       : new URL(src, baseURL);
 

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -110,10 +110,6 @@ export async function downloadAndResizeImage(
       // has to be escaped when working on the command line.
       .replace(/[()]/g, "")
       .replace(/\s+/g, "_")
-      // From legacy we have a lot of images that are named like
-      // `/@api/deki/files/247/=HTMLBlinkElement.gif` for example.
-      // Take this opportunity to clean that odd looking leading `=`.
-      .replace(/^=/, "")
       .toLowerCase()
   );
   // Before writing to disk, run it through the same imagemin

--- a/testing/integration/headless/test_cdn.py
+++ b/testing/integration/headless/test_cdn.py
@@ -179,16 +179,6 @@ def test_cached(base_url, is_behind_cdn, slug, status, expected_location):
 
 
 @pytest.mark.parametrize(
-    "slug,status",
-    [("/files/2767/hut.jpg", 301), ("/@api/deki/files/3613/=hut.jpg", 301)],
-)
-def test_cached_attachments(base_url, attachment_url, is_behind_cdn, slug, status):
-    """Ensure that these file-attachment requests are cached."""
-    expected_location = attachment_url + slug
-    assert_cached(base_url + slug, status, expected_location, is_behind_cdn)
-
-
-@pytest.mark.parametrize(
     "zone,status,expected_location",
     [
         ("Add-ons", 302, "/docs/Mozilla/Add-ons"),


### PR DESCRIPTION
## Summary

The usage of legacy images that start with `/@api/deki/` has been removed from content and translated-content (this can be checked by search the string `/@api/deki` in those two repos). We can now safely remove them.

Related issue: mdn/translated-content#10487

The replacement of prefix `=` of image file name has also been removed, I wrote a script to check all image references that contain an equal sign:

<details>
<summary>search.ts</summary>

```js
import { fromMarkdown } from "mdast-util-from-markdown";
import { visit } from "unist-util-visit";
import fs from "node:fs/promises";
import * as path from "node:path";
import { fdir } from "fdir";
import ora from "ora";
import yargs from "yargs";
import { hideBin } from "yargs/helpers";

const ESCAPE_CHARS_RE = /[.*+?^${}()|[\]\\]/g;

function findMatchesInText(
  haystack: string,
  { attribute = null } = {}
): Set<string> {
  // Need to remove any characters that can affect a regex if we're going
  // use the string in a manually constructed regex.
  const escaped = "[^'\"]+".replace(ESCAPE_CHARS_RE, "\\$&");
  const rex = attribute
    ? new RegExp(`${attribute}=['"](${escaped})['"]`, "g")
    : new RegExp(`(${escaped})`, "g");
  const matches = new Set<string>();
  for (const match of haystack.matchAll(rex)) {
    // check if the match contains an equal sign
    if (match[0].includes("=")) {
      matches.add(match[0]);
    }
  }
  return matches;
}

export function findImagesInMarkdown(rawContent: string): Set<string> {
  const matches = new Set<string>();
  const type = "image";
  const attributeType = "src";
  const tree = fromMarkdown(rawContent);
  // Find all the links and images in the markdown
  // we should also find any HTML elements that contain links or images
  visit(tree, [type, "html"], (node) => {
    if (node.type === "html") {
      const matchesInHtml = findMatchesInText(node.value, {
        attribute: attributeType,
      });
      for (const match of matchesInHtml) {
        matches.add(match);
      }
    } else if (node.type == type && node.url.includes("=")) {
      // else this would be a markdown link or image
      matches.add(node.url);
    }
  });
  return matches;
}

const spinner = ora().start();

async function main() {
  const { argv } = yargs(hideBin(process.argv)).command(
    "$0 [files..]",
    "Check the url locales of the given files",
    (yargs) => {
      yargs.positional("files", {
        describe:
          "The files to check (relative to the current working directory)",
        type: "string",
        array: true,
        default: ["../content/files/", "../translated-content/files/"],
      });
    }
  );

  const files = [];

  spinner.text = "Crawling files...";

  for (const fp of (argv as any).files as string[]) {
    const fstats = await fs.stat(fp);

    if (fstats.isDirectory()) {
      files.push(
        ...new fdir()
          .withBasePath()
          .filter((path) => path.endsWith(".md"))
          .crawl(fp)
          .sync()
      );
    } else if (fstats.isFile()) {
      files.push(fp);
    }
  }

  let exitCode = 0;
  const results = new Map<string, Set<string>>();

  for (const i in files) {
    const file = files[i];

    spinner.text = `${i}/${files.length}: ${file}...`;

    const relativePath = path.relative(process.cwd(), file);

    const originContent = await fs.readFile(relativePath, "utf8");
    const images = findImagesInMarkdown(originContent);
    if (images.size > 0) {
      results.set(relativePath, images);
    }

    spinner.start();
  }

  spinner.stop();

  for (const [file, images] of results) {
    console.log(`\n${file}`);
    for (const image of images) {
      console.log(`  ${image}`);
    }
  }
}

await main();
```

</details>

The result shows:

```plain
../translated-content/files/es/web/api/web_components/index.md
  https://pbs.twimg.com/media/EOW1l5dVAAADJuF?format=jpg&name=large

../translated-content/files/es/web/api/window/open/index.md
  menusystemcommands.png?size=webview

../translated-content/files/es/web/css/transform-function/index.md
  transform_functions_generic_transformation_cart.png?size=webview
  transform_functions_transform_composition_cart.png?size=webview

../translated-content/files/es/web/html/content_categories/index.md
  content_categories_venn.png?size=webview

../translated-content/files/es/web/html/element/input/index.md
  mozactionhint.png?size=webview

../translated-content/files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md
  =figure8.3.png

../translated-content/files/ru/learn/javascript/building_blocks/image_gallery/index.md
  https://github.com/ConstantineZz/javaScript/blob/master/gallery.png?raw=true

../translated-content/files/zh-tw/web/api/battery_status_api/index.md
  http://x.co/qr/batstat?s=165
```

Only the `=figure8.3.png` in `files/pt-br/conflicting/web/javascript/inheritance_and_the_prototype_chain/index.md` has the prefix `=`, while the file stored in this repo does have the `=` prefix, so the replacement is not necessary and safe to be removed.

---

## How did you test this change?

No additional test.
