### PR TITLE
fix(layout): add space between specifications table and footer box

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -248,6 +248,10 @@
     }
   }
 
+  #specifications + table {
+    margin-bottom: 2rem;
+  }
+
   @media (min-width: $screen-sm) {
     padding: 3rem;
     // Reduce space to article footer.


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/10886

### Problem

No gap between specifications table and footer "help improve" box when they're next to each other on the page

### Solution

Add margin-bottom to specifications table, which doesn't increase space to BCD table when that's between.

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/507e8c6b-938f-4146-a8ef-0e6e11d794dc)

#### Specifications to BCD gap

![image](https://github.com/user-attachments/assets/58f53fed-98cb-47ab-9b5b-3e08ed3e4998)


### After

![image](https://github.com/user-attachments/assets/29b6de84-eb23-4291-a544-3a5c206506f1)

#### Same specifications to BCD gap as before:

![image](https://github.com/user-attachments/assets/aa5ad30e-740f-4927-bfe9-40318330abf2)


---

## How did you test this change?

Locally, across breakpoints