### PR TITLE
fix(contributor-spotlight): some old pages not building

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -59,6 +59,7 @@ async function buildContributorSpotlight(
 ) {
   const prefix = "community/spotlight";
   const profileImg = "profile-image.jpg";
+  let featuredContributorFrontmatter: DocFrontmatter;
 
   for (const contributor of fs.readdirSync(contributorSpotlightRoot)) {
     const markdown = fs.readFileSync(
@@ -102,14 +103,19 @@ async function buildContributorSpotlight(
     if (options.verbose) {
       console.log("Wrote", jsonFilePath);
     }
+
     if (frontMatter.attributes.is_featured) {
-      return {
-        contributorName: frontMatter.attributes.contributor_name,
-        url: `/${locale}/${prefix}/${frontMatter.attributes.folder_name}`,
-        quote: frontMatter.attributes.quote,
-      };
+      featuredContributorFrontmatter = frontMatter.attributes;
     }
   }
+
+  return featuredContributorFrontmatter
+    ? {
+        contributorName: featuredContributorFrontmatter.contributor_name,
+        url: `/${locale}/${prefix}/${featuredContributorFrontmatter.folder_name}`,
+        quote: featuredContributorFrontmatter.quote,
+      }
+    : undefined;
 }
 
 export async function buildSPAs(options: {


### PR DESCRIPTION

## Summary

https://mozilla-hub.atlassian.net/browse/MP-1448

### Problem

Some contributor spotlight pages don't build because we bail as soon as we hit the featured contributor.

### Solution

Don't do that, build all contributor spotlight pages.

---

- `git checkout main`
- `yarn && yarn dev`
- visit http://localhost:3000/en-US/community/spotlight/yuji <- oh no it's not there 😱 
- `git checkout fix-building-old-featured-contributors`
- `yarn && yarn dev`
- visit http://localhost:3000/en-US/community/spotlight/yuji <- phew it's there 😌 