### PR TITLE
fix(cloud-function): use URL.pathname to resolve index.html only

### DIFF
--- a/cloud-function/src/middlewares/resolve-index-html.ts
+++ b/cloud-function/src/middlewares/resolve-index-html.ts
@@ -16,8 +16,7 @@ export async function resolveIndexHTML(
     if (!isAsset(pathname)) {
       pathname = path.join(pathname, "index.html");
     }
-    urlParsed.pathname = pathname;
-    req.url = urlParsed.toString();
+    req.url = pathname; // e.g. "/en-us/docs/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json"
     // Workaround for http-proxy-middleware v2 using `req.originalUrl`.
     // See: https://github.com/chimurai/http-proxy-middleware/pull/731
     req.originalUrl = req.url;


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/11270, a regression caused by https://github.com/mdn/yari/pull/9655.

### Problem

When migrating from `url.parse()` to `new URL()`, we accidentally started adding `req.protocol` and `req.headers.host` to the resolved URL.

### Solution

Use the resolved `pathname` without protocol/host/search/hash.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
curl -I http://localhost:5100/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json
HTTP/1.1 404 Not Found
```

### After


```
curl -I http://localhost:5100/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json
HTTP/1.1 200 Not Found
```

---

## How did you test this change?

Ran `npm start` in `/cloud-function`, and `curl -I http://localhost:5100/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_compatibility_for_manifest.json` separately.