### PR TITLE
fix(ssr): fix --no-docs (rename to --skip-docs)

### DIFF
--- a/build/ssr-cli.ts
+++ b/build/ssr-cli.ts
@@ -12,11 +12,11 @@ if (SENTRY_DSN_BUILD) {
 }
 
 program
-  .option("-n, --no-docs", "Do not build docs (only spas, blog...)", {
+  .option("-s, --skip-docs", "Do not build docs (only spas, blog...)", {
     default: false,
   })
   .action(async ({ options }) => {
-    await ssrAllDocuments({ noDocs: Boolean(options?.noDocs) });
+    await ssrAllDocuments({ skipDocs: Boolean(options?.skipDocs) });
   });
 
 program.run();

--- a/build/ssr.ts
+++ b/build/ssr.ts
@@ -14,11 +14,13 @@ export function ssrDocument(context: HydrationData) {
 }
 
 interface SSROptions {
-  noDocs?: boolean;
+  skipDocs?: boolean;
 }
 
-export async function ssrAllDocuments({ noDocs = false }: SSROptions = {}) {
-  const files = await findDocuments({ noDocs });
+export async function ssrAllDocuments({
+  skipDocs: skipDocs = false,
+}: SSROptions = {}) {
+  const files = await findDocuments({ skipDocs });
 
   const start = Date.now();
 
@@ -41,14 +43,15 @@ export async function ssrAllDocuments({ noDocs = false }: SSROptions = {}) {
   );
 }
 
-async function findDocuments(options: Pick<SSROptions, "noDocs">) {
+async function findDocuments(options: Pick<SSROptions, "skipDocs">) {
   const api = new fdir()
     .withFullPaths()
     .withErrors()
-    .exclude((dirName) => options.noDocs && dirName === "docs")
+    .exclude((dirName) => options.skipDocs && dirName === "docs")
     .filter(
       (filePath) =>
-        filePath.endsWith("index.json") || filePath.endsWith("404.json")
+        !filePath.endsWith("search-index.json") &&
+        (filePath.endsWith("index.json") || filePath.endsWith("404.json"))
     )
     .crawl(BUILD_OUT_ROOT);
   const docs = await api.withPromise();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier-check": "prettier --check .",
     "prettier-format": "prettier --write .",
     "render:html": "cross-env NODE_ENV=production NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node build/ssr-cli.ts",
-    "start": "(test -f client/build/asset-manifest.json || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -f popularities.json || yarn tool popularities) && (test -d client/build/en-us/_spas || yarn tool spas) && nf -j Procfile.start start",
+    "start": "(test -f client/build/asset-manifest.json || yarn build:client) && (test -f ssr/dist/main.js || yarn build:ssr) && (test -f popularities.json || yarn tool popularities) && (test -d client/build/en-us/_spas || yarn tool spas) && (test -d client/build/en-us/_spas/404.html || yarn render:html -s) && nf -j Procfile.start start",
     "start:client": "cd client && cross-env NODE_ENV=development BABEL_ENV=development PORT=3000 node scripts/start.js",
     "start:server": "node-dev --experimental-loader ts-node/esm server/index.ts",
     "start:static-server": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node server/static.ts",


### PR DESCRIPTION
## Summary

Fix --no-docs (rename to --skip-docs)
And ssr spas in `yarn start`.
This should be changed to be ad hoc ssred in the future.

### Problem

--no-docs had no effect and still rendered everything.

### Solution

It seems like caporal magically (probably documented somewhere) strips the `no` from `--no-docs` so the option is called `docs` instead of the expected `noDocs`. Therefore, this was broken. Now we use `--skip-docs` and it works as expected.

---

## How did you test this change?

Locally `yarn start` and visit a http://localhost:5042/en-US/foo
