### PR TITLE
fix: Render userScripts_legacy.register as userScripts.register (Legacy)

### DIFF
--- a/kumascript/macros/WebExtAllExamples.ejs
+++ b/kumascript/macros/WebExtAllExamples.ejs
@@ -45,7 +45,14 @@ function writeJavaScriptAPIs(apisJSON) {
   let output = "";
   for (let jsAPI of apisJSON) {
     var link = `/${lang}/${s_webextension_api_path}/${jsAPI.replace(".", "/")}`;
-    output += `<a href="${link}"><code>${jsAPI}</code></a><br/>`;
+    var label = `<code>${jsAPI}</code>`;
+    if (jsAPI === "userScripts_legacy.register") {
+      // The API is userScripts.register, but the URL is at userScripts_legacy
+      // because there is another API with the same name.
+      // See https://github.com/mdn/webextensions-examples/pull/579
+      label = "<code>userScripts.register</code> (Legacy)";
+    }
+    output += `<a href="${link}">${label}</a><br/>`;
   }
   return output;
 }


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->
Render `userScripts_legacy.register` as `userScripts.register (legacy)` in the example overview at https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Examples

See https://github.com/mdn/webextensions-examples/pull/579

### Problem

<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->
There are two versions of the `userScripts.register` API. In the API sidebar, documentation, BCD, etc., they are distinguished by the "(Legacy)" suffix. The documentation is at:
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts/register
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/userScripts_legacy/register

The current macro assumes that the URL slug and API name are identical. This is not the case for `userScripts.register`, so the `examples.json` index uses `userScripts_legacy.register` to refer to the legacy API. However, that causes the example to be rendered as "userScripts_legacy.register", which is not the name of the API.

### Solution

<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->
The patch fixes the issue by special-casing this one exception, and rendering the anchor label as `userScripts.register (Legacy)`.