### PR TITLE
fix(npm-publish): use default github token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+# Allows this check to run on Dependabot merge commits.
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 
-# Allows this check to run on Dependabot merge commits.
 permissions:
   contents: write
   pull-requests: write
@@ -19,8 +18,6 @@ jobs:
       - name: Release
         uses: googleapis/release-please-action@v4
         id: release
-        with:
-          token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Partially reverts https://github.com/mdn/yari/commit/82980d12f0613aa64edbbfc5d9ce6ece37b5c203#diff-8a5ce8b612395836520d0655143f732d08e747af57f3cfe76b5e283600106240L13, to allow the `npm-publish` to run successfully on Dependabot merge commits.

## How did you test this change?

It worked before, so it should work again.
