### PR TITLE
fix(sidebar): reuse icon margin for non-nested entries

### DIFF
--- a/client/src/document/organisms/sidebar/index.scss
+++ b/client/src/document/organisms/sidebar/index.scss
@@ -63,17 +63,15 @@
       padding-left: 0.5rem;
     }
 
-    ol {
-      li {
-        .icon {
-          margin-right: 0.01em;
-        }
+    li {
+      .icon {
+        margin-right: 0.01em;
+      }
 
-        &.no-bullet {
-          display: block;
-          font-weight: var(--font-body-strong-weight);
-          list-style-type: none;
-        }
+      &.no-bullet {
+        display: block;
+        font-weight: var(--font-body-strong-weight);
+        list-style-type: none;
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #11614.

### Problem

The non-standard and deprecated icons were missing a margin for non-nested sidebar list items.

### Solution

Generalize the corresponding style for all sidebar list items.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="358" alt="image" src="https://github.com/user-attachments/assets/0b8ed77b-a5a5-4fef-9bc0-900feceff614"> | <img width="358" alt="image" src="https://github.com/user-attachments/assets/23fb77c0-33ff-4377-a890-359c3988e33c"> | 

---

## How did you test this change?

Ran `yarn dev` locally and checked http://localhost:3000/en-US/docs/Web/API/PaymentAddress.