### PR TITLE
fix(observatory): better glean error keys

### DIFF
--- a/client/src/observatory/landing.tsx
+++ b/client/src/observatory/landing.tsx
@@ -78,7 +78,7 @@ export default function ObservatoryLanding() {
   useEffect(() => {
     if (error && !isMutating) {
       gleanClick(
-        `${OBSERVATORY}: error -> ${ERROR_MAP[error.name] || error.message}`
+        `${OBSERVATORY}: error -> ${ERROR_MAP[error.name] || error.name || error.message}`
       );
     }
   }, [error, isMutating, gleanClick]);


### PR DESCRIPTION
## Summary

Display the full individual error message to the user but use generic error names/codes for glean telemetry.

(MP-1397)

### Problem

Glean telemetry included the site name that failed to look up, which is not what we want in terms of error clasification.

### Solution

Use the existing error names that get sent ofrom the backend to construct the glean payload.

## How did you test this change?

Locally and on stage.