### PR TITLE
fix(flaws): shared assets images must no be flaws

### DIFF
--- a/build/check-images.ts
+++ b/build/check-images.ts
@@ -133,7 +133,10 @@ export function checkImageReferences(
           // might be something like `screenshot.png` for the sake of rendering
           // it now, we still want the full relative URL.
           img.attr("src", absoluteURL.pathname);
-        } else {
+        } else if (
+          absoluteURL.hostname !== "mdn.github.io" ||
+          !absoluteURL.pathname.startsWith("/shared-assets/")
+        ) {
           addImageFlaw(img, src, {
             explanation: "External image URL",
             externalImage: true,


### PR DESCRIPTION
## Summary

Don't flag shared assets as flaws.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/user-attachments/assets/a682e9c8-5d94-44b3-8823-4fa9d3d5fe1b)

### After

![image](https://github.com/user-attachments/assets/2add4de3-4bd0-43ad-a266-cceb25bc4604)

---

## How did you test this change?

Locally on http://localhost:3000/en-US/docs/Web/CSS/@layer
