### PR TITLE
enhance(a11y-nav): fix background and padding

### DIFF
--- a/client/src/ui/molecules/a11y-nav/index.scss
+++ b/client/src/ui/molecules/a11y-nav/index.scss
@@ -11,13 +11,16 @@ Keyboard & screen reader skip link menu
   z-index: var(--z-index-a11y);
 
   a {
-    background-color: rgba(255, 255, 255, 0.9);
+    background-color: var(--background-primary);
     font-weight: var(--font-body-strong-weight);
     left: 0;
-    padding: 0.5rem;
+    padding: 0.8rem;
     position: absolute;
     right: 0;
     text-align: center;
+    @media (max-width: #{$screen-md - 1}) {
+      padding: 1.125rem;
+    }
 
     &:hover,
     &:focus {


### PR DESCRIPTION
## Summary

- Adds support for dark scheme
- Improves paddings

### Problem

- Jump anchors (a11y nav) don’t support a dark scheme
- Link contrast is very low, especially with added transparency
- Padding is inconsistent with underlying UI elements

### Solution

- Use a variable for the background color
- Use opaque color for better contrast
- Adjust paddings

---

## Screenshots

### Before

<details>
<summary>Desktop</summary>

![before-desktop-light](https://github.com/user-attachments/assets/e94b7d67-eec6-49bd-b45a-674976d3b97a)
![before-desktop-dark](https://github.com/user-attachments/assets/04dc0bc7-5865-4d32-9ecd-e8b0e2a51b91)

</details>

<details>
<summary>Mobile</summary>

![before-mobile-light](https://github.com/user-attachments/assets/6b45bac7-1ddb-4e82-b052-96cde16f7970)
![before-mobile-dark](https://github.com/user-attachments/assets/d9464476-3c4a-4fd6-a392-92d09ddc4a3d)

</details>

### After

<details>
<summary>Desktop</summary>

![after-desktop-light](https://github.com/user-attachments/assets/abb98288-4554-4e8d-9218-51219c8d00a8)
![after-desktop-dark](https://github.com/user-attachments/assets/7808689f-db70-41a4-b3a7-0c7cffa0056d)

</details>

<details>
<summary>Mobile</summary>

![after-mobile-light](https://github.com/user-attachments/assets/f18e1c8a-3d08-4f1e-9de5-8d1cd02e0c83)
![after-mobile-dark](https://github.com/user-attachments/assets/1d838366-727e-411d-8383-e0d49a675df8)

</details>