### PR TITLE
fix(cloud-function): fix en-us asset fallback

### DIFF
--- a/cloud-function/src/handlers/proxy-content-assets.ts
+++ b/cloud-function/src/handlers/proxy-content-assets.ts
@@ -32,7 +32,7 @@ export const proxyContentAssets = createProxyMiddleware({
           ACTIVE_LOCALES.has(locale.toLowerCase())
         ) {
           const enUsAsset = await fetch(
-            `${target}${req.url?.slice(1).replace(locale, "en-US")}`
+            `${target}${req.url?.slice(1).replace(locale, "en-us")}`
           );
           if (enUsAsset?.ok) {
             res.statusCode = enUsAsset.status;


### PR DESCRIPTION
## Summary

Asset fallback happens after lowercase. So we need a lowercase en-US locale.

---

## How did you test this change?

Locally on a proper file system.
+ on stage.
