### PR TITLE
chore(observatory): remove links to old observatory

### DIFF
--- a/client/src/observatory/landing.tsx
+++ b/client/src/observatory/landing.tsx
@@ -96,12 +96,7 @@ export default function ObservatoryLanding() {
                 Launched in 2016, the HTTP Observatory enhances web security by
                 analyzing compliance with best security practices. It has
                 provided insights to over 6.9 million websites through 47
-                million scans. The{" "}
-                <a href="https://observatory.mozilla.org/">
-                  previous version of HTTP Observatory
-                </a>{" "}
-                is still available, however it is now deprecated and will soon
-                be sunsetted.
+                million scans.
               </p>
               {isMutating ? (
                 <Progress message={`Scanning ${cleanHostname}…`} />

--- a/copy/observatory/faq.md
+++ b/copy/observatory/faq.md
@@ -57,10 +57,9 @@ there is now no reason to provide the "public" flag.
 
 ## When did the move occur?
 
-The new HTTP Observatory was launched on MDN on July 2, 2024. The
-[old Mozilla Observatory](https://observatory.mozilla.org/) — containing HTTP
-Observatory plus other tools like TLS Observatory, SSH Observatory, and
-Third-party tests — has been deprecated and will be sunset in September 2024.
+The new HTTP Observatory was launched on MDN on July 2, 2024. The old Mozilla
+Observatory — containing HTTP Observatory plus other tools like TLS Observatory,
+SSH Observatory, and Third-party tests — has been sunset in October 2024.
 
 > **Note:** Historic scan data has been preserved, and is included in the
 > provided scan history for each domain.


### PR DESCRIPTION
## Summary
Removed link to old Observatory, since it redirects now to HTTP Observatory

(MP-1553)

