### PR TITLE
fix(placement): use variable for horizontal banner

### DIFF
--- a/client/src/playground/index.scss
+++ b/client/src/playground/index.scss
@@ -258,7 +258,11 @@ main.play {
 
                 > div.content {
                   align-items: end;
-                  background: linear-gradient(to left, #111 16rem, transparent);
+                  background: linear-gradient(
+                    to left,
+                    var(--place-new-side-background) 16rem,
+                    transparent
+                  );
                   flex-direction: column;
                   height: 100%;
                   justify-content: end;


### PR DESCRIPTION
## Summary

(MP-1500)

### Problem

The horizontal banner on Playground was using a hard-coded color (`#111`) for the gradient.

### Solution

Use the `--place-new-side-background` variable instead.

---

## Screenshots

### Before

<img width="707" alt="image" src="https://github.com/user-attachments/assets/31295749-e2b9-48ab-bb2a-7c5f642cd4d0">

### After

<img width="707" alt="image" src="https://github.com/user-attachments/assets/87ca8575-9be6-479d-b418-c99d72444c45">


---

## How did you test this change?

Ran `yarn dev` locally with `REACT_APP_KUMA_HOST=developer.allizom.org`, then tested on http://localhost:3000/en-US/play.

This is also deployed to stage, as of 2024-09-11.