### PR TITLE
fix(csp): allow images from prod (developer.mozilla.org)

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -155,6 +155,7 @@ export const CSP_DIRECTIVES = {
     "profile.stage.mozaws.net",
     "profile.accounts.firefox.com",
 
+    "developer.mozilla.org",
     "mdn.dev",
     "interactive-examples.mdn.mozilla.net",
     "interactive-examples.mdn.allizom.net",


### PR DESCRIPTION
Otherwise we cannot load `apple-touch-icon` and `favicon` on other pages, including localhost.

<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When running `yarn start`, and opening http://localhost:5042/en-US/ in the browser, two CSP errors appear in the console:

```
Content-Security-Policy: The page’s settings blocked the loading of a resource (img-src) at https://developer.mozilla.org/apple-touch-icon.528534bba673c38049c2.png because it violates the following directive: “img-src 'self' data: (...)

Content-Security-Policy: The page’s settings blocked the loading of a resource (img-src) at https://developer.mozilla.org/favicon-48x48.bc390275e955dacb2e65.png because it violates the following directive: “img-src 'self' data: (...)
```

### Solution

Add `developer.mozilla.org` to the CSP `img-src` directive.

---

## How did you test this change?

Ran `yarn start` on this branch, and no CSP errors appeared in the console when openingn http://localhost:5042/en-US/.