### PR TITLE
fix(deployer): avoid GitHub mentions

### DIFF
--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -172,10 +172,12 @@ def post_about_dangerous_content(
             for url in sorted(external_urls):
                 count = external_urls[url]
                 # Avoid GitHub mentions.
+                original_url = url
                 url = url.replace('https://github.com/', 'https://redirect.github.com/')
+                link = f"<{url}>" if url == original_url else f"[{original_url}](<{url}>)"
                 line = (
                     f"  - {'🚨 ' if url.startswith('http://') else ''}"
-                    f"<{url}> ({count} time{'' if count==1 else 's'})"
+                    f"{link} ({count} time{'' if count == 1 else 's'})"
                 )
                 if diff_lines:
                     # If this was available and it _did_ fine a URL, then

--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -171,6 +171,8 @@ def post_about_dangerous_content(
             external_urls_list = []
             for url in sorted(external_urls):
                 count = external_urls[url]
+                # Avoid GitHub mentions.
+                url = url.replace('https://github.com/', 'https://redirect.github.com/')
                 line = (
                     f"  - {'🚨 ' if url.startswith('http://') else ''}"
                     f"<{url}> ({count} time{'' if count==1 else 's'})"

--- a/deployer/src/deployer/analyze_pr.py
+++ b/deployer/src/deployer/analyze_pr.py
@@ -173,8 +173,10 @@ def post_about_dangerous_content(
                 count = external_urls[url]
                 # Avoid GitHub mentions.
                 original_url = url
-                url = url.replace('https://github.com/', 'https://redirect.github.com/')
-                link = f"<{url}>" if url == original_url else f"[{original_url}](<{url}>)"
+                url = url.replace("https://github.com/", "https://redirect.github.com/")
+                link = (
+                    f"<{url}>" if url == original_url else f"[{original_url}](<{url}>)"
+                )
                 line = (
                     f"  - {'🚨 ' if url.startswith('http://') else ''}"
                     f"{link} ({count} time{'' if count == 1 else 's'})"


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/12211.

### Problem

If content contains external links to GitHub issues/PRs, then the PR Review Companion comment causes noisy mentions, including on external repositories.

### Solution

Use the `redirect.github.com` domain to avoid the mentions.

---

## How did you test this change?

Trivial change, tested code snippet locally:

```sh
% python
Python 3.12.1 (main, May 29 2024, 12:14:34) [Clang 15.0.0 (clang-1500.3.9.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> count = 3
>>> url = 'https://github.com/foo'
>>> 
>>> # Avoid GitHub mentions.
>>> original_url = url
>>> url = url.replace('https://github.com/', 'https://redirect.github.com/')
>>> link = f"<{url}>" if url == original_url else f"[{original_url}](<{url}>)"
>>> line = (
...     f"  - {'🚨 ' if url.startswith('http://') else ''}"
...     f"{link} ({count} time{'' if count==1 else 's'})"
... )
>>> 
>>> print(line)
  - [https://github.com/foo](<https://redirect.github.com/foo>) (3 times)
```
