### PR TITLE
fix(macros/WebExtAllExamples): update branch name

### DIFF
--- a/kumascript/macros/WebExtAllExamples.ejs
+++ b/kumascript/macros/WebExtAllExamples.ejs
@@ -12,7 +12,7 @@ is generated using this macro.
 
 */
 
-const examplesBaseUrl = "https://github.com/mdn/webextensions-examples/tree/master/";
+const examplesBaseUrl = "https://github.com/mdn/webextensions-examples/tree/main/";
 const allExamples = await MDN.fetchWebExtExamples();
 const lang = env.locale;
 


### PR DESCRIPTION
## Summary

The `https://github.com/mdn/webextensions-examples/tree/master` redirects to `https://github.com/mdn/webextensions-examples/tree/main` .

### Solution

Update the URL.
