### PR TITLE
fix(macros/EmbedLiveSample): move sandbox attr behind ending tag

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -100,6 +100,5 @@ if (height) { %> height="<%= height %>"<% }
 %> src="<%- url %>"<%
 if (allowedFeatures) { %> allow="<%= allowedFeatures %>"<% }
 if ($token) { %> data-token="<%= JSON.stringify($token) %>"<% }
-sandbox="allow-scripts allow-same-origin"
-%>></iframe></div><%
+%> sandbox="allow-same-origin allow-scripts"></iframe></div><%
 if (hasScreenshot) { %></td></tr></tbody></table><% } %>

--- a/kumascript/tests/macros/EmbedLiveSample.test.ts
+++ b/kumascript/tests/macros/EmbedLiveSample.test.ts
@@ -16,7 +16,8 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><div class="example-header"></div><iframe class="sample-code-frame"' +
         ' title="Quotations sample"' +
         ' id="frame_quotations"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=quotations">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=quotations"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -28,7 +29,8 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><div class="example-header"></div><iframe class="sample-code-frame"' +
         ' title="SVG &amp;lt;switch&amp;gt; example sample"' +
         ' id="frame_svg_ltswitchgt_example"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_ltswitchgt_example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_ltswitchgt_example"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -39,7 +41,8 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><div class="example-header"></div><iframe class="sample-code-frame"' +
         ' title="SVG %3Cswitch%3E example sample"' +
         ' id="frame_svg_switch_example"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_switch_example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/SVG/Element/switch/runner.html?id=svg_switch_example"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -51,7 +54,8 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><div class="example-header"></div><iframe class="sample-code-frame"' +
         ' title="Dégradés linéaires simples sample"' +
         ' id="frame_dégradés_linéaires_simples"' +
-        ' src="https://live.mdnplay.dev/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS/runner.html?id=d%C3%A9grad%C3%A9s_lin%C3%A9aires_simples">' +
+        ' src="https://live.mdnplay.dev/fr/docs/Web/CSS/Utilisation_de_d%C3%A9grad%C3%A9s_CSS/runner.html?id=d%C3%A9grad%C3%A9s_lin%C3%A9aires_simples"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -62,7 +66,8 @@ describeMacro("EmbedLiveSample", function () {
       '<div class="code-example"><div class="example-header"></div><iframe class="sample-code-frame"' +
         ' title="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt; sample"' +
         ' id="frame_scriptalertxssscript"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=scriptalertxssscript">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=scriptalertxssscript"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -74,7 +79,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Example sample"' +
         ' id="frame_example"' +
         ' width="100%"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -86,7 +92,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Example sample"' +
         ' id="frame_example"' +
         ' width="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/border-top-width/runner.html?id=example"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -98,7 +105,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Images sample"' +
         ' id="frame_images"' +
         ' width="100%" height="250"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -111,7 +119,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="增加关键帧 sample"' +
         ' id="frame_增加关键帧"' +
         ' width="100%" height="250"' +
-        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations/runner.html?id=%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7">' +
+        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/CSS/CSS_Animations/Using_CSS_animations/runner.html?id=%E5%A2%9E%E5%8A%A0%E5%85%B3%E9%94%AE%E5%B8%A7"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -127,7 +136,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6 sample"' +
         ' id="frame_一个模板骨架"' +
         ' width="160" height="160"' +
-        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage/runner.html?id=%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6">' +
+        ' src="https://live.mdnplay.dev/zh-CN/docs/Web/API/Canvas_API/Tutorial/Basic_usage/runner.html?id=%E4%B8%80%E4%B8%AA%E6%A8%A1%E6%9D%BF%E9%AA%A8%E6%9E%B6"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -139,7 +149,8 @@ describeMacro("EmbedLiveSample", function () {
         ' title="Images sample"' +
         ' id="frame_images"' +
         ' width="100%" height="&#34;&gt;&lt;script&gt;alert(&#34;XSS&#34;);&lt;/script&gt;"' +
-        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images">' +
+        ' src="https://live.mdnplay.dev/en-US/docs/Web/HTML/Element/figure/runner.html?id=images"' +
+        ' sandbox="allow-same-origin allow-scripts">' +
         "</iframe></div>"
     );
   });
@@ -148,7 +159,8 @@ describeMacro("EmbedLiveSample", function () {
     ' title="Examples sample"' +
     ' id="frame_examples"' +
     ' width="700px" height="700px"' +
-    ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/flex-wrap/runner.html?id=examples">' +
+    ' src="https://live.mdnplay.dev/en-US/docs/Web/CSS/flex-wrap/runner.html?id=examples"' +
+    ' sandbox="allow-same-origin allow-scripts">' +
     "</iframe></div>";
   itMacro("Three arguments: ID, width, height (same slug)", function (macro) {
     macro.ctx.env.url = "/en-US/docs/Web/CSS/flex-wrap";


### PR DESCRIPTION
## Summary

- fixes https://github.com/mdn/content/issues/32019

### Problem

`sandbox="allow-same-origin allow-scripts` is not getting rendered in the build/preview output.

### Solution

It is because there is a typo in the EmbedLiveSample macro code. The `%>` is misplaced. 

---

## Screenshots

It is not a visual change.

---

## How did you test this change?

In local before and after change. A after the change the rendered live sample iframe started having `sandbox="allow-same-origin allow-script"` permission string.