### PR TITLE
chore(compat): port BCD table view measurement

### DIFF
--- a/client/src/lit/compat/compat-table.js
+++ b/client/src/lit/compat/compat-table.js
@@ -1,5 +1,6 @@
 import { html, LitElement } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { createRef, ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import { getActiveLegendItems } from "./legend.js";
@@ -25,6 +26,9 @@ import {
   labelFromString,
   versionLabelFromSupport,
 } from "./feature-row.js";
+import { GleanMixin } from "../glean-mixin.js";
+import "../viewed-controller.js";
+import { ViewedController } from "../viewed-controller.js";
 
 /**
  * @import { TemplateResult } from "lit"
@@ -79,7 +83,7 @@ export const LEGEND_LABELS = {
   more: "Has more compatibility info.",
 };
 
-class CompatTable extends LitElement {
+class CompatTable extends GleanMixin(LitElement) {
   static properties = {
     query: {},
     locale: {},
@@ -92,8 +96,14 @@ class CompatTable extends LitElement {
 
   static styles = styles;
 
+  _tableRef = createRef();
+
   constructor() {
     super();
+    /** @type {ViewedController} */
+    this.viewed = new ViewedController(this, this._tableRef, () =>
+      this._gleanClick(`${BCD_TABLE}: view -> ${this.query}`)
+    );
     this.query = "";
     /** @type {Identifier} */
     this.data = {};
@@ -183,6 +193,7 @@ class CompatTable extends LitElement {
       <figure class="table-container-inner">
         ${this._renderIssueLink()}
         <table
+          ${ref(this._tableRef)}
           class="bc-table bc-table-web"
           style="--browser-count: ${Object.keys(this._browsers).length}"
         >

--- a/client/src/lit/viewed-controller.js
+++ b/client/src/lit/viewed-controller.js
@@ -1,0 +1,93 @@
+/**
+ * @import { LitElement } from "lit";
+ * @import { Ref } from "lit/directives/ref"
+ */
+
+export class ViewedController {
+  #host;
+
+  /**
+   * @param {LitElement} host
+   * @param {Ref<Element>} target
+   * @param {Function} callback
+   * @param {IntersectionObserverInit} [intersectionObserverOptions]
+   */
+  constructor(
+    host,
+    target,
+    callback,
+    intersectionObserverOptions = {
+      threshold: 0.5,
+    }
+  ) {
+    this.#host = host;
+    this.#host.addController(this);
+
+    this.target = target;
+    this.callback = callback;
+    this.intersectionObserverOptions = intersectionObserverOptions;
+
+    this._visible = !document.hidden;
+    this._timer = null;
+    this._hasViewed = false;
+    this._onVisibilityChange = this.onVisibilityChange.bind(this);
+  }
+
+  hostConnected() {
+    document.addEventListener("visibilitychange", this._onVisibilityChange);
+  }
+
+  hostDisconnected() {
+    this.disconnectObserver();
+    document.removeEventListener("visibilitychange", this._onVisibilityChange);
+  }
+
+  hostUpdated() {
+    const target = this.target.value;
+    if (!target) {
+      console.error("[ViewedController] Target not found");
+    } else {
+      this._observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) =>
+          this._checkAndSetTimer(entry.isIntersecting)
+        );
+      }, this.intersectionObserverOptions);
+      this._observer.observe(target);
+    }
+  }
+
+  disconnectObserver() {
+    if (this._observer) {
+      this._observer.disconnect();
+    }
+  }
+
+  onVisibilityChange() {
+    this._visible = !document.hidden;
+    this._checkAndSetTimer();
+  }
+
+  /**
+   * If the page is visible and the element is intersecting, start a 1-second timer
+   * to dispatch the "view" event.
+   *
+   * If conditions are not met before the timer fires, clear the timer.
+   *
+   * @param {boolean} [isIntersecting=false]
+   */
+  _checkAndSetTimer(isIntersecting = false) {
+    if (!this._hasViewed && this._visible && isIntersecting) {
+      if (this._timer === null) {
+        this._timer = window.setTimeout(() => {
+          this._hasViewed = true;
+          this.callback();
+        }, 1000);
+      }
+    } else {
+      if (this._timer !== null) {
+        clearTimeout(this._timer);
+        this._timer = null;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We did not port the BCD table view measurement in https://github.com/mdn/yari/pull/12580.

### Solution

Port it.

---

## How did you test this change?

1. Replaced the `_gleanClick()` call with `console.log()`.
2. Ran `yarn dev`, opened http://localhost:3000/en-US/docs/Web/API/Window/gamepadconnected_event, and scrolled to the BCD table.
3. Observed log message in console.