### PR TITLE
fix(play/console): prevent spaces from being collapsed

### DIFF
--- a/client/src/lit/play/console.scss
+++ b/client/src/lit/play/console.scss
@@ -26,4 +26,5 @@ li {
 code {
   font-family: var(--font-code);
   tab-size: 4;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary

Fixes #12926 12926

### Problem

Multiple spaces in the console output are collapsed, resulting in incorrect output.

### Solution

Added `white-space: pre-wrap` property to the console's `code` element, which prevents multiple spaces being collapsed.

### Before

<img width="609" alt="image" src="https://github.com/user-attachments/assets/92255050-dab9-4666-986a-8ec093156ce5" />

### After

<img width="676" alt="image" src="https://github.com/user-attachments/assets/b3425de3-2dd6-4f6d-9346-592640d76051" />

