### PR TITLE
fix(tool/gather-git-history): skip German locale

### DIFF
--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -630,7 +630,7 @@ program
       const allHistory = {};
       for (const [relPath, value] of map) {
         const locale = relPath.split(path.sep)[0];
-        if (!isValidLocale(locale)) {
+        if (!isValidLocale(locale) && locale !== "de") {
           continue;
         }
         allHistory[relPath] = value;

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -652,7 +652,12 @@ program
           return 0;
         });
         const root = getRoot(locale);
-        const outputFile = path.join(root, locale, "_githistory.json");
+        const outputDir = path.join(root, locale);
+        if (!fs.existsSync(outputDir)) {
+          console.log(chalk.yellow(`Skipping ${locale}`));
+          continue;
+        }
+        const outputFile = path.join(outputDir, "_githistory.json");
         fs.writeFileSync(
           outputFile,
           JSON.stringify(Object.fromEntries(sorted), null, 2),


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

1. The `yarn tool gather-git-history` command fails, because it cannot write `files/de/_githistory.json`.
2. The command also gathers history for the German translation from the translated-content repo, which is not useful.

### Solution

1. Avoid writing `_githistory.json`, if the parent folder does not exist.
2. Stop gathering the git history for the German translation.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% yarn tool gather-git-history
yarn run v1.22.22
$ cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts gather-git-history

error: ENOENT: no such file or directory, open '/path/to/translated-content/files/de/_githistory.json'

error Command failed with exit code 1.
```

### After

```
% yarn tool gather-git-history
yarn run v1.22.22
$ cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./tool/cli.ts gather-git-history
Skipping de
Wrote 9 _githistory.json files
✨  Done in 22.41s.
```

---

## How did you test this change?

See above.