### PR TITLE
fix(livesamples): livesamples must not use port from parent

### DIFF
--- a/client/src/playground/utils.ts
+++ b/client/src/playground/utils.ts
@@ -42,6 +42,7 @@ export async function initPlayIframe(
     `${path || ""}${path?.endsWith("/") ? "" : "/"}runner.html`,
     window.location.origin
   );
+  url.port = "";
   url.host = host;
   url.search = "";
   url.searchParams.set("state", state);


### PR DESCRIPTION
## Summary

The new playground back-end broke live samples when running from content. This is because the `REACT_APP_PLAYGROUND_BASE_HOST` env variable is hardcoded. This should be fixed differently. But at least not break like it does.

Therefore, let's empty the port so it will gracefully fall back to mdnplay.dev.

---

## How did you test this change?

Locally
