### PR TITLE
enhance(seo): link technologies in homepage hero

### DIFF
--- a/client/src/homepage/featured-articles/index.scss
+++ b/client/src/homepage/featured-articles/index.scss
@@ -56,11 +56,6 @@
 
       a {
         color: var(--text-primary);
-
-        &:hover,
-        &:focus {
-          text-decoration: underline;
-        }
       }
     }
 

--- a/client/src/homepage/homepage-hero/index.tsx
+++ b/client/src/homepage/homepage-hero/index.tsx
@@ -1,8 +1,12 @@
 import "./index.scss";
 import { Search } from "../../ui/molecules/search";
 import Mandala from "../../ui/molecules/mandala";
+import { useLocale } from "../../hooks";
+import { HOMEPAGE_HERO } from "../../telemetry/constants";
 
 export function HomepageHero() {
+  const locale = useLocale();
+
   return (
     <div className="homepage-hero dark">
       <section>
@@ -11,8 +15,28 @@ export function HomepageHero() {
           <br /> by Developers
         </h1>
         <p>
-          Documenting web technologies, including CSS, HTML, and JavaScript,
-          since 2005.
+          Documenting web technologies, including{" "}
+          <a
+            href={`/${locale}/docs/Web/CSS`}
+            data-glean={`${HOMEPAGE_HERO}: css`}
+          >
+            CSS
+          </a>
+          ,{" "}
+          <a
+            href={`/${locale}/docs/Web/HTML`}
+            data-glean={`${HOMEPAGE_HERO}: html`}
+          >
+            HTML
+          </a>
+          , and{" "}
+          <a
+            href={`/${locale}/docs/Web/JavaScript`}
+            data-glean={`${HOMEPAGE_HERO}: js`}
+          >
+            JavaScript
+          </a>
+          , since 2005.
         </p>
         <Search id="hp-search" isHomepageSearch={true} />
       </section>

--- a/client/src/homepage/index.scss
+++ b/client/src/homepage/index.scss
@@ -17,4 +17,8 @@
   > *:first-child {
     margin-top: 0;
   }
+
+  a:hover {
+    text-decoration: underline;
+  }
 }

--- a/client/src/homepage/recent-contributions/index.scss
+++ b/client/src/homepage/recent-contributions/index.scss
@@ -57,7 +57,6 @@
 
       &:hover {
         color: var(--text-primary);
-        text-decoration: underline;
       }
     }
 

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -85,3 +85,4 @@ export const LANGUAGE = "language";
 export const LANGUAGE_REMEMBER = "language_remember";
 export const THEME_SWITCHER = "theme_switcher";
 export const SURVEY = "survey";
+export const HOMEPAGE_HERO = "homepage_hero";


### PR DESCRIPTION
## Summary

(MP-1550)

### Problem

The homepage hero mentions CSS, HTML, and JavaScript, but there is no link to content of this topic.

### Solution

Add links to the keywords.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="863" alt="image" src="https://github.com/user-attachments/assets/c5400b6d-41d7-4c75-a7f9-556b0d88ea61">

### After

<img width="863" alt="image" src="https://github.com/user-attachments/assets/8db051a3-fb92-4d43-982c-351e0eaf5c87">

---

## How did you test this change?

Ran `yarn dev`, opened http://localhost:3000/en-US/ and clicked each of the new links in the hero section. Also verified that underline on hover still works for the links in the other homepage sections.