### PR TITLE
chore(bin): deprecate yari bins + test rari bins

### DIFF
--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -70,6 +70,14 @@ jobs:
           yarn add file:$TARBALL
           yarn install
 
+      - name: (mdn/content) yarn rari-build --help
+        working-directory: mdn/content
+        run: yarn rari-build --help
+
+      - name: (mdn/content) yarn rari-tool --help
+        working-directory: mdn/content
+        run: yarn rari-tool --help
+
       - name: (mdn/content) yarn yari-build --help
         working-directory: mdn/content
         run: yarn yari-build --help

--- a/build/cli.ts
+++ b/build/cli.ts
@@ -464,7 +464,7 @@ if (SENTRY_DSN_BUILD) {
 }
 
 program
-  .name("build")
+  .name("[DEPRECATED] build")
   .option("-i, --interactive", "Ask what to do when encountering flaws", {
     default: false,
   })
@@ -599,6 +599,8 @@ program
       throw error;
     }
   });
+
+console.warn("\n🗑️  This command is deprecated, and will be removed soon.\n");
 
 program.run();
 function compareBigInt(a: bigint, b: bigint): number {

--- a/server/index.ts
+++ b/server/index.ts
@@ -570,6 +570,8 @@ app.use(staticMiddlewares);
 
 app.get("/*", async (_, res) => await send404(res));
 
+console.warn("\n🗑️  This command is deprecated, and will be removed soon.\n");
+
 if (!fs.existsSync(path.resolve(CONTENT_ROOT))) {
   throw new Error(`${path.resolve(CONTENT_ROOT)} does not exist!`);
 }

--- a/tool/cli.ts
+++ b/tool/cli.ts
@@ -233,7 +233,7 @@ function tryOrExit<T extends ActionParameters>(
 
 program
   .bin("yarn tool")
-  .name("tool")
+  .name("[DEPRECATED] tool")
   .version("0.0.0")
   .disableGlobalOption("--silent")
   .cast(false)
@@ -1103,5 +1103,7 @@ program
       return whatsdeployed(directory, output, dryRun);
     })
   );
+
+console.warn("\n🗑️  This command is deprecated, and will be removed soon.\n");
 
 program.run();


### PR DESCRIPTION
## Summary

Part of MP-1856 (Mozilla-internal).

### Problem

We're deprecating the `yari-{build,server,tool}` commands in favor of `rari-{build,server,tool}`, but we're only testing that `rari-server` works (indirectly via `yarn start`).

### Solution

1. Add deprecation warnings to the commands
2. Also test `rari-build` and `rari-tool`.

---

## How did you test this change?

See checks on this PR.