### PR TITLE
fix(cloud-function): remove --allow-unauthenticated option

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -385,7 +385,6 @@ jobs:
             --region=$region \
             --source=cloud-function \
             --trigger-http \
-            --allow-unauthenticated \
             --entry-point=mdnHandler \
             --concurrency=100 \
             --min-instances=10 \

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -399,7 +399,6 @@ jobs:
             --region=$region \
             --source=cloud-function \
             --trigger-http \
-            --allow-unauthenticated \
             --entry-point=mdnHandler \
             --concurrency=100 \
             --min-instances=1 \

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -328,7 +328,6 @@ jobs:
             --region=$region \
             --source=cloud-function \
             --trigger-http \
-            --allow-unauthenticated \
             --entry-point=mdnHandler \
             --concurrency=100 \
             --min-instances=1 \


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We set `--allow-unauthenticated` when deploying our Cloud Function, but this does not seem to be necessary, as we're routing internally from our GCP load balancer, as confirmed by [the new Review function](https://github.com/mdn/yari/pull/12694).

### Solution

Remove the `--allow-unauthenticated` flag.

---

## How did you test this change?

Applied the same change on the Review function, which is deployed, and can still be accessed through the load balancer (e.g. https://main.review.mdn.allizom.net/).