### PR TITLE
chore(macros/LearnSidebar): add Japanese translation  MathML section

### DIFF
--- a/kumascript/macros/LearnSidebar.ejs
+++ b/kumascript/macros/LearnSidebar.ejs
@@ -286,6 +286,8 @@ const l10nStrings = mdn.localStringMap({
       'Accessibility_assessment' : 'Accessibility assessment',
     'Performance' : 'パフォーマンス — ウェブサイトを高速かつ応答性の高いものにする',
       'Performance_guides' : 'パフォーマンスガイド',
+    'MathML_Writing_mathematics' : 'MathML — MathML を使用して数学を記述する',
+      'MathML_first_steps': 'MathML の最初のステップ',
     'Games_Developing_for_web' : 'ゲーム — ウェブ用ゲームの開発',
       'Guides_and_tutorials': 'ガイドとチュートリアル',
     'Tools_and_testing' : 'ツールとテスト',


### PR DESCRIPTION
## Summary
@hmatrjp @potappo , mdn-yari-ja

please review for this pull request

- issue:  [ サイドメニュー の翻訳(MathML) #785](https://github.com/mozilla-japan/translation/issues/785) 

### Problem

- There is no Japanese translation yet

#### English pages

- cf. https://developer.mozilla.org/en-US/docs/Learn/MathML
    - MathML — Writing mathematics with MathML
        - MathML_first_steps': 'MathML first steps'

#### Japanese pages

- cf. https://developer.mozilla.org/ja/docs/Learn/MathML
  - MathML — MathML を使用して数学を記述する 
  - MathML の最初のステップ 

|before| after |
| :----: | :----:| 
| ![スクリーンショット 2024-08-24 13 22 01](https://github.com/user-attachments/assets/989f2603-3b01-43b2-b1d7-d3d70df714d1)  |  ![スクリーンショット 2024-08-24 13 34 08](https://github.com/user-attachments/assets/26dc8883-7c0b-419a-a629-b7b02f995c11)  |

### Solution

translate japanese for LearnSidebar.ejs

### NOTICE

@mdn/core-dev

Please merge once mdn-yari-ja is approved.

### Before

- There is no Japanese translation yet

### After

- tranlate japanese for LearnSidebar.ejs
