### PR TITLE
ci: simplify cron expression

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -16,8 +16,7 @@ env:
 
 on:
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 */24 * * *"
+    - cron: "0 0 * * *"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -16,8 +16,7 @@ env:
 
 on:
   schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: "0 */24 * * *"
+    - cron: "0 0 * * *"
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We use a slightly confusing cron expression that shows up as an error in VSCode.

### Solution

Simplify it by replacing `*/24` by `0`.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="215" alt="image" src="https://github.com/user-attachments/assets/3d0d9f07-fc6a-44b8-b6f6-dbf81909295c" />

### After

<img width="191" alt="image" src="https://github.com/user-attachments/assets/7e7f4396-2ca8-4d2a-9ffe-280df2a4a6cb" />


---

## How did you test this change?

Looked at the line in VSCode.

Also verified that crontab.guru thinks [`0 */24 0 0`](https://crontab.guru/#0_*/24_*_*_*) is equivalent to [`0 0 * * *`](https://crontab.guru/#0_0_*_*_*) (i.e. the "next" timestamps are identical).
