### PR TITLE
fix(tables): backport table-container css

### DIFF
--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -1030,12 +1030,6 @@ html[lang="zh-TW"] a.only-in-en-us:after {
   .table-container {
     width: calc(100% + 6rem);
   }
-
-  .bc-table {
-    tbody th {
-      width: 20%;
-    }
-  }
 }
 
 @media (min-width: $screen-xl) {

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -996,3 +996,55 @@ html[lang="zh-TW"] a.only-in-en-us:after {
   margin-left: unset;
   vertical-align: baseline;
 }
+
+@media (max-width: $screen-sm - 1px) {
+  .table-container {
+    overflow-x: auto;
+  }
+}
+
+@media (min-width: $screen-sm) {
+  .table-container {
+    margin: 0 -3rem;
+    overflow: auto;
+    width: 100vw;
+  }
+
+  .table-container-inner {
+    min-width: max-content;
+    padding: 0 3rem;
+    position: relative;
+
+    &:after {
+      bottom: 0;
+      content: "";
+      height: 10px;
+      position: absolute;
+      right: 0;
+      width: 10px;
+    }
+  }
+}
+
+@media (min-width: $screen-md) {
+  .table-container {
+    width: calc(100% + 6rem);
+  }
+
+  .bc-table {
+    tbody th {
+      width: 20%;
+    }
+  }
+}
+
+@media (min-width: $screen-xl) {
+  .table-container {
+    margin: 0;
+    width: 100%;
+  }
+
+  .table-container-inner {
+    padding: 0;
+  }
+}


### PR DESCRIPTION
## Summary

The `.table-container` CSS got lost during the BCD table rewrite. This brings it back.
See https://github.com/mdn/yari/pull/12580/files#diff-fdb813fdf297c0274794c9f05b28c18b7b05b923e9e53f9ad8f1769d2bd41ded

### Problem

Tables are overflowing.



---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

![image](https://github.com/user-attachments/assets/b02c95ad-a2d4-4967-bdee-ba7c4cbad183)

### After

![image](https://github.com/user-attachments/assets/3e8b30df-1a4d-4488-8562-e8b99d202c42)

---

## How did you test this change?

Locally
