### PR TITLE
fix(rari): propagate rari exit code

### DIFF
--- a/bins/build.mjs
+++ b/bins/build.mjs
@@ -18,5 +18,5 @@ const child = spawn(rariBin, ["build", ...process.argv.slice(2)], {
 });
 
 child.on("close", (code) => {
-  process.exit(code);
+  process.exitCode = code;
 });

--- a/bins/build.mjs
+++ b/bins/build.mjs
@@ -13,4 +13,10 @@ config({
 
 process.env.BUILD_OUT_ROOT = process.env.BUILD_OUT_ROOT || BUILD_OUT_ROOT;
 
-spawn(rariBin, ["build", ...process.argv.slice(2)], { stdio: "inherit" });
+const child = spawn(rariBin, ["build", ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("close", (code) => {
+  process.exit(code);
+});

--- a/bins/tool.mjs
+++ b/bins/tool.mjs
@@ -19,5 +19,5 @@ const child = spawn(rariBin, ["content", ...process.argv.slice(2)], {
 });
 
 child.on("close", (code) => {
-  process.exit(code);
+  process.exitCode = code;
 });

--- a/bins/tool.mjs
+++ b/bins/tool.mjs
@@ -14,4 +14,10 @@ config({
 
 process.env.BUILD_OUT_ROOT = process.env.BUILD_OUT_ROOT || BUILD_OUT_ROOT;
 
-spawn(rariBin, ["content", ...process.argv.slice(2)], { stdio: "inherit" });
+const child = spawn(rariBin, ["content", ...process.argv.slice(2)], {
+  stdio: "inherit",
+});
+
+child.on("close", (code) => {
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

https://github.com/mdn/yari/pull/12351 showed that `yarn tool whatsdeployed` is not working but doesn't break CI, because running `yarn tool` always finishes with exit code 0, even if the underlying rari call fails.

### Solution

Propagate the exit code from the rari call.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

```
% yarn tool whatsdeployed
yarn run v1.22.22
$ node bins/tool.mjs whatsdeployed
Using env_file: /Users/claas/github/mdn/yari/.env
error: unrecognized subcommand 'whatsdeployed'

Usage: rari content [OPTIONS] <COMMAND>

For more information, try '--help'.
✨  Done in 0.25s.
```

### After

```
% yarn tool whatsdeployed 
yarn run v1.22.22
$ node bins/tool.mjs whatsdeployed
Using env_file: /Users/claas/github/mdn/yari/.env
error: unrecognized subcommand 'whatsdeployed'

Usage: rari content [OPTIONS] <COMMAND>

For more information, try '--help'.
error Command failed with exit code 2.
```

---

## How did you test this change?

Ran `yarn tool whatsdeployed` on `main` and this branch, see above.