### PR TITLE
feat(surveys): add German locale survey

### DIFF
--- a/client/src/ui/molecules/document-survey/surveys.ts
+++ b/client/src/ui/molecules/document-survey/surveys.ts
@@ -57,7 +57,7 @@ export const SURVEYS: Survey[] = [
     teaser: "Wie wär’s, wenn MDN auf Deutsch verfügbar wäre?",
     question: "Welche Sprache würdest du dann benutzen?",
     footnote:
-      "This is a survey. You're seeing this, because your browser indicates German as your preferred language.",
+      "You're seeing this survey, because your browser indicates German as your preferred language.",
     ...survey_duration(SurveyBucket.DE_LOCALE_2024),
     ...survey_rates(SurveyKey.DE_LOCALE_2024),
   },

--- a/client/src/ui/molecules/document-survey/surveys.ts
+++ b/client/src/ui/molecules/document-survey/surveys.ts
@@ -54,8 +54,8 @@ export const SURVEYS: Survey[] = [
     bucket: SurveyBucket.DE_LOCALE_2024,
     show: () => (navigator?.language || "").startsWith("de"),
     src: "https://survey.alchemer.com/s3/7881145/MDN-German-Locale-Survey",
-    teaser: "Was wäre, wenn MDN auf Deutsch übersetzt wäre?",
-    question: "Welche Sprache würdest du dann bevorzugen?",
+    teaser: "Wie wär’s, wenn MDN auf Deutsch verfügbar wäre?",
+    question: "Welche Sprache würdest du dann benutzen?",
     footnote:
       "This is a survey. You're seeing this, because your browser indicates German as your preferred language.",
     ...survey_duration(SurveyBucket.DE_LOCALE_2024),

--- a/client/src/ui/molecules/document-survey/surveys.ts
+++ b/client/src/ui/molecules/document-survey/surveys.ts
@@ -23,6 +23,7 @@ enum SurveyBucket {
   BROWSER_SURVEY_OCT_2022 = "BROWSER_SURVEY_OCT_2022",
   CONTENT_DISCOVERY_2023 = "CONTENT_DISCOVERY_2023",
   CSS_CASCADE_2022 = "CSS_CASCADE_2022",
+  DE_LOCALE_2024 = "DE_LOCALE_2024",
   FIREFOX_WEB_COMPAT_2023 = "FIREFOX_WEB_COMPAT_2023",
   INTEROP_2023 = "INTEROP_2023",
   WEB_COMPONENTS_2023 = "WEB_COMPONENTS_2023",
@@ -37,6 +38,7 @@ enum SurveyKey {
   CONTENT_DISCOVERY_2023 = "CONTENT_DISCOVERY_2023",
   CSS_CASCADE_2022_A = "CSS_CASCADE_2022_A",
   CSS_CASCADE_2022_B = "CSS_CASCADE_2022_B",
+  DE_LOCALE_2024 = "DE_LOCALE_2024",
   FIREFOX_WEB_COMPAT_2023 = "FIREFOX_WEB_COMPAT_2023",
   INTEROP_2023_CSS_HTML = "INTEROP_2023_CSS_HTML",
   INTEROP_2023_API_JS = "INTEROP_2023_API_JS",
@@ -48,14 +50,15 @@ enum SurveyKey {
 
 export const SURVEYS: Survey[] = [
   {
-    key: SurveyKey.DISCOVERABILITY_AUG_2023,
-    bucket: SurveyBucket.DISCOVERABILITY_AUG_2023,
-    show: (doc: Doc) => /en-US\/docs\/(Web|Learn)(\/|$)/i.test(doc.mdn_url),
-    src: "https://survey.alchemer.com/s3/7457498/MDN-Discoverability-User-Satisfaction",
-    teaser:
-      "At MDN, we are committed to improving the user experience on our website. To ensure that we are meeting this goal, we would like to hear your thoughts and feedback regarding your experience on MDN.",
-    question: "What’s your experience on MDN Web Docs?",
-    ...survey_duration(SurveyBucket.DISCOVERABILITY_AUG_2023),
-    ...survey_rates(SurveyKey.DISCOVERABILITY_AUG_2023),
+    key: SurveyKey.DE_LOCALE_2024,
+    bucket: SurveyBucket.DE_LOCALE_2024,
+    show: () => (navigator?.language || "").startsWith("de"),
+    src: "https://survey.alchemer.com/s3/7881145/MDN-German-Locale-Survey",
+    teaser: "Was wäre, wenn MDN auf Deutsch übersetzt wäre?",
+    question: "Welche Sprache würdest du dann bevorzugen?",
+    footnote:
+      "This is a survey. You're seeing this, because your browser indicates German as your preferred language.",
+    ...survey_duration(SurveyBucket.DE_LOCALE_2024),
+    ...survey_rates(SurveyKey.DE_LOCALE_2024),
   },
 ];


### PR DESCRIPTION
## Summary

(MP-1173)

### Problem

We will experiment with a German locale, but a) we need user research to understand expectations, and b) we want to recruit volunteers to review and give feedback about the German locale before the launch.

### Solution

Show a survey to **all** users whose browser preference indicate German (i.e. `navigator.language.startsWith('de')`).

Related changes:
- https://github.com/mdn/yari/pull/11274
- https://github.com/mdn/yari/pull/11273

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1428" alt="image" src="https://github.com/mdn/yari/assets/495429/8fada8b4-c993-4021-a1e3-4f7e6a6912c3">

### After

<img width="1428" alt="image" src="https://github.com/mdn/yari/assets/495429/d300db7c-7fc3-477c-95da-7f799703407d">

---

## How did you test this change?

Ran `yarn dev` locally, set "German (Germany)" as the preferred language in my browser, and looked at http://localhost:3000/en-US/docs/Web.
