### PR TITLE
fix(playground): run code even if it doesn't change

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -86,6 +86,7 @@ export default function Playground() {
   const [initialContent, setInitialContent] = useState<EditorContent | null>(
     null
   );
+  const [runCount, setRunCount] = useState(1);
   let { data: initialCode } = useSWRImmutable<EditorContent>(
     !stateParam && !shared && gistId
       ? `/api/v1/play/${encodeURIComponent(gistId)}`
@@ -134,10 +135,13 @@ export default function Playground() {
       );
       setVConsole([]);
       url.searchParams.set("state", state);
+      // ensure iframe reloads even if code doesn't change
+      url.searchParams.set("r", runCount.toString());
       url.pathname = `${codeSrc || code.src || ""}/runner.html`;
       setIframeSrc(url.href);
+      setRunCount(runCount + 1);
     },
-    [codeSrc, setVConsole, setIframeSrc]
+    [codeSrc, setVConsole, setIframeSrc, runCount, setRunCount]
   );
 
   useEffect(() => {

--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -86,7 +86,7 @@ export default function Playground() {
   const [initialContent, setInitialContent] = useState<EditorContent | null>(
     null
   );
-  const [runCount, setRunCount] = useState(1);
+  const [flipFlop, setFlipFlop] = useState(0);
   let { data: initialCode } = useSWRImmutable<EditorContent>(
     !stateParam && !shared && gistId
       ? `/api/v1/play/${encodeURIComponent(gistId)}`
@@ -136,12 +136,13 @@ export default function Playground() {
       setVConsole([]);
       url.searchParams.set("state", state);
       // ensure iframe reloads even if code doesn't change
-      url.searchParams.set("r", runCount.toString());
+      url.searchParams.set("f", flipFlop.toString());
       url.pathname = `${codeSrc || code.src || ""}/runner.html`;
       setIframeSrc(url.href);
-      setRunCount(runCount + 1);
+      // using an updater function causes the second "run" to not reload properly:
+      setFlipFlop((flipFlop + 1) % 2);
     },
-    [codeSrc, setVConsole, setIframeSrc, runCount, setRunCount]
+    [codeSrc, setVConsole, setIframeSrc, flipFlop, setFlipFlop]
   );
 
   useEffect(() => {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

### Problem

- When clicking "run" in the playground, if the code hasn't changed the console clears and nothing happens
- See this example: https://developer.mozilla.org/en-US/play?id=76Bf%2BoTQO7nfzPSaTS0sflgDOwZYzUDOVPD6aBOj5gdscDKySR1DyuDfNQ%2FFxc3iXsJnFZrn5DWpwV05
  - Click "run" repeatedly, you'll see the marquee keeps going, and the console clears but continues counting up from where it was before

### Solution

- Pretty trivial fix, since reloading the iframe directly isn't possible due to cross origin constraints, and I didn't want to add postMessage logic:
- just append a `&r=1` parameter giving the current run count

## How did you test this change?

locally with `yarn dev`