### PR TITLE
fix(cloud-function): improve 404 fallback handling

### DIFF
--- a/cloud-function/src/handlers/proxy-content.ts
+++ b/cloud-function/src/handlers/proxy-content.ts
@@ -53,7 +53,7 @@ export const proxyContent = createProxyMiddleware({
             res.statusCode = 200;
             res.setHeader("Content-Type", "text/html");
             return Buffer.from(await tryHtml.arrayBuffer());
-          } else if (!notFoundBuffer) {
+          } else if (!notFoundBuffer || WILDCARD_ENABLED) {
             const response = await fetch(`${target}${NOT_FOUND_PATH}`);
             notFoundBuffer = await response.arrayBuffer();
           }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

1. We were caching the 404 page regardless of whether the request succeeded.
2. We were caching the 404 page in the Review environment (i.e. serving a 404 page belonging to a different branch).
3. (We were caching only once the Promise resolved, potentially causing a race-condition.)

### Solution

1. Only cache the 404 page response if it's successful.
2. Don't cache the 404 page in the Review environment.
3. (Cache the Promise, instead of the resolved Promise.)

---

## How did you test this change?

Deployed [to stage](https://github.com/mdn/yari/actions/runs/13701590179) and [to the review environment](https://github.com/mdn/yari/actions/runs/13702426493), and tested 404s on both environments:

- https://developer.allizom.org/en-US/docs/Web/Sustainability
- http://main.review.mdn.allizom.net/en-US/docs/Web/Sustainability