### PR TITLE
chore(tools-menu): remove "New" indicator

### DIFF
--- a/client/src/ui/molecules/tools-menu/index.tsx
+++ b/client/src/ui/molecules/tools-menu/index.tsx
@@ -9,11 +9,7 @@ export const ToolsMenu = ({ visibleSubMenuId, toggleMenu }) => {
 
   const menu = {
     id: "tools",
-    label: (
-      <>
-        Tools <sup className="new">New</sup>
-      </>
-    ),
+    label: <>Tools</>,
     items: [
       {
         description: "Write, test and share your code",
@@ -28,7 +24,6 @@ export const ToolsMenu = ({ visibleSubMenuId, toggleMenu }) => {
         iconClasses: "submenu-icon",
         label: OBSERVATORY_TITLE,
         url: `/en-US/observatory`,
-        dot: "New",
       },
       {
         description: "Get real-time assistance and support",

--- a/client/src/ui/molecules/tools-menu/index.tsx
+++ b/client/src/ui/molecules/tools-menu/index.tsx
@@ -9,7 +9,7 @@ export const ToolsMenu = ({ visibleSubMenuId, toggleMenu }) => {
 
   const menu = {
     id: "tools",
-    label: <>Tools</>,
+    label: "Tools",
     items: [
       {
         description: "Write, test and share your code",


### PR DESCRIPTION
## Summary

(MP-1499)

### Problem

We launched HTTP Observatory on July 2nd, 2024, and have since had a "New" indicator on the new "Tools" menu and on the "HTTP Observatory" menu item in that menu, but 2 months have passed since.

### Solution

Remove the "New" indicator.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/2c3874e5-b917-4da8-aab2-a7f061d21130">

### After

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/0faeefb2-2444-467e-ad7a-badf510ec474">


---

## How did you test this change?

Ran `yarn dev` locally and checked http://localhost:3000/en-US/.
