### PR TITLE
chore(footer): add locale to www.mozilla.org links

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -179,7 +179,7 @@ export function Footer() {
 
         <div className="page-footer-moz">
           <a
-            href="https://www.mozilla.org/"
+            href={`https://www.mozilla.org/${locale}/`}
             className="footer-moz-logo-link"
             target="_blank"
             rel="noopener noreferrer"
@@ -189,7 +189,7 @@ export function Footer() {
           <ul className="footer-moz-list">
             <li className="footer-moz-item">
               <a
-                href="https://www.mozilla.org/privacy/websites/"
+                href={`https://www.mozilla.org/${locale}/privacy/websites/`}
                 className="footer-moz-link"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -199,7 +199,7 @@ export function Footer() {
             </li>
             <li className="footer-moz-item">
               <a
-                href="https://www.mozilla.org/privacy/websites/#cookies"
+                href={`https://www.mozilla.org/${locale}/privacy/websites/#cookies`}
                 className="footer-moz-link"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -209,7 +209,7 @@ export function Footer() {
             </li>
             <li className="footer-moz-item">
               <a
-                href="https://www.mozilla.org/about/legal/terms/mozilla"
+                href={`https://www.mozilla.org/${locale}/about/legal/terms/mozilla`}
                 className="footer-moz-link"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -219,7 +219,7 @@ export function Footer() {
             </li>
             <li className="footer-moz-item">
               <a
-                href="https://www.mozilla.org/about/governance/policies/participation/"
+                href={`https://www.mozilla.org/${locale}/about/governance/policies/participation/`}
                 className="footer-moz-link"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -233,7 +233,7 @@ export function Footer() {
           <p id="license" className="page-footer-legal-text">
             Visit{" "}
             <a
-              href="https://www.mozilla.org"
+              href={`https://www.mozilla.org/${locale}/`}
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Summary

(MP-1200)

### Problem

We link to several www.mozilla.org pages in the footer, but these don't include the current locale, causing a redirect.

### Solution

Add the locale to the links.

---

## How did you test this change?

Ran `yarn dev` locally and verified the link works in these locales:

- [x] en-US
- [x] es
- [x] fr
- [x] ja
- [ ] ko
- [x] pt-BR
- [x] ru
- [x] zh-CN
- [ ] zh-TW
