### PR TITLE
fix(top-navigation): prevent wrap

### DIFF
--- a/client/src/ui/organisms/top-navigation/index.scss
+++ b/client/src/ui/organisms/top-navigation/index.scss
@@ -45,7 +45,13 @@
     display: none;
   }
 
-  .top-navigation .top-navigation-wrap {
-    flex: 0;
+  .top-navigation {
+    .container {
+      flex-wrap: nowrap;
+    }
+
+    .top-navigation-wrap {
+      flex: 0;
+    }
   }
 }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The top navigation wraps on desktop widths between 992px and 1009px.

### Solution

Prevent wrap on desktop widths >= 992px (`$screen-lg`).

*Note*: Instead, it will overflow on the right, but it's still better than wrapping.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/a0f2541d-6b19-474a-8608-7dc2dac988f0">

### After

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/46c45c67-8053-44b2-882a-5ba5ab1f51d5">

---

## How did you test this change?

Ran `yarn dev` and opened http://localhost:3000/fr/ locally.
