### PR TITLE
enhance(server): introduce SERVER_HOST variable

### DIFF
--- a/docs/envvars.md
+++ b/docs/envvars.md
@@ -193,6 +193,12 @@ Flaw types to be fixed when running `fix-flaws`.
 
 ## Server
 
+### `SERVER_HOST`
+
+**Default: (undefined)**
+
+Set this to `0.0.0.0` to access the server from a different local device.
+
 ### `SERVER_PORT`
 
 **Default: `5042`**

--- a/server/index.ts
+++ b/server/index.ts
@@ -463,9 +463,10 @@ console.log(
     : ""
 );
 
+const HOST = process.env.SERVER_HOST || undefined;
 const PORT = parseInt(process.env.SERVER_PORT || "5042");
-app.listen(PORT, () => {
-  console.log(`Listening on port ${PORT}`);
+app.listen(PORT, HOST, () => {
+  console.log(`Listening on ${HOST ? `${HOST}:` : "port "}${PORT}`);
   if (process.env.EDITOR) {
     console.log(`Your EDITOR is set to: ${chalk.bold(process.env.EDITOR)}`);
   } else {

--- a/server/static.ts
+++ b/server/static.ts
@@ -253,5 +253,8 @@ app.get("/*", async (req, res) => {
     .sendFile(path.join(STATIC_ROOT, "en-us", "_spas", "404.html"));
 });
 
+const HOST = process.env.SERVER_HOST || undefined;
 const PORT = parseInt(process.env.SERVER_PORT || "5042");
-app.listen(PORT, () => console.log(`Listening on port ${PORT}`));
+app.listen(PORT, HOST, () =>
+  console.log(`Listening on ${HOST ? `${HOST}:` : "port "}${PORT}`)
+);


### PR DESCRIPTION
## Summary

Fixes #2298.

### Problem

Currently, it isn't possible to preview the local dev environment on a different local device, like a smartphone, because the server is only reachable locally.

### Solution

Introduce a `SERVER_HOST` environment variable that allows accessing the server when setting it to `0.0.0.0`.

---

## How did you test this change?

Ran `SERVER_HOST=0.0.0.0 yarn start:static-server` and verified I can access the server from another device on the local network.