### PR TITLE
enhance(ad-free): hide all banners completely

### DIFF
--- a/client/src/ui/organisms/placement/index.scss
+++ b/client/src/ui/organisms/placement/index.scss
@@ -272,6 +272,10 @@ section.place {
       width: initial;
     }
   }
+
+  html[data-nop] & {
+    display: none;
+  }
 }
 
 .dark section.place .pong-box2 {


### PR DESCRIPTION
## Summary

When paying MDN Plus subscribers enable the "Ad-free experience", we now hide all banners completely, rather than displaying empty sections.

Fixes #11645.

---

## Screenshots

| Before | After |
|--------|--------|
| ![Screen Shot 2024-09-10 at 17 18 54](https://github.com/user-attachments/assets/ec32522e-280c-4ddd-944d-1930b1a10c69) | ![Screen Shot 2024-09-10 at 17 18 58](https://github.com/user-attachments/assets/733cf252-a9f5-4346-b38f-c8f9619a5f6f) |
| ![Screen Shot 2024-09-10 at 17 19 32](https://github.com/user-attachments/assets/4109c28e-bdd0-4d12-b8f0-21f0b5e8d77c) | ![Screen Shot 2024-09-10 at 17 19 36](https://github.com/user-attachments/assets/689e94c3-6ac3-4eda-b613-7a980c26a2e8) | 

---

## How did you test this change?

Ran `yarn dev` with Rumba running locally, verified that the placement space is released both on mobile (xs, sm) and desktop (md).