### PR TITLE
fix(rari): adopt to rari changes

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -312,7 +312,7 @@ jobs:
           yarn rari content sync-translated-content
           yarn rari git-history
 
-          yarn rari build --issues client/build/issues.json --templ-stats
+          yarn rari build --all --issues client/build/issues.json --templ-stats
 
           # Sort DE search index by en-US popularity.
           node scripts/reorder-search-index.mjs client/build/en-us/search-index.json client/build/de/search-index.json

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -203,7 +203,7 @@ jobs:
           yarn rari content sync-translated-content
           yarn rari git-history
 
-          yarn rari build --issues client/build/issues.json --templ-stats
+          yarn rari build --all --issues client/build/issues.json --templ-stats
 
           # SSR all pages
           yarn render:html


### PR DESCRIPTION
## Summary

rari now needs `--all` to build everything.