### PR TITLE
fix(style): use em unit for Switch/Thumbs atoms

### DIFF
--- a/client/src/ui/atoms/switch/index.scss
+++ b/client/src/ui/atoms/switch/index.scss
@@ -7,7 +7,7 @@
     height: 0;
     margin: 0;
     opacity: 0;
-    width: 3rem;
+    width: 3em;
 
     &:checked + .slider {
       background-color: var(--text-link);
@@ -29,10 +29,10 @@
     background-color: var(--text-secondary);
     border-radius: 1.5em;
     cursor: pointer;
-    height: 1.5rem;
+    height: 1.5em;
     position: absolute;
     transition: 0.4s;
-    width: 3rem;
+    width: 3em;
 
     &:before {
       background-color: var(--background-primary);
@@ -48,6 +48,6 @@
   }
 
   .label {
-    margin-left: 0.5rem;
+    margin-left: 0.5em;
   }
 }

--- a/client/src/ui/atoms/thumbs/index.scss
+++ b/client/src/ui/atoms/thumbs/index.scss
@@ -2,8 +2,8 @@
   align-items: center;
   display: flex;
   flex-direction: row;
-  gap: 0.5rem;
-  height: 1.5rem;
+  gap: 0.5em;
+  height: 1.5em;
 
   .confirmation {
     animation-duration: 2.5s;


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Extracted from https://github.com/mdn/yari/pull/11518/.

### Problem

We were using `rem` in the `Switch` and `Thumbs` components, making these the same size even if the `font-size` is smaller in their context.

### Solution

Use `em` instead.

---

## Screenshots

(Omitted.)

---

## How did you test this change?

See https://github.com/mdn/yari/pull/11518/, this has been deployed on stage for several days.