### PR TITLE
style(eslint): allow referrers in target="_blank" links

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,15 @@
     ]
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "react/jsx-no-target-blank": [
+        "error",
+        {
+          "allowReferrer": true
+        }
+      ]
+    }
   },
   "jest": {
     "collectCoverageFrom": [


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We currently add `rel="noreferrer"` to all external links in our client, which has two effects:

1. The linked website will not see that the user is coming from MDN.
2. On older browser, it has the same effect as `rel="noopener"` (see [here](https://mathiasbynens.github.io/rel-noopener/#recommendations)).

However, there is no reason to hide MDN as the referrer, because the default `Referrer-Policy` applies, so that the destination only sees `https://developer.mozilla.org/`.

### Solution

Update the ESLint config for the `client/` and allow referrers in the `react/jsx-no-target-blank` rule.

_Note_: The rule will still require `noopener` instead.

---

## How did you test this change?

Made the change in https://github.com/mdn/yari/pull/11865 and it had the effect.
