### PR TITLE
fix(ui): check for `addEventListener` on `MediaQueryList`

### DIFF
--- a/client/src/ui-context.tsx
+++ b/client/src/ui-context.tsx
@@ -88,6 +88,12 @@ export function UIProvider(props: any) {
     if (dark.matches) {
       setColorScheme("dark");
     }
+
+    if (!("addEventListener" in dark)) {
+      // MediaQueryList doesn't inherit EventTarget in Safari < 14.
+      return;
+    }
+
     dark.addEventListener("change", setDark);
     const light = window.matchMedia("(prefers-color-scheme: light)");
     light.addEventListener("change", setLight);


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/9392.

### Problem

In Safari < 14, `MediaQueryList` does not inherit from `EventTarget`, which triggers an uncaught error, causing a blank page.

### Solution

Check if our `MediaQueryList` has `addEventListener`, and avoid calling it otherwise.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="536" alt="image" src="https://github.com/user-attachments/assets/985716a8-3520-4f29-b45e-288a9c0a7379" /> | <img width="536" alt="image" src="https://github.com/user-attachments/assets/e75c75bb-932d-45d1-9e95-e90db906383f" /> |

---

## How did you test this change?

Ran `yarn dev` and tested on BrowserStack Live with iOS 13 on iPhone 11 via BrowserStack Local.
