### PR TITLE
enhance(cloud-function): serve {favicon.ico,robots.txt} from /static

### DIFF
--- a/cloud-function/src/app.ts
+++ b/cloud-function/src/app.ts
@@ -26,6 +26,7 @@ import { proxyPong } from "./handlers/proxy-pong.js";
 import { handleRunner } from "./internal/play/index.js";
 import { proxyContentAssets } from "./handlers/proxy-content-assets.js";
 import { proxySharedAssets } from "./handlers/proxy-shared-assets.js";
+import { resolveFaviconRobots } from "./middlewares/resolve-favicon-robots.js";
 
 const router = Router();
 router.use(cookieParser());
@@ -59,6 +60,7 @@ router.get("/shared-assets/*", requireOrigin(Origin.play), proxySharedAssets);
 router.get(
   ["/assets/*", "/sitemaps/*", "/static/*", "/[^/]+.[^/]+"],
   requireOrigin(Origin.main),
+  resolveFaviconRobots,
   proxyContent
 );
 router.get(

--- a/cloud-function/src/middlewares/resolve-favicon-robots.ts
+++ b/cloud-function/src/middlewares/resolve-favicon-robots.ts
@@ -1,0 +1,32 @@
+import { NextFunction, Request, Response } from "express";
+
+const MAPPING: Record<string, string> = {
+  "/static/favicon.ico": "/favicon.ico",
+  "/static/robots.txt": "/robots.txt",
+};
+
+/**
+ * Workaround for Google Cloud Function always returning HTTP 404 for favicon.ico/robots.txt.
+ *
+ * See: https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/5679093ecb850ceece3af8b313c0d8aa04870635/src/server.ts#L148-L153
+ *
+ * From our load balancer, we point to `/static/{favicon.ico,robots.txt}` instead.
+ */
+export async function resolveFaviconRobots(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+) {
+  const { pathname } = new URL(
+    req.url,
+    `${req.protocol}://${req.headers.host}`
+  );
+  console.log({ pathname });
+  if (typeof MAPPING[pathname] === "string") {
+    req.url = MAPPING[pathname];
+    // Workaround for http-proxy-middleware v2 using `req.originalUrl`.
+    // See: https://github.com/chimurai/http-proxy-middleware/pull/731
+    req.originalUrl = req.url;
+  }
+  next();
+}


### PR DESCRIPTION
## Summary

Mitigates a limitation of Google Cloud Functions, which always return HTTP 404 for `/favicon.ico` and `/robots.txt`.

Serving these from `/static` allows us to rewrite the paths in our load balancer before hitting the Cloud Function.

Allows us to serve `/robots.txt` in our review environment, where we don't have a "default" deployment to serve statically from.

---

## Screenshots

```bash
% curl http://localhost:8080/static/robots.txt   
User-agent: *
Sitemap: https://developer.mozilla.org/sitemap.xml

Disallow: /api/
Disallow: /*/files/
Disallow: /media
```

---

## How did you test this change?

Ran `npm run server` in `/cloud-function` and opened: http://localhost:8080/static/robots.txt