### PR TITLE
fix(deployer): stream bulk actions to avoid rate limit

### DIFF
--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from collections import Counter
 
 import click
-from elasticsearch.helpers import parallel_bulk
+from elasticsearch.helpers import streaming_bulk
 from elasticsearch_dsl import Index
 from elasticsearch_dsl.connections import connections
 from selectolax.parser import HTMLParser
@@ -90,10 +90,9 @@ def index(
     errors_counter = Counter()
     t0 = time.time()
     with get_progressbar() as bar:
-        for success, info in parallel_bulk(
+        for success, info in streaming_bulk(
             connection,
             generator(),
-            thread_count=1,
             # If the bulk indexing failed, it will by default raise a BulkIndexError.
             # Setting this to 'False' will suppress that.
             raise_on_exception=False,

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -90,9 +90,10 @@ def index(
     errors_counter = Counter()
     t0 = time.time()
     with get_progressbar() as bar:
-        for success, info in bulk(
+        for success, info in parallel_bulk(
             connection,
             generator(),
+            thread_count=1,
             # If the bulk indexing failed, it will by default raise a BulkIndexError.
             # Setting this to 'False' will suppress that.
             raise_on_exception=False,

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from collections import Counter
 
 import click
-from elasticsearch.helpers import bulk
+from elasticsearch.helpers import parallel_bulk
 from elasticsearch_dsl import Index
 from elasticsearch_dsl.connections import connections
 from selectolax.parser import HTMLParser

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from collections import Counter
 
 import click
-from elasticsearch.helpers import parallel_bulk
+from elasticsearch.helpers import bulk
 from elasticsearch_dsl import Index
 from elasticsearch_dsl.connections import connections
 from selectolax.parser import HTMLParser
@@ -90,7 +90,7 @@ def index(
     errors_counter = Counter()
     t0 = time.time()
     with get_progressbar() as bar:
-        for success, info in parallel_bulk(
+        for success, info in bulk(
             connection,
             generator(),
             # If the bulk indexing failed, it will by default raise a BulkIndexError.


### PR DESCRIPTION
## Summary

(MP-1840)

### Problem

Elasticsearch indexing is failing with [HTTP 429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429).

### Solution

Reduce the number of requests by using `streaming_bulk()` instead of `parallel_bulk()`.

---

## How did you test this change?

Tested on stage: https://github.com/mdn/yari/actions/runs/12671649983/job/35318581296#step:24:32

```
Delete old index 'mdn_docs_20250108003944'
Delete old index 'mdn_docs_20250108114416'
Delete old index 'mdn_docs_20250108125257'
Delete old index 'mdn_docs_20250108134736'
Reassign the 'mdn_docs' alias from old index to mdn_docs_20250108150818
Took 3m 46s to index 58,266 documents. Approximately 257.5 docs/second
Count shards - successful: 58,266 failed: 0
Counts - worked: 58,266 errors: 0
```