### PR TITLE
fix(tsconfig): don't allow importing ts extensions in pwa

### DIFF
--- a/client/pwa/tsconfig.json
+++ b/client/pwa/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "es2021", "webworker"],
+    "allowImportingTsExtensions": false,
     "noEmit": false,
     "preserveConstEnums": true,
     "strictNullChecks": false,


### PR DESCRIPTION
follow up to https://github.com/mdn/yari/pull/12221

Already deployed and tested in stage: https://github.com/mdn/yari/commit/c03ae6d1a4cb74c6f8df7adb1762229713c43883