### PR TITLE
chore(kumascript): stop reporting link with en-US fallback as flaw

### DIFF
--- a/kumascript/src/api/web.ts
+++ b/kumascript/src/api/web.ts
@@ -144,17 +144,6 @@ const web = {
       hrefSplit[1] = "en-US";
       const enUSPage = this.info.getPageByURL(hrefSplit.join("/"));
       if (enUSPage.url) {
-        // But it's still a flaw. Record it so that translators can write a
-        // translated document to "fill the hole".
-        if (!ignoreFlawMacro) {
-          flaw = this.env.recordNonFatalError(
-            "broken-link",
-            `${hrefpath} does not exist but fell back to ${enUSPage.url}`
-          );
-          flawAttribute = ` data-flaw-src="${util.htmlEscape(
-            flaw.macroSource
-          )}"`;
-        }
         content ??= enUSPage.short_title ?? enUSPage.title;
         const title = ONLY_AVAILABLE_IN_ENGLISH(this.env.locale);
 


### PR DESCRIPTION
## Summary

### Problem

Translated-content shouldn't link to `en-US`, but yari emits a flaw for links to the current locale if the page is not yet translated. This causes a lot of noise in the context of the review companion on translated-content PRs.

### Solution

Remove the corresponding flaw.

---

## How did you test this change?

Trivial change.