### PR TITLE
fix(build): fix iframe title + div ids

### DIFF
--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -52,8 +52,8 @@ var MIN_HEIGHT = 60;
 // Note that if the 'height' is a string like '100%' it won't be a
 // problem because `parseInt('100%') := 100` which is more than `MIN_HEIGHT`
 // assuming it's value is less than 100.
-if (height) {
-  height = Math.max(parseInt(height), MIN_HEIGHT);
+if (height && parseInt(height) < MIN_HEIGHT) {
+  height = MIN_HEIGHT;
 }
 
 var sampleUrl = "";

--- a/kumascript/macros/EmbedLiveSample.ejs
+++ b/kumascript/macros/EmbedLiveSample.ejs
@@ -52,8 +52,8 @@ var MIN_HEIGHT = 60;
 // Note that if the 'height' is a string like '100%' it won't be a
 // problem because `parseInt('100%') := 100` which is more than `MIN_HEIGHT`
 // assuming it's value is less than 100.
-if (height && parseInt(height) < MIN_HEIGHT) {
-  height = MIN_HEIGHT;
+if (height) {
+  height = Math.max(parseInt(height), MIN_HEIGHT);
 }
 
 var sampleUrl = "";

--- a/kumascript/src/api/util.ts
+++ b/kumascript/src/api/util.ts
@@ -313,7 +313,7 @@ export class HTMLTool {
       // then collect the closest blocks of code for the live sample.
       console.warn(
         chalk.yellow(
-          `invalid header id in live sample ${sectionID} within ${this.pathDescription}`
+          `Live sample references heading id ${sectionID}, but this doesn't exist in ${this.pathDescription}`
         )
       );
       result = collectClosestCode(findSectionStart(this.$, iframeID));

--- a/kumascript/src/api/util.ts
+++ b/kumascript/src/api/util.ts
@@ -4,15 +4,11 @@
  */
 import sanitizeFilename from "sanitize-filename";
 import * as cheerio from "cheerio";
+import chalk from "chalk";
 
 const H1_TO_H6_TAGS = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
 const HEADING_TAGS = new Set([...H1_TO_H6_TAGS, "hgroup"]);
-const INJECT_SECTION_ID_TAGS = new Set([
-  ...HEADING_TAGS,
-  "section",
-  "div",
-  "dt",
-]);
+const INJECT_SECTION_ID_TAGS = new Set([...HEADING_TAGS, "section", "dt"]);
 const LIVE_SAMPLE_PARTS = ["html", "css", "js"];
 const SECTION_ID_DISALLOWED = /["#$%&+,/:;=?@[\]^`{|}~')(\\]/g;
 
@@ -130,7 +126,6 @@ function collectClosestCode($start) {
       ];
     });
     if (pairs.some(([, code]) => !!code)) {
-      $start.prop("title", $level.first(":header").text());
       return Object.fromEntries(pairs);
     }
   }
@@ -316,6 +311,11 @@ export class HTMLTool {
       // We're here because we can't find the sectionID, so instead we're going
       // to find the live-sample iframe by its id (iframeID, NOT sectionID), and
       // then collect the closest blocks of code for the live sample.
+      console.warn(
+        chalk.yellow(
+          `invalid header id in live sample ${sectionID} within ${this.pathDescription}`
+        )
+      );
       result = collectClosestCode(findSectionStart(this.$, iframeID));
       if (!result) {
         throw new KumascriptError(

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/index.html
@@ -16,7 +16,7 @@ that the page must be fully rendered before extracting the live samples,
 and also tests that prerequisites are handled as part of the rendering
 and live-sample-building process.
 -->
-<div id="Flex_1">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_1") }}</div>
+<section id="Flex_1">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_1") }}</section>
 <p>{{ EmbedLiveSample('Flex_1', '300', '200') }}</p>
-<div id="Flex_2">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_2") }}</div>>
+<section id="Flex_2">{{ Page("Learn/CSS/CSS_layout/Introduction/Flex/Stuff", "Flex_2") }}</section>>
 <p>{{ EmbedLiveSample('Flex_2', '300', '200') }}</p>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/flex/stuff/index.html
@@ -10,7 +10,7 @@ tags:
   - Learn
   - flexbox
 ---
-<div id="Flex_1">
+<section id="Flex_1">
 <div class="hidden">
 <h6 id="Flexbox_Example_1">Flexbox Example 1</h6>
 
@@ -35,9 +35,9 @@ tags:
   &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
+</section>
 
-<div id="Flex_2">
+<section id="Flex_2">
 <div class="hidden">
 <h6 id="Flexbox_Example_2">Flexbox Example 2</h6>
 
@@ -66,4 +66,4 @@ tags:
     &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
+</section>

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/grid/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/grid/index.html
@@ -17,7 +17,7 @@ and also tests that prerequisites are handled as part of the rendering
 and live-sample-building process.
 -->
 
-<div id="Grid_1">
+<section id="Grid_1">
 <div class="hidden">
 <h6 id="Grid_example_1">Grid example 1</h6>
 
@@ -48,10 +48,10 @@ and live-sample-building process.
     &lt;div class="box6"&gt;Six&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
+</section>
 {{ EmbedLiveSample('Grid_1', '300', '330') }}
 
-<div id="Grid_2">
+<section id="Grid_2">
 <div class="hidden">
 <h6 id="Grid_example_2">Grid example 2</h6>
 
@@ -94,5 +94,5 @@ and live-sample-building process.
     &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
+</section>
 {{ EmbedLiveSample('Grid_2', '300', '330') }}

--- a/testing/content/files/en-us/learn/css/css_layout/introduction/index.html
+++ b/testing/content/files/en-us/learn/css/css_layout/introduction/index.html
@@ -29,7 +29,7 @@ and some from other pages.
 
 <h2 id="Grid_Layout">Grid Layout</h2>
 <p>{{ EmbedLiveSample('Grid_1', '300', '330', "", "Learn/CSS/CSS_layout/Introduction/Grid") }}</p>
-<div id="Grid_2">
+<section id="Grid_2">
 <div class="hidden">
 <h6 id="Grid_example_2">Grid example 2</h6>
 
@@ -72,6 +72,6 @@ and some from other pages.
     &lt;div class="box3"&gt;Three&lt;/div&gt;
 &lt;/div&gt;
 </pre>
-</div>
+</section>
 
 <p>{{ EmbedLiveSample('Grid_2', '300', '330') }}</p>


### PR DESCRIPTION
## Summary

- Don't mututate the DOM in collectClosestCode. We'll use the same title as with regual live samples.
- Don't add ids to divs?! Currnet we add ids to notes by accident: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_grid_layout/Masonry_layout#sect1



---

## How did you test this change?
Locally
