### PR TITLE
feat(workflows): add test-de-build stub

### DIFF
--- a/.github/workflows/test-de-build.yml
+++ b/.github/workflows/test-de-build.yml
@@ -1,0 +1,24 @@
+name: Test-DE Build
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron: "0 */24 * * *"
+
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: "Notes"
+        required: false
+        default: ${DEFAULT_NOTES}
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    # When run from `main` branch (schedule or manual), trigger workflow on `test-de` branch instead.
+    if: ${{ github.repository == 'mdn/yari' && github.ref_name == 'main'  }}
+    steps:
+      - run: gh workflow run "${{ github.workflow }}" --repo "${{ github.repository }}" --ref "test-de"
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## Summary

(MP-1177)

### Problem

We have a new environment that we want to deploy regularly, but using the workflow version from the branch.

### Solution

Add new workflow, using the same approach as the stage-build, triggering a run on the `test-de` when run on the `main` branch (manually or via schedule). 

---

## How did you test this change?

This cannot really be tested, but the approach works for the `stage-build`, and the `test-de-build` is working (tested by copying the new workflow to the `xyz-build`, and manually running that existing workflow).