### PR TITLE
chore(curriculum): change scrimba copy/links

### DIFF
--- a/client/src/curriculum/landing.tsx
+++ b/client/src/curriculum/landing.tsx
@@ -144,17 +144,16 @@ function About({ section }) {
             <Suspense>{!isServer && <ScrimInline url={SCRIM_URL} />}</Suspense>
           </div>
           <p>
-            Learn our curriculum with high quality, interactive courses from our
-            partner{" "}
+            Learn our curriculum with Scrimba's interactive{" "}
             <a
-              href="https://scrimba.com/?via=mdn"
+              href="https://scrimba.com/learn/frontend?via=mdn"
               className="external"
               target="_blank"
               rel="noreferrer"
             >
-              Scrimba
+              Frontend Developer Career Path
             </a>
-            {" !"}
+            .
           </p>
         </section>
       </div>

--- a/client/src/curriculum/partner-banner.tsx
+++ b/client/src/curriculum/partner-banner.tsx
@@ -9,23 +9,19 @@ export function PartnerBanner() {
     <section className="curriculum-partner-banner-container">
       <div className="partner-banner">
         <section>
-          <h2>
-            Learn the curriculum with{" "}
+          <h2>Learn the curriculum with Scrimba and become job ready</h2>
+          <p>
             <a
-              href="https://scrimba.com?via=mdn"
+              href="https://scrimba.com/learn/frontend?via=mdn"
               target="_blank"
               rel="origin noreferrer"
               className="external"
             >
-              Scrimba
+              Scrimba's Frontend Developer Career Path
             </a>{" "}
-            and become job ready
-          </h2>
-          <p>
-            Scrimba's Frontend Developer Career Path teaches the MDN Curriculum
-            Core with fun interactive lessons and challenges, knowledgeable
-            teachers, and a supportive community. Go from zero to landing your
-            first front-end job!
+            teaches the MDN Curriculum Core with fun interactive lessons and
+            challenges, knowledgeable teachers, and a supportive community. Go
+            from zero to landing your first front-end job!
           </p>
           <a
             href="https://scrimba.com/learn/frontend?via=mdn"


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

https://mozilla-hub.atlassian.net/browse/MP-1547

### Problem

- A user reached out to report they couldn't find the MDN course on Scrimba
- This was due to having some links to Scrimba's home page, rather than directly to the course

### Solution

- Remove the links to Scrimba's home page, replace with links to the course

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/f99c5d60-5d8f-4c90-a853-b318c2a69147)


### After

![image](https://github.com/user-attachments/assets/6761828d-73a1-49c2-90b6-2247046f4220)


---

## How did you test this change?

- `yarn dev`
- localhost:3000
