### PR TITLE
fix(ai-help): handle invalid chat ids correctly

### DIFF
--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -485,7 +485,14 @@ export function useAiChat({
     if (r) {
       reset();
     }
-  }, [isHistoryEnabled, searchParams, chatId, reset, handleError]);
+  }, [
+    isHistoryEnabled,
+    removeChatIdFromUrl,
+    searchParams,
+    chatId,
+    reset,
+    handleError,
+  ]);
 
   useEffect(() => {
     if (remoteQuota !== undefined) {

--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -407,7 +407,7 @@ export function useAiChat({
     });
   }, [setSearchParams, chatId]);
 
-  const removeChatIdFromUrl = () => {
+  const removeChatIdFromUrl = useCallback(() => {
     setSearchParams(
       (prev) => {
         prev.delete("c");
@@ -415,7 +415,7 @@ export function useAiChat({
       },
       { replace: true }
     );
-  };
+  }, [setSearchParams]);
 
   useEffect(() => {
     if (!isHistoryEnabled) {

--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -2,7 +2,7 @@
 // License: Apache 2.0 - https://github.com/supabase/supabase/blob/0f1254252f6b066e088a40617f239744e3a1e22b/LICENSE
 import type { OpenAI } from "openai";
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 
 import { SSE } from "sse.js";
 import useSWR, { mutate } from "swr";
@@ -341,7 +341,6 @@ export interface UseAiChatOptions {
 export function useAiChat({
   messageTemplate = (message) => message,
 }: UseAiChatOptions = {}) {
-  const navigate = useNavigate();
   const gleanClick = useGleanClick();
   const eventSourceRef = useRef<SSE>();
 
@@ -409,13 +408,10 @@ export function useAiChat({
   }, [setSearchParams, chatId]);
 
   const removeChatIdFromUrl = () => {
-    const searchParams = new URLSearchParams(window.location.search);
-
-    searchParams.delete("c");
-
-    navigate(
-      {
-        search: searchParams.toString(),
+    setSearchParams(
+      (prev) => {
+        prev.delete("c");
+        return prev;
       },
       { replace: true }
     );

--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -450,13 +450,30 @@ export function useAiChat({
             throw new Error("no treeState");
           }
         } catch (e) {
-          setPreviousChatId(undefined);
-          setChatId(convId);
-          setPath([]);
-          dispatchState({
-            type: "reset",
-          });
-          handleError(e);
+          if (e instanceof Error && e.message.startsWith("404")) {
+            setPreviousChatId(undefined);
+            setChatId(undefined);
+            setPath([]);
+            dispatchState({
+              type: "reset",
+            });
+            window.history.replaceState(
+              "",
+              "",
+              window.location.protocol +
+                "//" +
+                window.location.host +
+                window.location.pathname
+            );
+          } else {
+            setPreviousChatId(undefined);
+            setChatId(convId);
+            setPath([]);
+            dispatchState({
+              type: "reset",
+            });
+            handleError(e);
+          }
         }
         setIsHistoryLoading(false);
       };

--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -407,8 +407,21 @@ export function useAiChat({
     });
   }, [setSearchParams, chatId]);
 
+  const clearParamsFromUrl = () => {
+    window.history.replaceState(
+      "",
+      "",
+      window.location.protocol +
+        "//" +
+        window.location.host +
+        window.location.pathname
+    );
+  };
+
   useEffect(() => {
     if (!isHistoryEnabled) {
+      // If we got a chat id passed in without history enabled, clear parameters from URL
+      clearParamsFromUrl();
       return;
     }
     let timeoutID;
@@ -450,28 +463,18 @@ export function useAiChat({
             throw new Error("no treeState");
           }
         } catch (e) {
+          setPreviousChatId(undefined);
+          setPath([]);
+          dispatchState({
+            type: "reset",
+          });
+          // If we got a 404 from the API, reset and remove the parameter from the URL,
+          // do not show an error.
           if (e instanceof Error && e.message.startsWith("404")) {
-            setPreviousChatId(undefined);
             setChatId(undefined);
-            setPath([]);
-            dispatchState({
-              type: "reset",
-            });
-            window.history.replaceState(
-              "",
-              "",
-              window.location.protocol +
-                "//" +
-                window.location.host +
-                window.location.pathname
-            );
+            clearParamsFromUrl();
           } else {
-            setPreviousChatId(undefined);
             setChatId(convId);
-            setPath([]);
-            dispatchState({
-              type: "reset",
-            });
             handleError(e);
           }
         }


### PR DESCRIPTION
## Summary

This fixes an issue where an AI Help URL with a chat id parameter (`&c=...`) is being requested and the chat referenced either 
* has been deleted
* does belong to a different user

While not leaking information to unauthorized accounts, there were a set of of confusing errors displayed.

The behaviour now has changed. If the chat belongs to a different user or has been deleted, the backend's `404` response is being catched and the user gets a fresh AI Help chat with the parameter cleared from the URL.

We also clear the plate if history is disabled for the user.

(MP-1455)

## How did you test this change?

### 1
* With history enabled, create a chat. Click on the corresponding history item to include the chat id parameter in the URL.
* Copy/note down the URL
* Log in to another account
* Paste the URL from above
* Response is a pristine AI Help page and the parameter has been cleared from the URL.

### 2
* Log in to the original account
* Delete the chat from the history
* Paste the URL from above
* Response is a pristine AI Help page and the parameter has been cleared from the URL.

### 3
* Log into the original account
* Turn off history
* Paste the URL from above
* Response is a pristine AI Help page and the parameter has been cleared from the URL.

### 4
* Log into the secondary account
* Turn history off
* Paste in the URL from above
* Response is a pristine AI Help page and the parameter has been cleared from the URL.
