### PR TITLE
fix(build): ignore GITHUB_REF in mdn/yari

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -67,7 +67,10 @@ function getCurrentGitBranch(root: string) {
     // Only bother getting fancy if the root is CONTENT_ROOT.
     // For other possible roots, just leave it to the default.
     if (root === CONTENT_ROOT) {
-      if (process.env.GITHUB_REF) {
+      if (
+        process.env.GITHUB_REF &&
+        process.env.GITHUB_REPOSITORY !== "mdn/yari"
+      ) {
         name = process.env.GITHUB_REF.split("/").slice(2).join("/");
       } else {
         // Most probably, you're hacking on the content, using Yari to preview,


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

On stage, the "View this page on GitHub" links to the mdn/content repo always point to the `next` branch, even though the build used the `main` content branch, because the build system uses the `GITHUB_REF` environment variable.

### Solution

Ignore the `GITHUB_REF` environment variable in mdn/yari.

---

## How did you test this change?

Deployed to stage and tested that "View this page on GitHub" on https://developer.allizom.org/en-US/docs/Learn/HTML links to the right content branch (`main`).