### PR TITLE
fix(observatory): update FAQ question about move

### DIFF
--- a/copy/observatory/faq.md
+++ b/copy/observatory/faq.md
@@ -57,10 +57,10 @@ there is now no reason to provide the "public" flag.
 
 ## When did the move occur?
 
-HTTP Observatory was launched on MDN on July 2, 2024, with the existing Mozilla
-Observatory site redirecting to it. Other tools like TLS Observatory, SSH
-Observatory, and Third-party tests have been deprecated, and will be sunset in
-September 2024.
+The new HTTP Observatory was launched on MDN on July 2, 2024. The
+[old Mozilla Observatory](https://observatory.mozilla.org/) — containing HTTP
+Observatory plus other tools like TLS Observatory, SSH Observatory, and
+Third-party tests — has been deprecated and will be sunset in September 2024.
 
 > **Note:** Historic scan data has been preserved, and is included in the
 > provided scan history for each domain.


### PR DESCRIPTION
## Summary

(MP-1317)

### Problem

The Observatory FAQ mentions that the old Mozilla Observatory redirects, but it doesn't yet.

### Solution

Update the FAQ, removing the mention of the redirect.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1145" alt="image" src="https://github.com/mdn/yari/assets/495429/9280da7e-42d0-4535-885b-1c1ca0725a2c">

### After

<img width="1145" alt="image" src="https://github.com/mdn/yari/assets/495429/b61a671b-b573-4022-8d28-59e084203a05">


---

## How did you test this change?

Ran `yarn dev` locally and checked http://localhost:3000/en-US/observatory/docs/faq#when-did-the-move-occur-.
