### PR TITLE
fix(playground): preserve HTML comments

### DIFF
--- a/client/public/runner.html
+++ b/client/public/runner.html
@@ -62,8 +62,12 @@
           parent.innerHTML = html;
         } else {
           for (const child of dummy.childNodes) {
-            if (child.nodeType == Node.TEXT_NODE) {
+            if (child.nodeType === Node.TEXT_NODE) {
               parent.appendChild(document.createTextNode(child.textContent));
+              continue;
+            }
+            if (child.nodeType === Node.COMMENT_NODE) {
+              parent.appendChild(document.createComment(child.data));
               continue;
             }
             if (child.nodeType !== Node.ELEMENT_NODE) {


### PR DESCRIPTION
This fixes MDN examples involving comments (e.g. https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/data), as well as being the Correct thing to do.

I also took the liberty of converting that `==` into an `===` since I am 99.999% sure the `==` was not intended.

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

It fixes [this example of reading a Comment's `data`](https://developer.mozilla.org/en-US/docs/Web/API/CharacterData/data#reading_a_comment_using_data). There may be other examples that are fixed by this, IDK, I don't have it in me to even try to figure out how to figure that out.

I did not file an issue first because I am tired, and I do not understand the point of filing an issue first if I already have the code to fix the problem, and I am fairly certain the issue is not contentious (or at least, I don't think it should be...?)

I also did not run `yarn`, or sign my commits, sorry. That's a lot of work to put in for a small drive-by fix. If this is a blocker but the actual code looks OK, feel free to just steal it & re-apply in a proper commit. I'd like to be credited if so but I'd rather the fix get committed without any credit to me than the fix not get committed at all.

### Problem

Comments are discarded (elided?) when running the playground.

### Solution

It clones comments too instead of discarding them.

---

## How did you test this change?

I did not; the code is extremely simple & very obviously correct.
