### PR TITLE
chore(ssr): let search engines index German locale

### DIFF
--- a/ssr/render.tsx
+++ b/ssr/render.tsx
@@ -145,10 +145,6 @@ export default function render(
   // Open Graph protocol expects `language_TERRITORY` format.
   const ogLocale = locale.replace("-", "_");
 
-  if (locale === "de") {
-    // Prevent experimental German locale from being indexed.
-    onlyFollow = true;
-  }
   const robotsContent =
     !ALWAYS_ALLOW_ROBOTS || (doc && doc.noIndexing) || noIndexing
       ? "noindex, nofollow"


### PR DESCRIPTION
## Summary

The German translation has been launched on production for almost 4 weeks, and there have been no major issues, so we're ready to expose the locale to search engines.

(MP-1642)

---

## How did you test this change?

Trivial change, removing the special treatment.