### PR TITLE
fix(utils): hash-awareness of url-to-folder-path

### DIFF
--- a/content/utils.ts
+++ b/content/utils.ts
@@ -121,6 +121,8 @@ export async function toPrettyJSON(value: unknown) {
 }
 
 export function urlToFolderPath(url: string) {
+  // Split off any # part of the URL (ex: passed in from redirect targets).
+  [url] = url.split("#");
   const [, locale, , ...slugParts] = url.split("/");
   return path.join(locale.toLowerCase(), _slugToFolder(slugParts.join("/")));
 }

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -90,7 +90,8 @@ function resolve(slug: string) {
   }
   const url = buildURL(DEFAULT_LOCALE_LC, slug);
   const resolved = Redirect.resolve(url);
-  const doc = Document.read(Document.urlToFolderPath(resolved));
+  const [resolvedWithoutHash] = resolved.split("#");
+  const doc = Document.read(Document.urlToFolderPath(resolvedWithoutHash));
   return doc?.metadata.slug ?? slug;
 }
 

--- a/tool/sync-translated-content.ts
+++ b/tool/sync-translated-content.ts
@@ -90,8 +90,7 @@ function resolve(slug: string) {
   }
   const url = buildURL(DEFAULT_LOCALE_LC, slug);
   const resolved = Redirect.resolve(url);
-  const [resolvedWithoutHash] = resolved.split("#");
-  const doc = Document.read(Document.urlToFolderPath(resolvedWithoutHash));
+  const doc = Document.read(Document.urlToFolderPath(resolved));
   return doc?.metadata.slug ?? slug;
 }
 


### PR DESCRIPTION
## Summary

Discovered this while working on sync translated content. `function urlToFolderPath(url: string)` fails if the URL contains a hash part.

### Problem

Breaks sync-translated-content for some edge cases

### Solution

Hash part of url is being broken off before passed on.

## How did you test this change?

Ran sync-translated-content locally.