### PR TITLE
fix(observatory): update landing page copy

### DIFF
--- a/client/src/observatory/landing.tsx
+++ b/client/src/observatory/landing.tsx
@@ -96,10 +96,11 @@ export default function ObservatoryLanding() {
                 Launched in 2016, the HTTP Observatory enhances web security by
                 analyzing compliance with best security practices. It has
                 provided insights to over 6.9 million websites through 47
-                million scans. If you still need to access the previous version
-                of HTTP Observatory,{" "}
-                <a href="https://observatory.mozilla.org/">click here</a>.
-                Please note the old Observatory is now deprecated and will soon
+                million scans. The{" "}
+                <a href="https://observatory.mozilla.org/">
+                  previous version of HTTP Observatory
+                </a>{" "}
+                is still available, however it is now deprecated and will soon
                 be sunsetted.
               </p>
               {isMutating ? (


### PR DESCRIPTION
## Summary

Updates the text on the Observatory landing page.

(MP-1314)

## Screenshots

### Before

<img width="667" alt="image" src="https://github.com/mdn/yari/assets/45551/b95d40c9-07b9-445f-904e-bb6f066cd52a">

### After

<img width="678" alt="image" src="https://github.com/mdn/yari/assets/45551/463bec61-60e1-4c6c-9de7-2e216cd12a57">

---

## How did you test this change?

locally