### PR TITLE
enhance(ad-free): hide top-banner completely

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -102,7 +102,7 @@
     <script>
       /**
        * If we modify this script, we must update the CSP hash as follows:
-       * 1. Run `npx jest testing/tests/csp.test.ts --watch`
+       * 1. Run `yarn run jest testing/tests/csp.test.ts --watch`
        * 2. Open `libs/constants/index.js` and find the current hash in CSP_SCRIPT_SRC_VALUES.
        * 3. Remove the old "previous" hash and replace it with the old "current" hash.
        * 4. Replace the old "current" hash with the new hash from the failing test (step 1).
@@ -124,6 +124,8 @@
           o &&
             ((document.documentElement.className = o),
             (document.documentElement.style.backgroundColor = c[o]));
+          const n = window.localStorage.getItem("nop");
+          n && (document.documentElement.dataset["nop"] = n);
         } catch (e) {
           console.warn("Unable to read theme from localStorage", e);
         }

--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -322,6 +322,10 @@ section.place.hp-main {
       }
     }
   }
+
+  html[data-nop] & {
+    display: none;
+  }
 }
 
 div.empty-place {

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -170,10 +170,10 @@ function setSessionStorageData(data: User) {
 function setNoPlacementFlag(noAds: boolean) {
   try {
     if (noAds) {
-      window.localStorage.setItem("nop", "yes");
+      localStorage.setItem("nop", "yes");
       document.documentElement.dataset["nop"] = "yes";
     } else {
-      window.localStorage.removeItem("nop");
+      localStorage.removeItem("nop");
       delete document.documentElement.dataset["nop"];
     }
   } catch (e) {

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -167,6 +167,20 @@ function setSessionStorageData(data: User) {
   }
 }
 
+function setNoPlacementFlag(noAds: boolean) {
+  try {
+    if (noAds) {
+      window.localStorage.setItem("nop", "yes");
+      document.documentElement.dataset["nop"] = "yes";
+    } else {
+      window.localStorage.removeItem("nop");
+      delete document.documentElement.dataset["nop"];
+    }
+  } catch (e) {
+    console.warn("Unable to write nop to localStorage", e);
+  }
+}
+
 export function UserDataProvider(props: { children: React.ReactNode }) {
   const { data, error, isLoading, mutate } = useSWR<User | null, Error | null>(
     DISABLE_AUTH ? null : "/api/v1/whoami",
@@ -230,18 +244,7 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
       // The user is definitely signed in or not signed in.
       data.offlineSettings = OfflineSettingsData.read();
       setSessionStorageData(data);
-
-      try {
-        if (data?.settings?.noAds) {
-          window.localStorage.setItem("nop", "yes");
-          document.documentElement.dataset["nop"] = "yes";
-        } else {
-          window.localStorage.removeItem("nop");
-          delete document.documentElement.dataset["nop"];
-        }
-      } catch (e) {
-        console.warn("Unable to write nop to localStorage", e);
-      }
+      setNoPlacementFlag(data?.settings?.noAds ?? false);
 
       // Let's initialize the MDN Worker if applicable.
       if (!window.mdnWorker && data?.offlineSettings?.offline) {

--- a/client/src/user-context.tsx
+++ b/client/src/user-context.tsx
@@ -231,6 +231,18 @@ export function UserDataProvider(props: { children: React.ReactNode }) {
       data.offlineSettings = OfflineSettingsData.read();
       setSessionStorageData(data);
 
+      try {
+        if (data?.settings?.noAds) {
+          window.localStorage.setItem("nop", "yes");
+          document.documentElement.dataset["nop"] = "yes";
+        } else {
+          window.localStorage.removeItem("nop");
+          delete document.documentElement.dataset["nop"];
+        }
+      } catch (e) {
+        console.warn("Unable to write nop to localStorage", e);
+      }
+
       // Let's initialize the MDN Worker if applicable.
       if (!window.mdnWorker && data?.offlineSettings?.offline) {
         import("./settings/mdn-worker").then(({ getMDNWorker }) => {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -56,7 +56,7 @@ export function switchTheme(theme: Theme, set: (theme: Theme) => void) {
   const html = document.documentElement;
 
   if (window && html) {
-    html.classList.toggle(theme, true);
+    html.className = theme;
     html.style.backgroundColor = "";
 
     setTimeout(() => {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -56,7 +56,7 @@ export function switchTheme(theme: Theme, set: (theme: Theme) => void) {
   const html = document.documentElement;
 
   if (window && html) {
-    html.className = theme;
+    html.classList.toggle(theme, true);
     html.style.backgroundColor = "";
 
     setTimeout(() => {

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -84,9 +84,9 @@ export const CSP_SCRIPT_SRC_VALUES = [
 
   // 1. Theme switching.
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-uogddBLIKmJa413dyT0iPejBg3VFcO+4x6B+vw3jng0='",
-  // - Current hash:
   "'sha256-EehWlTYp7Bqy57gDeQttaWKp0ukTTEUKGP44h8GVeik='",
+  // - Current hash:
+  "'sha256-IISch7Ojsf7U3PG/Vf/EzMoRW8DLdWzbF1lkoYYSiWA='",
 ];
 export const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -86,7 +86,7 @@ export const CSP_SCRIPT_SRC_VALUES = [
   // - Previous hash (to avoid cache invalidation issues):
   "'sha256-EehWlTYp7Bqy57gDeQttaWKp0ukTTEUKGP44h8GVeik='",
   // - Current hash:
-  "'sha256-IISch7Ojsf7U3PG/Vf/EzMoRW8DLdWzbF1lkoYYSiWA='",
+  "'sha256-XNBp89FG76amD8BqrJzyflxOF9PaWPqPqvJfKZPCv7M='",
 ];
 export const CSP_DIRECTIVES = {
   "default-src": ["'self'"],


### PR DESCRIPTION
## Summary

(MP-1059)

### Problem

We’re showing the “Get real-time assistance with your coding queries. Try [AI Help](https://developer.mozilla.org/en-US/plus/ai-help) now!” top-banner fallback, even if paying subscribers have enabled the Ad-Free Experience.

### Solution

Hide the top-banner fallback if the Ad-Free Experience is enabled.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1418" alt="image" src="https://github.com/mdn/yari/assets/495429/645ef56a-f136-40ac-b970-19b5c9e53af2">

### After

<img width="1418" alt="image" src="https://github.com/mdn/yari/assets/495429/2ec67a08-16f3-4a41-aca8-a4b252d160e7">

---

## How did you test this change?

Ran `yarn dev` locally with local Rumba and changed the "Ad-free Experience" setting.
