### PR TITLE
fix(notecard): misaligned icon, excessive internal padding

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -189,12 +189,6 @@
       margin-bottom: 1rem;
       margin-left: 1rem;
 
-      .notecard {
-        p {
-          padding-left: 0;
-        }
-      }
-
       dl {
         /* Nested definition list. */
         border-left: 1px solid var(--border-primary);

--- a/client/src/ui/molecules/notecards/index.scss
+++ b/client/src/ui/molecules/notecards/index.scss
@@ -31,7 +31,7 @@
     mask-repeat: no-repeat;
     mask-size: contain;
     position: absolute;
-    top: 1.5rem;
+    top: 1.35rem;
     width: 1rem;
   }
 
@@ -103,17 +103,24 @@
 
   // extra classes added to fix specificity.
 
-  ul,
-  ol {
-    padding-left: 2rem;
-  }
+  &,
+  .main-page-content &,
+  dd & {
+    ul,
+    ol {
+      padding-left: 1rem;
+    }
 
-  ul,
-  p {
-    padding-bottom: 0.5rem;
+    ul,
+    ol,
+    li,
+    p {
+      margin: 0;
+      padding-bottom: 0.5rem;
 
-    &:last-child {
-      padding-bottom: 0;
+      &:last-child {
+        padding-bottom: 0;
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

- Notecard icon is misaligned with text
- On https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio#preload there's excessive padding within the notecard

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

- Align icon with text
- Override `.main-page-content` and `dd` styles (long term we need a better solution for this, it's frustrating to have to override styles, perhaps something like the notecard should live in the shadow dom?)

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/mdn/yari/assets/755354/3cc1d3e5-da5a-4163-ae17-1926f23ceb7e)


### After

![image](https://github.com/mdn/yari/assets/755354/41c4dd92-0347-41c4-ab71-7fbc24f5a34e)


---

## How did you test this change?

`yarn dev`, clicked around a few pages
