### PR TITLE
feat(playground): support state param in playground

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -195,9 +195,7 @@ export default function Playground() {
         } else if (stateParam) {
           try {
             let { state } = await decompressFromBase64(stateParam);
-            console.log(state);
             let code = JSON.parse(state || "{}") as EditorContent;
-            console.log(code);
             setEditorContent(code);
           } catch (e) {
             console.error(e);

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -11,7 +11,12 @@ import prettierPluginHTML from "prettier/plugins/html";
 import { Button } from "../ui/atoms/button";
 import Editor, { EditorHandle } from "./editor";
 import { SidePlacement } from "../ui/organisms/placement";
-import { compressAndBase64Encode, EditorContent, SESSION_KEY } from "./utils";
+import {
+  compressAndBase64Encode,
+  decompressFromBase64,
+  EditorContent,
+  SESSION_KEY,
+} from "./utils";
 
 import "./index.scss";
 import { PLAYGROUND_BASE_HOST } from "../env";
@@ -68,6 +73,7 @@ export default function Playground() {
   const gleanClick = useGleanClick();
   let [searchParams, setSearchParams] = useSearchParams();
   const gistId = searchParams.get("id");
+  const stateParam = searchParams.get("state");
   let [dialogState, setDialogState] = useState(DialogState.none);
   let [shared, setShared] = useState(false);
   let [shareUrl, setShareUrl] = useState<URL | null>(null);
@@ -80,7 +86,9 @@ export default function Playground() {
     null
   );
   let { data: initialCode } = useSWRImmutable<EditorContent>(
-    !shared && gistId ? `/api/v1/play/${encodeURIComponent(gistId)}` : null,
+    !stateParam && !shared && gistId
+      ? `/api/v1/play/${encodeURIComponent(gistId)}`
+      : null,
     async (url) => {
       const response = await fetch(url);
 
@@ -98,7 +106,11 @@ export default function Playground() {
     },
     {
       fallbackData:
-        (!gistId && state === State.initial && load(SESSION_KEY)) || undefined,
+        (!stateParam &&
+          !gistId &&
+          state === State.initial &&
+          load(SESSION_KEY)) ||
+        undefined,
     }
   );
   const htmlRef = useRef<EditorHandle | null>(null);
@@ -172,23 +184,35 @@ export default function Playground() {
   };
 
   useEffect(() => {
-    if (state === State.initial || state === State.remote) {
-      if (initialCode && Object.values(initialCode).some(Boolean)) {
-        setEditorContent(initialCode);
-        if (!gistId) {
-          // don't auto run shared code
-          updateWithCode(initialCode);
+    (async () => {
+      if (state === State.initial || state === State.remote) {
+        if (initialCode && Object.values(initialCode).some(Boolean)) {
+          setEditorContent(initialCode);
+          if (!gistId) {
+            // don't auto run shared code
+            updateWithCode(initialCode);
+          }
+        } else if (stateParam) {
+          try {
+            let { state } = await decompressFromBase64(stateParam);
+            console.log(state);
+            let code = JSON.parse(state || "{}") as EditorContent;
+            console.log(code);
+            setEditorContent(code);
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          setEditorContent({
+            html: HTML_DEFAULT,
+            css: CSS_DEFAULT,
+            js: JS_DEFAULT,
+          });
         }
-      } else {
-        setEditorContent({
-          html: HTML_DEFAULT,
-          css: CSS_DEFAULT,
-          js: JS_DEFAULT,
-        });
+        setState(State.ready);
       }
-      setState(State.ready);
-    }
-  }, [initialCode, state, gistId]);
+    })();
+  }, [initialCode, state, gistId, stateParam]);
 
   useEffect(() => {
     window.addEventListener("message", messageListener);

--- a/client/src/playground/utils.ts
+++ b/client/src/playground/utils.ts
@@ -78,3 +78,32 @@ export async function compressAndBase64Encode(inputString: string) {
 
   return { state, hash };
 }
+
+function base64ToBytes(base64: string): ArrayBuffer {
+  const binString = atob(base64);
+  const len = binString.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binString.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export async function decompressFromBase64(base64String: string) {
+  if (!base64String) {
+    return { state: null, hash: null };
+  }
+  const bytes = base64ToBytes(base64String);
+  const hashBuffer = await window.crypto.subtle.digest("SHA-256", bytes);
+  const hashArray = Array.from(new Uint8Array(hashBuffer)).slice(0, 20);
+  const hash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+
+  const decompressionStream = new DecompressionStream("deflate-raw");
+
+  const decompressedStream = new Response(
+    new Blob([bytes]).stream().pipeThrough(decompressionStream)
+  ).arrayBuffer();
+
+  const state = new TextDecoder().decode(await decompressedStream);
+  return { state, hash };
+}


### PR DESCRIPTION
## Summary

Not actively used except for the _open in playground_ button on [full screen live samples](https://867f29786f56c0ce98cf867e4314fc5aa96d69d6.mdnplay.dev/runner.html?state=dU9LDsIgEL0KYW3FxB1%2BNh6hMW7Y0OlEaimQArFN07tLaWKM0dW8eZn3mYmC95TTxrgYyCQMIRIATSjAattzImOwh4WuG%2B%2B0HDmptIU2U8%2BmDoqT%2Fc4NeVfY3FV4E7MwwmTjLUQfbPfLv8cKAaSLvdO4iuiGqtDp1Oq41gqjw5OgoBDayg6CkgyxJuwszP8jLb1fqBz%2BpUohj%2BXxNH0PCTA0xbVktQXPblixS1myz6p0fgE%3D)

### Problem

_open in playground_ button brings the user to an empty playground.

### Solution

Load the content into the playground.

---

## How did you test this change?

locally
