### PR TITLE
chore(flaws): exclude /en-US/observatory/* from broken-link flaw

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -286,7 +286,7 @@ export function getBrokenLinksFlaws(
     } else if (
       href.startsWith("/") &&
       !href.startsWith("//") &&
-      !/^\/(discord|en-US\/(blog|curriculum))(\/|$)/.test(href)
+      !/^\/(discord|en-US\/(blog|curriculum|observatory))(\/|$)/.test(href)
     ) {
       // Got to fake the domain to sensible extract the .search and .hash
       const absoluteURL = new URL(href, "http://www.example.com");

--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -234,6 +234,7 @@ export function getBrokenLinksFlaws(
     } else if (
       href.startsWith("https://developer.mozilla.org/") &&
       !href.startsWith("https://developer.mozilla.org/en-US/curriculum/") &&
+      !href.startsWith("https://developer.mozilla.org/en-US/observatory") &&
       !href.startsWith("https://developer.mozilla.org/en-US/blog/")
     ) {
       // It might be a working 200 OK link but the link just shouldn't

--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -326,7 +326,7 @@ var text = mdn.localStringMap({
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/X-Frame-Options`, null, "X-Frame-Options")%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Headers/X-XSS-Protection`, null, "X-XSS-Protection")%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/Security/Practical_implementation_guides`)%></li>
-                <li><a href="https://developer.mozilla.org/en-US/observatory">HTTP Observatory</a></li>
+                <li><a href="/en-US/observatory">HTTP Observatory</a></li>
             </ol>
         </details>
     </li>


### PR DESCRIPTION
## Summary

(MP-1320)

### Problem

Linking to HTTP Observatory from content causes a flaw.

### Solution

Add an exception in the broken-link flaw implementation.

---

## Screenshots

### Before

<img width="1145" alt="image" src="https://github.com/mdn/yari/assets/495429/466e3775-dd9c-4caa-9fc8-7f839f479b2f">

### After

<img width="1145" alt="image" src="https://github.com/mdn/yari/assets/495429/1509c752-c070-41fb-92e5-6113359e79a7">

---

## How did you test this change?

Ran `yarn dev` and checked locally:
- http://localhost:3000/en-US/docs/Web/HTTP for the link in the `HTTPSidebar`, and
- http://localhost:3000/en-US/docs/Web/Security/Practical_implementation_guides for the in-content links.
