### PR TITLE
fix(baseline): hide on /MDN/ pages

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -548,7 +548,7 @@ export async function buildDocument(
 }
 
 function addBaseline(doc: Partial<Doc>) {
-  if (doc.browserCompat) {
+  if (doc.browserCompat && !doc.mdn_url?.includes("/docs/MDN/")) {
     const filteredBrowserCompat = doc.browserCompat.filter(
       (query) =>
         // temporary blocklist while we wait for per-key baseline statuses


### PR DESCRIPTION
## Summary

Fixes #11328.

### Problem

The Baseline banner was also shown on the [Compatibility tables and the browser compatibility data repository (BCD)](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables) page, which is part of the [MDN Writing Guidelines](https://developer.mozilla.org/en-US/docs/MDN/Writing_guidelines).

### Solution

Hide the Baseline banner in the MDN meta docs.

---

## Screenshots

### Before

<img width="1143" alt="image" src="https://github.com/mdn/yari/assets/495429/cf18e377-b0ca-4469-9246-0690ceff99b2">

### After

<img width="1143" alt="image" src="https://github.com/mdn/yari/assets/495429/1762d4ac-b432-4eb4-836f-abd3f7c17751">

---

## How did you test this change?

Ran `yarn dev` and checked these pages locally:

- http://localhost:3000/en-US/docs/MDN/Writing_guidelines/Page_structures/Compatibility_tables
- http://localhost:3000/en-US/docs/Web/CSS/grid