### PR TITLE
fix(cloud-function): override Cache-Control for Review environment

### DIFF
--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 import { CSP_VALUE } from "./internal/constants/index.js";
 import { isLiveSampleURL } from "./utils.js";
-import { ORIGIN_TRIAL_TOKEN } from "./env.js";
+import { ORIGIN_TRIAL_TOKEN, WILDCARD_ENABLED } from "./env.js";
 
 const HASHED_MAX_AGE = 60 * 60 * 24 * 365;
 const DEFAULT_MAX_AGE = 60 * 60;
@@ -63,6 +63,10 @@ function getCacheControl(statusCode: number, url: string) {
   }
 
   if (200 <= statusCode && statusCode < 300) {
+    if (WILDCARD_ENABLED) {
+      return "max-age=0, no-cache, no-store, must-revalidate";
+    }
+
     const maxAge = getCacheMaxAgeForUrl(url);
     return `public, max-age=${maxAge}`;
   }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The Review environment sets `cache-control: public, max-age: 3600`, which increases the chances of reviewers seeing outdated pages:

```shell
% curl -si https://pr26205.review.mdn.allizom.net/zh-CN/docs/Web/URI | grep cache-control
cache-control: public, max-age=3600
```

### Solution

Set the header to the same value as in the old Review environment:

```shell
% curl -si https://pr26084.content.dev.mdn.mozit.cloud/fr/docs/Web/API/Document/createTreeWalker | grep cache-control
cache-control: max-age=0, no-cache, no-store, must-revalidate
```

---

## How did you test this change?

[Deployed](https://github.com/mdn/yari/actions/runs/13761761219) this branch, and tested:

```shell
% curl -si https://pr26205.review.mdn.allizom.net/zh-CN/docs/Web/URI | grep cache-control
cache-control: max-age=0, no-cache, no-store, must-revalidate
```