### PR TITLE
fix(play): avoid double-slash in runner URL

### DIFF
--- a/client/src/lit/play/runner.js
+++ b/client/src/lit/play/runner.js
@@ -50,6 +50,7 @@ export class PlayRunner extends LitElement {
           js: code?.js || "",
         })
       );
+      const prefix = (srcPrefix || "").replace(/\/$/, "");
       signal.throwIfAborted();
       // We're using a random subdomain for origin isolation.
       const url = new URL(
@@ -62,7 +63,7 @@ export class PlayRunner extends LitElement {
             }${PLAYGROUND_BASE_HOST}`
       );
       url.searchParams.set("state", state);
-      url.pathname = `${srcPrefix || ""}/runner.html`;
+      url.pathname = `${prefix}/runner.html`;
       const src = url.href;
       // update iframe src without adding to browser history
       this.shadowRoot


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/12621.

### Problem

When opening a live sample in the Playground, it doesn't load locally on port 5042, due to a double-slash (`//`), which gets redirected to an underscore (`_`).

### Solution

Avoid the double-slash by trimming the trailing slash on the live sample prefix.

---

## Screenshots

### Before

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/abde8092-9063-4cb8-a1c4-e73118f1f711" />

### After

<img width="1427" alt="image" src="https://github.com/user-attachments/assets/e0620285-07a9-4818-98d9-a61c7384ed1a" />

---

## How did you test this change?

1. Ran `yarn dev`.
2. Opened http://localhost:5042/en-US/docs/Web/API/HTMLMarqueeElement#examples
3. Clicked on "Play"
4. Checked the Runner output
