### PR TITLE
fix(font): disable contextual variant ligatures in headings

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -14,6 +14,8 @@
   h4,
   h5,
   h6 {
+    font-variant-ligatures: no-contextual;
+
     a:link,
     a:visited {
       color: var(--text-primary);


### PR DESCRIPTION
## Summary

Unblocks https://github.com/mdn/content/pull/36810.

### Problem

The font we're using has contextual ligatures that render `-->` as an arrow, which is not what we expect, at least in headings.

### Solution

Disable contextual font variant ligatures in headings.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="773" alt="image" src="https://github.com/user-attachments/assets/80560875-8830-4cd6-9000-692f5c9d8aed">

### After

<img width="773" alt="image" src="https://github.com/user-attachments/assets/daf93daa-b8ed-4524-92b4-51abfc8588ea">

---

## How did you test this change?

Viewed https://pr36810.content.dev.mdn.mozit.cloud/en-US/docs/Web/HTML/Comments and manually edited the CSS.