### PR TITLE
fix(stage-build): abort main merge on conflict

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -103,7 +103,7 @@ jobs:
           git checkout main
           git status
           git checkout -
-          git merge main --no-edit
+          git merge main --no-edit || git merge --abort
 
       - uses: actions/checkout@v4
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}


### PR DESCRIPTION
## Summary

(MP-1778)

### Problem

The stage-build merges the latest `main` into `next` before deploying, but if there are merge conflicts, the stage-build fails.

### Solution

Abort the merge if it failed, so that the stage-build can continue anyhow. 

---

## How did you test this change?

Will cherry-pick into `next`.
