### PR TITLE
fix(curriculum): fix module overview sidescroll

### DIFF
--- a/client/src/curriculum/index.scss
+++ b/client/src/curriculum/index.scss
@@ -112,6 +112,8 @@
 
 .curriculum-content-container {
   > .curriculum-content {
+    max-width: 100%;
+
     h1,
     h2,
     h3,


### PR DESCRIPTION
## Summary

Width was missing so the whole page became scrollable.

---

## Screenshots

### Before


| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/afc86b29-8b12-4e2c-99a2-d0f4297a3276) | ![image](https://github.com/user-attachments/assets/2a1e0a34-3eea-4aac-95a8-514995786565) |


---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
