### PR TITLE
chore(deps): migrate to googleapis/release-please-action

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   build:
     if: github.repository == 'mdn/yari'
@@ -16,8 +12,10 @@ jobs:
 
     steps:
       - name: Release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

1. The [google-github-actions/release-please-action](https://github.com/google-github-actions/release-please-action) action we're using is deprecated.
2. Checks are not running on release-please PRs (see [here](https://github.com/mdn/yari/pull/11991)).

### Solution

1. Migrates to [googleapis/release-please-action](https://github.com/googleapis/release-please-action).
2. Use Personal Access Token to create release-please PR.

---

## How did you test this change?

Hard to test without merging to `main`.