### PR TITLE
fix(placement): fix pattern regex

### DIFF
--- a/client/src/placement-context.tsx
+++ b/client/src/placement-context.tsx
@@ -31,27 +31,27 @@ const PLACEMENT_MAP: Record<PlacementType, { typ: string; pattern: RegExp }> = {
   side: {
     typ: "side",
     pattern:
-      /\/[^/]+\/(play|docs\/|blog\/|observatory\/?|curriculum\/[^$]|search$)/i,
+      /^\/[^/]+\/(play|docs\/|blog\/|observatory\/?|curriculum\/[^$]|search$)/i,
   },
   top: {
     typ: "top-banner",
-    pattern: /\/[^/]+\/(?!$|_homepage$).*/i,
+    pattern: /^\/[^/]+\/(?!$|_homepage$).*/i,
   },
   hpTop: {
     typ: "top-banner",
-    pattern: /\/[^/]+\/($|_homepage$)/i,
+    pattern: /^\/[^/]+\/($|_homepage$)/i,
   },
   hpMain: {
     typ: "hp-main",
-    pattern: /\/[^/]+\/($|_homepage$)/i,
+    pattern: /^\/[^/]+\/($|_homepage$)/i,
   },
   hpFooter: {
     typ: "hp-footer",
-    pattern: /\/[^/]+\/($|_homepage$)/i,
+    pattern: /^\/[^/]+\/($|_homepage$)/i,
   },
   bottom: {
     typ: "bottom-banner",
-    pattern: /\/[^/]+\/docs\//i,
+    pattern: /^\/[^/]+\/docs\//i,
   },
 };
 


### PR DESCRIPTION
## Summary

Missing `^` in the regex was matching routes that shouldn't match. 

`/\/[^/]+\/($|_homepage$)/i.test("/en-US/curriculum/") === true`

But it shouldn't. Adding a `^` fixes this.

## How did you test this change?

Locally
