### PR TITLE
fix(build): return early on error

### DIFF
--- a/client/scripts/build.js
+++ b/client/scripts/build.js
@@ -76,7 +76,7 @@ function build() {
             err["postcssNode"].selector;
         }
 
-        reject(errMessage);
+        return reject(errMessage);
       }
       if (stats.hasErrors()) {
         return reject(


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Fixes a flaw in the build script

### Problem

Error condition/reject did not return and subsequent code continued to be execute, leading to unhelpful error messages.

### Solution

Return the rejected promise

---

## How did you test this change?

locally
