### PR TITLE
enhance(telemetry): measure search source + change

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -325,6 +325,8 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
     );
   }, [resultItems, inputValue]);
 
+  const [hasChanged, setHasChanged] = useState(false);
+
   const searchResults = (() => {
     if (!isOpen || !inputValue.trim()) {
       return null;
@@ -493,6 +495,10 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           onChange(event) {
             if (event.target instanceof HTMLInputElement) {
               onChangeInputValue(event.target.value);
+              if (!hasChanged) {
+                gleanClick(`quick-search-change: ${id}`);
+                setHasChanged(true);
+              }
             }
           },
           ref: (input) => {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -245,7 +245,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
   );
 
   const resultClick: React.MouseEventHandler<HTMLAnchorElement> = () => {
-    gleanClick(quicksearchPing(`${inputValue} ${id}`));
+    gleanClick(quicksearchPing(`${id} -> ${inputValue}`));
   };
 
   const {

--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -245,7 +245,7 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
   );
 
   const resultClick: React.MouseEventHandler<HTMLAnchorElement> = () => {
-    gleanClick(quicksearchPing(inputValue));
+    gleanClick(quicksearchPing(`${inputValue} ${id}`));
   };
 
   const {


### PR DESCRIPTION
## Summary

(MP-1605)

### Problem

We don't know:

- how the "quick" searches are distributed between the central homepage search and the top search,
- how many users type in the search without clicking on a result.

### Solution

1. Add the search `id` to the existing `quick-search` measurement.
2. Add a new `quick-search-change` measurement.

| Search action | Examples |
|--------|--------|
| Change (edit/type) [once] | `quick-search-change: hp-search`<br>`quick-search-change: top-nav-search` |
| Click item (incl. "No results") | `quick-search: hp-search -> flex`<br>`quick-search: top-nav-search -> array.map ` |

---

## How did you test this change?

Ran `yarn dev` and tested http://localhost:3000/en-US/ with these `.env` settings:

```
REACT_APP_GLEAN_DEBUG=true
REACT_APP_GLEAN_ENABLED=true
```
