### PR TITLE
chore(ai-help): replace GPT-3.5 Turbo with GPT-4o mini

### DIFF
--- a/client/src/plus/ai-help/banners.tsx
+++ b/client/src/plus/ai-help/banners.tsx
@@ -19,14 +19,14 @@ export function AiHelpBanner({
         <Icon name="bell-ring" />
         <strong>
           {isSubscriber
-            ? "GPT-4-powered AI Help."
+            ? "GPT-4o-powered AI Help."
             : "Supercharge your AI Help experience with our paid subscriptions."}
         </strong>
       </p>
       <p>
         {isSubscriber
           ? "Now with chat history, enhanced context, and optimized prompts."
-          : "Upgrade to MDN Plus 5 or MDN Supporter 10 to unlock the potential of GPT-4-powered AI Help."}
+          : "Upgrade to MDN Plus 5 or Supporter 10 to unlock the full potential of GPT-4o-powered AI Help."}
       </p>
       {!isSubscriber && (
         <SignUpLink gleanContext={`${AI_HELP}: upsell-banner`} toPlans={true} />

--- a/client/src/plus/ai-help/history.scss
+++ b/client/src/plus/ai-help/history.scss
@@ -176,7 +176,7 @@
 .ai-help-history-activation {
   background-color: var(--background-secondary);
   border-radius: 0.25rem;
-  // Align "Answer History" with "GPT-4-powered AI Help".
+  // Align "Answer History" with "GPT-4o-powered AI Help".
   margin-top: 3.5rem;
   padding: 0.25rem;
 

--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -610,7 +610,7 @@ export function AIHelpInner() {
   const isQuotaLoading = quota === undefined;
   const hasQuota = !isQuotaLoading && quota !== null;
   const hasConversation = messages.length > 0;
-  const gptVersion = isPlusSubscriber(user) ? "GPT-4" : "GPT-3.5";
+  const gptVersion = isPlusSubscriber(user) ? "GPT-4o" : "GPT-4o mini";
 
   function isQuotaExceeded(quota: Quota | null | undefined): quota is Quota {
     return quota ? quota.remaining <= 0 : false;
@@ -920,8 +920,8 @@ export function AIHelpInner() {
                       </header>
                       <div className="modal-body">
                         <p>
-                          Our AI Help feature integrates GPT-3.5 for MDN Plus
-                          free users and GPT-4 for paying subscribers,
+                          Our AI Help feature integrates GPT-4o mini for MDN
+                          Plus free users and GPT-4o for paying subscribers,
                           leveraging Large Language Models (LLMs) developed by{" "}
                           <a
                             href="https://platform.openai.com/docs/api-reference/models"
@@ -1111,7 +1111,7 @@ function ReportIssueOnGitHubLink({
       .join("\n") || "(None)"
   );
   // TODO Persist model in messages and read it from there.
-  sp.set("model", isSubscriber ? "gpt-4" : "gpt-3.5");
+  sp.set("model", isSubscriber ? "gpt-4o" : "gpt-4o mini");
   sp.set("template", "ai-help-answer.yml");
 
   url.search = sp.toString();

--- a/client/src/plus/ai-help/landing.tsx
+++ b/client/src/plus/ai-help/landing.tsx
@@ -50,8 +50,10 @@ export function AIHelpLanding() {
             <figure>
               <GPT4SVG role="none" />
               <figcaption>
-                <h3>GPT-4-Powered</h3>
-                <p>Unlock GPT-4's potential with our paid subscriptions</p>
+                <h3>GPT-4o-Powered</h3>
+                <p>
+                  Unlock GPT-4o's full potential with our paid subscriptions
+                </p>
               </figcaption>
             </figure>
           </div>

--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -31,7 +31,7 @@ export default function OfferOverviewFeatures() {
           <p>
             No need to scroll through page after page to find your answers.
             Introducing an AI assistant that can answer all your web development
-            questions in real time. Powered by OpenAI GPT-3.5 and GPT-4.
+            questions in real time. Powered by OpenAI GPT-4o and GPT-4o mini.
           </p>
           <Button href="/en-US/plus/docs/features/ai-help" target="_self">
             Learn more →

--- a/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-subscribe/index.tsx
@@ -78,7 +78,7 @@ const PLUS_FEATURES = [
   ["updates", "Filter and sort updates"],
   ["collections", "Collections of articles"],
   ["offline", "MDN Offline"],
-  ["ai-help", "AI Help", "beta"],
+  ["ai-help", "AI Help"],
 ];
 
 const CORE: OfferDetailsProps = {
@@ -88,7 +88,7 @@ const CORE: OfferDetailsProps = {
     ["updates", "Filter and sort updates"],
     ["collections", "Up to 3 collections"],
     ["playground", "Share playgrounds"],
-    ["ai-help", "AI Help: 5 questions per day", "beta"],
+    ["ai-help", "AI Help: 5 questions per day"],
   ],
   includes: "Includes:",
   cta: "Start with Core",

--- a/copy/plus/features/ai-help.md
+++ b/copy/plus/features/ai-help.md
@@ -7,7 +7,7 @@ title: AI Help
 > Get real-time assistance and support
 
 AI Help, available for both free and paid MDN Plus subscribers, utilizes OpenAI
-GPT-3.5 for free users and GPT-4 for paying subscribers to enhance the MDN
+GPT-4o mini for free users and GPT-4o for paying subscribers to enhance the MDN
 experience. It offers quick and effective access to MDN's broad database. It
 specializes in searching and summarizing MDN content to directly address your
 queries. Additionally, for web development queries not covered in MDN, AI Help


### PR DESCRIPTION
## Summary

(MP-1429)

### Problem

We have been using GPT-3.5 Turbo for free users, but meanwhile GPT-4o mini has been released and is more powerful and cheaper at the same time.

### Solution

The backend change happens in https://github.com/mdn/rumba/pull/546, while this PR updates the frontend copy.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="1127" alt="image" src="https://github.com/user-attachments/assets/bdc08e9c-8aaf-4e15-972e-ff938e87a493"> | <img width="1127" alt="image" src="https://github.com/user-attachments/assets/432ad158-bc2a-4add-a7aa-020cabd828f8"> |
| <img width="1127" alt="image" src="https://github.com/user-attachments/assets/28c4a508-4717-4fed-9485-13d0d464f250"> | <img width="1127" alt="image" src="https://github.com/user-attachments/assets/9100b1d5-96d7-4572-a547-d31e8790bd27"> |
| <img width="1127" alt="image" src="https://github.com/user-attachments/assets/76c25c5b-9dc3-4698-81c7-296a621afcd7"> | <img width="1127" alt="image" src="https://github.com/user-attachments/assets/5da64320-a0d2-4666-b51d-5f18cdcd8e46"> |

---

## How did you test this change?

Ran `yarn dev` with local Rumba running.
