### PR TITLE
ci(dev-build): grant permission to comment PR

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -36,6 +36,8 @@ env:
 permissions:
   # Authenticate with GCP.
   id-token: write
+  # Post comment in pull request.
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `dev-build` fails to post a comment in the PR that it deployed (see [here](https://github.com/mdn/yari/actions/runs/13902275110/job/38896744932#step:27:1)):

```
 GraphQL: Resource not accessible by integration (addComment)
```

### Solution

Grant `pull-requests: write` permission.

---

## How did you test this change?

Will trigger a `dev-build` on this PR.