### PR TITLE
fix(play): access blank runner on subdomain

### DIFF
--- a/client/src/lit/play/runner.js
+++ b/client/src/lit/play/runner.js
@@ -81,7 +81,7 @@ export class PlayRunner extends LitElement {
     return html`
       <iframe
         src="${window.location
-          .protocol}//${PLAYGROUND_BASE_HOST}/runner.html?blank"
+          .protocol}//blank.${PLAYGROUND_BASE_HOST}/runner.html?blank"
         title="runner"
         sandbox="allow-scripts allow-same-origin allow-forms ${this.sandbox}"
       ></iframe>


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

https://github.com/mdn/yari/pull/12630 fixed an issue with the Playground, but started loading a blank runner without a subdomain, which is not covered by the CSP frame-src directive, which only allows `*.mdnplay.dev`.

### Solution

Access the blank runner from the `blank.mdnplay.dev` subdomain.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
