### PR TITLE
fix(macros/LearnSidebar): add missing entry

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -447,6 +447,7 @@ const sections = [
           "CSS/Building_blocks/Sizing_items_in_CSS",
           "CSS/Building_blocks/Images_media_form_elements",
           "CSS/Building_blocks/Styling_tables",
+          "CSS/Building_blocks/Advanced_styling_effects",
           "CSS/Building_blocks/Debugging_CSS",
           "CSS/Building_blocks/Organizing",
           "CSS/Building_blocks/Fundamental_CSS_comprehension",


### PR DESCRIPTION
## Summary

- related to https://github.com/mdn/content/pull/34534

### Solution

Add a new entry `Advanced_styling_effects` to the macro.

---

## How did you test this change?

In the local dev environment tested with and without the changes.