### PR TITLE
fix(playground): use localhost if on localhost

### DIFF
--- a/client/src/playground/index.tsx
+++ b/client/src/playground/index.tsx
@@ -126,11 +126,13 @@ export default function Playground() {
 
       // We're using a random subdomain for origin isolation.
       const url = new URL(
-        `${window.location.protocol}//${
-          PLAYGROUND_BASE_HOST.startsWith("localhost")
-            ? ""
-            : `${subdomain.current}.`
-        }${PLAYGROUND_BASE_HOST}`
+        window.location.hostname.endsWith("localhost")
+          ? window.location.origin
+          : `${window.location.protocol}//${
+              PLAYGROUND_BASE_HOST.startsWith("localhost")
+                ? ""
+                : `${subdomain.current}.`
+            }${PLAYGROUND_BASE_HOST}`
       );
       setVConsole([]);
       url.searchParams.set("state", state);

--- a/client/src/playground/utils.ts
+++ b/client/src/playground/utils.ts
@@ -35,15 +35,17 @@ export async function initPlayIframe(
     JSON.stringify(editorContent)
   );
   const path = iframe.getAttribute("data-live-path");
-  const host = PLAYGROUND_BASE_HOST.startsWith("localhost")
-    ? PLAYGROUND_BASE_HOST
-    : `${hash}.${PLAYGROUND_BASE_HOST}`;
   const url = new URL(
     `${path || ""}${path?.endsWith("/") ? "" : "/"}runner.html`,
     window.location.origin
   );
-  url.port = "";
-  url.host = host;
+  if (!window.location.hostname.endsWith("localhost")) {
+    const host = PLAYGROUND_BASE_HOST.startsWith("localhost")
+      ? PLAYGROUND_BASE_HOST
+      : `${hash}.${PLAYGROUND_BASE_HOST}`;
+    url.port = "";
+    url.host = host;
+  }
   url.search = "";
   url.searchParams.set("state", state);
   iframe.src = url.href;

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -20,6 +20,8 @@ function config(app) {
   app.use(`**/*.(gif|jpeg|jpg|mp3|mp4|ogg|png|svg|webm|webp|woff2)`, proxy);
   // All those root-level images like /favicon-48x48.png
   app.use("/*.(png|webp|gif|jpe?g|svg)", proxy);
+  // Proxy play runner
+  app.use("/**/runner.html", proxy);
 }
 
 export default config;


### PR DESCRIPTION

## Summary

When running on localhost use localhost for playground urls.

### Problem

Live samples use the prod playground (mdnplay.dev) when running `yarn start` in content. And the playground itself is broken.

### Solution

Use `window.location` to determine whether to use localhost.

---

## How did you test this change?

Locally
