### PR TITLE
fix(libs/play): avoid `clear-site-data: cache` in Chrome browsers

### DIFF
--- a/libs/play/index.js
+++ b/libs/play/index.js
@@ -28,16 +28,14 @@ export const ORIGIN_MAIN = process.env["ORIGIN_MAIN"] || "localhost";
 export function withRunnerResponseHeaders(req, res) {
   const headers = new Headers({
     "x-content-type-options": "nosniff",
-    "clear-site-data": '"cache", "cookies", "storage"',
+    // Clear-Site-Data: cache` is slow in Chrome (https://crbug.com/40233601).
+    // See: https://github.com/mdn/yari/issues/12775
+    "clear-site-data": req.headers["user-agent"]?.includes("Chrome/")
+      ? '"cookies", "storage"'
+      : '"cache", "cookies", "storage"',
     "strict-transport-security": "max-age=63072000",
     "content-security-policy": PLAYGROUND_UNSAFE_CSP_VALUE,
   });
-
-  // Workaround for https://crbug.com/40233601.
-  // See: https://github.com/mdn/yari/issues/12775
-  if (req.headers["user-agent"]?.includes("Chrome/")) {
-    headers.delete("clear-site-data");
-  }
 
   res.setHeaders(headers);
 }


### PR DESCRIPTION
## Summary

Fixes #12775.

### Problem

Clear-Site-Data handling in Chrome takes up to several seconds (specifically the `cache` value).

See: https://issues.chromium.org/issues/40233601

Verified that this affects Chrome, Edge, and Brave.

### Solution

Stop sending the `Clear-Site-Data: cache` for Chrome browsers.

Note: Firefox and Safari are not affected.

---

## How did you test this change?

We [disabled the header on stage](https://github.com/mdn/yari/commit/2f429e5220df106b01d0caa7f93dbda14838ea10), and could no longer reproduce the issue then.