### PR TITLE
fix(build): use pipefail to fail builds

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -131,6 +131,8 @@ jobs:
           REACT_APP_DISABLE_AUTH: true
 
         run: |
+          set -eo pipefail
+
           # Info about which CONTENT_* environment variables were set and to what.
           echo "CONTENT_ROOT=$CONTENT_ROOT"
           echo "CONTENT_TRANSLATED_ROOT=$CONTENT_TRANSLATED_ROOT"

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -255,6 +255,7 @@ jobs:
           REACT_APP_AI_FEEDBACK_GITHUB_REPO: mdn/ai-feedback
 
         run: |
+          set -eo pipefail
 
           # Info about which CONTENT_* environment variables were set and to what.
           echo "CONTENT_ROOT=$CONTENT_ROOT"

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -269,6 +269,7 @@ jobs:
           SENTRY_RELEASE: ${{ github.sha }}
 
         run: |
+          set -eo pipefail
 
           # Info about which CONTENT_* environment variables were set and to what.
           echo "CONTENT_ROOT=$CONTENT_ROOT"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -160,6 +160,7 @@ jobs:
           # Observatory
           REACT_APP_OBSERVATORY_API_URL: https://observatory-api.mdn.allizom.net
         run: |
+          set -eo pipefail
 
           # Info about which CONTENT_* environment variables were set and to what.
           echo "CONTENT_ROOT=$CONTENT_ROOT"


### PR DESCRIPTION
## Summary

(MP-1443)

### Problem

In our build workflows, we build all locales concurrently in background jobs, but if one of the background jobs fails, this does not fail the build, and the incomplete build is sync’ed to the Cloud Storage and to the AI Help index.

### Solution

Enable `pipefail` to ensure the build fails immediately if any background job fails.

---

## How did you test this change?

Triggered [this test-build](https://github.com/mdn/yari/actions/runs/10400285387/job/28800555972#step:8:11) on this branch, and it failed as expected. 