### PR TITLE
fix(server): Inter wouldn't load on Linux 🐧

### DIFF
--- a/server/middlewares.ts
+++ b/server/middlewares.ts
@@ -8,20 +8,29 @@ import { STATIC_ROOT } from "../libs/env/index.js";
 import { resolveFundamental } from "../libs/fundamental-redirects/index.js";
 import { getLocale } from "../libs/locale-utils/index.js";
 
-// Lowercase every request because every possible file we might have
-// on disk is always in lowercase.
-// This only helps when you're on a filesystem (e.g. Linux) that is case
-// sensitive.
-const slugRewrite = (req, res, next) => {
+const slugLowercase = (req, res, next) => {
   req.url = req.url.toLowerCase();
   next();
 };
+
+const staticServer = express.static(STATIC_ROOT, {
+  setHeaders: (res) => {
+    if (res.req.path.endsWith("/runner.html")) {
+      res.setHeader("Content-Security-Policy", PLAYGROUND_UNSAFE_CSP_VALUE);
+    } else {
+      res.setHeader("Content-Security-Policy", CSP_VALUE);
+    }
+  },
+});
+
+// This is necessary for case-sensitive filesystems, such as on Linux 🐧
+export const staticMiddlewares = [staticServer, slugLowercase, staticServer];
 
 /**
  * This function is returns an object with {url:string, status:number}
  * if there's some place to redirect to, otherwise an empty object.
  */
-const originRequest = (req, res, next) => {
+export const originRequestMiddleware = (req, res, next) => {
   const { url: fundamentalRedirectUrl, status } = resolveFundamental(req.url);
   if (fundamentalRedirectUrl && status) {
     res.redirect(status, fundamentalRedirectUrl);
@@ -50,17 +59,3 @@ const originRequest = (req, res, next) => {
     next();
   }
 };
-
-export const staticMiddlewares = [
-  slugRewrite,
-  express.static(STATIC_ROOT, {
-    setHeaders: (res) => {
-      if (res.req.path.endsWith("/runner.html")) {
-        res.setHeader("Content-Security-Policy", PLAYGROUND_UNSAFE_CSP_VALUE);
-      } else {
-        res.setHeader("Content-Security-Policy", CSP_VALUE);
-      }
-    },
-  }),
-];
-export const originRequestMiddleware = originRequest;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Inter has never loaded for me in local development, I always had to comment out the `@font-face` declaration and load it locally, but I never dug into why this was happening.

### Solution

Don't lowercase everything by default in the server, first attempt to load the *actual* path, then if nothing is found horrifically mutate it to satisfy the absurdities introduced by appeasing the use of filesystems which quite clearly exhibit incorrect behaviour.

---

## How did you test this change?

Use a sensitive filesystem
`yarn && yarn dev`
visited http://localhost:5042/en-US/docs/Web
Inter loads! :tada: 
