### PR TITLE
refactor(cloud-function): don't return value in handler

### DIFF
--- a/cloud-function/src/handlers/handle-stripe-plans.ts
+++ b/cloud-function/src/handlers/handle-stripe-plans.ts
@@ -15,7 +15,10 @@ interface Result {
   plans: PlanResult;
 }
 
-export async function handleStripePlans(req: Request, res: Response) {
+export async function handleStripePlans(
+  req: Request,
+  res: Response
+): Promise<void> {
   const lookupData =
     ORIGIN_MAIN === "developer.mozilla.org" ? prodLookup : stageLookup;
 
@@ -24,7 +27,8 @@ export async function handleStripePlans(req: Request, res: Response) {
   const supportedCurrency = lookupData.countryToCurrency[countryCode];
 
   if (!supportedCurrency) {
-    return res.sendStatus(404).end();
+    res.sendStatus(404).end();
+    return;
   }
 
   const localeHeader = req.headers["accept-language"];
@@ -47,7 +51,8 @@ export async function handleStripePlans(req: Request, res: Response) {
 
   const plans = lookupData.langCurrencyToPlans[key];
   if (!plans) {
-    return res.sendStatus(500).end();
+    res.sendStatus(500).end();
+    return;
   }
 
   const planResult: PlanResult = {};
@@ -67,12 +72,10 @@ export async function handleStripePlans(req: Request, res: Response) {
     plans: planResult,
   } satisfies Result;
 
-  return (
-    res
-      .status(200)
-      // Google CDN cannot partition by country, so we can only cache in browser.
-      .setHeader("Cache-Control", "private, max-age=86400")
-      .setHeader("Content-Type", "application/json")
-      .end(JSON.stringify(result))
-  );
+  res
+    .status(200)
+    // Google CDN cannot partition by country, so we can only cache in browser.
+    .setHeader("Cache-Control", "private, max-age=86400")
+    .setHeader("Content-Type", "application/json")
+    .end(JSON.stringify(result));
 }

--- a/cloud-function/src/handlers/proxy-kevel.ts
+++ b/cloud-function/src/handlers/proxy-kevel.ts
@@ -28,7 +28,7 @@ const handleViewed = createPongViewedHandler(coder);
 const plusLookup =
   ORIGIN_MAIN === "developer.mozilla.org" ? prodPlusLookup : stagePlusLookup;
 
-export async function proxyKevel(req: Request, res: Response) {
+export async function proxyKevel(req: Request, res: Response): Promise<void> {
   const countryCode = getRequestCountry(req);
 
   const plusAvailable = countryCode in plusLookup.countryToCurrency;
@@ -41,7 +41,8 @@ export async function proxyKevel(req: Request, res: Response) {
 
   if (pathname === "/pong/get") {
     if (req.method !== "POST") {
-      return res.sendStatus(405).end();
+      res.sendStatus(405).end();
+      return;
     }
 
     const { body } = req;
@@ -53,34 +54,40 @@ export async function proxyKevel(req: Request, res: Response) {
 
     payload.plusAvailable = plusAvailable;
 
-    return res
+    res
       .status(status)
       .setHeader("cache-control", "no-store")
       .setHeader("content-type", "application/json")
       .end(JSON.stringify(payload));
+    return;
   } else if (req.path === "/pong/click") {
     if (req.method !== "GET") {
-      return res.sendStatus(405).end();
+      res.sendStatus(405).end();
+      return;
     }
     const params = new URLSearchParams(search);
     try {
       const { status, location } = await handleClick(params);
       if (location && (status === 301 || status === 302)) {
-        return res.redirect(location);
+        res.redirect(location);
+        return;
       } else {
-        return res.sendStatus(502).end();
+        res.sendStatus(502).end();
+        return;
       }
     } catch (e) {
       console.error(e);
     }
   } else if (pathname === "/pong/viewed") {
     if (req.method !== "POST") {
-      return res.sendStatus(405).end();
+      res.sendStatus(405).end();
+      return;
     }
     const params = new URLSearchParams(search);
     try {
       await handleViewed(params);
-      return res.sendStatus(201).end();
+      res.sendStatus(201).end();
+      return;
     } catch (e) {
       console.error(e);
     }
@@ -89,17 +96,19 @@ export async function proxyKevel(req: Request, res: Response) {
       decodeURIComponent(pathname.substring("/pimg/".length))
     );
     if (!src) {
-      return res.sendStatus(400).end();
+      res.sendStatus(400).end();
+      return;
     }
     const { buf, contentType } = await fetchImage(src);
-    return res
+    res
       .status(200)
       .set({
         "cache-control": "max-age=86400",
         "content-type": contentType,
       })
       .end(Buffer.from(buf));
+    return;
   }
 
-  return res.status(204).end();
+  res.status(204).end();
 }

--- a/cloud-function/src/handlers/proxy-pong.ts
+++ b/cloud-function/src/handlers/proxy-pong.ts
@@ -4,7 +4,7 @@ import { proxyKevel } from "./proxy-kevel.js";
 
 import type { Request, Response } from "express";
 
-export async function proxyPong(req: Request, res: Response) {
+export async function proxyPong(req: Request, res: Response): Promise<void> {
   if (BSA_ENABLED) {
     return proxyBSA(req, res);
   }

--- a/cloud-function/src/middlewares/require-origin.ts
+++ b/cloud-function/src/middlewares/require-origin.ts
@@ -3,13 +3,17 @@ import type { NextFunction, Request, Response } from "express";
 import { Origin, getOriginFromRequest } from "../env.js";
 
 export function requireOrigin(...expectedOrigins: Origin[]) {
-  return async (req: Request, res: Response, next: NextFunction) => {
+  return async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
     const actualOrigin = getOriginFromRequest(req);
 
     if (expectedOrigins.includes(actualOrigin)) {
-      return next();
+      next();
     } else {
-      return res.sendStatus(404).end();
+      res.sendStatus(404).end();
     }
   };
 }

--- a/libs/play/index.js
+++ b/libs/play/index.js
@@ -337,6 +337,7 @@ function playSubdomain(hostname) {
 /**
  * @param {express.Request} req
  * @param {express.Response} res
+ * @returns {Promise<void>}
  */
 export async function handleRunner(req, res) {
   const url = new URL(req.url, "https://example.com");
@@ -358,7 +359,8 @@ export async function handleRunner(req, res) {
     !state ||
     (!isLocalhost && !hasMatchingHash && !isIframeOnMDN)
   ) {
-    return res.status(404).end();
+    res.status(404).end();
+    return;
   }
 
   const json = JSON.parse(state);
@@ -367,7 +369,7 @@ export async function handleRunner(req, res) {
   if (req.headers["sec-fetch-dest"] === "iframe" || codeParam === codeCookie) {
     const html = renderHtml(json);
     withRunnerResponseHeaders(res);
-    return res.status(200).send(html);
+    res.status(200).send(html);
   } else {
     const rand = crypto.randomUUID();
     res.cookie("code", rand, {
@@ -380,7 +382,7 @@ export async function handleRunner(req, res) {
     urlWithCode.search = "";
     urlWithCode.searchParams.set("state", stateParam);
     urlWithCode.searchParams.set("code", rand);
-    return res
+    res
       .status(200)
       .send(
         renderWarning(


### PR DESCRIPTION
## Summary

Unblocks https://github.com/mdn/yari/pull/12563.

### Problem

https://github.com/mdn/yari/pull/12563 updates dependencies, including express types, and these now make sure that nothing is returned inside handlers, [causing TypeScript lint errors](https://github.com/mdn/yari/actions/runs/13113630056/job/36582769231?pr=12563#step:10:13).

### Solution

Avoid returning values, by moving the return statement below.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Will cherry-pick into https://github.com/mdn/yari/pull/12563, then revert.