### PR TITLE
fix(search): pass key as prop

### DIFF
--- a/client/src/search.tsx
+++ b/client/src/search.tsx
@@ -372,8 +372,8 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
           [
             ...resultItems.map((item, i) => (
               <div
+                key={item.url}
                 {...getItemProps({
-                  key: item.url,
                   className: `result-item ${
                     i === highlightedIndex ? "highlight " : ""
                   }`,
@@ -392,11 +392,11 @@ function InnerSearchNavigateWidget(props: InnerSearchNavigateWidgetProps) {
               </div>
             )),
             <div
+              key="nothing-found"
               {...getItemProps({
                 className:
                   "nothing-found result-item " +
                   (highlightedIndex === resultItems.length ? "highlight" : ""),
-                key: "nothing-found",
                 item: onlineSearch,
                 index: resultItems.length,
               })}


### PR DESCRIPTION
## Summary

Before we get:
Warning: A props object containing a "key" prop is being spread into JSX


## How did you test this change?

Locally.
