### PR TITLE
fix(login): don't double encodeURI

### DIFF
--- a/client/src/ui/atoms/login-link/index.tsx
+++ b/client/src/ui/atoms/login-link/index.tsx
@@ -35,7 +35,7 @@ export function useLoginUrl() {
   const sp = new URLSearchParams();
 
   let next = pathname ? pathname + search : `/${locale}/`;
-  sp.set("next", encodeURI(next));
+  sp.set("next", next);
 
   let prefix = "";
   // When doing local development with Yari, the link to authenticate in Kuma


### PR DESCRIPTION
## Summary

URLSearchParams.toString() handles this. So we must not encode the parameter.

(MP-1360)

### Problem

We double encode and Playground links break when logging in.

### Solution

Don't double encode.
