### PR TITLE
fix(interactive-examples): allow wasm in csp

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -63,6 +63,7 @@ export const ACTIVE_LOCALES = new Set([
 export const CSP_SCRIPT_SRC_VALUES = [
   "'report-sample'",
   "'self'",
+  "'wasm-unsafe-eval'",
 
   // GA4.
   "https://www.google-analytics.com/analytics.js",


### PR DESCRIPTION
## Summary

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution

> If a page has a CSP header and 'wasm-unsafe-eval' isn't specified in the script-src directive, WebAssembly is blocked from loading and executing on the page.

---

## How did you test this change?

Haven't yet: will get on test