### PR TITLE
feat(sidebars): remove 'Common MIME Types', rename main page

### DIFF
--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -22,8 +22,7 @@ var text = mdn.localStringMap({
     'ResourcesURI': 'Resources and URIs',
     'Identifying': 'Identifying resources on the Web',
     'DataURLs': 'Data URLs',
-    'MIMETypes': 'Introduction to MIME types',
-    'ListMIMETypes': 'Common MIME types',
+    'MIMETypes': 'Media types (MIME types)',
     'WWWorNotWWW': 'Choosing between www and non-www URLs',
     'Messages': 'HTTP Messages',
     'Session': 'A typical HTTP session',
@@ -62,7 +61,6 @@ var text = mdn.localStringMap({
     'Identifying': 'Identificación de recursos en la Web',
     'DataURLs': 'URLs de Datos',
     'MIMETypes': 'Presentación de tipos MIME',
-    'ListMIMETypes': 'Lista completa de tipos MIME',
     'WWWorNotWWW': 'Elección entre URLs con y sin www',
     'Messages': 'Mensajes HTTP',
     'Session': 'Una típica comunicación HTTP',
@@ -97,7 +95,6 @@ var text = mdn.localStringMap({
     'Identifying': 'Identifier des ressources sur le Web',
     'DataURLs': 'URL de données',
     'MIMETypes': 'Introduction aux types MIME',
-    'ListMIMETypes': 'Types MIME usuels',
     'WWWorNotWWW': 'Choisir entre les URL avec ou sans www',
     'Messages': 'Messages HTTP',
     'Session': 'Une session HTTP typique',
@@ -136,7 +133,6 @@ var text = mdn.localStringMap({
     'Identifying': 'ウェブ上のリソースの識別',
     'DataURLs': 'データ URL',
     'MIMETypes': 'MIME タイプ入門',
-    'ListMIMETypes': 'よくある MIME タイプ',
     'WWWorNotWWW': 'www 付きと www なしの URL の選択',
     'Messages': 'HTTP メッセージ',
     'Session': '典型的な HTTP セッション',
@@ -175,7 +171,6 @@ var text = mdn.localStringMap({
     'Identifying': '웹의 리소스 식별하기',
     'DataURLs': '데이터 URLs',
     'MIMETypes': 'MIME 타입 소개',
-    'ListMIMETypes': 'MIME 타입의 전체 리스트',
     'WWWorNotWWW': 'www와 non-www URL 중에서 선택하기',
     'Messages': 'HTTP 메시지',
     'Session': '전형적인 HTTP 세션',
@@ -214,7 +209,6 @@ var text = mdn.localStringMap({
     'Identifying': 'Идентификация ресурсов в Вебе',
     'DataURLs': 'Data URL',
     'MIMETypes': 'Введение в MIME типы',
-    'ListMIMETypes': 'Неполный список типов MIME',
     'WWWorNotWWW': 'Choosing between www and non-www URLs',
     'Messages': 'Сообщения HTTP',
     'Session': 'HTTP сессия',
@@ -253,7 +247,6 @@ var text = mdn.localStringMap({
     'Identifying': '标识互联网上的内容',
     'DataURLs': 'Data URL',
     'MIMETypes': 'MIME 类型介绍',
-    'ListMIMETypes': '常见的 MIME 类型',
     'WWWorNotWWW': '选择 www 或非 www 域名？',
     'Messages': 'HTTP 消息',
     'Session': '典型的 HTTP 会话',
@@ -297,7 +290,6 @@ var text = mdn.localStringMap({
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web`, null, text['Identifying'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Data_URLs`, null, text['DataURLs'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types`, null, text['MIMETypes'])%></li>
-                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types`, null, text['ListMIMETypes'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs`, null, text['WWWorNotWWW'])%></li>
             </ol>
         </details>


### PR DESCRIPTION
## Summary

This PR removes the "Common MIME Types" page in favor of consolidating information into the 'main" guide page for this.

### Problem

A standalone page is being deleted and incorporated into a main guide page.

### Solution

Remove the nav item for the deleted page.

__Changes:__
The following page is renamed:

* 'Introduction to MIME types' -> 'Media types (MIME types)'

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

In the deletion PR preview:

https://pr34269.content.dev.mdn.mozit.cloud/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types

![image](https://github.com/user-attachments/assets/5f921e8a-4628-44bd-a4b7-38055ab3bfcf)

### After

![image](https://github.com/user-attachments/assets/e38b64b6-fa52-43fc-a8e6-63470f900e54)

## How did you test this change?

1. Checkout https://github.com/mdn/content/pull/34269
2. `yarn && yarn dev`
3. localhost:3000


__Related issues and pull requests:__

- [ ] https://github.com/mdn/content/pull/34269