### PR TITLE
fix(seo): remove contributors.txt from robots.txt

### DIFF
--- a/tool/build-robots-txt.ts
+++ b/tool/build-robots-txt.ts
@@ -12,7 +12,6 @@ User-agent: *
 Sitemap: https://developer.mozilla.org/sitemap.xml
 
 Disallow: /api/
-Disallow: /*/contributors.txt
 Disallow: /*/files/
 Disallow: /media
 `;


### PR DESCRIPTION
## Summary

(MP-1199)

### Problem

We added `*/contributors.txt` to the `robots.txt` with the intention to hide those pages from Google, but in fact it seems to prevent Google from seeing the `X-Robots-Tag` header, so Google keeps the pages in the index, although we would like to have them removed from the index.

### Solution

Remove the `*/contributors.txt` entry from the `robots.txt` again.

---

## How did you test this change?

Trivial change.