### PR TITLE
chore(macros): add "except shared" condition to AvailableinWorkers

### DIFF
--- a/kumascript/macros/AvailableInWorkers.ejs
+++ b/kumascript/macros/AvailableInWorkers.ejs
@@ -7,6 +7,7 @@
 //      'window_and_dedicated': only in DedicatedWorker (and in Window)
 //      'dedicated': only in DedicatedWorker
 //      'window_and_worker_except_service': all workers but ServiceWorker (and in Window)
+//      'window_and_worker_except_shared': all workers but shared workers (and in Window)
 //      'worker_except_service': all workers but ServiceWorker (and no window)
 //      'window_and_service': only in ServiceWorker (and in Window)
 //      'service': only in ServiceWorker
@@ -54,6 +55,10 @@ const textNotService = mdn.localString({
   "zh-TW": `此功能可在 <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Worker</a>（不包括 <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Worker</a>）中使用。`,
 });
 
+const textNotShared = mdn.localString({
+  "en-US": `This feature is available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/SharedWorkerGlobalScope">Shared Web Workers</a>.`,
+});
+
 const textNotServiceNotWindow = mdn.localString({
   "en-US": `This feature is only available in <a href="/${locale}/docs/Web/API/Web_Workers_API">Web Workers</a>, except for <a href="/${locale}/docs/Web/API/Service_Worker_API">Service Workers</a>.`,
   "ja": `この機能は<a href="/${locale}/docs/Web/API/Web_Workers_API">ウェブワーカー</a>内でのみ利用可能ですが、<a href="/${locale}/docs/Web/API/Service_Worker_API">サービスワーカー</a>では使用できません。`,
@@ -90,6 +95,7 @@ const associatedText = {
   default: () => textDefault,
   worker: () => textWorker,
   window_and_worker_except_service: () => textNotService,
+  window_and_worker_except_shared: () => textNotShared,
   worker_except_service: () => textNotServiceNotWindow,
   window_and_dedicated: () => textDedicated,
   dedicated: () => textDedicatedOnly,


### PR DESCRIPTION
… except for shared

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

I am adding MDN content that shows a feature is now supported in dedicated and service workers. See https://github.com/mdn/content/pull/36060

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

The AvaiIableInWorkers macro does not support the combination of supported in workers except for shared workers.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

I have added an argument option, "window_and_worker_except_shared", which displays text supporting this case.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

With the macro call looking like this — `{{AvailableInWorkers("window_and_worker_except_shared")}}` — the generated banner now looks like this:

![Screenshot 2024-10-01 at 11 26 36](https://github.com/user-attachments/assets/4dd7252a-9a69-4c2c-a5bb-1d4eeac6588a)

---

## How did you test this change?

I included the macro call with my new argument in a test page on https://github.com/mdn/content/pull/36060, set the content repo directory as the source of the content to display in my yari repo env file, and then ran it locally to verify it was working properly.

