### PR TITLE
fix(build): use pipefail to fail function deployments

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -349,6 +349,8 @@ jobs:
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
         run: |-
+          set -eo pipefail
+
           for region in europe-west1 us-west1 asia-east1; do
             gcloud beta functions deploy mdn-prod-prod-$region \
             --gen2 \

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -365,6 +365,8 @@ jobs:
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
         run: |-
+          set -eo pipefail
+
           for region in europe-west1 us-west1 asia-east1; do
             gcloud beta functions deploy mdn-nonprod-stage-$region \
             --gen2 \

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -245,6 +245,8 @@ jobs:
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
         run: |-
+          set -eo pipefail
+
           for region in europe-west3; do
             gcloud beta functions deploy mdn-nonprod-test-$region \
             --gen2 \


### PR DESCRIPTION
## Summary

Follow-up to MP-1443 and https://github.com/mdn/yari/pull/11637.

### Problem

We don't notice if a Cloud Function deployment fails, because the failing command is piped into `sed`, which always succeeds.

### Solution

Enable `pipefail`.

---

## How did you test this change?

Not explicitly tested, as it replicates the change from a previous PR.