### PR TITLE
fix(seo): add missing sitemaps

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -274,14 +274,14 @@ jobs:
 
           du -sh client/build
 
-          # Generate sitemap index file
-          yarn build --sitemap-index
-
           # Build the blog
           yarn build:blog
 
           # Build the curriculum
           yarn build:curriculum
+
+          # Generate sitemap index file
+          yarn build --sitemap-index
 
           # Generate whatsdeployed files.
           yarn tool whatsdeployed --output client/build/_whatsdeployed/code.json

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -290,14 +290,14 @@ jobs:
 
           du -sh client/build
 
-          # Generate sitemap index file
-          yarn build --sitemap-index
-
           # Build the blog
           yarn build:blog
 
           # Build the curriculum
           yarn build:curriculum
+
+          # Generate sitemap index file
+          yarn build --sitemap-index
 
           # Generate whatsdeployed files.
           yarn tool whatsdeployed --output client/build/_whatsdeployed/code.json

--- a/.github/workflows/xyz-build.yml
+++ b/.github/workflows/xyz-build.yml
@@ -181,14 +181,14 @@ jobs:
 
           du -sh client/build
 
-          # Generate sitemap index file
-          yarn build --sitemap-index
-
           # Build the blog
           yarn build:blog
 
           # Build the curriculum
           yarn build:curriculum
+
+          # Generate sitemap index file
+          yarn build --sitemap-index
 
           # Generate whatsdeployed files.
           yarn tool whatsdeployed --output client/build/_whatsdeployed/code.json

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { gzipSync } from "node:zlib";
 
 import { fdir } from "fdir";
 import { Feed } from "feed";
@@ -38,6 +39,7 @@ import { extractSections } from "./extract-sections.js";
 import { HydrationData } from "../libs/types/hydration.js";
 import { DEFAULT_LOCALE } from "../libs/constants/index.js";
 import { memoize } from "../content/utils.js";
+import { makeSitemapXML } from "./sitemaps.js";
 
 const READ_TIME_FILTER = /[\w<>.,!?]+/;
 const HIDDEN_CODE_BLOCK_MATCH = /```.*hidden[\s\S]*?```/g;
@@ -493,5 +495,37 @@ export async function buildAuthors(options: { verbose?: boolean }) {
         console.log("Copied", from, "to", to);
       }
     }
+  }
+}
+
+export async function buildBlogSitemap(options: { verbose?: boolean }) {
+  const posts = await allPostFrontmatter();
+
+  const items = posts.map((post) => ({
+    slug: `${post.slug}/`,
+    modified: new Date(post.date).toISOString(),
+  }));
+
+  const index = {
+    slug: "",
+    modified: items
+      .map((p) => p.modified)
+      .sort((a, b) => b.localeCompare(a))
+      .at(0),
+  };
+
+  const xml = makeSitemapXML(`/${DEFAULT_LOCALE}/blog/`, [index, ...items]);
+
+  const sitemapDir = path.join(
+    BUILD_OUT_ROOT,
+    "sitemaps",
+    DEFAULT_LOCALE.toLowerCase(),
+    "blog"
+  );
+  await fs.mkdir(sitemapDir, { recursive: true });
+  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
+  await fs.writeFile(sitemapFilePath, gzipSync(xml));
+  if (options.verbose) {
+    console.log("Wrote", sitemapFilePath);
   }
 }

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -38,7 +38,7 @@ import { extractSections } from "./extract-sections.js";
 import { HydrationData } from "../libs/types/hydration.js";
 import { DEFAULT_LOCALE } from "../libs/constants/index.js";
 import { memoize } from "../content/utils.js";
-import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
+import { buildSitemap } from "./sitemaps.js";
 
 const READ_TIME_FILTER = /[\w<>.,!?]+/;
 const HIDDEN_CODE_BLOCK_MATCH = /```.*hidden[\s\S]*?```/g;
@@ -513,8 +513,10 @@ export async function buildBlogSitemap(options: { verbose?: boolean }) {
       .at(0),
   };
 
-  const xml = makeSitemapXML(`/${DEFAULT_LOCALE}/blog/`, [index, ...items]);
-  const sitemapFilePath = await writeSitemap(xml, DEFAULT_LOCALE, "blog");
+  const sitemapFilePath = await buildSitemap([index, ...items], {
+    slugPrefix: `/${DEFAULT_LOCALE}/blog/`,
+    pathSuffix: [DEFAULT_LOCALE, "blog"],
+  });
 
   if (options.verbose) {
     console.log("Wrote", sitemapFilePath);

--- a/build/blog.ts
+++ b/build/blog.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { gzipSync } from "node:zlib";
 
 import { fdir } from "fdir";
 import { Feed } from "feed";
@@ -39,7 +38,7 @@ import { extractSections } from "./extract-sections.js";
 import { HydrationData } from "../libs/types/hydration.js";
 import { DEFAULT_LOCALE } from "../libs/constants/index.js";
 import { memoize } from "../content/utils.js";
-import { makeSitemapXML } from "./sitemaps.js";
+import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
 
 const READ_TIME_FILTER = /[\w<>.,!?]+/;
 const HIDDEN_CODE_BLOCK_MATCH = /```.*hidden[\s\S]*?```/g;
@@ -515,16 +514,8 @@ export async function buildBlogSitemap(options: { verbose?: boolean }) {
   };
 
   const xml = makeSitemapXML(`/${DEFAULT_LOCALE}/blog/`, [index, ...items]);
+  const sitemapFilePath = await writeSitemap(xml, DEFAULT_LOCALE, "blog");
 
-  const sitemapDir = path.join(
-    BUILD_OUT_ROOT,
-    "sitemaps",
-    DEFAULT_LOCALE.toLowerCase(),
-    "blog"
-  );
-  await fs.mkdir(sitemapDir, { recursive: true });
-  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
-  await fs.writeFile(sitemapFilePath, gzipSync(xml));
   if (options.verbose) {
     console.log("Wrote", sitemapFilePath);
   }

--- a/build/build-blog.ts
+++ b/build/build-blog.ts
@@ -4,9 +4,11 @@ import {
   buildBlogFeed,
   buildBlogIndex,
   buildBlogPosts,
+  buildBlogSitemap,
 } from "./blog.js";
 
 await buildBlogIndex({ verbose: true });
 await buildBlogPosts({ verbose: true });
 await buildAuthors({ verbose: true });
 await buildBlogFeed({ verbose: true });
+await buildBlogSitemap({ verbose: true });

--- a/build/build-curriculum.ts
+++ b/build/build-curriculum.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
-import { buildCurriculum } from "./curriculum.js";
+import { buildCurriculum, buildCurriculumSitemap } from "./curriculum.js";
 
-buildCurriculum({ verbose: true });
+await buildCurriculum({ verbose: true });
+await buildCurriculumSitemap({ verbose: true });

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -2,7 +2,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import zlib from "node:zlib";
 
 import chalk from "chalk";
 import cliProgress from "cli-progress";
@@ -28,7 +27,11 @@ import {
 } from "./index.js";
 import { Doc, DocMetadata, Flaws } from "../libs/types/document.js";
 import SearchIndex from "./search-index.js";
-import { makeSitemapXML, makeSitemapIndexXML } from "./sitemaps.js";
+import {
+  makeSitemapXML,
+  makeSitemapIndexXML,
+  writeSitemap,
+} from "./sitemaps.js";
 import { humanFileSize } from "./utils.js";
 import { initSentry } from "./sentry.js";
 import { macroRenderTimes } from "../kumascript/src/render.js";
@@ -342,17 +345,8 @@ async function buildDocuments(
   }
 
   for (const [locale, docs] of Object.entries(docPerLocale)) {
-    const sitemapDir = path.join(
-      BUILD_OUT_ROOT,
-      "sitemaps",
-      locale.toLowerCase()
-    );
-    fs.mkdirSync(sitemapDir, { recursive: true });
-    const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
-    fs.writeFileSync(
-      sitemapFilePath,
-      zlib.gzipSync(makeSitemapXML(`/${locale}/docs/`, docs))
-    );
+    const xml = makeSitemapXML(`/${locale}/docs/`, docs);
+    await writeSitemap(xml, locale);
   }
 
   searchIndex.sort();

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -350,7 +350,7 @@ async function buildDocuments(
     const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
     fs.writeFileSync(
       sitemapFilePath,
-      zlib.gzipSync(makeSitemapXML(locale, docs))
+      zlib.gzipSync(makeSitemapXML(`/${locale}/docs/`, docs))
     );
   }
 

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -32,6 +32,7 @@ import { makeSitemapXML, makeSitemapIndexXML } from "./sitemaps.js";
 import { humanFileSize } from "./utils.js";
 import { initSentry } from "./sentry.js";
 import { macroRenderTimes } from "../kumascript/src/render.js";
+import { fdir } from "fdir";
 
 const { program } = caporal;
 const { prompt } = inquirer;
@@ -514,33 +515,23 @@ program
         if (!options.quiet) {
           console.log(chalk.yellow("Building sitemap index file..."));
         }
-        const sitemapsBuilt = [];
-        const locales = [];
-        for (const locale of VALID_LOCALES.keys()) {
-          const sitemapFilePath = path.join(
-            BUILD_OUT_ROOT,
-            "sitemaps",
-            locale,
-            "sitemap.xml.gz"
-          );
-          if (fs.existsSync(sitemapFilePath)) {
-            sitemapsBuilt.push(sitemapFilePath);
-            locales.push(locale);
-          }
-        }
-
+        const sitemapsBuilt = new fdir()
+          .filter((p) => p.endsWith("/sitemap.xml.gz"))
+          .withFullPaths()
+          .crawl(path.join(BUILD_OUT_ROOT, "sitemaps"))
+          .sync()
+          .sort()
+          .map((fp) => fp.replace(BUILD_OUT_ROOT, ""));
         const sitemapIndexFilePath = path.join(BUILD_OUT_ROOT, "sitemap.xml");
         fs.writeFileSync(
           sitemapIndexFilePath,
-          makeSitemapIndexXML(
-            sitemapsBuilt.map((fp) => fp.replace(BUILD_OUT_ROOT, ""))
-          )
+          makeSitemapIndexXML(sitemapsBuilt)
         );
 
         if (!options.quiet) {
           console.log(
             chalk.green(
-              `Sitemap index file built with locales: ${locales.join(", ")}.`
+              `Sitemap index file built referencing ${sitemapsBuilt.length} sitemaps:\n- ${sitemapsBuilt.join("\n- ")}`
             )
           );
         }

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -27,11 +27,7 @@ import {
 } from "./index.js";
 import { Doc, DocMetadata, Flaws } from "../libs/types/document.js";
 import SearchIndex from "./search-index.js";
-import {
-  makeSitemapXML,
-  makeSitemapIndexXML,
-  writeSitemap,
-} from "./sitemaps.js";
+import { makeSitemapIndexXML, buildSitemap } from "./sitemaps.js";
 import { humanFileSize } from "./utils.js";
 import { initSentry } from "./sentry.js";
 import { macroRenderTimes } from "../kumascript/src/render.js";
@@ -345,8 +341,10 @@ async function buildDocuments(
   }
 
   for (const [locale, docs] of Object.entries(docPerLocale)) {
-    const xml = makeSitemapXML(`/${locale}/docs/`, docs);
-    await writeSitemap(xml, locale);
+    await buildSitemap(docs, {
+      slugPrefix: `/${locale}/docs/`,
+      pathSuffix: [locale],
+    });
   }
 
   searchIndex.sort();

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -531,7 +531,7 @@ program
         if (!options.quiet) {
           console.log(
             chalk.green(
-              `Sitemap index file built referencing ${sitemapsBuilt.length} sitemaps:\n- ${sitemapsBuilt.join("\n- ")}`
+              `Wrote sitemap index referencing ${sitemapsBuilt.length} sitemaps:\n${sitemapsBuilt.map((s) => `- ${s}`).join("\n")}`
             )
           );
         }

--- a/build/curriculum.ts
+++ b/build/curriculum.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import fs from "node:fs/promises";
-import { gzipSync } from "node:zlib";
 
 import { fdir } from "fdir";
 import frontmatter from "front-matter";
@@ -40,7 +39,7 @@ import { memoize, slugToFolder } from "../content/utils.js";
 // @ts-ignore
 import { renderHTML } from "../ssr/dist/main.js";
 import { CheerioAPI } from "cheerio";
-import { makeSitemapXML } from "./sitemaps.js";
+import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
 
 export const allFiles = memoize(async () => {
   const api = new fdir()
@@ -445,16 +444,8 @@ export async function buildCurriculumSitemap(options: { verbose?: boolean }) {
   }
 
   const xml = makeSitemapXML("", items);
+  const sitemapFilePath = await writeSitemap(xml, DEFAULT_LOCALE, "curriculum");
 
-  const sitemapDir = path.join(
-    BUILD_OUT_ROOT,
-    "sitemaps",
-    DEFAULT_LOCALE.toLowerCase(),
-    "curriculum"
-  );
-  await fs.mkdir(sitemapDir, { recursive: true });
-  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
-  await fs.writeFile(sitemapFilePath, gzipSync(xml));
   if (options.verbose) {
     console.log("Wrote", sitemapFilePath);
   }

--- a/build/curriculum.ts
+++ b/build/curriculum.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import fs from "node:fs/promises";
+import { gzipSync } from "node:zlib";
 
 import { fdir } from "fdir";
 import frontmatter from "front-matter";
@@ -39,6 +40,7 @@ import { memoize, slugToFolder } from "../content/utils.js";
 // @ts-ignore
 import { renderHTML } from "../ssr/dist/main.js";
 import { CheerioAPI } from "cheerio";
+import { makeSitemapXML } from "./sitemaps.js";
 
 export const allFiles = memoize(async () => {
   const api = new fdir()
@@ -427,4 +429,33 @@ function setCurriculumTypes($: CheerioAPI) {
       }
     }
   });
+}
+
+export async function buildCurriculumSitemap(options: { verbose?: boolean }) {
+  const index = await buildCurriculumIndex();
+  const items = [];
+  while (index.length) {
+    const current = index.shift();
+    items.push({
+      slug: current.url,
+    });
+    if (current.children) {
+      index.push(...current.children);
+    }
+  }
+
+  const xml = makeSitemapXML("", items);
+
+  const sitemapDir = path.join(
+    BUILD_OUT_ROOT,
+    "sitemaps",
+    DEFAULT_LOCALE.toLowerCase(),
+    "curriculum"
+  );
+  await fs.mkdir(sitemapDir, { recursive: true });
+  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
+  await fs.writeFile(sitemapFilePath, gzipSync(xml));
+  if (options.verbose) {
+    console.log("Wrote", sitemapFilePath);
+  }
 }

--- a/build/curriculum.ts
+++ b/build/curriculum.ts
@@ -39,7 +39,7 @@ import { memoize, slugToFolder } from "../content/utils.js";
 // @ts-ignore
 import { renderHTML } from "../ssr/dist/main.js";
 import { CheerioAPI } from "cheerio";
-import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
+import { buildSitemap } from "./sitemaps.js";
 
 export const allFiles = memoize(async () => {
   const api = new fdir()
@@ -443,8 +443,9 @@ export async function buildCurriculumSitemap(options: { verbose?: boolean }) {
     }
   }
 
-  const xml = makeSitemapXML("", items);
-  const sitemapFilePath = await writeSitemap(xml, DEFAULT_LOCALE, "curriculum");
+  const sitemapFilePath = await buildSitemap(items, {
+    pathSuffix: [DEFAULT_LOCALE, "curriculum"],
+  });
 
   if (options.verbose) {
     console.log("Wrote", sitemapFilePath);

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -1,6 +1,6 @@
 export function makeSitemapXML(
-  locale: string,
-  docs: { slug: string; modified: string }[]
+  prefix: string,
+  docs: { slug: string; modified?: string }[]
 ) {
   const sortedDocs = docs.slice().sort((a, b) => a.slug.localeCompare(b.slug));
 
@@ -9,7 +9,7 @@ export function makeSitemapXML(
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     ...sortedDocs.map((doc) => {
-      const loc = `<loc>https://developer.mozilla.org/${locale}/docs/${doc.slug}</loc>`;
+      const loc = `<loc>https://developer.mozilla.org${prefix}${doc.slug}</loc>`;
       const modified = doc.modified
         ? `<lastmod>${doc.modified.toString().split("T")[0]}</lastmod>`
         : "";

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -4,10 +4,25 @@ import { gzipSync } from "node:zlib";
 
 import { BUILD_OUT_ROOT } from "../libs/env/index.js";
 
-export function makeSitemapXML(
-  prefix: string,
-  docs: { slug: string; modified?: string }[]
+interface SitemapEntry {
+  slug: string;
+  modified?: string;
+}
+
+export async function buildSitemap(
+  entries: SitemapEntry[],
+  {
+    slugPrefix = "",
+    pathSuffix = [],
+  }: { slugPrefix?: string; pathSuffix?: string[] }
 ) {
+  const xml = makeSitemapXML(slugPrefix, entries);
+  const path = await writeSitemap(xml, ...pathSuffix);
+
+  return path;
+}
+
+function makeSitemapXML(prefix: string, docs: SitemapEntry[]) {
   const sortedDocs = docs.slice().sort((a, b) => a.slug.localeCompare(b.slug));
 
   // Based on https://support.google.com/webmasters/answer/183668?hl=en
@@ -45,7 +60,7 @@ export function makeSitemapIndexXML(paths: string[]) {
   ].join("\n");
 }
 
-export async function writeSitemap(xml: string, ...paths: string[]) {
+async function writeSitemap(xml: string, ...paths: string[]) {
   const dirPath = join(
     BUILD_OUT_ROOT,
     "sitemaps",

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -2,7 +2,9 @@ import { join } from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import { gzipSync } from "node:zlib";
 
-import { BUILD_OUT_ROOT } from "../libs/env/index.js";
+import { BASE_URL, BUILD_OUT_ROOT } from "../libs/env/index.js";
+
+const SITEMAP_BASE_URL = BASE_URL.replace(/\/$/, "");
 
 interface SitemapEntry {
   slug: string;
@@ -30,7 +32,7 @@ function makeSitemapXML(prefix: string, docs: SitemapEntry[]) {
     '<?xml version="1.0" encoding="UTF-8"?>',
     '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
     ...sortedDocs.map((doc) => {
-      const loc = `<loc>https://developer.mozilla.org${prefix}${doc.slug}</loc>`;
+      const loc = `<loc>${SITEMAP_BASE_URL}${prefix}${doc.slug}</loc>`;
       const modified = doc.modified
         ? `<lastmod>${doc.modified.toString().split("T")[0]}</lastmod>`
         : "";
@@ -51,7 +53,7 @@ export function makeSitemapIndexXML(paths: string[]) {
     ...sortedPaths.map((path) => {
       return (
         "<sitemap>" +
-        `<loc>https://developer.mozilla.org${path}</loc>` +
+        `<loc>${SITEMAP_BASE_URL}${path}</loc>` +
         `<lastmod>${new Date().toISOString().split("T")[0]}</lastmod>` +
         "</sitemap>"
       );

--- a/build/sitemaps.ts
+++ b/build/sitemaps.ts
@@ -1,3 +1,9 @@
+import { join } from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+
+import { BUILD_OUT_ROOT } from "../libs/env/index.js";
+
 export function makeSitemapXML(
   prefix: string,
   docs: { slug: string; modified?: string }[]
@@ -37,4 +43,18 @@ export function makeSitemapIndexXML(paths: string[]) {
     }),
     "</sitemapindex>",
   ].join("\n");
+}
+
+export async function writeSitemap(xml: string, ...paths: string[]) {
+  const dirPath = join(
+    BUILD_OUT_ROOT,
+    "sitemaps",
+    ...paths.map((p) => p.toLowerCase())
+  );
+  await mkdir(dirPath, { recursive: true });
+
+  const filePath = join(dirPath, "sitemap.xml.gz");
+  await writeFile(filePath, gzipSync(xml));
+
+  return filePath;
 }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -1,8 +1,6 @@
 import fs from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { gzipSync } from "node:zlib";
 
 import frontmatter from "front-matter";
 import { fdir, PathsOutput } from "fdir";
@@ -32,7 +30,7 @@ import { getSlugByBlogPostUrl, splitSections } from "./utils.js";
 import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
-import { makeSitemapXML } from "./sitemaps.js";
+import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
 
 const FEATURED_ARTICLES = [
   "blog/learn-javascript-console-methods/",
@@ -393,10 +391,8 @@ export async function buildSPAs(options: {
       modified: "",
     }))
   );
-  const sitemapDir = path.join(BUILD_OUT_ROOT, "sitemaps", "misc");
-  await mkdir(sitemapDir, { recursive: true });
-  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
-  await writeFile(sitemapFilePath, gzipSync(sitemapXml));
+  const sitemapFilePath = writeSitemap(sitemapXml, "misc");
+
   if (!options.quiet) {
     console.log("Wrote", sitemapFilePath);
   }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -30,7 +30,7 @@ import { getSlugByBlogPostUrl, splitSections } from "./utils.js";
 import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
-import { makeSitemapXML, writeSitemap } from "./sitemaps.js";
+import { buildSitemap } from "./sitemaps.js";
 
 const FEATURED_ARTICLES = [
   "blog/learn-javascript-console-methods/",
@@ -384,14 +384,13 @@ export async function buildSPAs(options: {
   }
 
   // Sitemap.
-  const sitemapXml = makeSitemapXML(
-    "",
+  const sitemapFilePath = await buildSitemap(
     sitemap.map(({ url }) => ({
       slug: url,
       modified: "",
-    }))
+    })),
+    { pathSuffix: ["misc"] }
   );
-  const sitemapFilePath = writeSitemap(sitemapXml, "misc");
 
   if (!options.quiet) {
     console.log("Wrote", sitemapFilePath);

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
 
 import frontmatter from "front-matter";
 import { fdir, PathsOutput } from "fdir";
@@ -30,6 +32,7 @@ import { getSlugByBlogPostUrl, splitSections } from "./utils.js";
 import { findByURL } from "../content/document.js";
 import { buildDocument } from "./index.js";
 import { findPostBySlug } from "./blog.js";
+import { makeSitemapXML } from "./sitemaps.js";
 
 const FEATURED_ARTICLES = [
   "blog/learn-javascript-console-methods/",
@@ -113,6 +116,9 @@ export async function buildSPAs(options: {
   verbose?: boolean;
 }) {
   let buildCount = 0;
+  const sitemap: {
+    url: string;
+  }[] = [];
 
   // The URL isn't very important as long as it triggers the right route in the <App/>
   const locale = DEFAULT_LOCALE;
@@ -195,6 +201,12 @@ export async function buildSPAs(options: {
         if (options.verbose) {
           console.log("Wrote", filePath);
         }
+
+        if (!noIndexing && !onlyFollow) {
+          sitemap.push({
+            url,
+          });
+        }
       }
     }
   }
@@ -260,6 +272,10 @@ export async function buildSPAs(options: {
       }
       const filePathContext = path.join(outPath, "index.json");
       fs.writeFileSync(filePathContext, JSON.stringify(context));
+
+      sitemap.push({
+        url,
+      });
     }
   }
 
@@ -354,6 +370,10 @@ export async function buildSPAs(options: {
         console.log("Wrote", filePath);
       }
 
+      sitemap.push({
+        url,
+      });
+
       // Also, dump the recent pull requests in a file so the data can be gotten
       // in client-side rendering.
       const filePathContext = path.join(outPath, "index.json");
@@ -363,6 +383,22 @@ export async function buildSPAs(options: {
         console.log("Wrote", filePathContext);
       }
     }
+  }
+
+  // Sitemap.
+  const sitemapXml = makeSitemapXML(
+    "",
+    sitemap.map(({ url }) => ({
+      slug: url,
+      modified: "",
+    }))
+  );
+  const sitemapDir = path.join(BUILD_OUT_ROOT, "sitemaps", "misc");
+  await mkdir(sitemapDir, { recursive: true });
+  const sitemapFilePath = path.join(sitemapDir, "sitemap.xml.gz");
+  await writeFile(sitemapFilePath, gzipSync(sitemapXml));
+  if (!options.quiet) {
+    console.log("Wrote", sitemapFilePath);
   }
 
   if (!options.quiet) {

--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -42,7 +42,7 @@ export function withContentResponseHeaders(
     res.setHeader("X-Robots-Tag", "noindex, nofollow");
   }
 
-  if (req.url?.endsWith("/sitemap.xml.gz")) {
+  if (res.statusCode === 200 && req.url?.endsWith("/sitemap.xml.gz")) {
     res.setHeader("Content-Type", "application/xml");
     res.setHeader("Content-Encoding", "gzip");
   }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1169)

### Problem

Our sitemaps currently only cover the content pages, and don't cover Blog, Curriculum, and other pages.

### Solution

Add sub-sitemaps for the Blog, the Curriculum, and miscellaneous pages, and create the sitemap index universally.

Also:
- Uses the `BASE_URL` in the sitemaps, so that links on stage are pointing to stage.
- Fixes a minor bug where the `Content-Encoding: gzip` header was also set for non-existing sitemaps, causing a "Content Encoding Error" in the browser, because our HTTP 404 page isn't gzip-encoded.

---

## How did you test this change?

Ran `yarn build:blog && yarn build:curriculum && yarn tool spas && yarn build --sitemap-index` and verified the output.