### PR TITLE
chore(macros/WebExtExamples): add zh translations

### DIFF
--- a/kumascript/macros/WebExtExamples.ejs
+++ b/kumascript/macros/WebExtExamples.ejs
@@ -27,7 +27,7 @@ const desiredHeading = $0 || "h3";
 const s_example_addons = mdn.localString({
     "en-US": "Example extensions",
     "zh-CN": "示例扩展",
-    "zh-TW": "示例擴充套件",
+    "zh-TW": "範例擴充套件",
 });
 
 /*

--- a/kumascript/macros/WebExtExamples.ejs
+++ b/kumascript/macros/WebExtExamples.ejs
@@ -25,7 +25,9 @@ const examplesBaseURL = "https://github.com/mdn/webextensions-examples/tree/main
 const desiredHeading = $0 || "h3";
 
 const s_example_addons = mdn.localString({
-    "en-US": "Example extensions"
+    "en-US": "Example extensions",
+    "zh-CN": "示例扩展",
+    "zh-TW": "示例擴充套件",
 });
 
 /*


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->
add zh-CN and zh-TW localization of WebExtExamples macro

zh-TW localization of "WebExtension" is referenced [here](https://addons.mozilla.org/zh-TW/firefox/addon/motrixwebextension/)

/cc @mdn/yari-content-zh 