### PR TITLE
fix(compat): hide erraneous "Support unknown" notes + avoid history wrap

### DIFF
--- a/client/src/lit/compat/compat-table.js
+++ b/client/src/lit/compat/compat-table.js
@@ -548,11 +548,17 @@ class CompatTable extends LitElement {
                   iconName: "footnote",
                   label: "No support",
                 }
-              : {
-                  iconName: "unknown",
-                  label: "Support unknown",
-                },
-        ].flat();
+              : null,
+        ]
+          .flat()
+          .filter(Boolean);
+
+        if (supportNotes.length === 0) {
+          supportNotes.push({
+            iconName: "unknown",
+            label: "Support unknown",
+          });
+        }
 
         /**
          * @type {Array<{iconName: string; label: string | TemplateResult }>}

--- a/client/src/lit/compat/index.scss
+++ b/client/src/lit/compat/index.scss
@@ -453,8 +453,6 @@ dl.bc-notes-list {
 
 .bcd-cell-text-copy {
   color: var(--text-primary);
-  display: flex;
-  gap: 0.5ch;
 }
 
 .bc-supports-yes {


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The new BCD table has two issues:

1. The notes in the support history sometimes contain "Support unknown" unexpectedly.
2. The browser name and version in the support history wrap unexpectedly on very small screens (xs).

### Solution

1. Show "Support unknown" only if there is no other history entry.
2. Make the container of the browser name and version a block instead of a flex element.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="296" alt="image" src="https://github.com/user-attachments/assets/1d582ac5-44f6-43d9-9b96-b4fc66e78a91" /> | <img width="296" alt="image" src="https://github.com/user-attachments/assets/589172cf-e378-4909-b3ee-59762326e28c" /> |

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
