### PR TITLE
fix(macros/jsxref): fix dot handling

### DIFF
--- a/kumascript/macros/jsxref.ejs
+++ b/kumascript/macros/jsxref.ejs
@@ -29,8 +29,8 @@ const anchor = $2 || '';
 const wrap = !$3;
 
 let slug = apiName.replace('()', '').replace('.prototype.', '.');
-if (apiName.includes(".") && !apiName.includes("..")) {
-    // E.g. "Array.filter", but not "try...catch".
+if (apiName.includes(".") && !apiName.includes("/")) {
+    // E.g. "Array.filter", but not "Statements/try...catch".
     slug = slug.replace('.', '/');
 }
 


### PR DESCRIPTION
## Summary

Previously we replaces all single dots with a slash. This resulted in:
`{{jsxref("Operators/new%2Etarget", "new.target")}}`

An alternative is to change the logic to:

If there is an slash in the 1st parameter don't replace the dots. This works for all en-US and the issue I found in translated content where alread broken.


### Problem

Allow `{{jsxref("Operators/new.target", "new.target")}}`

### Solution

Change the logic and don't replace dot's if there's slashes.

---

## How did you test this change?

Locally
