### PR TITLE
fix(cloud-function): serve `favicon.icon` + `robots.txt`

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -388,6 +388,7 @@ jobs:
             --memory=2GB \
             --timeout=120s \
             --run-service-account=run-prod-prod-functions@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com \
+            --set-env-vars="IGNORED_ROUTES=" \
             --set-env-vars="ORIGIN_MAIN=developer.mozilla.org" \
             --set-env-vars="ORIGIN_LIVE_SAMPLES=live.mdnplay.dev" \
             --set-env-vars="ORIGIN_PLAY=mdnplay.dev" \

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -84,6 +84,7 @@ jobs:
             --memory=2GB \
             --timeout=120s \
             --run-service-account=run-mdn-review-functions@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com \
+            --set-env-vars="IGNORED_ROUTES=" \
             --set-env-vars="WILDCARD_ENABLED=true" \
             --set-env-vars="SOURCE_CONTENT=https://storage.googleapis.com/${{ vars.GCP_BUCKET_NAME }}/" \
             --set-env-vars="BSA_ENABLED=true" \

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -402,6 +402,7 @@ jobs:
             --memory=2GB \
             --timeout=120s \
             --run-service-account=run-nonprod-stage-functions@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com \
+            --set-env-vars="IGNORED_ROUTES=" \
             --set-env-vars="ORIGIN_MAIN=developer.allizom.org" \
             --set-env-vars="ORIGIN_LIVE_SAMPLES=live.mdnyalp.dev" \
             --set-env-vars="ORIGIN_PLAY=mdnyalp.dev" \

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -336,6 +336,7 @@ jobs:
             --memory=2GB \
             --timeout=120s \
             --run-service-account=run-nonprod-test-functions@${{ secrets.GCP_PROJECT_NAME }}.iam.gserviceaccount.com \
+            --set-env-vars="IGNORED_ROUTES=" \
             --set-env-vars="ORIGIN_MAIN=test.developer.allizom.org" \
             --set-env-vars="ORIGIN_LIVE_SAMPLES=live.test.mdnyalp.dev" \
             --set-env-vars="ORIGIN_PLAY=test.mdnyalp.dev" \

--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@adzerk/decision-sdk": "^1.0.0-beta.20",
-        "@google-cloud/functions-framework": "^3.4.2",
+        "@google-cloud/functions-framework": "^3.5.1",
         "@sentry/google-cloud-serverless": "^8.38.0",
         "@yari-internal/constants": "file:src/internal/constants",
         "@yari-internal/fundamental-redirects": "file:src/internal/fundamental-redirects",
@@ -98,19 +98,19 @@
       }
     },
     "node_modules/@google-cloud/functions-framework": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-3.4.2.tgz",
-      "integrity": "sha512-yJcxfVgjLoKFO3p6Wy6Fc+Gi6l3PFSwJg4m0mjebx/UHdLeXLYYxgKMP8RCODaApXEWXbSITIjXO0m5kSv2Ilw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/functions-framework/-/functions-framework-3.5.1.tgz",
+      "integrity": "sha512-J01F8mCAb9SEsEGOJjKR/1UHmZTzBWIBNjAETtiPx7Xie3WgeWTvMnfrbsZbaBG0oePkepRxo28R8Fi9B2J++A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/express": "4.17.21",
+        "@types/express": "^4.17.21",
         "body-parser": "^1.18.3",
-        "cloudevents": "^8.0.0",
-        "express": "^4.16.4",
-        "minimist": "^1.2.7",
+        "cloudevents": "^8.0.2",
+        "express": "^4.21.2",
+        "minimist": "^1.2.8",
         "on-finished": "^2.3.0",
         "read-pkg-up": "^7.0.1",
-        "semver": "^7.3.5"
+        "semver": "^7.6.3"
       },
       "bin": {
         "functions-framework": "build/src/main.js",

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -15,7 +15,7 @@
     "gcp-build": "npm run build",
     "prepare": "([ ! -e ../libs ] || npm run copy-internal)",
     "proxy": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node src/proxy.ts",
-    "server": "npm run build && functions-framework --target=mdnHandler",
+    "server": "npm run build && functions-framework --target=mdnHandler --ignored-routes \"\"",
     "server:watch": "nodemon --exec npm run server",
     "start": "nf start"
   },

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@adzerk/decision-sdk": "^1.0.0-beta.20",
-    "@google-cloud/functions-framework": "^3.4.2",
+    "@google-cloud/functions-framework": "^3.5.1",
     "@sentry/google-cloud-serverless": "^8.38.0",
     "@yari-internal/constants": "file:src/internal/constants",
     "@yari-internal/fundamental-redirects": "file:src/internal/fundamental-redirects",


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Previously, the Cloud Function framework didn't support routing `/favicon.ico` and `/robots.txt` requests, so we had to apply a workaround in our infrastructure, proxying them directly to our Google Cloud Storage bucket.

### Solution

The framework introduced [a new feature](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/679) that allows us to opt-in to route these paths:

1. By invoking the framework with ` --ignored-routes ""` during development.
2. By deploying the function with an empty `IGNORED_ROUTES` environment variable.

---

## How did you test this change?

1. Tested locally by running `npm run server` in `/cloud-function` and accessing http://localhost:8080/
2. Will deploy to stage, and update our infrastructure to no longer proxy these paths directly to the bucket.