### PR TITLE
Add margin to block-level math

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -471,6 +471,10 @@ pre {
   }
 }
 
+math[display="block"] {
+  margin: 1rem 0 2rem;
+}
+
 .example-good,
 .example-bad {
   padding: 0 1rem;


### PR DESCRIPTION
⚠️ [There’s a PR](https://github.com/mdn/content/pull/34751) that enforces block rendering for all block-level math. They should be merged together.

## Summary

It adds margins for block-level math:

```html
<math display="block">
  …
</math>
```

The same margins as `<p>` and `<pre>` have.

### Problem

Block-level math, rendered outside of paragraphs, doesn’t have margins:

<img width="823" alt="image" src="https://github.com/mdn/yari/assets/105274/55704bb7-1286-4f7c-a644-ee73d0b1a1f5">

### Solution

Now it does:

```css
math[display="block"] {
  margin: 1rem 0 2rem;
}
```

<img width="829" alt="image" src="https://github.com/mdn/yari/assets/105274/7484e4b4-f016-416d-9b49-25f4a2e5b3fa">