### PR TITLE
enhance(libs/play): allow runner embedded on review pages

### DIFF
--- a/cloud-function/README.md
+++ b/cloud-function/README.md
@@ -36,6 +36,8 @@ The function uses the following environment variables:
   requests to the main site.
 - `ORIGIN_LIVE_SAMPLES` (default: `"localhost"`) - The expected `Host` header
   value for requests to live samples.
+- `ORIGIN_REVIEW` (default: `"content.dev.mdn.mozit.cloud"`) - The host of the
+  content preview pages.
 - `SOURCE_CONTENT` (default: `"http://localhost:8100"`) - The URL at which the
   client build is served.
 - `SOURCE_API` (default: `"https://developer.allizom.org/"`) - The URL at which

--- a/libs/play/index.js
+++ b/libs/play/index.js
@@ -4,6 +4,8 @@ import he from "he";
 
 export const ORIGIN_PLAY = process.env["ORIGIN_PLAY"] || "localhost";
 export const ORIGIN_MAIN = process.env["ORIGIN_MAIN"] || "localhost";
+export const ORIGIN_REVIEW =
+  process.env["ORIGIN_REVIEW"] || "content.dev.mdn.mozit.cloud";
 
 /** @import { IncomingMessage, ServerResponse } from "http" */
 /** @import * as express from "express" */
@@ -336,7 +338,12 @@ function playSubdomain(hostname) {
  * @param {URL} referer
  */
 function isMDNReferer(referer) {
-  return referer.hostname === ORIGIN_MAIN;
+  const { hostname } = referer;
+  return (
+    hostname === ORIGIN_MAIN ||
+    hostname === ORIGIN_REVIEW ||
+    hostname.endsWith(`.${ORIGIN_REVIEW}`)
+  );
 }
 
 /**

--- a/libs/play/index.js
+++ b/libs/play/index.js
@@ -333,6 +333,13 @@ function playSubdomain(hostname) {
 }
 
 /**
+ * @param {URL} referer
+ */
+function isMDNReferer(referer) {
+  return referer.hostname === ORIGIN_MAIN;
+}
+
+/**
  * @param {express.Request} req
  * @param {express.Response} res
  */
@@ -351,8 +358,7 @@ export async function handleRunner(req, res) {
   const isLocalhost = req.hostname === "localhost";
   const hasMatchingHash = playSubdomain(req.hostname) === hash;
   const isIframeOnMDN =
-    referer.hostname === ORIGIN_MAIN &&
-    req.headers["sec-fetch-dest"] === "iframe";
+    isMDNReferer(referer) && req.headers["sec-fetch-dest"] === "iframe";
 
   if (
     !stateParam ||


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The Playground runner yields a HTTP 404 if embedded on the Review Companion pages, because the runner subdomain doesn't match the hash and the referrer isn't MDN.

### Solution

Recognize the Review Companion host as a valid MDN referrer.

---

## Screenshots

### Before

(Note: The error shown is a new Firefox Nightly feature shown in case of empty HTTP 404 errors.)

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/9f802284-2a22-457c-9aef-8ef4a72befbc" />

### After

<img width="1122" alt="image" src="https://github.com/user-attachments/assets/6bde9f7e-7f1e-4439-a827-5d9a7b50b52a" />

---

## How did you test this change?

Deployed to stage (see [this run](https://github.com/mdn/yari/actions/runs/13454420041/job/37595208705)) and tested using the [Redirector extension](https://addons.mozilla.org/en-US/firefox/addon/redirector/) with the following redirect:

- Redirect: `https://*.mdnplay.dev/*`
- to: `https://$1.mdnyalp.dev/$2`
- Pattern type: Wildcard
- Apply to (Advanced options): Main window + IFrames
