### PR TITLE
fix(placement): reuse TextColor/BackgroundColor for "AD" link

### DIFF
--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -36,24 +36,24 @@ section.place {
     width: 11rem;
 
     .pong-note {
-      background-color: #fff6;
+      background-color: var(--place-new-side-color);
       border: 1px solid #111a;
       border-radius: 0.25rem;
-      color: #fff;
+      color: var(--place-new-side-background);
       font-size: 0.625rem;
       margin: 0.5rem;
+      opacity: 0.4;
       padding: 0 0.25rem;
       position: absolute;
       right: 0;
-      text-decoration: none;
       text-decoration: underline;
       text-transform: uppercase;
       top: 0;
       width: max-content;
 
       &:hover {
-        background-color: #fff;
-        color: #111;
+        opacity: unset;
+        text-decoration: none;
       }
     }
 

--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -37,7 +37,7 @@ section.place {
 
     .pong-note {
       background-color: var(--place-new-side-color);
-      border: 1px solid #111a;
+      border: 1px solid var(--place-new-side-background);
       border-radius: 0.25rem;
       color: var(--place-new-side-background);
       font-size: 0.625rem;


### PR DESCRIPTION
# Summary

(MP-1400)

### Problem

https://github.com/mdn/yari/pull/11498 added custom color support for the new sidebar format, but the color of the "AD" link remained hard-coded, which causes contrast issues.

### Solution

Reuse `TextColor` for the link background and `BackgroundColor` for the link text, while maintaining the current opacity of 40%.

*Note*: The hover effect stays the same, i.e. the opacity is unset and the underline is removed on hover.

---

## Screenshots

| | Default state | Hover state |
|--------|--------|--------|
| Before | <img width="191" alt="image" src="https://github.com/user-attachments/assets/36b896f1-c189-4017-a596-f528afd1d227"> | <img width="191" alt="image" src="https://github.com/user-attachments/assets/194fb09e-4cf4-42dd-8ec3-66c7848a6d82"> |
| After | <img width="191" alt="image" src="https://github.com/user-attachments/assets/87486c18-1f6f-4b06-a3b1-ba8aa1fbf8b8"> | <img width="191" alt="image" src="https://github.com/user-attachments/assets/0f460fed-a5e0-48de-a654-96db778f1710"> | 

---

## How did you test this change?

Ran `yarn dev` with `REACT_APP_KUMA_HOST=developer.allizom.org` and refreshed http://localhost:3000/en-US/docs/Learn/HTML until a placement using the new sidebar format showed up.
