### PR TITLE
feat(syntax-highlight): alias wat to wasm

### DIFF
--- a/client/src/document/code/syntax-highlight.tsx
+++ b/client/src/document/code/syntax-highlight.tsx
@@ -21,6 +21,7 @@ const PRISM_LANGUAGES = components.languages as Record<
 // because Prism is an implementation detail.
 const ALIASES = new Map([
   ["vue", "markup"], // See https://github.com/PrismJS/prism/issues/1665#issuecomment-536529608
+  ["wat", "wasm"],
   ...Object.entries(PRISM_LANGUAGES).flatMap(([lang, config]) => {
     if (config.alias) {
       const aliases =


### PR DESCRIPTION
## Summary

We'd like to use `wat` rather than `wasm` on code blocks for syntax highlighting, as it's technically more correct: https://github.com/mdn/content/pull/38927#discussion_r2026499099

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/69969757-d252-4bb3-9f76-b44305eaad7f)

### After

![image](https://github.com/user-attachments/assets/259e8948-0cd6-4f8f-b2e1-5c988cc76da4)

---

## How did you test this change?

Changed the

````
```wasm
````

to

````
```wat
````

in content/files/en-us/webassembly/guides/text_format_to_wasm/index.md