### PR TITLE
refactor(hooks): make `useViewed()` reusable

### DIFF
--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -280,15 +280,18 @@ interface ViewedTimer {
   timeout: number | null;
 }
 
-export function useViewed(callback: Function) {
-  const timer = useRef<ViewedTimer>({ timeout: null });
-  const isVisible = usePageVisibility();
-  const [node, setNode] = useState<HTMLElement>();
-  const isIntersecting = useIsIntersecting(node, {
+export function useViewed(
+  callback: Function,
+  intersectionObserverOptions: IntersectionObserverInit = {
     root: null,
     rootMargin: "0px",
     threshold: 0.5,
-  });
+  }
+) {
+  const timer = useRef<ViewedTimer>({ timeout: null });
+  const isVisible = usePageVisibility();
+  const [node, setNode] = useState<HTMLElement>();
+  const isIntersecting = useIsIntersecting(node, intersectionObserverOptions);
 
   useEffect(() => {
     if (timer.current.timeout !== -1) {

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -290,7 +290,7 @@ export function useViewed(
 ) {
   const timer = useRef<ViewedTimer>({ timeout: null });
   const isVisible = usePageVisibility();
-  const [node, setNode] = useState<HTMLElement>();
+  const [node, setNode] = useState<HTMLElement | undefined>();
   const isIntersecting = useIsIntersecting(node, intersectionObserverOptions);
 
   useEffect(() => {
@@ -301,6 +301,7 @@ export function useViewed(
           timer.current = {
             timeout: window.setTimeout(() => {
               timer.current = { timeout: -1 };
+              setNode(undefined);
               callback();
             }, 1000),
           };

--- a/client/src/hooks.ts
+++ b/client/src/hooks.ts
@@ -290,7 +290,7 @@ export function useViewed(
 ) {
   const timer = useRef<ViewedTimer>({ timeout: null });
   const isVisible = usePageVisibility();
-  const [node, setNode] = useState<HTMLElement | undefined>();
+  const [node, setNode] = useState<HTMLElement>();
   const isIntersecting = useIsIntersecting(node, intersectionObserverOptions);
 
   useEffect(() => {
@@ -301,7 +301,6 @@ export function useViewed(
           timer.current = {
             timeout: window.setTimeout(() => {
               timer.current = { timeout: -1 };
-              setNode(undefined);
               callback();
             }, 1000),
           };


### PR DESCRIPTION
## Summary

Extracted from https://github.com/mdn/yari/pull/12030.

### Problem

The `useViewed()` hook is not really reusable, because it sets specific `IntersectionOptions`, ~~and doesn't disconnect the `IntersectionObserver`~~.

### Solution

1. Introduce an `options` parameter.
2. ~~Disconnect the observer once the observed node was viewed.~~

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
