### PR TITLE
chore(deps-dev): remove react-is

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "react": "^18.3.1",
     "react-app-polyfill": "^3.0.0",
     "react-dom": "^18.3.1",
-    "react-is": "^18.3.1",
     "react-refresh": "^0.16",
     "react-router": "^7.0.2",
     "react-router-dom": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13044,7 +13044,7 @@ react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^18.0.0, react-is@^18.3.1:
+react-is@^18.0.0:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==


### PR DESCRIPTION
## Summary

Noticed in https://github.com/mdn/yari/pull/12261.

### Problem

We depend on `react-is`, although we don't use it.

### Solution

Remove the dependency.

---

## How did you test this change?

Searched for `react-is` and `ReactIs`.