### PR TITLE
chore(surveys): close German locale survey

### DIFF
--- a/client/src/ui/molecules/document-survey/surveys.ts
+++ b/client/src/ui/molecules/document-survey/surveys.ts
@@ -1,5 +1,4 @@
 import { Doc } from "../../../../../libs/types/document";
-import { survey_duration, survey_rates } from "../../../env";
 
 export interface Survey {
   key: SurveyKey;
@@ -48,17 +47,4 @@ enum SurveyKey {
   DISCOVERABILITY_AUG_2023 = "DISCOVERABILITY_AUG_2023",
 }
 
-export const SURVEYS: Survey[] = [
-  {
-    key: SurveyKey.DE_LOCALE_2024,
-    bucket: SurveyBucket.DE_LOCALE_2024,
-    show: () => (navigator?.language || "").startsWith("de"),
-    src: "https://survey.alchemer.com/s3/7881145/MDN-German-Locale-Survey",
-    teaser: "Wie wär’s, wenn MDN auf Deutsch verfügbar wäre?",
-    question: "Welche Sprache würdest du dann benutzen?",
-    footnote:
-      "You're seeing this survey, because your browser indicates German as your preferred language.",
-    ...survey_duration(SurveyBucket.DE_LOCALE_2024),
-    ...survey_rates(SurveyKey.DE_LOCALE_2024),
-  },
-];
+export const SURVEYS: Survey[] = [];


### PR DESCRIPTION
## Summary

(MP-1192)

### Problem

We're running a German locale survey since Saturday, June 8th, and we have received enough responses.

### Solution

Close the survey, removing it from the site.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1153" alt="image" src="https://github.com/mdn/yari/assets/495429/d8955f6a-4f91-442b-9b87-94c6f760bd17">

### After

<img width="1153" alt="image" src="https://github.com/mdn/yari/assets/495429/282931ef-1adc-4428-b5e0-3d4d1cb757b5">

---

## How did you test this change?

Ran `yarn dev` and checked http://localhost:3000/en-US/docs/Web locally.