### PR TITLE
fix(layout): avoid sidebar overflow beyond footer

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -254,6 +254,7 @@
   }
   @media (min-width: $screen-md) {
     display: flex;
+    position: sticky;
   }
   @media (min-width: $screen-lg), (min-height: $screen-height-place-limit) {
     display: block;

--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -254,7 +254,7 @@
   }
   @media (min-width: $screen-md) {
     display: flex;
-    position: sticky;
+    position: relative;
   }
   @media (min-width: $screen-lg), (min-height: $screen-height-place-limit) {
     display: block;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

Fixes  #11609.

### Problem


If the sidebar contains many elements, an unnecessary scroll area would be added on devices with a width between 768px and 1200px.

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution

The same issue did not occur on desktop, so I first identified which element's style was different. After confirming that the issue was occurring with the `.sidebar` element, I applied position: sticky as it was on the desktop.


<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->




---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/user-attachments/assets/2ec06898-546d-420c-98e0-b5e6905124ef)

![화면 기록 2024-08-10 21 34 11](https://github.com/user-attachments/assets/59117d2f-af94-426a-8b70-545fd2cb1bd3)


<!-- Replace this line with your screenshot (or video). -->

### After

![image](https://github.com/user-attachments/assets/3bdd6422-1355-4b91-adea-7db5ac0e9362)

![화면 기록 2024-08-10 21 38 32](https://github.com/user-attachments/assets/618a6d66-ee53-4b3e-87ed-297d2ba76bce)




<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

- On local machine, at [http://localhost:5042/en-US/docs/Glossary](http://localhost:5042/en-US/docs/Glossary).

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
