### PR TITLE
fix(placement): remove empty side placement section

### DIFF
--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -64,9 +64,8 @@ export function SidePlacement() {
     ].filter(([_, v]) => Boolean(v))
   );
 
-  return !placementData?.side ? (
-    <section className="place side"></section>
-  ) : placementData.side.cta && placementData.side.heading ? (
+  return !placementData?.side ? null : placementData.side.cta &&
+    placementData.side.heading ? (
     <PlacementInner
       pong={placementData.side}
       extraClassNames={["side", "new-side"]}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes #11645

### Problem

As explained in the issue, this PR is meant to make the `sidebar-inner` menu full height, as a paying user with ad-free experience.

### Solution

I replaced the empty section of the `SidePlacement` component by `null` in order to render nothing.

It might not be the right solution though. The empty section was maybe there for a reason but as a fairly new contributor, I couldn't find any, thus removing this element was the best choice in that case.

If I missed something, I can rollback and simply add:
```scss
section.place {
  // ...

  &:empty {
    display: none;
  }

  //...
}
```

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/25b246c1-d0fe-4c6a-8b3f-42c2cd78a388)

### After

![image](https://github.com/user-attachments/assets/7cfefa11-4b8f-43ef-9287-d80aa4c52503)
