### PR TITLE
fix(build): prevent adding `only-in-en-us` css class to external links

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -329,10 +329,8 @@ export function getBrokenLinksFlaws(
                 const enUSResolved = Redirect.resolve(enUSHrefNormalized);
                 let suggestion = null;
                 let enUSFallbackURL = null;
-                const hostname = new URL(enUSResolved, "http://www.example.com")
-                  .hostname;
                 // check if the resolved URL is an external URL
-                if (hostname !== "www.example.com") {
+                if (!enUSResolved.startsWith("/")) {
                   // external URL
                   suggestion = enUSResolved;
                 } else if (enUSResolved !== enUSHrefNormalized) {

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -329,7 +329,13 @@ export function getBrokenLinksFlaws(
                 const enUSResolved = Redirect.resolve(enUSHrefNormalized);
                 let suggestion = null;
                 let enUSFallbackURL = null;
-                if (enUSResolved !== enUSHrefNormalized) {
+                const hostname = new URL(enUSResolved, "http://www.example.com")
+                  .hostname;
+                // check if the resolved URL is an external URL
+                if (hostname !== "www.example.com") {
+                  // external URL
+                  suggestion = enUSResolved;
+                } else if (enUSResolved !== enUSHrefNormalized) {
                   enUSFallbackURL =
                     enUSResolved +
                     absoluteURL.search +

--- a/testing/content/files/en-us/_redirects.txt
+++ b/testing/content/files/en-us/_redirects.txt
@@ -5,3 +5,4 @@
 /en-US/docs/Web/HTML/Element/anchor	/en-US/docs/Web/HTML/Element/a
 /en-US/docs/Web/JavaScript/Reference/Stern_mode	/en-US/docs/Web/JavaScript/Reference/Strict_mode
 /en-US/docs/Web/JavaScript/Reference/Global_Objects/Flag	/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+/en-US/docs/Web/Redirect_to_external_page	https://external.example.com/

--- a/testing/translated-content/files/zh-cn/web/externallinks/index.md
+++ b/testing/translated-content/files/zh-cn/web/externallinks/index.md
@@ -1,0 +1,9 @@
+---
+title: An external link
+slug: Web/ExternalLinks
+---
+
+The following link should be redirected to an external site (see the
+`_redirects.txt` file in default locale):
+
+[redirected to external site](/zh-CN/docs/Web/Redirect_to_external_page)


### PR DESCRIPTION
## Summary

Fixes: mdn/rari#348

### Problem

The resolved redirection link may also be an external one. But we haven't check this before assigning the `enUSFallbackURL`, which caused the `only-in-en-us` CSS class to be added accidentally to the external links.

### Solution

Check whether the resolved URL is an external one, if so, do not assign the `enUSFallbackURL`. Which means, the `only-in-en-us` CSS class would not be added.

---

## Screenshots

Checkout the git commit sha `f277be087b9484b077fc734e5192d83bc3ee04a1`, which is the last commit sha before the fix in translated-content (mdn/translated-content#21711).

Check the section `/zh-CN/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension#打包和发布`:

### Before

See: mdn/rari#348

### After

![image](https://github.com/mdn/yari/assets/15844309/e09688ea-8c7d-4b3a-ac27-63e86903ce73)

---

## How did you test this change?

Run `yarn dev`, and check the rendered page.
