### PR TITLE
fix(interactive-example): isolate messages to runner origin

### DIFF
--- a/client/src/lit/play/runner.js
+++ b/client/src/lit/play/runner.js
@@ -33,6 +33,7 @@ export class PlayRunner extends LitElement {
 
   /** @param {MessageEvent} e  */
   _onMessage({ data: { typ, prop, args }, origin, source }) {
+    /** @type {string | undefined} */
     let uuid = new URL(origin, "https://example.com").hostname.split(".")[0];
     if (uuid !== this._subdomain && source && "location" in source) {
       // we could be on localhost, check `source` for the uuid param we set

--- a/client/src/lit/play/runner.js
+++ b/client/src/lit/play/runner.js
@@ -36,8 +36,9 @@ export class PlayRunner extends LitElement {
     /** @type {string | undefined} */
     let uuid = new URL(origin, "https://example.com").hostname.split(".")[0];
     if (uuid !== this._subdomain && source && "location" in source) {
-      // we could be on localhost, check `source` for the uuid param we set
-      // NB: this doesn't work cross origin
+      // `origin` doesn't contain the uuid on localhost
+      // so check `source` for the uuid param we set
+      // this only works on localhost (it errors cross-origin)
       try {
         uuid =
           new URLSearchParams(source.location.search).get("uuid") || undefined;


### PR DESCRIPTION
## Summary
### Problem

We have a wasm page with multiple interactive examples on it, and they get each other's console messages: https://test.developer.allizom.org/en-US/docs/WebAssembly/Reference/Control_flow/call

### Solution

Isolate the messages based on subdomain/uuid: we have to use two approaches to work on prod cross origin and locally

---

## How did you test this change?

Tested locally, will get on test to properly test the cross origin code, but did some initial testing through a playground: https://developer.mozilla.org/en-US/play?id=A3BoDCQCUgRGE4dwjU9hP0qyJuCBgP5StleMoTlnGvv1qiEiJ6%2FWksl7pVZWynGSadlXBvxPPzy%2FhFdN