### PR TITLE
fix(blog): avoid overflow + double padding

### DIFF
--- a/client/src/blog/post.scss
+++ b/client/src/blog/post.scss
@@ -81,7 +81,10 @@
 
   > .blog-post {
     grid-area: post;
-    max-width: 52rem;
+
+    @media (min-width: $screen-lg) {
+      max-width: 52rem;
+    }
 
     + .section-newsletter h2 {
       font: var(--type-heading-h3);

--- a/client/src/blog/post.scss
+++ b/client/src/blog/post.scss
@@ -6,6 +6,7 @@
   grid-template-areas:
     "post"
     "newsletter";
+  padding: 0;
   width: 100%;
 
   @media (min-width: $screen-lg) {


### PR DESCRIPTION
## Summary

Fixes #11110.

### Problem

Blog posts were overflowing on smaller screens, and the horizontal padding was too big.

### Solution

1. Only set `max-width: 52rem` on larger screens, to avoid overflow on smaller screens.
2. Only set horizontal padding once on the `<article>`, not also on the `<main>` element.

---

## Screenshots

| Before | After |
|--------|--------|
| ![Screen Shot 2025-01-24 at 10 44 29](https://github.com/user-attachments/assets/f989754a-5d87-4cd3-80c5-0f2d4ca6c7fe) | ![Screen Shot 2025-01-24 at 10 45 58](https://github.com/user-attachments/assets/61a3bbd7-8af0-475e-a2b9-0030e262482d) | 

---

## How did you test this change?

Ran `yarn build:prepare && yarn start`, then visited http://localhost:5042/en-US/blog/javascript-temporal-is-coming/ locally.