### PR TITLE
fix(curriculum): add via to scrim

### DIFF
--- a/client/src/curriculum/landing.tsx
+++ b/client/src/curriculum/landing.tsx
@@ -122,7 +122,7 @@ function Header({ section, h1 }: { section: any; h1?: string }) {
   );
 }
 
-const SCRIM_URL = "https://v2.scrimba.com/s06icdv";
+const SCRIM_URL = "https://v2.scrimba.com/s06icdv?via=mdn";
 
 function About({ section }) {
   const { title, content, id } = section.value;


### PR DESCRIPTION
## Summary

Adding our referrer parameter to the embedded scrim.
Previously this triggered a bug, but it's fixed now.

