### PR TITLE
fix(baseline): catch computeBaseline() error

### DIFF
--- a/build/web-features.ts
+++ b/build/web-features.ts
@@ -27,10 +27,14 @@ export function addBaseline(doc: Partial<Doc>) {
 function getStatuses(bcdKey: string) {
   for (const feature of Object.values(features)) {
     if (feature.status && feature.compat_features?.includes(bcdKey)) {
-      return {
-        featureStatus: feature.status,
-        keyStatus: computeBaseline({ compatKeys: [bcdKey] }),
-      };
+      try {
+        return {
+          featureStatus: feature.status,
+          keyStatus: computeBaseline({ compatKeys: [bcdKey] }),
+        };
+      } catch (e) {
+        console.error(e);
+      }
     }
   }
   return {};


### PR DESCRIPTION
## Summary

(MP-1442)

### Problem

The `computeBaseline()` function, provided by the [compute-baseline](https://www.npmjs.com/package/compute-baseline) package, throws an `Error` if the passed value is not a valid BCD key, which can happen when a key is removed from BCD while still being referenced in mdn/content, and then it fails our build.

### Solution

Wrap the call in a try-catch block.

---

## How did you test this change?

Ran `yarn build --locale en-us`.