### PR TITLE
fix(playground): remove duplicate editor scrollbar

### DIFF
--- a/client/src/playground/index.scss
+++ b/client/src/playground/index.scss
@@ -199,7 +199,6 @@ main.play {
               var(--editor-header-padding) - var(--editor-header-border-width)
           );
           margin: 0.5rem 0 0;
-          overflow-y: scroll;
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #12572.

### Problem

When a code block has overflowed text, a second vertical scroll bar appears; the original one never becomes active.
I see this in Firefox and Edge on Windows 10.

### Solution

remove `overflow-y: scroll;` in class "play-editor" on line 202

---

## Screenshots

removes the inner scroll bar
![image](https://github.com/user-attachments/assets/4830df52-412a-4235-b36d-7109b701d457)


### Before

![image](https://github.com/user-attachments/assets/8b8bfe17-f79a-446b-ad52-c039988d0b44)

### After

![image](https://github.com/user-attachments/assets/6c383405-024d-435b-9eda-41cf210ce1c7)

---

## How did you test this change?

using the browser dev tools, toggled off this rule
