### PR TITLE
fix(playground): fix layout in chrome when all editors are collapsed

### DIFF
--- a/client/src/playground/index.scss
+++ b/client/src/playground/index.scss
@@ -171,6 +171,7 @@ main.play {
 
         background-color: var(--background-secondary);
         border: var(--editor-header-border-width) solid var(--border-primary);
+        height: 0;
         min-height: var(--editor-header-height);
         width: 100%;
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

follow up to https://github.com/mdn/yari/pull/12137

### Problem

The fix for Chrome canary meant closed editors in release Chrome would still show some of the editor:

![developer mozilla org_en-US_play](https://github.com/user-attachments/assets/c47d25a7-e947-405e-8799-28324462217a)


### Solution

Make the height 0 (or, really, the min-height we set) when the editor is closed

---

## How did you test this change?

Tested locally with Firefox nightly, release, Chrome, and Epiphany