### PR TITLE
 fix(cloud-function): avoid double slash for canonical url with trailing slash

### DIFF
--- a/cloud-function/src/middlewares/redirect-non-canonicals.ts
+++ b/cloud-function/src/middlewares/redirect-non-canonicals.ts
@@ -34,13 +34,23 @@ export async function redirectNonCanonicals(
       typeof REDIRECTS[source] == "string" &&
       REDIRECTS[source] !== originalSource
     ) {
-      const target = REDIRECTS[source] + suffix + parsedUrl.search;
-      return redirect(res, target, {
-        status: 301,
-        cacheControlSeconds: THIRTY_DAYS,
-      });
+      const target = joinPath(REDIRECTS[source], suffix) + parsedUrl.search;
+      if (pathname !== target) {
+        return redirect(res, target, {
+          status: 301,
+          cacheControlSeconds: THIRTY_DAYS,
+        });
+      }
     }
   }
 
   next();
+}
+
+function joinPath(a: string, b: string) {
+  if (a.endsWith("/") && b.startsWith("/")) {
+    return a + b.slice(1);
+  } else {
+    return a + b;
+  }
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1355)

### Problem

We noticed that https://developer.mozilla.org/en-US/curriculum/index.json gets redirected to https://developer.mozilla.org/en-US/curriculum//index.json, which is a regression introduced by https://github.com/mdn/yari/pull/11151.

### Solution

When handling `index.json` requests, avoid a double slash if the corresponding page's canonical URL has a trailing slash.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```console
% curl -I https://developer.mozilla.org/en-US/curriculum/index.json                                                                   ═
HTTP/2 301 
location: /en-US/curriculum//index.json
```

### After

```console
% curl -I https://developer.allizom.org/en-US/curriculum/index.json                                                                   ✭
HTTP/2 200
```

---

## How did you test this change?

Deployed to stage on July 9.