### PR TITLE
fix(markdown): Always render noteblock titles on its own line

### DIFF
--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -122,22 +122,6 @@ export function buildLocalizedHandlers(locale: Locale): Handlers {
           node.children[0].children[0].value =
             node.children[0].children[0].value.replace(/\[!\w+\]\n?/, "");
 
-          // If the type isn't a callout, add the magic keyword
-          if (!isCallout) {
-            node.children[0].children.unshift({
-              type: "strong",
-              children: [
-                {
-                  type: "text",
-                  value: type.magicKeyword,
-                },
-              ],
-            });
-            node.children[0].children[1].value =
-              (["zh-CN", "zh-TW"].includes(locale) ? "" : " ") +
-              node.children[0].children[1].value;
-          }
-
           // Remove blank line if there is one
           if (
             node.children[0].children.length === 1 &&
@@ -145,8 +129,24 @@ export function buildLocalizedHandlers(locale: Locale): Handlers {
           ) {
             node.children.splice(0, 1);
           }
+
+          // If the type isn't a callout, add the magic keyword
+          if (!isCallout) {
+            node.children.unshift({
+              type: "strong",
+              children: [
+                {
+                  type: "text",
+                  value: type.magicKeyword,
+                },
+              ],
+              properties: {
+                className: ["notecard-title"],
+              },
+            });
+          }
         } else {
-          // Remove "Callout:" text
+          // Remove "Callout:" text from non-GFM notecard
           if (isCallout) {
             if (node.children[0].children.length <= 1) {
               node.children.splice(0, 1);


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

This PR updates the GFM noteblock rendering to always put the title ("Note:", "Warning:", etc.) on its own line, regardless of how the Markdown is formatted.

> [!IMPORTANT]
> GitHub has named noteblocks as ["Alerts"](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).

### Problem

One issue that is currently preventing us from performing mass GFM noteblock conversion is a Prettier bug, which causes lines starting with special characters (like \[ or \`) to get wrapped to the same line as the noteblock declaration (like ``> [!NOTE] > `code` cannot be used``).

### Solution

The simplest solution I could think of was to update the rendering to be more similar to how GitHub renders its noteblocks.

> [!NOTE]
> This is how GitHub's noteblocks look.

---

## Screenshots

### Test Markdown

```md
> [!NOTE]
> This is a note.

> [!WARNING]
> This is a warning.

> [!CALLOUT]
> This is a callout.

> [!NOTE]
>
> This is a multi-line note.

> [!WARNING]
>
> This is a multi-line warning.

> [!CALLOUT]
>
> This is a multi-line callout.
```

### Before

<img width="623" alt="before" src="https://github.com/user-attachments/assets/e31029ac-4c7a-42cf-a209-b131a5b5bbb9">

### After

<img width="621" alt="after" src="https://github.com/user-attachments/assets/9d1ffd8d-8b68-4666-8ab6-aa348c740ec6">
