### PR TITLE
fix(macros/AccessibilitySidebar): list subpages via en-US

### DIFF
--- a/kumascript/macros/AccessibilitySidebar.ejs
+++ b/kumascript/macros/AccessibilitySidebar.ejs
@@ -110,8 +110,7 @@ async function renderSubsection(subsection) {
 
 
 async function renderDirectory(directory) {
-  const path = `${baseURL}${directory}`;
-  const output = await template("ListSubpagesForSidebar", [path, true, true]);
+  const output = await template("ListSubpagesForSidebar", [directory, true, true]);
 
   return output;
 }


### PR DESCRIPTION
## Summary

### Problem

The `AccessibilitySidebar` fails to render in translated-content, if one of these pages is not translated:
- Web/Accessibility/Understanding_WCAG
- Web/Accessibility/ARIA/attributes
- Web/Accessibility/ARIA/roles

See: https://github.com/mdn/translated-content/actions/runs/9391342326/job/25863283761#step:7:45

### Solution

Remove the `/${locale}/docs/` prefix from the `ListSubpagesForSidebar` call, to ensure the English locale is used to determine the list of pages.

---

## Screenshots

### Before

<img width="1228" alt="image" src="https://github.com/mdn/yari/assets/495429/e9abeb0f-3067-4ab1-aa7c-ba693c23bc48">

### After

<img width="1228" alt="image" src="https://github.com/mdn/yari/assets/495429/e6f3f785-fe14-4914-ae4a-e991d5469c8c">

---

## How did you test this change?

Ran `yarn && yarn dev` with https://github.com/mdn/translated-content/commit/94ae204c5574bed08ac257d5102d27eb2aa1238c.