### PR TITLE
fix(macros/ListSubpages): list subpages via default locale

### DIFF
--- a/kumascript/macros/AddonSidebar.ejs
+++ b/kumascript/macros/AddonSidebar.ejs
@@ -250,7 +250,7 @@ async function renderItem(slug) {
           ]) %>
         </ol>
       <%-
-        await wiki.tree(baseURL + "WebExtensions/manifest.json", 1, 0, 0, 1)
+        await wiki.tree(baseURL + "WebExtensions/manifest.json", 1, false, false, true)
       %>
       </details>
     </li>

--- a/kumascript/macros/ListSubpages.ejs
+++ b/kumascript/macros/ListSubpages.ejs
@@ -2,15 +2,16 @@
 // Inserts a tree of subpages of the specified page.
 //
 // Parameters:
-//  $0 - The path of the page whose subpages should be listed
+//  $0 - The path of the page whose subpages should be listed.
+//       The non-localized subpages will also be included.
 //  $1 - The depth of the tree to build; if not specified, only one level is listed
 //  $2 - If specified and non-zero, the list is sorted in reverse
 //  $3 - If specified and non-zero, the list is output as <ol> instead of the default <ul>
 
-var path = $0 || env.url;
-var depth = $1 || 1;
-var reverse = $2 || 0;
-var ordered = $3 || 0;
+const path = $0 || env.url;
+const depth = Number($1 || 1);
+const reverse = Boolean($2 || 0);
+const ordered = Boolean($3 || 0);
 
 %>
 <%- await wiki.tree(path, depth, 0, reverse, ordered) %>

--- a/kumascript/macros/QuickLinksWithSubpages.ejs
+++ b/kumascript/macros/QuickLinksWithSubpages.ejs
@@ -8,6 +8,8 @@
 // Parameters:
 //
 //  $0  Optional; the page whose subpages are to be included.
+//    The non-localized subpages will also be included.
+//    If not specified, the current page's subpages are used.
 %>
 <section id="Quick_links" data-macro="QuickLinksWithSubpages">
 <%-await template("ListSubpages", [$0, 2, 0, 1])%>

--- a/kumascript/tests/macros/addonsidebar.test.ts
+++ b/kumascript/tests/macros/addonsidebar.test.ts
@@ -58,6 +58,18 @@ const SUMMARIES = {
 };
 
 const MANIFEST_SLUG = "Mozilla/Add-ons/WebExtensions/manifest.json";
+const LOCALES = ["en-US", "fr", "ja"];
+
+function listTranslations(title: string) {
+  const results = LOCALES.map((locale) => ({
+    title,
+    locale,
+  }));
+  function getTranslations() {
+    return results;
+  }
+  return getTranslations;
+}
 
 function getMockResultForGetChildren(doc_url) {
   const locale = new URL(doc_url, "http://example.com").pathname.split("/")[1];
@@ -68,6 +80,7 @@ function getMockResultForGetChildren(doc_url) {
       subpages: [],
       slug: `${MANIFEST_SLUG}/author`,
       title: "author",
+      translations: listTranslations("author"),
     },
     {
       locale: `${locale}`,
@@ -75,6 +88,7 @@ function getMockResultForGetChildren(doc_url) {
       subpages: [],
       slug: `${MANIFEST_SLUG}/background`,
       title: "background",
+      translations: listTranslations("background"),
     },
     {
       locale: `${locale}`,
@@ -82,6 +96,7 @@ function getMockResultForGetChildren(doc_url) {
       subpages: [],
       slug: `${MANIFEST_SLUG}/theme`,
       title: "theme",
+      translations: listTranslations("theme"),
     },
     {
       locale: `${locale}`,
@@ -89,6 +104,7 @@ function getMockResultForGetChildren(doc_url) {
       subpages: [],
       slug: `${MANIFEST_SLUG}/version`,
       title: "version",
+      translations: listTranslations("version"),
     },
   ];
 }
@@ -144,9 +160,12 @@ describeMacro("AddonSidebar", function () {
         macroSource: "foo",
       };
     };
+    macro.ctx.web.smartLink = jest.fn((groupUrl, _, text) => {
+      return `<a href='${groupUrl}'>${text}</a>`;
+    });
   });
 
-  for (const locale of ["en-US", "fr", "ja"]) {
+  for (const locale of LOCALES) {
     itMacro(`with locale ${locale}`, function (macro) {
       macro.ctx.env.locale = locale;
       macro.ctx.env.slug = "Mozilla/Add-ons/AMO";


### PR DESCRIPTION


## Summary

Fix the problem mentioned [here](https://github.com/mdn/yari/issues/7438#issuecomment-2039107840). So it fixes #7438.

The changes have been made within this PR:

- The `wiki.tree()` method will include all the subpages even if the page is not localized. This This improves the experience for non-English users. (https://github.com/mdn/yari/issues/7438#issuecomment-2039107840)

Additional changes:

- The type hint has been added to some methods to improve the development experience.
- The built-in sorting methods has been used to sort numerically ([`Intl.Collato`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/Collator#numeric)). Note, only sort by the default titles which will keep the order of the articles consistent with en-US.

### Problem

See the problem described above, and https://github.com/mdn/translated-content/pull/21366#discussion_r1628621489

---

## Screenshots

Some of the pages which has used `{{QuickLinksWithSubPages}}` macro or `{{ListSubpages}}` macro.

### QuickLinksWithSubPages

| Slug | Note | Before | After |
| --- | --- | --- | --- |
| /zh-CN/docs/Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image | has the `/<locale>/docs/` prefix | ![image](https://github.com/mdn/yari/assets/15844309/0053eb53-6593-4ba8-aee5-ddc2606164a9) | ![image](https://github.com/mdn/yari/assets/15844309/657e596f-4dc0-4349-b6c3-d16874dc9824) |
| /zh-CN/docs/Web/Performance/Critical_rendering_path | Does not have the locale prefix | ![image](https://github.com/mdn/yari/assets/15844309/aff639c9-60a4-4852-8f32-82abfba7e542) | ![image](https://github.com/mdn/yari/assets/15844309/408542b4-3669-45ca-b40a-386a48e92a17) |
| /en-US/docs/Web/Performance/Critical_rendering_path | default locale | ![image](https://github.com/mdn/yari/assets/15844309/a933b694-073e-4ea9-a0d6-eb72eeabe0d9) | ![image](https://github.com/mdn/yari/assets/15844309/d2d8317f-62fb-44f3-aca7-f68a8dbae3ca) | ![image](https://github.com/mdn/yari/assets/15844309/f2f3bd18-5753-4b71-969d-9c4be5d959b3) |

### ListSubpages

| Slug | Note | Before | After |
| --- | --- | --- | --- |
| /zh-CN/docs/Mozilla/Firefox/Releases | be sorted in reverse order (numeric) | ![image](https://github.com/mdn/yari/assets/15844309/7d9a0b82-3fc0-47e2-bb36-a6653b5999ab) | ![image](https://github.com/mdn/yari/assets/15844309/52a9fe9e-3c00-45e4-b821-9a2bf4883688) |
| /en-US/docs/Mozilla/Firefox/Releases | default locale | ![image](https://github.com/mdn/yari/assets/15844309/6c116c64-5ed4-48e3-b106-60aa50144b80) | ![image](https://github.com/mdn/yari/assets/15844309/dc95e27c-d1ab-4917-ac3a-19daba5f3e3f) |
| /es/docs/Web/Progressive_web_apps/Guides | the first param is not given | ![image](https://github.com/mdn/yari/assets/15844309/5e734271-3c9e-490c-bc09-252246421257) | ![image](https://github.com/mdn/yari/assets/15844309/4f2d8fd4-4c76-4927-a020-f54b3c8c353a) |

### AddonSidebar

Check the "Manifest keys" section.

`/zh-CN/docs/Mozilla/Add-ons/Contact_us`

#### Before

![image](https://github.com/mdn/yari/assets/15844309/c4ce5d60-9449-4e70-9b8e-8290e02f201f)

#### After

![image](https://github.com/mdn/yari/assets/15844309/4e4e89f6-3e93-4989-8353-4ed4319a155b)

---

## How did you test this change?

Check the pages which has used `{{QuickLinksWithSubPages}}`, `{{ListSubpages}}`, or `{{AddonSidebar}}` macro.
