### PR TITLE
fix(curriculum): remove autofocus on scrim

### DIFF
--- a/client/src/curriculum/scrim.tsx
+++ b/client/src/curriculum/scrim.tsx
@@ -27,7 +27,6 @@ export function ScrimIframe({
             <div className="partner-header">
               <span>Clicking will load content from scrimba.com</span>
               <button
-                autoFocus
                 tabIndex={0}
                 onClick={() => {
                   if (showDialog) {


### PR DESCRIPTION
## Summary

Scrim should not have autofocus set. Remove it.

### Problem

Scrim full screen button had autofocus.

### Solution

Remove autofocus attribute.

---

## Screenshots


### Before

![image](https://github.com/mdn/yari/assets/3604775/048b27b5-1b99-42dc-aed8-2eb63a3f4874)

### After

![image](https://github.com/mdn/yari/assets/3604775/dc570482-b94d-4e3c-a057-d6e959193fce)

---

## How did you test this change?

Locally.
