### PR TITLE
fix(pong): fix invalid default value

### DIFF
--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -53,7 +53,7 @@ export function SidePlacement() {
 
   return !placementData?.side ? (
     <section className="place side"></section>
-  ) : placementData.side.cta ? (
+  ) : placementData.side.cta && placementData.side.heading ? (
     <PlacementInner
       pong={placementData.side}
       extraClassNames={["side", "new-side"]}

--- a/libs/pong/pong2.js
+++ b/libs/pong/pong2.js
@@ -95,16 +95,7 @@ export function createPong2GetHandler(zoneKeys, coder) {
           if (v === null) {
             return null;
           }
-          const {
-            copy,
-            image,
-            alt,
-            click,
-            view,
-            cta,
-            colors,
-            heading = {},
-          } = v;
+          const { copy, image, alt, click, view, cta, colors, heading } = v;
           return [
             p,
             {


### PR DESCRIPTION
## Summary

Don't default to an object for the heading (shouldn't have been there in the first place).


### Problem

This causes a blank page when cta was set. Which it shouldn't be.
