### PR TITLE
enhance(language-menu): explain "Remember language" + link announcement

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,15 @@
     ]
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "react/jsx-no-target-blank": [
+        "error",
+        {
+          "allowReferrer": true
+        }
+      ]
+    }
   },
   "jest": {
     "collectCoverageFrom": [

--- a/client/package.json
+++ b/client/package.json
@@ -21,15 +21,7 @@
     ]
   },
   "eslintConfig": {
-    "extends": "react-app",
-    "rules": {
-      "react/jsx-no-target-blank": [
-        "error",
-        {
-          "allowReferrer": true
-        }
-      ]
-    }
+    "extends": "react-app"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/client/src/ui/atoms/icon/index.scss
+++ b/client/src/ui/atoms/icon/index.scss
@@ -7,11 +7,11 @@ $icons: "add-filled", "add", "altname", "bell", "bell-filled", "bell-ring",
   "mastodon", "menu-filled", "menu", "mobile", "more", "theme-dark", "new-topic",
   "next", "no", "nodejs", "nonstandard", "note-info", "note-warning",
   "note-deprecated", "opera", "padlock", "partial", "play", "prefix", "preview",
-  "previous", "queue", "queued", "quote", "return", "safari", "samsunginternet",
-  "search", "send", "server", "sidebar", "simple-firefox", "small-arrow",
-  "theme-light", "star-filled", "star", "theme-os-default", "thumbs-down",
-  "thumbs-up", "trash", "trash-filled", "twitter-x", "unknown", "warning",
-  "webview", "yes", "yes-circle";
+  "previous", "question-mark", "queue", "queued", "quote", "return", "safari",
+  "samsunginternet", "search", "send", "server", "sidebar", "simple-firefox",
+  "small-arrow", "theme-light", "star-filled", "star", "theme-os-default",
+  "thumbs-down", "thumbs-up", "trash", "trash-filled", "twitter-x", "unknown",
+  "warning", "webview", "yes", "yes-circle";
 
 .icon {
   --size: var(--icon-size, 1rem);

--- a/client/src/ui/molecules/submenu/index.scss
+++ b/client/src/ui/molecules/submenu/index.scss
@@ -47,7 +47,7 @@
     width: 100%;
   }
 
-  a,
+  li > a,
   .submenu-item {
     align-items: center;
     border: 1px solid transparent;

--- a/client/src/ui/organisms/article-actions/language-menu/index.scss
+++ b/client/src/ui/organisms/article-actions/language-menu/index.scss
@@ -31,6 +31,12 @@
         background-color: unset;
       }
 
+      .group {
+        align-items: center;
+        display: flex;
+        gap: 0.5em;
+      }
+
       .switch {
         display: flex;
       }
@@ -39,9 +45,17 @@
         font-style: italic;
         font-variation-settings: "slnt" -10;
         margin-top: 0.5em;
+      }
 
-        .icon {
-          margin-right: unset;
+      .icon {
+        margin-right: unset;
+      }
+
+      a[href] .icon-question-mark {
+        background-color: var(--icon-secondary);
+
+        &:hover {
+          background-color: var(--text-link);
         }
       }
     }

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -156,7 +156,6 @@ function LocaleRedirectSetting() {
     }
   }
 
-  // eslint-disable react/jsx-no-target-blank
   return (
     <form className="submenu-item locale-redirect-setting">
       <div className="group">

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-target-blank */
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -168,7 +167,7 @@ function LocaleRedirectSetting() {
         </Switch>
         <a
           href="https://github.com/orgs/mdn/discussions/739"
-          rel="external noopener"
+          rel="external noopener noreferrer"
           target="_blank"
           title="Enable this setting to automatically switch to this language when it's available. (Click to learn more.)"
         >

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-target-blank */
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-no-target-blank */
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
@@ -17,6 +18,7 @@ import {
 } from "../../../../utils";
 import { GleanThumbs } from "../../../atoms/thumbs";
 import { Switch } from "../../../atoms/switch";
+import { Icon } from "../../../atoms/icon";
 
 // This needs to match what's set in 'libs/constants.js' on the server/builder!
 const PREFERRED_LOCALE_COOKIE_NAME = "preferredlocale";
@@ -154,15 +156,26 @@ function LocaleRedirectSetting() {
     }
   }
 
+  // eslint-disable react/jsx-no-target-blank
   return (
     <form className="submenu-item locale-redirect-setting">
-      <Switch
-        name="locale-redirect"
-        checked={locale === preferredLocale}
-        toggle={toggle}
-      >
-        Remember language
-      </Switch>
+      <div className="group">
+        <Switch
+          name="locale-redirect"
+          checked={locale === preferredLocale}
+          toggle={toggle}
+        >
+          Remember language
+        </Switch>
+        <a
+          href="https://github.com/orgs/mdn/discussions"
+          rel="external noopener"
+          target="_blank"
+          title="Enable this setting to automatically switch to this language when it's available. (Click to learn more.)"
+        >
+          <Icon name="question-mark" />
+        </a>
+      </div>
       <GleanThumbs feature="locale-redirect" question="Is this useful?" />
     </form>
   );

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -168,7 +168,7 @@ function LocaleRedirectSetting() {
           Remember language
         </Switch>
         <a
-          href="https://github.com/orgs/mdn/discussions"
+          href="https://github.com/orgs/mdn/discussions/739"
           rel="external noopener"
           target="_blank"
           title="Enable this setting to automatically switch to this language when it's available. (Click to learn more.)"

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -148,7 +148,7 @@ function LocaleRedirectSetting() {
         maxAge: 60 * 60 * 24 * 365 * 3,
       });
       setPreferredLocale(locale);
-      gleanClick(`${LANGUAGE_REMEMBER}: ${oldValue} -> ${locale}`);
+      gleanClick(`${LANGUAGE_REMEMBER}: ${oldValue ?? 0} -> ${locale}`);
     } else {
       deleteCookie(PREFERRED_LOCALE_COOKIE_NAME);
       setPreferredLocale(undefined);

--- a/client/src/ui/organisms/article-actions/language-menu/index.tsx
+++ b/client/src/ui/organisms/article-actions/language-menu/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-target-blank */
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 


### PR DESCRIPTION
## Summary

(MP-1540)

### Problem

https://github.com/mdn/yari/pull/11518 added the experimental "Remember language" setting, but there is no explanation.

### Solution

Add a question mark icon with a `title`, and link to the GitHub discussion that announces the feature.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="261" alt="image" src="https://github.com/user-attachments/assets/acb22500-e80b-4df0-9c2b-78a7a77ec330">

### After

<img width="261" alt="image" src="https://github.com/user-attachments/assets/8d0532ca-8d73-4f67-9a3d-a01b106ff73a">


---

## How did you test this change?

Ran `yarn dev` locally and checked out the language menu at http://localhost:3000/en-US/docs/Web.
