### PR TITLE
fix(interactive-examples): open targetless `<area>`s in parent window

### DIFF
--- a/client/src/lit/interactive-example/example.js
+++ b/client/src/lit/interactive-example/example.js
@@ -1,7 +1,10 @@
 window.addEventListener("click", (event) => {
   // open links in parent frame if they have no `_target` set
   const target = event.target;
-  if (target instanceof HTMLAnchorElement) {
+  if (
+    target instanceof HTMLAnchorElement ||
+    target instanceof HTMLAreaElement
+  ) {
     const hrefAttr = target.getAttribute("href");
     const targetAttr = target.getAttribute("target");
     if (hrefAttr && !hrefAttr.startsWith("#") && !targetAttr) {


### PR DESCRIPTION
## Summary

Fixes issue raised in content PR review: https://github.com/mdn/content/pull/38257#discussion_r1965382224

---

## How did you test this change?

Tested locally
