### PR TITLE
fix(curriculum): avoid underline on focus

### DIFF
--- a/client/src/curriculum/partner-banner.scss
+++ b/client/src/curriculum/partner-banner.scss
@@ -64,6 +64,7 @@
             }
           }
 
+          &:focus,
           &:visited,
           &:hover {
             text-decoration: none;


### PR DESCRIPTION
## Summary

Don't show text-decoration on :active for partner banner main link.

### Problem

`:active` adds a underline.

### Solution

set it to `none`.

---

## Screenshots

### Before
![image](https://github.com/mdn/yari/assets/3604775/57d8c8b2-2849-4f6d-97a0-0fe239de641f)


### After

![image](https://github.com/mdn/yari/assets/3604775/866467d0-c5a2-4761-aed3-eb47eed72297)
The curly underline is supposed to be gone on focus.

---

## How did you test this change?

locally
