### PR TITLE
fix(play): proxy `/runner.html` locally, not just subpaths

### DIFF
--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -21,7 +21,7 @@ function config(app) {
   // All those root-level images like /favicon-48x48.png
   app.use("/*.(png|webp|gif|jpe?g|svg)", proxy);
   // Proxy play runner
-  app.use("/**/runner.html", proxy);
+  app.use("**/runner.html", proxy);
 }
 
 export default config;


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

- play `iframes` loading `/runner.html` locally wouldn't load the runner, but instead the homepage

### Solution

- remove extra `/` from beginning of wildcard path

---

## How did you test this change?

Locally with `yarn dev`