### PR TITLE
fix(m2h): don't delete p's in li's

### DIFF
--- a/client/src/curriculum/index.scss
+++ b/client/src/curriculum/index.scss
@@ -192,6 +192,13 @@
         color: var(--text-visited);
       }
     }
+
+    ol,
+    ul {
+      li > p {
+        display: contents;
+      }
+    }
   }
 
   &.with-sidebar {

--- a/client/src/curriculum/index.scss
+++ b/client/src/curriculum/index.scss
@@ -196,7 +196,7 @@
     ol,
     ul {
       li > p {
-        display: contents;
+        margin: 0;
       }
     }
   }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -112,7 +112,7 @@
       margin: 0.5rem 0;
 
       > p {
-        display: contents;
+        margin: 0;
       }
     }
   }

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -110,6 +110,10 @@
 
     li {
       margin: 0.5rem 0;
+
+      > p {
+        display: contents;
+      }
     }
   }
 

--- a/markdown/m2h/handlers/index.ts
+++ b/markdown/m2h/handlers/index.ts
@@ -191,8 +191,10 @@ export function buildLocalizedHandlers(locale: Locale): Handlers {
         children:
           "children" in item
             ? item.children.flatMap((child) =>
-                "tagName" in child && child.tagName == "p"
-                  ? child.children
+                "tagName" in child &&
+                child.tagName == "p" &&
+                child.children?.length === 0
+                  ? []
                   : [child]
               )
             : [],


### PR DESCRIPTION
## Summary

In order to have more predictable html we keep the p's (expect for empty ones).
### Problem

```md
- foobar
- foo
  
  bar
```

is 

```html
<ul>
  <li>
    <p>foobar</p>
  </li>
  <li>
    <p>foo</p>
    <p>bar</p>
  </li>
</ul>
```

in gfm, but

```html
<ul>
  <li>foobar</li>
  <li>
    foo
    bar
  </li>
</ul>
```


### Solution

Don't delete the `<p>`'s but set `margin: 0` to minimize impact.
---

## Screenshots

No visual diff.

---

## How did you test this change?

Locally, stage deployment pending.
