### PR TITLE
Update IDs for expanded PAB and OWD headings

### DIFF
--- a/client/src/about/index.tsx
+++ b/client/src/about/index.tsx
@@ -137,8 +137,8 @@ function Tabs({ section }: { section: AboutSection }) {
     const hash = document.location.hash.startsWith("#our_team")
       ? "#our_team"
       : document.location.hash.startsWith("#our_partners") ||
-          document.location.hash === "#pab" ||
-          document.location.hash === "#owd"
+          document.location.hash === "#product_advisory_board" ||
+          document.location.hash === "#open_web_docs"
         ? "#our_partners"
         : document.location.hash;
     const tab = section.H3s?.findIndex(({ value }) => `#${value.id}` === hash);


### PR DESCRIPTION
## Summary

It goes along with the corresponding content update.

```diff
- #### PAB
+ #### Product Advisory Board
- #### OWD
+ #### Open Web Docs
```

See https://github.com/mdn/generic-content/pull/4

### Note

I’d only wait for the decision to merge content before following with this one.