### PR TITLE
feat(telemetry): measure survey actions

### DIFF
--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -80,3 +80,4 @@ export const BASELINE = Object.freeze({
 export const CLIENT_SIDE_NAVIGATION = "client_side_nav";
 export const LANGUAGE = "language";
 export const THEME_SWITCHER = "theme_switcher";
+export const SURVEY = "survey";

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -56,6 +56,7 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
 
   const [originalState] = React.useState(() => getSurveyState(survey.bucket));
   const [state, setState] = React.useState(() => originalState);
+  const seen = React.useRef<boolean>(!!originalState.seen_at);
 
   React.useEffect(() => {
     writeSurveyState(survey.bucket, state);
@@ -103,7 +104,10 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
         ...state,
         seen_at: Date.now(),
       });
-      gleanClick(`${SURVEY}: seen ${survey.bucket}`);
+      if (!seen.current) {
+        seen.current = true;
+        gleanClick(`${SURVEY}: seen ${survey.bucket}`);
+      }
     }
   }, [state, gleanClick, survey.bucket]);
 

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -90,13 +90,14 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
           ...state,
           opened_at: Date.now(),
         });
+        gleanClick(`${SURVEY}: opened ${survey.bucket}`);
       }
     };
 
     current.addEventListener("toggle", listener);
 
     return () => current.removeEventListener("toggle", listener);
-  }, [details, state, survey]);
+  }, [details, state, survey, gleanClick]);
 
   React.useEffect(() => {
     if (!state.seen_at) {

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -82,19 +82,19 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
   }, [measure]);
 
   function dismiss() {
+    measure("dismissed");
     setState({
       ...state,
       dismissed_at: Date.now(),
     });
-    measure("dismissed");
   }
 
   function submitted() {
+    measure("submitted");
     setState({
       ...state,
       submitted_at: Date.now(),
     });
-    measure("submitted");
   }
 
   React.useEffect(() => {
@@ -105,11 +105,11 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
 
     const listener = () => {
       if (current.open && !state.opened_at) {
+        measure("opened");
         setState({
           ...state,
           opened_at: Date.now(),
         });
-        measure("opened");
       }
     };
 

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -68,9 +68,11 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
 
   const seen = React.useCallback(() => {
     setState((state) => {
-      if (!state.seen_at) {
-        measure("seen");
+      if (state.seen_at) {
+        return state;
       }
+
+      measure("seen");
 
       return {
         ...state,

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -62,22 +62,13 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
   }, [state, survey.bucket]);
 
   const seen = React.useCallback(() => {
-    if (state.seen_at) {
-      return;
-    }
+    setState((state) => ({
+      ...state,
+      seen_at: Date.now(),
+    }));
 
-    const timeoutId = setTimeout(
-      () =>
-        setState((state) => ({
-          ...state,
-          seen_at: Date.now(),
-        })),
-      0
-    );
     gleanClick(`${SURVEY}: seen ${survey.bucket}`);
-
-    return () => clearTimeout(timeoutId);
-  }, [gleanClick, state.seen_at, survey.bucket]);
+  }, [gleanClick, survey.bucket]);
 
   function dismiss() {
     setState({
@@ -117,10 +108,12 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
   }, [details, state, survey, gleanClick]);
 
   React.useEffect(() => {
-    const timeoutId = setTimeout(() => seen(), 0);
+    if (!state.seen_at) {
+      const timeoutId = setTimeout(seen, 0);
 
-    return () => clearTimeout(timeoutId);
-  }, [seen]);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [seen, state.seen_at]);
 
   React.useEffect(() => {
     // For this to work, the Survey needs this JavaScript action:

--- a/client/src/ui/molecules/document-survey/index.tsx
+++ b/client/src/ui/molecules/document-survey/index.tsx
@@ -7,6 +7,8 @@ import { useIsServer } from "../../../hooks";
 import { Icon } from "../../atoms/icon";
 import { useLocation } from "react-router";
 import { DEV_MODE, WRITER_MODE } from "../../../env";
+import { useGleanClick } from "../../../telemetry/glean-context";
+import { SURVEY } from "../../../telemetry/constants";
 
 const FORCE_SURVEY_PREFIX = "#FORCE_SURVEY=";
 
@@ -49,6 +51,7 @@ export function DocumentSurvey({ doc }: { doc: Doc }) {
 }
 
 function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
+  const gleanClick = useGleanClick();
   const details = React.useRef<HTMLDetailsElement | null>(null);
 
   const [originalState] = React.useState(() => getSurveyState(survey.bucket));
@@ -63,6 +66,7 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
       ...state,
       dismissed_at: Date.now(),
     });
+    gleanClick(`${SURVEY}: dismissed ${survey.bucket}`);
   }
 
   function submitted() {
@@ -70,6 +74,7 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
       ...state,
       submitted_at: Date.now(),
     });
+    gleanClick(`${SURVEY}: submitted ${survey.bucket}`);
   }
 
   React.useEffect(() => {
@@ -98,8 +103,9 @@ function SurveyDisplay({ survey, force }: { survey: Survey; force: boolean }) {
         ...state,
         seen_at: Date.now(),
       });
+      gleanClick(`${SURVEY}: seen ${survey.bucket}`);
     }
-  }, [state]);
+  }, [state, gleanClick, survey.bucket]);
 
   React.useEffect(() => {
     // For this to work, the Survey needs this JavaScript action:


### PR DESCRIPTION
## Summary

Related to MP-1173. Extracted from https://github.com/mdn/yari/pull/11272.

### Problem

We don't know, how many users see, open, submit, or dismiss our surveys.

### Solution

Add measurements: `survey: seen/opened/submitted/dismissed {survey}`

---

## How did you test this change?

Ran `yarn dev` and verified with the Glean Debug ping viewer.