### PR TITLE
fix(ssr): ensure locale is set

### DIFF
--- a/ssr/render.tsx
+++ b/ssr/render.tsx
@@ -159,7 +159,7 @@ export default function render(
   return (
     "<!doctype html>" +
     renderToString(
-      <html lang={locale} prefix="og: https://ogp.me/ns#">
+      <html lang={DEFAULT_LOCALE} prefix="og: https://ogp.me/ns#">
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width,initial-scale=1" />

--- a/ssr/render.tsx
+++ b/ssr/render.tsx
@@ -76,6 +76,10 @@ export default function render(
     blogMeta = null,
   }: HydrationData = { url }
 ) {
+  if (!locale) {
+    locale = (doc && doc.locale) || DEFAULT_LOCALE;
+  }
+
   const canonicalURL = `${BASE_URL}${url}`;
 
   let realPageTitle = pageTitle;
@@ -139,10 +143,7 @@ export default function render(
   }
 
   // Open Graph protocol expects `language_TERRITORY` format.
-  const ogLocale = (locale || (doc && doc.locale) || DEFAULT_LOCALE).replace(
-    "-",
-    "_"
-  );
+  const ogLocale = locale.replace("-", "_");
 
   if (locale === "de") {
     // Prevent experimental German locale from being indexed.
@@ -158,7 +159,7 @@ export default function render(
   return (
     "<!doctype html>" +
     renderToString(
-      <html lang={locale || DEFAULT_LOCALE} prefix="og: https://ogp.me/ns#">
+      <html lang={locale} prefix="og: https://ogp.me/ns#">
         <head>
           <meta charSet="utf-8" />
           <meta name="viewport" content="width=device-width,initial-scale=1" />


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

(MP-1717)

### Problem

The German locale experiment is accidentally exposed to search engines, because `locale` is unset here:

https://github.com/mdn/yari/blob/22d6890571155ed7d99d8fa37edcc78ca1001981/ssr/render.tsx#L147-L150

~~**Note**: This also causes the `html[lang]` to be wrong on translated content, e.g. `en-US` instead of `fr` on https://developer.mozilla.org/fr/docs/Web/HTML.~~ (This seems to be intentional, see: https://github.com/mdn/yari/pull/2958)

### Solution

Ensure that `locale` has a value, rather than coalescing everywhere.

---

## How did you test this change?

Change is trivial, so aiming to push it out directly.