### PR TITLE
fix(baseline): hide when feature status differs from BCD key status

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -43,7 +43,7 @@ import {
   postProcessExternalLinks,
   postProcessSmallerHeadingIDs,
 } from "./utils.js";
-import { getWebFeatureStatus } from "./web-features.js";
+import { addBaseline } from "./web-features.js";
 export { default as SearchIndex } from "./search-index.js";
 export { gather as gatherGitHistory } from "./git-history.js";
 export { buildSPAs } from "./spas.js";
@@ -548,54 +548,6 @@ export async function buildDocument(
     document.metadata.slug.startsWith("conflicting/");
 
   return { doc: doc as Doc, liveSamples, fileAttachmentMap, plainHTML };
-}
-
-function addBaseline(doc: Partial<Doc>) {
-  if (doc.browserCompat && !doc.mdn_url?.includes("/docs/MDN/")) {
-    const filteredBrowserCompat = doc.browserCompat.filter(
-      (query) =>
-        // temporary blocklist while we wait for per-key baseline statuses
-        // or another solution to the baseline/bcd table discrepancy problem
-        ![
-          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/async-clipboard.yml
-          "api.Clipboard.read",
-          "api.Clipboard.readText",
-          "api.Clipboard.write",
-          "api.Clipboard.writeText",
-          "api.ClipboardEvent",
-          "api.ClipboardEvent.ClipboardEvent",
-          "api.ClipboardEvent.clipboardData",
-          "api.ClipboardItem",
-          "api.ClipboardItem.ClipboardItem",
-          "api.ClipboardItem.getType",
-          "api.ClipboardItem.presentationStyle",
-          "api.ClipboardItem.types",
-          "api.Navigator.clipboard",
-          "api.Permissions.permission_clipboard-read",
-          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/custom-elements.yml
-          "api.CustomElementRegistry",
-          "api.CustomElementRegistry.builtin_element_support",
-          "api.CustomElementRegistry.define",
-          "api.Window.customElements",
-          "css.selectors.defined",
-          "css.selectors.host",
-          "css.selectors.host-context",
-          "css.selectors.part",
-          // https://github.com/web-platform-dx/web-features/blob/cf718ad/feature-group-definitions/input-event.yml
-          "api.Element.input_event",
-          "api.InputEvent.InputEvent",
-          "api.InputEvent.data",
-          "api.InputEvent.dataTransfer",
-          "api.InputEvent.getTargetRanges",
-          "api.InputEvent.inputType",
-          // https://github.com/web-platform-dx/web-features/issues/1038
-          // https://github.com/web-platform-dx/web-features/blob/64d2cfd/features/screen-orientation-lock.dist.yml
-          "api.ScreenOrientation.lock",
-          "api.ScreenOrientation.unlock",
-        ].includes(query)
-    );
-    return getWebFeatureStatus(...filteredBrowserCompat);
-  }
 }
 
 interface BuiltLiveSamplePage {

--- a/build/web-features.ts
+++ b/build/web-features.ts
@@ -1,16 +1,37 @@
 import { features } from "web-features";
+import { computeBaseline } from "compute-baseline";
 
-export function getWebFeatureStatus(...bcdKeys: string[]) {
-  if (bcdKeys.length === 0) {
-    return;
+import type { Doc } from "../libs/types/document.js";
+
+export function addBaseline(doc: Partial<Doc>) {
+  if (doc.browserCompat && !doc.mdn_url?.includes("/docs/MDN/")) {
+    if (doc.browserCompat.length !== 1) {
+      return;
+    }
+
+    const key = doc.browserCompat[0];
+    const { featureStatus, keyStatus } = getStatuses(key);
+
+    if (!featureStatus) {
+      return;
+    }
+
+    if (featureStatus.baseline !== keyStatus.baseline) {
+      return;
+    }
+
+    return featureStatus;
   }
+}
 
+function getStatuses(key: string) {
   for (const feature of Object.values(features)) {
-    if (
-      feature.status &&
-      feature.compat_features?.some((feature) => bcdKeys.includes(feature))
-    ) {
-      return feature.status;
+    if (feature.status && feature.compat_features?.includes(key)) {
+      return {
+        featureStatus: feature.status,
+        keyStatus: computeBaseline({ compatKeys: [key] }),
+      };
     }
   }
+  return {};
 }

--- a/build/web-features.ts
+++ b/build/web-features.ts
@@ -4,13 +4,13 @@ import { computeBaseline } from "compute-baseline";
 import type { Doc } from "../libs/types/document.js";
 
 export function addBaseline(doc: Partial<Doc>) {
-  if (doc.browserCompat && !doc.mdn_url?.includes("/docs/MDN/")) {
-    if (doc.browserCompat.length !== 1) {
-      return;
-    }
-
-    const key = doc.browserCompat[0];
-    const { featureStatus, keyStatus } = getStatuses(key);
+  if (
+    doc.browserCompat &&
+    doc.browserCompat.length == 1 &&
+    !doc.mdn_url?.includes("/docs/MDN/")
+  ) {
+    const bcdKey = doc.browserCompat[0];
+    const { featureStatus, keyStatus } = getStatuses(bcdKey);
 
     if (!featureStatus) {
       return;
@@ -24,12 +24,12 @@ export function addBaseline(doc: Partial<Doc>) {
   }
 }
 
-function getStatuses(key: string) {
+function getStatuses(bcdKey: string) {
   for (const feature of Object.values(features)) {
-    if (feature.status && feature.compat_features?.includes(key)) {
+    if (feature.status && feature.compat_features?.includes(bcdKey)) {
       return {
         featureStatus: feature.status,
-        keyStatus: computeBaseline({ compatKeys: [key] }),
+        keyStatus: computeBaseline({ compatKeys: [bcdKey] }),
       };
     }
   }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "cli-progress": "^3.12.0",
     "codemirror": "^6.0.1",
     "compression": "^1.7.4",
+    "compute-baseline": "^0.1.1",
     "cookie": "^0.6.0",
     "cookie-parser": "^1.4.6",
     "css-tree": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2343,6 +2343,14 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@js-temporal/polyfill@^0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.4.tgz#4c26b4a1a68c19155808363f520204712cfc2558"
+  integrity sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==
+  dependencies:
+    jsbi "^4.3.0"
+    tslib "^2.4.1"
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
@@ -5406,6 +5414,11 @@ common-path-prefix@^3.0.0:
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
   integrity sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==
 
+compare-versions@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.0.tgz#3f2131e3ae93577df111dba133e6db876ffe127a"
+  integrity sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==
+
 compressible@~2.0.16:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
@@ -5425,6 +5438,14 @@ compression@^1.7.4:
     on-headers "~1.0.2"
     safe-buffer "5.1.2"
     vary "~1.1.2"
+
+compute-baseline@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/compute-baseline/-/compute-baseline-0.1.1.tgz#26139c562a6609825dfde30ad9f5707619975216"
+  integrity sha512-1JWSHeDUwlWBnhnCUDEgKSgXb3UWtCkV8FPTV6YwNGHxLqA/SNfOcTsY74IXv19EqbuMsKBClhh+OPNjMnOZDQ==
+  dependencies:
+    "@js-temporal/polyfill" "^0.4.4"
+    compare-versions "^6.1.0"
 
 compute-scroll-into-view@^2.0.4:
   version "2.0.4"
@@ -10086,6 +10107,11 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsbi@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
+  integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
 
 jsdom@^20.0.0:
   version "20.0.3"
@@ -15249,6 +15275,11 @@ tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.6
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.4.1:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

https://mozilla-hub.atlassian.net/browse/MP-874

Also see: https://github.com/mdn/yari/issues/11546

### Problem

- We maintain an manual blocklist of BCD keys to not display Baseline banners for, since they're potentially confusing
- Some BCD keys are part of a feature which has a higher status (i.e. Baseline low or high if the BCD key is not Baseline, or Baseline high if the BCD key is Baseline low), and so we display an incorrect banner on those pages:
  - e.g. https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrackAudioSourceNode

### Solution

- Compute the per-key Baseline status for each page with `compute-baseline`, and if that status disagrees with the feature status, hide the banner

---

## How did you test this change?

- `yarn`
- `yarn build --nohtml --locale en-us` to generate `client/build/en-us/build.json` which can be compared to https://developer.mozilla.org/en-US/build.json
  - as expected (from the analysis in https://github.com/mdn/yari/issues/11546) we have 2307 pages where the statuses are the same
- `yarn dev`
  - clicked around specific problem areas, like the Clipboard API
    - as expected, the banner appears on pages where the BCD table "agrees" with the banner:
      - http://localhost:3000/en-US/docs/Web/API/Clipboard/read
      - http://localhost:3000/en-US/docs/Web/API/Clipboard/readText
      - http://localhost:3000/en-US/docs/Web/API/Clipboard/write
    - and is hidden on pages where the BCD table "disagrees":
      - http://localhost:3000/en-US/docs/Web/API/Clipboard
      -  http://localhost:3000/en-US/docs/Web/API/Clipboard/writeText
    - and is also hidden on pages with multiple BCD tables:
      - http://localhost:3000/en-US/docs/Web/API/Clipboard_API
  - ensured http://localhost:3000/en-US/docs/Web/API/MediaStreamTrackAudioSourceNode shows no banner


