### PR TITLE
fix(interactive-examples): focus choice on click

### DIFF
--- a/client/src/lit/interactive-example/with-choices.js
+++ b/client/src/lit/interactive-example/with-choices.js
@@ -32,6 +32,13 @@ export const InteractiveExampleWithChoices = (Base) =>
     }
 
     /** @param {MouseEvent} event  */
+    #choiceFocus({ target }) {
+      if (target instanceof PlayEditor) {
+        target.focus();
+      }
+    }
+
+    /** @param {MouseEvent} event  */
     #choiceSelect({ target }) {
       if (target instanceof PlayEditor) {
         this.#updateUnsupported(target);
@@ -102,6 +109,7 @@ export const InteractiveExampleWithChoices = (Base) =>
           </header>
           <div
             class="choice-wrapper"
+            @click=${this.#choiceFocus}
             @focus=${this.#choiceSelect}
             @update=${this.#choiceUpdate}
           >

--- a/client/src/lit/play/editor.js
+++ b/client/src/lit/play/editor.js
@@ -66,6 +66,10 @@ export class PlayEditor extends LitElement {
     return this._editor ? this._editor.state.doc.toString() : this._value;
   }
 
+  focus() {
+    this._editor?.focus();
+  }
+
   /**
    * @param {string} type
    */


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/12890.

### Problem

In interactive CSS examples with choices, clicking outside of the actual CSS text doesn't select the choice.

### Solution

Focus the editor on click, which will in turn select the choice.

---

## How did you test this change?

1. Ran `yarn dev`
2. Opened http://localhost:3000/en-US/docs/Web/CSS/content-visibility
3. Clicked inside the second choice, but outside of the CSS text.
4. Verified that the choice gets selected.
