### PR TITLE
feature(translated-content): add github contributor profile list UI

### DIFF
--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -102,6 +102,32 @@
       margin-top: 0.25rem;
     }
 
+    .contributors-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
+    }
+
+    .contributor-item {
+      transition: transform 0.2s ease-in-out;
+    }
+
+    .contributor-item:hover {
+      transform: translateY(-5px);
+    }
+
+    .contributor-card {
+      text-decoration: none;
+      color: #333;
+    }
+
+    .contributor-avatar {
+      width: 40px;
+      height: 40px;
+      border-radius: 50%;
+      margin-bottom: 10px;
+      box-shadow: 5px 5px 5px rgb(128, 128, 128);
+    }
+
     .last-modified-date {
       margin-bottom: 0;
       margin-top: 2rem;
@@ -113,3 +139,18 @@
     }
   }
 }
+
+// @media (max-width: 768px) {
+//   .contributors-grid {
+//     grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
+//   }
+
+//   .contributor-image-container {
+//     width: 40px;
+//     height: 40px;
+//   }
+
+//   .contributor-id {
+//     font-size: 10px;
+//   }
+// }

--- a/client/src/document/organisms/article-footer/index.scss
+++ b/client/src/document/organisms/article-footer/index.scss
@@ -116,16 +116,16 @@
     }
 
     .contributor-card {
-      text-decoration: none;
       color: #333;
+      text-decoration: none;
     }
 
     .contributor-avatar {
-      width: 40px;
-      height: 40px;
       border-radius: 50%;
-      margin-bottom: 10px;
       box-shadow: 5px 5px 5px rgb(128, 128, 128);
+      height: 40px;
+      margin-bottom: 10px;
+      width: 40px;
     }
 
     .last-modified-date {
@@ -139,18 +139,3 @@
     }
   }
 }
-
-// @media (max-width: 768px) {
-//   .contributors-grid {
-//     grid-template-columns: repeat(auto-fill, minmax(50px, 1fr));
-//   }
-
-//   .contributor-image-container {
-//     width: 40px;
-//     height: 40px;
-//   }
-
-//   .contributor-id {
-//     font-size: 10px;
-//   }
-// }

--- a/client/src/document/organisms/article-footer/index.tsx
+++ b/client/src/document/organisms/article-footer/index.tsx
@@ -127,7 +127,6 @@ export function ArticleFooter({ doc }) {
     gleanClick(`${ARTICLE_FOOTER}: feedback -> ${reason}`);
   }
 
-  console.log("doc", doc);
   return (
     <aside className="article-footer">
       <div className="article-footer-inner">


### PR DESCRIPTION
## Summary

Add the feature to enhance visual elements for page contributors.

### Problem

I was thinking about an alternative to the page provided as txt. 

https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/of/contributors.txt

### Solution

I suggest showing the profile at least after yari(github). **However, there is a problem with my PR. I'm requesting the github API, but there are limitations.**

---

## Screenshots

### Before

<img width="565" alt="image" src="https://github.com/user-attachments/assets/538f86ab-f895-4957-af9f-a48a30184c09">

### After

<img width="555" alt="스크린샷 2024-09-07 오전 12 23 14" src="https://github.com/user-attachments/assets/5e11dc60-7e27-41fc-8986-3d04d40dcc92">

## Related Discussion

- https://github.com/orgs/mdn/discussions/728