### PR TITLE
chore(play): allow new review host

### DIFF
--- a/cloud-function/README.md
+++ b/cloud-function/README.md
@@ -36,8 +36,6 @@ The function uses the following environment variables:
   requests to the main site.
 - `ORIGIN_LIVE_SAMPLES` (default: `"localhost"`) - The expected `Host` header
   value for requests to live samples.
-- `ORIGIN_REVIEW` (default: `"content.dev.mdn.mozit.cloud"`) - The host of the
-  content preview pages.
 - `SOURCE_CONTENT` (default: `"http://localhost:8100"`) - The URL at which the
   client build is served.
 - `SOURCE_API` (default: `"https://developer.allizom.org/"`) - The URL at which

--- a/libs/play/index.js
+++ b/libs/play/index.js
@@ -4,8 +4,6 @@ import he from "he";
 
 export const ORIGIN_PLAY = process.env["ORIGIN_PLAY"] || "localhost";
 export const ORIGIN_MAIN = process.env["ORIGIN_MAIN"] || "localhost";
-export const ORIGIN_REVIEW =
-  process.env["ORIGIN_REVIEW"] || "content.dev.mdn.mozit.cloud";
 
 /** @import { IncomingMessage, ServerResponse } from "http" */
 /** @import * as express from "express" */
@@ -474,8 +472,9 @@ function isMDNReferer(referer) {
   const { hostname } = referer;
   return (
     hostname === ORIGIN_MAIN ||
-    hostname === ORIGIN_REVIEW ||
-    hostname.endsWith(`.${ORIGIN_REVIEW}`)
+    // Review Companion (old/new).
+    hostname.endsWith(`.content.dev.mdn.mozit.cloud`) ||
+    hostname.endsWith(`.review.mdn.allizom.net`)
   );
 }
 


### PR DESCRIPTION
## Summary

Part of MP-1889 (Mozilla-internal), extracted from https://github.com/mdn/yari/pull/12694.

### Problem

The [new review environment](https://github.com/mdn/yari/pull/12694) is ready, but the interactive examples don't work yet, because the new host isn't recognized as a valid Playground referrer.

### Solution

Inline the existing `ORIGIN_REVIEW` environment variable, and add the host of the new environment.

---

## How did you test this change?

Trivial change.