### PR TITLE
fix(flaws): re-add href to broken links as data

### DIFF
--- a/build/flaws/broken-links.ts
+++ b/build/flaws/broken-links.ts
@@ -71,7 +71,9 @@ function mutateLink(
       "summary"
     );
     $element.attr("title", titleWhenMissing);
+    const href = $element.attr("href");
     $element.attr("href", null);
+    $element.attr("data-href", href);
   }
 }
 


### PR DESCRIPTION
## Summary

We want to keep the url for debug/analyze purposes.
See #12076
