### PR TITLE
chore(deps): bump cookie from 0.5.0 to 0.7.2 in /cloud-function

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -1476,9 +1476,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -4434,7 +4434,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "accept-language-parser": "^1.5.0",
-        "cookie": "^0.5.0"
+        "cookie": "^0.7.0"
       }
     },
     "src/internal/pong": {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes a build issue where `npm ci` in `/cloud-function` fails.

### Problem

For some reason, `npm ci` fails in `/cloud-function` during build.

### Solution

Ran `npm install` to update the `package-lock.json`.

---

## How did you test this change?

Will merge this into `next` and kick off a stage build.