### PR TITLE
fix(compat): refine BCD table style

### DIFF
--- a/client/src/lit/compat/index-desktop.scss
+++ b/client/src/lit/compat/index-desktop.scss
@@ -103,6 +103,7 @@
 
   .bc-notes-list {
     margin-left: 20%;
+    max-width: 80vw;
     width: auto;
   }
 

--- a/client/src/lit/compat/index.scss
+++ b/client/src/lit/compat/index.scss
@@ -197,8 +197,12 @@ table {
     border-left: 15px solid var(--border-primary);
   }
 
-  .bc-has-history:not(:focus-within) .timeline {
+  .timeline {
     display: none;
+  }
+
+  .bc-has-history:focus-within .timeline {
+    display: initial;
   }
 }
 


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Follow-up to https://github.com/mdn/yari/pull/12580.

### Problem

1. Performance of large tables was poor in Safari, apparently due to the use of `:not(:focus-within)`.
2. Expanding the support history sometimes increased the table width in the overflow layout (sm).

### Solution

1. Replace `:not(:focus-within)` rule by two rules (default + `:focus-within`).
2. Limit the width of the support history.

---

## How did you test this change?

Ran `yarn dev` and tested on http://localhost:3000/en-US/docs/Web/API/Window#browser_compatibility.

1. Verified that expanding the support history is now much faster in Safari.
2. Verified that expanding the `alert` x Opera cell no longer causes the table to grow on a md screen (768x1024). 