### PR TITLE
fix(release): correct the filename of the `ssr` cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "yari-build": "build/cli.js",
     "yari-build-blog": "build/build-blog.js",
     "yari-filecheck": "filecheck/cli.js",
-    "yari-render-html": "build/cli-ssr.js",
+    "yari-render-html": "build/ssr-cli.js",
     "yari-server": "server/index.js",
     "yari-tool": "tool/cli.js"
   },


### PR DESCRIPTION
## Summary

Correct the filename of the `ssr` cli, see: https://github.com/mdn/yari/blob/main/build/ssr-cli.ts

The wrong path prevented `yarn` from creating the symbol-link `yari-render-html` in `node_modules/.bin`

### Solution

Correct the file path.

## How did you test this change?

No test has been done to this PR. It's a simple fix.
