### PR TITLE
enhance(layout): add margin for "(en-US)" indicator

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -818,12 +818,6 @@ math[display="block"] {
   }
 }
 
-.only-in-en-us {
-  span {
-    font-size: 0.8125rem;
-  }
-}
-
 a.page-not-created {
   cursor: not-allowed;
 
@@ -958,30 +952,37 @@ html a.only-in-en-us:after {
 
 html[lang="de"] a.only-in-en-us:after {
   content: "(engl.)";
+  margin-left: 0.5ch;
 }
 
 html[lang="es"] a.only-in-en-us:after {
   content: "(inglés)";
+  margin-left: 0.5ch;
 }
 
 html[lang="fr"] a.only-in-en-us:after {
   content: "(angl.)";
+  margin-left: 0.5ch;
 }
 
 html[lang="ja"] a.only-in-en-us:after {
   content: "(英語)";
+  margin-left: 0.5ch;
 }
 
 html[lang="ko"] a.only-in-en-us:after {
   content: "(영어)";
+  margin-left: 0.5ch;
 }
 
 html[lang="ru"] a.only-in-en-us:after {
   content: "(англ.)";
+  margin-left: 0.5ch;
 }
 
 html[lang="pt-BR"] a.only-in-en-us:after {
   content: "(inglês)";
+  margin-left: 0.5ch;
 }
 
 html[lang="zh-CN"] a.only-in-en-us:after {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -947,50 +947,46 @@ html a.only-in-en-us:after {
   content: "(en-US)";
   display: inline-block;
   font-size: var(--type-tiny-font-size);
+  margin-left: 0.5ch;
   vertical-align: super;
 }
 
 html[lang="de"] a.only-in-en-us:after {
   content: "(engl.)";
-  margin-left: 0.5ch;
 }
 
 html[lang="es"] a.only-in-en-us:after {
   content: "(inglés)";
-  margin-left: 0.5ch;
 }
 
 html[lang="fr"] a.only-in-en-us:after {
   content: "(angl.)";
-  margin-left: 0.5ch;
 }
 
 html[lang="ja"] a.only-in-en-us:after {
   content: "(英語)";
-  margin-left: 0.5ch;
 }
 
 html[lang="ko"] a.only-in-en-us:after {
   content: "(영어)";
-  margin-left: 0.5ch;
 }
 
 html[lang="ru"] a.only-in-en-us:after {
   content: "(англ.)";
-  margin-left: 0.5ch;
 }
 
 html[lang="pt-BR"] a.only-in-en-us:after {
   content: "(inglês)";
-  margin-left: 0.5ch;
 }
 
 html[lang="zh-CN"] a.only-in-en-us:after {
   content: "（英语）";
+  margin-left: unset;
   vertical-align: baseline;
 }
 
 html[lang="zh-TW"] a.only-in-en-us:after {
   content: "（英語）";
+  margin-left: unset;
   vertical-align: baseline;
 }


### PR DESCRIPTION
## Summary

This PR adds margin for "(en-US)" indicator to improve visual perception.
Also the `.only-in-en-us span` CSS class was removed because it is no longer used (as far as I understand).

Relates: #11052

### Problem

Now "(en-US)" indicator "sticks" to link text. This applies to all locales except `zh-CN` and `zh-TW` (because in Chinese the bracket symbol already includes an extra space and it looks harmonious).

### Solution

This PR adds `margin-left: 0.5ch;` to "(en-US)" indicator in `de`, `es`, `fr`, `ja`, `ko`, `ru` and `pt-BR` locale.

Alternative method: add an indent to the main `html a.only-in-en-us:after` class and make exceptions for `zh-CN` and `zh-TW`.

---

## Screenshots

| Locale | Before | After |
|--------|--------|--------|
| `es` | ![image](https://github.com/user-attachments/assets/af99c9bf-34c2-4660-8e82-cbabcf2747db) | ![image](https://github.com/user-attachments/assets/16c0926a-8662-40a7-bc96-50c2cee9c88b) |
| `fr` | ![image](https://github.com/user-attachments/assets/825ac07b-da17-41e6-865d-15261f027386) | ![image](https://github.com/user-attachments/assets/9ee46b5a-fe34-453b-8d66-4b66f78751d2) |
| `ja` | ![image](https://github.com/user-attachments/assets/b278bd92-8ad5-408f-9892-de56136d3630) | ![image](https://github.com/user-attachments/assets/f9e05722-0dae-4b91-9c88-a7a1f481a7cd) |
| `ko` | ![image](https://github.com/user-attachments/assets/aba5b55b-f115-4011-8e1e-3643ee576b69) | ![image](https://github.com/user-attachments/assets/cf49471a-b6c2-4d64-8afc-183a6937f0d8) | 
| `ru` | ![image](https://github.com/user-attachments/assets/90d97f77-694f-41f5-886c-315c4b017e54) | ![image](https://github.com/user-attachments/assets/eef14252-ef16-40db-b871-feb54a686fb7) |
| `pt-BR` | ![image](https://github.com/user-attachments/assets/a6fd56b7-2d59-4205-9e2b-05515c62c9ae) | ![image](https://github.com/user-attachments/assets/be042d6d-5100-49f6-8e2d-3271a272e72e) | 
