### PR TITLE
fix(sidebars): change slugs for URI documents in HTTP sidebar

### DIFF
--- a/kumascript/macros/HTTPSidebar.ejs
+++ b/kumascript/macros/HTTPSidebar.ejs
@@ -294,11 +294,11 @@ var text = mdn.localStringMap({
         <details>
             <summary><%=text['ResourcesURI']%></summary>
             <ol>
-                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web`, null, text['Identifying'])%></li>
-                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Data_URLs`, null, text['DataURLs'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/URI`, null, text['Identifying'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/URI/Schemes/data`, null, text['DataURLs'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types`, null, text['MIMETypes'])%></li>
                 <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types`, null, text['ListMIMETypes'])%></li>
-                <li><%-web.smartLink(`/${locale}/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs`, null, text['WWWorNotWWW'])%></li>
+                <li><%-web.smartLink(`/${locale}/docs/Web/URI/Authority/Choosing_between_www_and_non-www_URLs`, null, text['WWWorNotWWW'])%></li>
             </ol>
         </details>
     </li>


### PR DESCRIPTION
## Summary

There was a reshuffle of some pages under HTTP following https://github.com/mdn/content/pull/35202/files

### Problem

Some links in the HTTP sidebar are broken.

### Solution

Update slugs in HTTPSidebar macro to point to new locations.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/10ec699a-5d8a-4ee2-862e-84eb59359d2f)


### After

![image](https://github.com/user-attachments/assets/bc0b781d-e9c3-4642-9159-1823165fbe56)


## How did you test this change?

* `yarn && yarn dev`
* localhost:3000
* visit `http://localhost:3000/en-US/docs/Web/HTTP`