### PR TITLE
chore(client): remove unnecessary GA pageview event

### DIFF
--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -62,7 +62,6 @@ export class HTTPError extends Error {
 }
 
 export function Document(props /* TODO: define a TS interface for this */) {
-  const { gtag } = useGA();
   const gleanClick = useGleanClick();
   const isServer = useIsServer();
 
@@ -137,14 +136,6 @@ export function Document(props /* TODO: define a TS interface for this */) {
     if (doc && !error) {
       if (mountCounter.current > 0) {
         const location = window.location.toString();
-        // 'dimension19' means it's a client-side navigation.
-        // I.e. not the initial load but the location has now changed.
-        // Note that in local development, where you use `localhost:3000`
-        // this will always be true because it's always client-side navigation.
-        gtag("event", "pageview", {
-          dimension19: "Yes",
-          page_location: location,
-        });
         gleanClick(`${CLIENT_SIDE_NAVIGATION}: ${location}`);
       }
 
@@ -152,7 +143,7 @@ export function Document(props /* TODO: define a TS interface for this */) {
       // a client-side navigation happened.
       mountCounter.current++;
     }
-  }, [gtag, gleanClick, doc, error]);
+  }, [gleanClick, doc, error]);
 
   React.useEffect(() => {
     const location = document.location;

--- a/client/src/document/index.tsx
+++ b/client/src/document/index.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import useSWR, { mutate } from "swr";
 
 import { WRITER_MODE, PLACEMENT_ENABLED } from "../env";
-import { useGA } from "../ga-context";
 import { useIsServer, useLocale } from "../hooks";
 
 import { useDocumentURL, useDecorateCodeExamples, useRunSample } from "./hooks";

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -14,7 +14,6 @@ const SearchResults = React.lazy(() => import("./search-results"));
 
 export function SiteSearch() {
   const isServer = useIsServer();
-  const { gtag } = useGA();
   const gleanClick = useGleanClick();
   const [searchParams] = useSearchParams();
 
@@ -34,24 +33,14 @@ export function SiteSearch() {
 
   const mountCounter = React.useRef(0);
   React.useEffect(() => {
-    if (gtag) {
-      if (mountCounter.current > 0) {
-        const location = window.location.toString();
-        // 'dimension19' means it's a client-side navigation.
-        // I.e. not the initial load but the location has now changed.
-        // Note that in local development, where you use `localhost:3000`
-        // this will always be true because it's always client-side navigation.
-        gtag("event", "pageview", {
-          dimension19: "Yes",
-          page_location: location,
-        });
-        gleanClick(`${CLIENT_SIDE_NAVIGATION}: ${location}`);
-      }
-      // By counting every time a document is mounted, we can use this to know if
-      // a client-side navigation happened.
-      mountCounter.current++;
+    if (mountCounter.current > 0) {
+      const location = window.location.toString();
+      gleanClick(`${CLIENT_SIDE_NAVIGATION}: ${location}`);
     }
-  }, [query, page, gtag, gleanClick]);
+    // By counting every time a document is mounted, we can use this to know if
+    // a client-side navigation happened.
+    mountCounter.current++;
+  }, [query, page, gleanClick]);
 
   return (
     <div className="main-wrapper site-search">

--- a/client/src/site-search/index.tsx
+++ b/client/src/site-search/index.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { useIsServer } from "../hooks";
 import { Loading } from "../ui/atoms/loading";
 import { MainContentContainer } from "../ui/atoms/page-content";
-import { useGA } from "../ga-context";
 import { useGleanClick } from "../telemetry/glean-context";
 import "./index.scss";
 import { SidePlacement } from "../ui/organisms/placement";


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We record a custom GA "pageview" event on alleged client-side navigations, but the number is too high to be true, and we don't need to measure it with GA4, because we're already measuring this event with Glean.

### Solution

Stop measuring the GA event.

---

## How did you test this change?

Deployed to stage in https://github.com/mdn/yari/actions/runs/12635590221.