### PR TITLE
refactor(bcd): extract SupportType that includes "removed"

### DIFF
--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -11,6 +11,7 @@ import {
   isTruthy,
   versionIsPreview,
   SupportStatementExtended,
+  SupportType,
   bugURLToString,
   SimpleSupportStatementExtended,
 } from "./utils";
@@ -20,7 +21,7 @@ import { DEFAULT_LOCALE } from "../../../../../libs/constants";
 export function getCurrentSupportType(
   support: SupportStatementExtended | undefined,
   browser: BCD.BrowserStatement
-): "no" | "yes" | "partial" | "preview" | "removed-partial" | "unknown" {
+): SupportType {
   if (!support) {
     return "unknown";
   }
@@ -135,40 +136,26 @@ function versionLabelFromSupport(
 
 function getCurrentStatus(
   support: BCD.SupportStatement | undefined,
-  supportClassName:
-    | "no"
-    | "yes"
-    | "partial"
-    | "preview"
-    | "removed-partial"
-    | "unknown",
+  supportType: SupportType,
   browser: BCD.BrowserStatement
 ) {
   const currentSupport = getCurrentSupport(support);
 
-  return getStatus(currentSupport, supportClassName, browser);
+  return getStatus(currentSupport, supportType, browser);
 }
 
 function getStatus(
   currentSupport: SimpleSupportStatementExtended | undefined,
-  supportClassName:
-    | "no"
-    | "yes"
-    | "partial"
-    | "preview"
-    | "removed-partial"
-    | "unknown",
+  supportType: SupportType,
   browser: BCD.BrowserStatement
 ) {
   const added = currentSupport?.version_added ?? null;
   const lastVersion = currentSupport?.version_last ?? null;
 
-  let status:
-    | { isSupported: "unknown" }
-    | {
-        isSupported: "no" | "yes" | "partial" | "preview" | "removed-partial";
-        label?: React.ReactNode;
-      };
+  let status: {
+    isSupported: SupportType;
+    label?: React.ReactNode;
+  };
 
   switch (added) {
     case null:
@@ -185,7 +172,7 @@ function getStatus(
       break;
     default:
       status = {
-        isSupported: supportClassName,
+        isSupported: supportType,
         label: versionLabelFromSupport(added, lastVersion, browser),
       };
       break;
@@ -204,8 +191,8 @@ const CellText = React.memo(
     timeline?: boolean;
   }) => {
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
-    const supportClassName = getCurrentSupportType(support, browser);
-    const status = getCurrentStatus(support, supportClassName, browser);
+    const supportType = getCurrentSupportType(support, browser);
+    const status = getCurrentStatus(support, supportType, browser);
 
     let label: string | React.ReactNode;
     let title = "";
@@ -256,9 +243,9 @@ const CellText = React.memo(
           <span className="icon-wrap">
             <abbr
               className={`
-              bc-level-${supportClassName}
+              bc-level-${supportType}
               icon
-              icon-${supportClassName}`}
+              icon-${supportType}`}
               title={title}
             >
               <span className="bc-support-level">{title}</span>

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -17,7 +17,7 @@ import {
 import { LEGEND_LABELS } from "./legend";
 import { DEFAULT_LOCALE } from "../../../../../libs/constants";
 
-function getSupportClassName(
+export function getCurrentSupportType(
   support: SupportStatementExtended | undefined,
   browser: BCD.BrowserStatement
 ): "no" | "yes" | "partial" | "preview" | "removed-partial" | "unknown" {
@@ -25,8 +25,17 @@ function getSupportClassName(
     return "unknown";
   }
 
+  const currentSupport = getCurrentSupport(support)!;
+
+  return getSupportType(currentSupport, browser);
+}
+
+function getSupportType(
+  support: SimpleSupportStatementExtended,
+  browser: BCD.BrowserStatement
+) {
   let { flags, version_added, version_removed, partial_implementation } =
-    getCurrentSupport(support)!;
+    support;
 
   let className;
   if (version_added === null) {
@@ -195,7 +204,7 @@ const CellText = React.memo(
     timeline?: boolean;
   }) => {
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
-    const supportClassName = getSupportClassName(support, browser);
+    const supportClassName = getCurrentSupportType(support, browser);
     const status = getCurrentStatus(support, supportClassName, browser);
 
     let label: string | React.ReactNode;
@@ -448,7 +457,7 @@ function getNotes(
             <React.Fragment key={i}>
               <div className="bc-notes-wrapper">
                 <dt
-                  className={`bc-supports-${getSupportClassName(
+                  className={`bc-supports-${getCurrentSupportType(
                     item,
                     browser
                   )} bc-supports`}
@@ -492,7 +501,7 @@ function CompatCell({
   onToggle: () => void;
   locale: string;
 }) {
-  const supportClassName = getSupportClassName(support, browserInfo);
+  const supportClassName = getCurrentSupportType(support, browserInfo);
   // NOTE: 1-5-21, I've forced hasNotes to return true, in order to
   // make the details view open all the time.
   // Whenever the support statement is complex (array with more than one entry)

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -123,6 +123,51 @@ function versionLabelFromSupport(
   );
 }
 
+function getCurrentStatus(
+  support: BCD.SupportStatement | undefined,
+  supportClassName:
+    | "no"
+    | "yes"
+    | "partial"
+    | "preview"
+    | "removed-partial"
+    | "unknown",
+  browser: BCD.BrowserStatement
+) {
+  const currentSupport = getCurrentSupport(support);
+
+  const added = currentSupport?.version_added ?? null;
+  const lastVersion = currentSupport?.version_last ?? null;
+
+  let status:
+    | { isSupported: "unknown" }
+    | {
+        isSupported: "no" | "yes" | "partial" | "preview" | "removed-partial";
+        label?: React.ReactNode;
+      };
+  switch (added) {
+    case null:
+      status = { isSupported: "unknown" };
+      break;
+    case true:
+      status = { isSupported: lastVersion ? "no" : "yes" };
+      break;
+    case false:
+      status = { isSupported: "no" };
+      break;
+    case "preview":
+      status = { isSupported: "preview" };
+      break;
+    default:
+      status = {
+        isSupported: supportClassName,
+        label: versionLabelFromSupport(added, lastVersion, browser),
+      };
+      break;
+  }
+  return status;
+}
+
 const CellText = React.memo(
   ({
     support,
@@ -133,40 +178,9 @@ const CellText = React.memo(
     browser: BCD.BrowserStatement;
     timeline?: boolean;
   }) => {
-    const currentSupport = getCurrentSupport(support);
-
-    const added = currentSupport?.version_added ?? null;
-    const lastVersion = currentSupport?.version_last ?? null;
-
     const browserReleaseDate = getSupportBrowserReleaseDate(support);
     const supportClassName = getSupportClassName(support, browser);
-
-    let status:
-      | { isSupported: "unknown" }
-      | {
-          isSupported: "no" | "yes" | "partial" | "preview" | "removed-partial";
-          label?: React.ReactNode;
-        };
-    switch (added) {
-      case null:
-        status = { isSupported: "unknown" };
-        break;
-      case true:
-        status = { isSupported: lastVersion ? "no" : "yes" };
-        break;
-      case false:
-        status = { isSupported: "no" };
-        break;
-      case "preview":
-        status = { isSupported: "preview" };
-        break;
-      default:
-        status = {
-          isSupported: supportClassName,
-          label: versionLabelFromSupport(added, lastVersion, browser),
-        };
-        break;
-    }
+    const status = getCurrentStatus(support, supportClassName, browser);
 
     let label: string | React.ReactNode;
     let title = "";

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -12,6 +12,7 @@ import {
   versionIsPreview,
   SupportStatementExtended,
   bugURLToString,
+  SimpleSupportStatementExtended,
 } from "./utils";
 import { LEGEND_LABELS } from "./legend";
 import { DEFAULT_LOCALE } from "../../../../../libs/constants";
@@ -136,6 +137,20 @@ function getCurrentStatus(
 ) {
   const currentSupport = getCurrentSupport(support);
 
+  return getStatus(currentSupport, supportClassName, browser);
+}
+
+function getStatus(
+  currentSupport: SimpleSupportStatementExtended | undefined,
+  supportClassName:
+    | "no"
+    | "yes"
+    | "partial"
+    | "preview"
+    | "removed-partial"
+    | "unknown",
+  browser: BCD.BrowserStatement
+) {
   const added = currentSupport?.version_added ?? null;
   const lastVersion = currentSupport?.version_last ?? null;
 
@@ -145,6 +160,7 @@ function getCurrentStatus(
         isSupported: "no" | "yes" | "partial" | "preview" | "removed-partial";
         label?: React.ReactNode;
       };
+
   switch (added) {
     case null:
       status = { isSupported: "unknown" };

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -35,30 +35,30 @@ function getSupportType(
   support: SimpleSupportStatementExtended,
   browser: BCD.BrowserStatement
 ): SupportType {
-  let { flags, version_added, version_removed, partial_implementation } =
+  const { flags, version_added, version_removed, partial_implementation } =
     support;
 
-  let className: SupportType;
   if (version_added === null) {
-    className = "unknown";
+    return "unknown";
   } else if (versionIsPreview(version_added, browser)) {
-    className = "preview";
+    return "preview";
   } else if (version_added) {
     if (version_removed) {
-      className = "removed";
+      if (partial_implementation) {
+        return "removed-partial";
+      } else {
+        return "removed";
+      }
     } else if (flags && flags.length) {
-      className = "no";
+      return "no";
+    } else if (partial_implementation) {
+      return "partial";
     } else {
-      className = "yes";
+      return "yes";
     }
   } else {
-    className = "no";
+    return "no";
   }
-  if (partial_implementation) {
-    className = version_removed ? "removed-partial" : "partial";
-  }
-
-  return className;
 }
 
 function getSupportClassName(supportType: SupportType): string {

--- a/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
+++ b/client/src/document/ingredients/browser-compatibility-table/feature-row.tsx
@@ -286,20 +286,39 @@ function Icon({ name }: { name: string }) {
 }
 
 function CellIcons({ support }: { support: BCD.SupportStatement | undefined }) {
-  const supportItem = getCurrentSupport(support);
-  if (!supportItem) {
+  const attrs = getCurrentSupportAttributes(support);
+
+  if (!attrs) {
     return null;
   }
 
   const icons = [
-    supportItem.prefix && <Icon key="prefix" name="prefix" />,
-    hasNoteworthyNotes(supportItem) && <Icon key="footnote" name="footnote" />,
-    supportItem.alternative_name && <Icon key="altname" name="altname" />,
-    supportItem.flags && <Icon key="disabled" name="disabled" />,
-    hasMore(support) && <Icon key="more" name="more" />,
+    attrs.pre && <Icon key="prefix" name="prefix" />,
+    attrs.note && <Icon key="footnote" name="footnote" />,
+    attrs.alt && <Icon key="altname" name="altname" />,
+    attrs.flag && <Icon key="disabled" name="disabled" />,
+    attrs.more && <Icon key="more" name="more" />,
   ].filter(Boolean);
 
   return icons.length ? <div className="bc-icons">{icons}</div> : null;
+}
+
+export function getCurrentSupportAttributes(
+  support: BCD.SimpleSupportStatement | BCD.SimpleSupportStatement[] | undefined
+) {
+  const supportItem = getCurrentSupport(support);
+
+  if (!supportItem) {
+    return null;
+  }
+
+  return {
+    pre: !!supportItem.prefix,
+    note: hasNoteworthyNotes(supportItem),
+    alt: !!supportItem.alternative_name,
+    flag: !!supportItem.flags,
+    more: hasMore(support),
+  };
 }
 
 function FlagsNote({

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -12,6 +12,14 @@ export interface SimpleSupportStatementExtended
   version_last?: BCD.VersionValue;
 }
 
+export type SupportType =
+  | "no"
+  | "yes"
+  | "partial"
+  | "preview"
+  | "removed-partial"
+  | "unknown";
+
 export type SupportStatementExtended =
   | SimpleSupportStatementExtended
   | SimpleSupportStatementExtended[];

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -2,7 +2,8 @@ import type BCD from "@mdn/browser-compat-data/types";
 
 // Extended for the fields, beyond the bcd types, that are extra-added
 // exclusively in Yari.
-interface SimpleSupportStatementExtended extends BCD.SimpleSupportStatement {
+export interface SimpleSupportStatementExtended
+  extends BCD.SimpleSupportStatement {
   // Known for some support statements where the browser *version* is known,
   // as opposed to just "true" and if the version release date is known.
   release_date?: string;

--- a/client/src/document/ingredients/browser-compatibility-table/utils.ts
+++ b/client/src/document/ingredients/browser-compatibility-table/utils.ts
@@ -17,6 +17,7 @@ export type SupportType =
   | "yes"
   | "partial"
   | "preview"
+  | "removed"
   | "removed-partial"
   | "unknown";
 


### PR DESCRIPTION
## Summary

Extracted from #12030.

(Part of MP-1619.)

### Problem

The BCD table implementation doesn't distinguish the "removed" support type, because it is currently rendered like "no" support type, but we want to distinguish it when measuring BCD cell clicks in https://github.com/mdn/yari/pull/12030.

### Solution

Extract some functions to separate concerns, and map the new "removed" support type to the "no" support class name.

---

## Screenshots

(No difference in rendering.)

---

## How did you test this change?

~~Ran `yarn build --locale en-us` both on `main` and this branch, and verified that they yield the same output.~~ (This doesn't mean anything, as the BCD table is rendered on demand.)