### PR TITLE
chore(placement): update Scrimba banner

### DIFF
--- a/client/src/ui/organisms/placement/index.tsx
+++ b/client/src/ui/organisms/placement/index.tsx
@@ -89,23 +89,7 @@ function TopPlacementFallbackContent() {
   });
   const now = Date.now();
 
-  return now < Date.parse("2024-12-25") ? (
-    <p className="fallback-copy">
-      Take our daily challenges on Scrimba until 24th December and win exciting
-      prizes.{" "}
-      <a
-        href="https://scrimba.com/javascriptmas?via=mdn"
-        target="_blank"
-        rel="noreferrer"
-        ref={observedNode}
-        onClick={() => {
-          gleanClick(BANNER_SCRIMBA_CLICK);
-        }}
-      >
-        Join now
-      </a>
-    </p>
-  ) : (
+  return (
     <p className="fallback-copy">
       Learn front-end development with high quality, interactive courses from{" "}
       <a
@@ -119,7 +103,10 @@ function TopPlacementFallbackContent() {
       >
         Scrimba
       </a>
-      . Enroll now!
+      .{" "}
+      {now < Date.parse("2025-01-08")
+        ? "Enroll now and save 25% this New Year!"
+        : "Enroll now!"}
     </p>
   );
 }


### PR DESCRIPTION
## Summary

(MP-1821)

### Problem

Scrimba has a 25% discount for New Year, and we don't promote it yet.

### Solution

Update the Scrimba banner to mention the discount before 2025-01-08.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/b2b0e773-1219-4f26-a491-6c9cb045df17" />

### After

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/948df1f8-b813-469f-a27b-2cee0e406377" />

---

## How did you test this change?

Ran `yarn dev` and viewed http://localhost:3000/en-US/ locally.