### PR TITLE
fix(dev-server): fix top level assets with rari

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -513,7 +513,7 @@ if (RARI) {
       "/en-US/community/index.json",
       "/en-US/plus/docs/*",
       "/en-US/observatory/docs/*",
-      "/:locale/",
+      "/:locale([a-z]{2}(?:(?:-[A-Z]{2})?))/",
     ],
     async (req, res) => {
       try {


### PR DESCRIPTION
## Summary

`"/:locale/"` was catching to top level assets. So we narrow it down with a regex.

---

## How did you test this change?

Locally: `yarn start:rari`
