### PR TITLE
enhance(macros/SeeCompatTable): refer to BC table only if it exists

### DIFF
--- a/kumascript/macros/SeeCompatTable.ejs
+++ b/kumascript/macros/SeeCompatTable.ejs
@@ -1,15 +1,27 @@
 <%
 
-const str = mdn.localString({
-  "es": "<strong>Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a></strong><br />Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
-  "fr": "<strong>Cette fonction est expérimentale</strong><br />Puisque cette fonction est toujours en développement dans certains navigateurs, veuillez consulter le <a href='#compatibilité_des_navigateurs'>tableau de compatibilité</a> pour les préfixes à utiliser selon les navigateurs.<br />Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
-  "ja": "<strong>これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。</strong><br />本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
-  "ko": "<strong>이 기능은 <a href='/ko/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#실험적'>실험적인 기능</a>입니다.</strong><br />프로덕션 환경에서 사용하기 전에 <a href='#브라우저_호환성'>브라우저 호환성 표</a>를 주의 깊게 확인하세요.",
-  "zh-CN": "<strong>这是一项<a href='/zh-CN/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#实验性'>实验性技术</a></strong><br />在将其用于生产之前，请仔细检查<a href='#浏览器兼容性'>浏览器兼容性表格</a>。",
-  "zh-TW": "<strong>這是一個<a href='/zh-TW/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#實驗性質'>實驗中的功能</a></strong><br />此功能在某些瀏覽器尚在開發中，請參考<a href='#瀏覽器相容性'>兼容表格</a>以得到不同瀏覽器用的前輟。",
-  "en-US": "<strong>This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a></strong><br />Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
-  "pt-BR": "<strong>Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a></strong><br />Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
-  "ru": "<strong>Это экспериментальная технология</strong><br />Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
+const description = mdn.localString({
+  "es": "Esta es una <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnología experimental</a>",
+  "fr": "Cette fonction est expérimentale",
+  "ja": "これは<a href='/ja/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#実験的'>実験的な機能</a>です。",
+  "ko": "이 기능은 <a href='/ko/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#실험적'>실험적인 기능</a>입니다.",
+  "zh-CN": "这是一项<a href='/zh-CN/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#实验性'>实验性技术</a>",
+  "zh-TW": "這是一個<a href='/zh-TW/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete#實驗性質'>實驗中的功能</a>",
+  "en-US": "This is an <a href='/en-US/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>experimental technology</a>",
+  "pt-BR": "Esta é uma <a href='/pt-BR/docs/MDN/Contribute/Guidelines/Conventions_definitions#experimental'>tecnologia experimental</a>",
+  "ru": "Это экспериментальная технология."
+});
+
+const seeCompatTable = mdn.localString({
+  "es": "Comprueba la <a href='#browser_compatibility'>Tabla de compabilidad de navegadores</a> cuidadosamente antes de usarla en producción.",
+  "fr": "Il convient de noter qu'une fonctionnalité expérimentale peut voir sa syntaxe ou son comportement modifié dans le futur en fonction des évolutions de la spécification.",
+  "ja": "本番で使用する前に<a href='#ブラウザーの互換性'>ブラウザー互換性一覧表</a>をチェックしてください。",
+  "ko": "프로덕션 환경에서 사용하기 전에 <a href='#브라우저_호환성'>브라우저 호환성 표</a>를 주의 깊게 확인하세요.",
+  "zh-CN": "在将其用于生产之前，请仔细检查<a href='#浏览器兼容性'>浏览器兼容性表格</a>。",
+  "zh-TW": "此功能在某些瀏覽器尚在開發中，請參考<a href='#瀏覽器相容性'>兼容表格</a>以得到不同瀏覽器用的前輟。",
+  "en-US": "Check the <a href='#browser_compatibility'>Browser compatibility table</a> carefully before using this in production.",
+  "pt-BR": "Verifique a <a href='#browser_compatibility'>tabela de compatibilidade entre Navegadores</a> cuidadosamente antes de usar essa funcionalidade em produção.",
+  "ru": "Так как спецификация этой технологии ещё не стабилизировалась, смотрите <a href='#browser_compatibility'>таблицу совместимости</a> по поводу использования в различных браузерах. Также заметьте, что синтаксис и поведение экспериментальной технологии может измениться в будущих версиях браузеров, вслед за изменениями спецификации."
 });
 
 const title = mdn.localString({
@@ -27,5 +39,5 @@ const title = mdn.localString({
 %>
 <div class="notecard experimental">
     <h4><%= title %></h4>
-    <p><%- str %></p>
+    <p><strong><%- description %></strong><% if (env['browser-compat']) { %><br /><%- seeCompatTable %><% } %></p>
 </div>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/rari/issues/174.

### Problem

The `{{SeeCompatTable}}` macro refers to the browser compatibility table, even if the page doesn't have one.

### Solution

Only show it on pages that have a `browser-compat` frontmatter key.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1352" alt="image" src="https://github.com/mdn/yari/assets/495429/b60108d4-af0f-4c64-8ba5-755c7edcdbc8">

### After

<img width="1352" alt="image" src="https://github.com/mdn/yari/assets/495429/d41d1e76-d45d-4957-bb05-125e8d59cfe3">

---

## How did you test this change?

Ran `yarn dev` locally and checked the following pages:

- http://localhost:3000/en-US/docs/Web/API/WebUSB_API (no BCD table)
- http://localhost:3000/en-US/docs/Web/API/USBInterface (has BCD table)
