### PR TITLE
chore(curriculum): add metrics to measure scrimba funnel

### DIFF
--- a/client/src/curriculum/landing.tsx
+++ b/client/src/curriculum/landing.tsx
@@ -15,8 +15,10 @@ import "./index.scss";
 import "./landing.scss";
 import { ProseSection } from "../../../libs/types/document";
 import { PartnerBanner } from "./partner-banner";
-import { useIsServer } from "../hooks";
+import { useIsServer, useViewed } from "../hooks";
 import scrimBg from "../assets/curriculum/landing-scrim.png";
+import { useGleanClick } from "../telemetry/glean-context";
+import { CURRICULUM } from "../telemetry/constants";
 
 const ScrimInline = lazy(() => import("./scrim-inline"));
 
@@ -133,6 +135,12 @@ function About({ section }) {
   const { title, content, id } = section.value;
   const html = useMemo(() => ({ __html: content }), [content]);
   const isServer = useIsServer();
+  const gleanClick = useGleanClick();
+  const observedNode = useViewed(() => {
+    const url = new URL(SCRIM_URL);
+    const id = url.pathname.slice(1);
+    gleanClick(`${CURRICULUM}: scrim view id:${id}`);
+  });
 
   return (
     <section key={id} className="landing-about-container">
@@ -148,6 +156,7 @@ function About({ section }) {
                   url={SCRIM_URL}
                   img={scrimBg}
                   scrimTitle="MDN + Scrimba partnership announcement scrim"
+                  ref={observedNode}
                 />
               )}
             </Suspense>

--- a/client/src/curriculum/partner-banner.tsx
+++ b/client/src/curriculum/partner-banner.tsx
@@ -25,6 +25,9 @@ export function PartnerBanner() {
               target="_blank"
               rel="origin noreferrer"
               className="external"
+              onClick={() => {
+                gleanClick(`${CURRICULUM}: partner banner click`);
+              }}
             >
               Scrimba's Frontend Developer Career Path
             </a>{" "}
@@ -37,6 +40,9 @@ export function PartnerBanner() {
             target="_blank"
             rel="origin noreferrer"
             className="external"
+            onClick={() => {
+              gleanClick(`${CURRICULUM}: partner banner click`);
+            }}
           >
             Find out more
           </a>

--- a/client/src/curriculum/partner-banner.tsx
+++ b/client/src/curriculum/partner-banner.tsx
@@ -1,12 +1,21 @@
 import ThemedPicture from "../ui/atoms/themed-picture";
+import { useGleanClick } from "../telemetry/glean-context";
+import { useViewed } from "../hooks";
+import { CURRICULUM } from "../telemetry/constants";
+
 import bannerDark from "../../public/assets/curriculum/curriculum-partner-banner-illustration-large-dark.svg";
 import bannerLight from "../../public/assets/curriculum/curriculum-partner-banner-illustration-large-light.svg";
 
 import "./partner-banner.scss";
 
 export function PartnerBanner() {
+  const gleanClick = useGleanClick();
+  const observedNode = useViewed(() => {
+    gleanClick(`${CURRICULUM}: partner banner view`);
+  });
+
   return (
-    <section className="curriculum-partner-banner-container">
+    <section className="curriculum-partner-banner-container" ref={observedNode}>
       <div className="partner-banner">
         <section>
           <h2>Learn the curriculum with Scrimba and become job ready</h2>

--- a/client/src/curriculum/scrim-inline.ts
+++ b/client/src/curriculum/scrim-inline.ts
@@ -80,6 +80,7 @@ class ScrimInline extends LitElement {
               target="_blank"
               rel="origin noreferrer"
               class="external"
+              data-glean="${CURRICULUM}: scrim link id:${this._scrimId}"
             >
               <span class="visually-hidden">Open on Scrimba</span>
             </a>

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useMemo,
+} from "react";
 import { useLocation, useNavigationType, useParams } from "react-router-dom";
 import { DEFAULT_LOCALE } from "../../libs/constants";
 import { isValidLocale } from "../../libs/locale-utils";
@@ -269,3 +275,51 @@ export const useScrollToAnchor = () => {
     }
   });
 };
+
+interface Timer {
+  timeout: number | null;
+}
+
+const INTERSECTION_OPTIONS = {
+  root: null,
+  rootMargin: "0px",
+  threshold: 0.5,
+};
+
+export function useViewed(callback: Function) {
+  const timer = useRef<Timer>({ timeout: null });
+  const isVisible = usePageVisibility();
+
+  const [node, setNode] = useState<HTMLElement>();
+  const isIntersecting = useIsIntersecting(node, INTERSECTION_OPTIONS);
+
+  const sendViewed = useCallback(() => {
+    timer.current = { timeout: -1 };
+    callback();
+  }, [callback]);
+
+  useEffect(() => {
+    if (timer.current.timeout !== -1) {
+      // timeout !== -1 means the viewed has not been sent
+      if (isVisible && isIntersecting) {
+        if (timer.current.timeout === null) {
+          timer.current = {
+            timeout: window.setTimeout(sendViewed, 1000),
+          };
+        }
+      }
+    }
+    return () => {
+      if (timer.current.timeout !== null && timer.current.timeout !== -1) {
+        clearTimeout(timer.current.timeout);
+        timer.current = { timeout: null };
+      }
+    };
+  }, [isVisible, isIntersecting, sendViewed]);
+
+  return useCallback((node: HTMLElement | null) => {
+    if (node) {
+      setNode(node);
+    }
+  }, []);
+}

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -276,27 +276,19 @@ export const useScrollToAnchor = () => {
   });
 };
 
-interface Timer {
+interface ViewedTimer {
   timeout: number | null;
 }
 
-const INTERSECTION_OPTIONS = {
-  root: null,
-  rootMargin: "0px",
-  threshold: 0.5,
-};
-
 export function useViewed(callback: Function) {
-  const timer = useRef<Timer>({ timeout: null });
+  const timer = useRef<ViewedTimer>({ timeout: null });
   const isVisible = usePageVisibility();
-
   const [node, setNode] = useState<HTMLElement>();
-  const isIntersecting = useIsIntersecting(node, INTERSECTION_OPTIONS);
-
-  const sendViewed = useCallback(() => {
-    timer.current = { timeout: -1 };
-    callback();
-  }, [callback]);
+  const isIntersecting = useIsIntersecting(node, {
+    root: null,
+    rootMargin: "0px",
+    threshold: 0.5,
+  });
 
   useEffect(() => {
     if (timer.current.timeout !== -1) {
@@ -304,7 +296,10 @@ export function useViewed(callback: Function) {
       if (isVisible && isIntersecting) {
         if (timer.current.timeout === null) {
           timer.current = {
-            timeout: window.setTimeout(sendViewed, 1000),
+            timeout: window.setTimeout(() => {
+              timer.current = { timeout: -1 };
+              callback();
+            }, 1000),
           };
         }
       }
@@ -315,7 +310,7 @@ export function useViewed(callback: Function) {
         timer.current = { timeout: null };
       }
     };
-  }, [isVisible, isIntersecting, sendViewed]);
+  }, [isVisible, isIntersecting, callback]);
 
   return useCallback((node: HTMLElement | null) => {
     if (node) {

--- a/client/src/telemetry/constants.ts
+++ b/client/src/telemetry/constants.ts
@@ -22,6 +22,7 @@ export const BANNER_BLOG_LAUNCH_CLICK = "banner_blog_launch_click";
 export const AI_HELP = "ai_help";
 export const BANNER_AI_HELP_CLICK = "banner_ai_help_click";
 export const BANNER_SCRIMBA_CLICK = "banner_scrimba_click";
+export const BANNER_SCRIMBA_VIEW = "banner_scrimba_view";
 export const PLAYGROUND = "play_action";
 export const AI_EXPLAIN = "ai_explain";
 export const SETTINGS = "settings";

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -92,22 +92,7 @@ export function SidePlacement() {
 function TopPlacementFallbackContent() {
   const gleanClick = useGleanClick();
 
-  return Date.now() < Date.parse("2024-10-12") ? (
-    <p className="fallback-copy">
-      Learn front-end development with a 30% discount on{" "}
-      <a
-        href="https://scrimba.com/learn/frontend?via=mdn"
-        target="_blank"
-        rel="noreferrer"
-        onClick={() => {
-          gleanClick(BANNER_SCRIMBA_CLICK);
-        }}
-      >
-        Scrimba
-      </a>{" "}
-      &mdash; limited time offer!
-    </p>
-  ) : (
+  return (
     <p className="fallback-copy">
       Learn front-end development with high quality, interactive courses from{" "}
       <a

--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -5,7 +5,10 @@ import "./index.scss";
 import { useGleanClick } from "../../../telemetry/glean-context";
 import { Status, usePlacement } from "../../../placement-context";
 import { Payload as PlacementData } from "../../../../../libs/pong/types";
-import { BANNER_SCRIMBA_CLICK } from "../../../telemetry/constants";
+import {
+  BANNER_SCRIMBA_CLICK,
+  BANNER_SCRIMBA_VIEW,
+} from "../../../telemetry/constants";
 
 interface PlacementRenderArgs {
   place: any;
@@ -76,6 +79,9 @@ export function SidePlacement() {
 
 function TopPlacementFallbackContent() {
   const gleanClick = useGleanClick();
+  const observedNode = useViewed(() => {
+    gleanClick(BANNER_SCRIMBA_VIEW);
+  });
 
   return (
     <p className="fallback-copy">
@@ -84,6 +90,7 @@ function TopPlacementFallbackContent() {
         href="https://scrimba.com/learn/frontend?via=mdn"
         target="_blank"
         rel="noreferrer"
+        ref={observedNode}
         onClick={() => {
           gleanClick(BANNER_SCRIMBA_CLICK);
         }}


### PR DESCRIPTION
## Summary

https://mozilla-hub.atlassian.net/browse/MP-1611

~~NB: this currently has inconsistent handling of custom glean pings on external links, which should be resolved after discussion:~~
- ~~the `data-glean` attribute in `<scrim-inline>` causes the `external-link` ping to not bed sent~~
- ~~the `onClick` attribute in `PartnerBanner` will be sent alongside the `external-link` ping~~
- ~~the external links in `TopPlacementFallbackContent` don't send a `external-link` ping, as they don't have an `"external"` class~~
- solved in https://github.com/mdn/yari/pull/11981

Split into a few commits for ease of reviewing.

### Problem

- We lack some scrimba metrics to understand our funnel
- These include impression metrics

### Solution

- Add various click metrics
- Also make the placement impression logic generic and extract it into a hook for use sending impression metrics

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->

-
  ```
  REACT_APP_GLEAN_ENABLED=true
  REACT_APP_GLEAN_DEBUG=true
  ```
  in `.env`
- `yarn dev`
- localhost:3000, observed browser console
