### PR TITLE
chore(deps): pin cheerio to 1.0.0-rc.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "accept-language-parser": "^1.5.0",
     "async": "^3.2.6",
     "chalk": "^5.3.0",
-    "cheerio": "^1.0.0-rc.12",
+    "cheerio": "1.0.0-rc.12",
     "cli-progress": "^3.12.0",
     "codemirror": "^6.0.1",
     "compression": "^1.7.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5259,7 +5259,7 @@ cheerio-select@^2.1.0:
     domhandler "^5.0.3"
     domutils "^3.0.1"
 
-cheerio@^1.0.0-rc.12:
+cheerio@1.0.0-rc.12:
   version "1.0.0-rc.12"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
   integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/11618.

### Problem

We required cheerio via `^1.0.0-rc.12`, but this version range includes the latest `1.0.0` version, which has some breaking changes and [we won't upgrade](https://github.com/mdn/yari/pull/11667#issuecomment-2334322149) to it.

### Solution

Pin cheerio to the specific `1.0.0-rc.12` version instead.

---

## How did you test this change?

Trivial change.