### PR TITLE
chore(deps): bump micromatch from 4.0.5 to 4.0.8 in /cloud-function

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -2781,11 +2781,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
## Summary

Bumps `micromatch` in `/cloud-function` from 4.0.5 to 4.0.8.

---

## How did you test this change?

Not directly tested, but this is a patch version.