### PR TITLE
chore(news): add scrimba partnership to news

### DIFF
--- a/build/spas.ts
+++ b/build/spas.ts
@@ -40,10 +40,10 @@ const FEATURED_ARTICLES = [
 ];
 
 const LATEST_NEWS: (NewsItem | string)[] = [
+  "blog/mdn-scrimba-partnership/",
   "blog/mdn-http-observatory-launch/",
   "blog/mdn-curriculum-launch/",
   "blog/baseline-evolution-on-mdn/",
-  "blog/introducing-the-mdn-playground/",
 ];
 
 const PAGE_DESCRIPTIONS = Object.freeze({


### PR DESCRIPTION

## Summary

Places the scrimba partnership on the news section on the home page.

## Screenshots

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/8a0b7167-1f24-4359-8b78-37723d77ceb5">

## How did you test this change?

locally and on stage