### PR TITLE
chore(macros/LearnSidebar): add Event bubbling guide

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -515,6 +515,7 @@ const sections = [
           "JavaScript/Building_blocks/Build_your_own_function",
           "JavaScript/Building_blocks/Return_values",
           "JavaScript/Building_blocks/Events",
+          "JavaScript/Building_blocks/Event_bubbling",
           "JavaScript/Building_blocks/Image_gallery",
         ]
       },


### PR DESCRIPTION
## Summary

Add event bubbling guide to Learn sidebar.

### Problem

https://github.com/mdn/content/pull/34496 added a new chapter to the JS "building blocks" module, and it needs to appear in the Learn sidebar.

### Solution

Add it to the Learn sidebar.

---

## Screenshots


### Before

<img width="314" alt="Screen Shot 2024-07-01 at 9 32 22 AM" src="https://github.com/mdn/yari/assets/432915/c8558056-6d21-482e-9749-bcad0a994761">


### After

<img width="333" alt="Screen Shot 2024-07-01 at 9 29 06 AM" src="https://github.com/mdn/yari/assets/432915/53ff2b42-73a7-4571-8d90-869caad24544">


---

## How did you test this change?

Ran yarn dev, looked at screen.