### PR TITLE
Make footer icons visually focusable

### DIFF
--- a/client/src/ui/organisms/footer/index.tsx
+++ b/client/src/ui/organisms/footer/index.tsx
@@ -24,21 +24,21 @@ export function Footer() {
           <ul className="social-icons">
             <li>
               <a
-                className="icon icon-mastodon"
                 href="https://mozilla.social/@mdn"
                 target="_blank"
                 rel="me noopener noreferrer"
               >
+                <span className="icon icon-mastodon"></span>
                 <span className="visually-hidden">MDN on Mastodon</span>
               </a>
             </li>
             <li>
               <a
-                className="icon icon-twitter-x"
                 href="https://twitter.com/mozdevnet"
                 target="_blank"
                 rel="noopener noreferrer"
               >
+                <span className="icon icon-twitter-x"></span>
                 <span className="visually-hidden">
                   MDN on X (formerly Twitter)
                 </span>
@@ -46,20 +46,17 @@ export function Footer() {
             </li>
             <li>
               <a
-                className="icon icon-github-mark-small"
                 href="https://github.com/mdn/"
                 target="_blank"
                 rel="noopener noreferrer"
               >
+                <span className="icon icon-github-mark-small"></span>
                 <span className="visually-hidden">MDN on GitHub</span>
               </a>
             </li>
             <li>
-              <a
-                className="icon icon-feed"
-                href="/en-US/blog/rss.xml"
-                target="_blank"
-              >
+              <a href="/en-US/blog/rss.xml" target="_blank">
+                <span className="icon icon-feed"></span>
                 <span className="visually-hidden">MDN Blog RSS Feed</span>
               </a>
             </li>


### PR DESCRIPTION
### Problem

Social icons in the MDN footer are not visually focusable when navigated via the keyboard.

### Solution

Applying masks to interactive elements hides the outline, so I moved icons inside the link as an additional span.

There might be other cases when an interactive element is also an icon, but I couldn’t find any.

---

## Screenshots

### Before

https://github.com/user-attachments/assets/6a36b0ab-48ac-4c06-b634-1cd83f8ae887

### After

https://github.com/user-attachments/assets/8a037e47-feba-4e14-82f5-df89c56d6ce3