### PR TITLE
fix(ai-help): set chatId on user message

### DIFF
--- a/client/src/plus/ai-help/index.tsx
+++ b/client/src/plus/ai-help/index.tsx
@@ -983,7 +983,9 @@ export function AIHelpInner() {
                 ))}
               </section>
             )}
-            {hash === "#debug" && <pre>{JSON.stringify(datas, null, 2)}</pre>}
+            {hash === "#debug" && (
+              <pre>{JSON.stringify({ datas, messages, quota }, null, 2)}</pre>
+            )}
           </section>
         )}
       </Container>

--- a/client/src/plus/ai-help/use-ai.ts
+++ b/client/src/plus/ai-help/use-ai.ts
@@ -240,6 +240,7 @@ function messageReducer(state: MessageTreeState, messageAction: MessageAction) {
             ...newState.currentNode.request,
             messageId,
             parentId,
+            chatId,
           },
         });
         newState.nodes[messageId] = newState.currentNode;


### PR DESCRIPTION
## Summary

(MP-658, MP-1478)

### Problem

When editing a question after it was initially submitted (without reloading the page), submitting the updated question causes a new topic, because the question is missing the `chatId` reference.

### Solution

Make sure that the `chatId` is set on the question, so that the re-submitted question lands in the same chat.

---

## Screenshots
### Before

https://github.com/user-attachments/assets/0eb05b59-a1eb-4098-bb1a-d95a800323ff

### After

https://github.com/user-attachments/assets/4f5b0ed9-5ab7-4bed-895b-58b2547ec35c

---

## How did you test this change?

1. Ran `yarn dev` locally with Rumba running locally.
2. Opened http://localhost:3000/en-US/plus/ai-help locally.
3. Asked "How to center a div with CSS? Answer in one word." and waited for the response.
4. Edited the question, then resubmitted it.
5. Verified that the edited question remained in the same chat/tree.