### PR TITLE
feature(curriculum): move banner one block upwards

### DIFF
--- a/client/src/curriculum/landing.tsx
+++ b/client/src/curriculum/landing.tsx
@@ -42,12 +42,15 @@ export function CurriculumLanding(appProps: HydrationData<any, CurriculumDoc>) {
           }
           if (section.value.id === "modules") {
             const { title, id } = (section as ProseSection).value;
+            console.log(title);
             return (
               <>
                 <section key={`${id}-1`} className="modules">
                   {title && <DisplayH2 id={id} title={title} />}
                   {doc?.modules && <ModulesListList modules={doc.modules} />}
                 </section>
+                <PartnerBanner />
+
                 <section key={`${id}-2`} className="landing-stairway">
                   <div>
                     <div id="stairway1-container">
@@ -100,7 +103,6 @@ export function CurriculumLanding(appProps: HydrationData<any, CurriculumDoc>) {
           return null;
         }}
       />
-      <PartnerBanner />
     </CurriculumLayout>
   );
 }


### PR DESCRIPTION
## Summary

Move the Scrimba banner on the curriculum landing page one block above.

(MP-1464)

## Screenshots

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/6886b288-69ee-4158-9a09-cb2302811b00">

## How did you test this change?

locally and on stage