### PR TITLE
fix(observatory): set sidebar/TOC background-color

### DIFF
--- a/client/src/observatory/docs/index.scss
+++ b/client/src/observatory/docs/index.scss
@@ -1,6 +1,7 @@
 @use "../../ui/vars" as *;
 
 .observatory {
+  --background-toc-active: var(--observatory-border);
   --category-color: var(--observatory-accent);
 
   .article-actions-container {


### PR DESCRIPTION
## Summary

(MP-1318)

### Problem

The current item in the sidebar and TOC of the HTTP Observatory docs has no background-color, which is inconsistent with other sidebars and TOCs.

### Solution

Define the `--background-toc-active` variable, which is used for this, reusing the `--observatory-border` color.

---

## Screenshots

### Before

<img width="1431" alt="image" src="https://github.com/mdn/yari/assets/495429/46a3c478-8a01-4c3b-814f-539133ee10c6">

<img width="1431" alt="image" src="https://github.com/mdn/yari/assets/495429/3673177e-3a7c-4214-8e15-f764648d1145">


### After

<img width="1431" alt="image" src="https://github.com/mdn/yari/assets/495429/b244f6eb-d40e-4e25-8f21-6e7fbd7fd7fb">
<img width="1431" alt="image" src="https://github.com/mdn/yari/assets/495429/cf38df5a-cec7-4ffc-a5bd-8fa0be4fc717">

---

## How did you test this change?

Will deploy to stage by July 5, 2024.