### PR TITLE
fix(play): use correct code font across locales

### DIFF
--- a/client/src/lit/play/editor.scss
+++ b/client/src/lit/play/editor.scss
@@ -11,5 +11,11 @@
   .cm-editor {
     height: 100%;
     width: 100%;
+
+    * {
+      // codemirror uses `font-family: monospace;` in multiple places
+      // which causes weird fonts to be used in various locales
+      font-family: var(--font-code) !important;
+    }
   }
 }


### PR DESCRIPTION
## Summary

### Problem

`font-face: monospace` results in unusual fonts being used across ko, jp, zh-CN and zh-TW, e.g: https://test.developer.allizom.org/ja/docs/Web/JavaScript/Guide/Regular_expressions/Assertions

### Solution

Force the use of our code fonts in codemirror, using a wildcard to apply to all aspects of the ui (i.e. the dynamic dropdowns, as well as the editor).

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/2c669030-2e98-44ec-9e06-9bd502749dc1)

### After

![image](https://github.com/user-attachments/assets/a3433755-fd14-487c-b068-b835f4a34dca)


---

## How did you test this change?

Locally, `yarn dev`, localhost:3000
