### PR TITLE
fix(package): run render:html on prepack

### DIFF
--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -91,8 +91,8 @@ jobs:
           curl --retry-connrefused --retry 5 -I http://localhost:5042
 
           # Basically, test if it 200 OKs. If not, this'll exit non-zero.
-          curl http://localhost:5042/en-US/ > /dev/null
-          curl http://localhost:5042/en-US/docs/MDN/Kitchensink > /dev/null
+          curl --fail http://localhost:5042/en-US/ > /dev/null
+          curl --fail http://localhost:5042/en-US/docs/MDN/Kitchensink > /dev/null
 
       - name: Test viewing the dev server
         env:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "install:all:npm": "find . -mindepth 2 -name 'package-lock.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -0 sh -cx 'npm --prefix $(dirname $0) install'",
     "jest": "node --experimental-vm-modules --expose-gc ./node_modules/.bin/jest --logHeapUsage",
     "m2h": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node markdown/m2h/cli.ts",
-    "prepack": "yarn build:dist",
+    "prepack": "yarn render:html && yarn build:dist",
     "prepare": "(husky || true) && yarn install:all && yarn install:all:npm",
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",


### PR DESCRIPTION
## Summary

Fixes #11365.

### Problem

Since https://github.com/mdn/yari/pull/10953, `yarn tool spas` no longer builds `index.html` files, and these are instead built via `yarn render:html`, but this command isn't run when packaging yari for npm.

### Solution

Run `yarn render:html` as part of the `prepack` script.

---

## How did you test this change?

Fixed the `npm-published-simulation.yml` workflow to actually fail when http://localhost:5042/en-US/ returns an HTTP error.