### PR TITLE
fix(search): hide "No query, no results" on server

### DIFF
--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -64,7 +64,7 @@ export function SiteSearch() {
               {page && page !== "1" && `(page ${page})`}
             </h1>
           ) : (
-            <h1>No query, no results.</h1>
+            !isServer && <h1>No query, no results.</h1>
           )}
 
           {!isServer && (


### PR DESCRIPTION
## Summary

Fixes #4006.

### Problem

When opening the full-text search, a "No query, no results" message appears shortly, because the query is empty during server-side rendering.

### Solution

Hide the message during server-side rendering.

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/en-US/search/?q=html with the internet connection slowed down via DevTools.