### PR TITLE
fix(cloud-function): sanitize pong/get input

### DIFF
--- a/libs/pong/pong2.js
+++ b/libs/pong/pong2.js
@@ -4,14 +4,25 @@ import anonymousIpByCC from "./cc2ip.js";
 
 export function createPong2GetHandler(zoneKeys, coder) {
   return async (body, countryCode, userAgent) => {
-    const { pongs = null } = body;
+    let { pongs = null } = body;
+
+    // Validate.
+    if (!Array.isArray(pongs)) {
+      return { statusCode: 400, payload: { status: "invalid" } };
+    }
+
+    // Sanitize.
+    pongs = pongs.filter((p) => p in zoneKeys);
+
+    if (pongs.length == 0) {
+      return { statusCode: 400, payload: { status: "empty" } };
+    }
+
     const anonymousIp = anonymousIpByCC(countryCode);
 
-    const placements = pongs
-      .filter((p) => p in zoneKeys)
-      .map((p) => {
-        return { name: p, zoneKey: [zoneKeys[p]] };
-      });
+    const placements = pongs.map((p) => {
+      return { name: p, zoneKey: [zoneKeys[p]] };
+    });
 
     const requests = placements.map(async ({ name, zoneKey }) => {
       const res = await (


### PR DESCRIPTION
## Summary

(MP-1167)

### Problem

We don't validate/sanitize the input on the `/pong/get` endpoint, causing HTTP 500 errors in our logs.

### Solution

Validate and sanitize the input.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% xh post http://localhost:5100/pong/get
HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Content-Length: 49
Content-Type: text/html; charset=utf-8
Date: Fri, 31 May 2024 17:33:11 GMT
Keep-Alive: timeout=5
X-Google-Status: crash

Cannot read properties of null (reading 'filter')
```

```
% xh post http://localhost:5100/pong/get --json 'pong:="foo"' 
HTTP/1.1 500 Internal Server Error
Connection: keep-alive
Content-Length: 49
Content-Type: text/html; charset=utf-8
Date: Fri, 31 May 2024 17:32:54 GMT
Keep-Alive: timeout=5
X-Google-Status: crash

Cannot read properties of null (reading 'filter')
```

```
% xh post http://localhost:5100/pong/get --json 'pongs:=["foo"]'
HTTP/1.1 200 OK
Cache-Control: no-store
Connection: keep-alive
Content-Length: 2
Content-Type: application/json
Date: Fri, 31 May 2024 17:32:23 GMT
Keep-Alive: timeout=5

{}
```

```
% xh post http://localhost:5100/pong/get --json 'pongs:=["foo", "side"]'
HTTP/1.1 200 OK
Cache-Control: no-store
Connection: keep-alive
Content-Length: 2
Content-Type: application/json
Date: Fri, 31 May 2024 17:33:39 GMT
Keep-Alive: timeout=5

{}
```

### After

```
% xh post http://localhost:5100/pong/get
HTTP/1.1 400 Bad Request
Cache-Control: no-store
Connection: keep-alive
Content-Length: 20
Content-Type: application/json
Date: Fri, 31 May 2024 17:34:05 GMT
Keep-Alive: timeout=5

{
    "status": "invalid"
}
```

```
% xh post http://localhost:5100/pong/get --json 'pongs:="foo"'
HTTP/1.1 400 Bad Request
Cache-Control: no-store
Connection: keep-alive
Content-Length: 20
Content-Type: application/json
Date: Fri, 31 May 2024 17:34:18 GMT
Keep-Alive: timeout=5

{
    "status": "invalid"
}
```

```
% xh post http://localhost:5100/pong/get --json 'pongs:=["foo"]'
HTTP/1.1 400 Bad Request
Cache-Control: no-store
Connection: keep-alive
Content-Length: 18
Content-Type: application/json
Date: Fri, 31 May 2024 17:34:31 GMT
Keep-Alive: timeout=5

{
    "status": "empty"
}
```

```
% xh post http://localhost:5100/pong/get --json 'pongs:=["side","newType"]'
HTTP/1.1 200 OK
Cache-Control: no-store
Connection: keep-alive
Content-Length: 28
Content-Type: application/json
Date: Fri, 31 May 2024 17:34:44 GMT
Keep-Alive: timeout=5

{
    "status": "geo_unsupported"
}
```

---

## How did you test this change?

Ran `npm i && npm start` in `/cloud-function`, and the following commands in a separate terminal:

```
xh post http://localhost:5100/pong/get
xh post http://localhost:5100/pong/get --json 'pongs:="foo"'
xh post http://localhost:5100/pong/get --json 'pongs:=["foo"]'
xh post http://localhost:5100/pong/get --json 'pongs:=["side","newType"]'
```
