### PR TITLE
fix(build): don't run bundlesize action on PRs from forks

### DIFF
--- a/.github/workflows/pr-bundlesize-compare.yml
+++ b/.github/workflows/pr-bundlesize-compare.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   # Build current and upload stats.json
   build-head:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "Build head"
     permissions:
       contents: read
@@ -46,6 +47,7 @@ jobs:
 
   # Build base for comparison and upload stats.json
   build-base:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "Build base"
     permissions:
       contents: read
@@ -86,6 +88,7 @@ jobs:
 
   # run the action against the stats.json files
   compare:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     name: "Compare base & head bundle sizes"
     runs-on: ubuntu-latest
     needs: [build-base, build-head]


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

https://mozilla-hub.atlassian.net/browse/MP-1562

### Problem

- the bundlesize action is erroring out on PRs coming from forks, presumably due to a permissions issue, see: https://github.com/mdn/yari/actions/runs/11123128068/job/30905902030

### Solution

- skip running the action if it comes from a fork: https://github.com/mdn/yari/actions/runs/11123275197/job/30906385146?pr=11886

---

## How did you test this change?

With this test PR: https://github.com/mdn/yari/pull/11886
