### PR TITLE
enhance(play): log empty array values as `<1 empty slot>` / `<2 empty slots>`

### DIFF
--- a/client/src/lit/play/console-utils.js
+++ b/client/src/lit/play/console-utils.js
@@ -25,7 +25,7 @@ export function formatArray(input) {
         i++;
       }
       if (emptyCount === 1) {
-        output += "<empty>";
+        output += "<1 empty slot>";
       } else {
         output += `<${emptyCount} empty slots>`;
       }

--- a/client/src/lit/play/console-utils.js
+++ b/client/src/lit/play/console-utils.js
@@ -4,6 +4,7 @@
  * - quotes around strings in arrays
  * - square brackets around arrays
  * - adds commas appropriately (with spacing)
+ * - identifies empty slots
  * designed to be used recursively
  * @param {any} input - The output to log.
  * @returns Formatted output as a string.
@@ -17,6 +18,8 @@ export function formatArray(input) {
       output += "Array [";
       output += formatArray(input[i]);
       output += "]";
+    } else if (!input.hasOwnProperty(i)) {
+      output += "<empty>";
     } else {
       output += formatOutput(input[i]);
     }

--- a/client/src/lit/play/console-utils.js
+++ b/client/src/lit/play/console-utils.js
@@ -19,7 +19,16 @@ export function formatArray(input) {
       output += formatArray(input[i]);
       output += "]";
     } else if (!input.hasOwnProperty(i)) {
-      output += "<empty>";
+      let emptyCount = 1;
+      while (i + 1 < l && !input.hasOwnProperty(i + 1)) {
+        emptyCount++;
+        i++;
+      }
+      if (emptyCount === 1) {
+        output += "<empty>";
+      } else {
+        output += `<${emptyCount} empty slots>`;
+      }
     } else {
       output += formatOutput(input[i]);
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/12943.

### Problem

The Playground console formatted empty slots in arrays as `undefined`.

### Solution

Format these as `<1 empty slot>` or `<2 empty slots>` instead.

---

## Screenshots

| Before | After |
|--------|--------|
| <img width="779" alt="image" src="https://github.com/user-attachments/assets/1d450454-2c4f-42f2-b169-d9f2cef52c45" /> | <img width="779" alt="image" src="https://github.com/user-attachments/assets/f4113070-32ef-4243-b20d-cd9e5c1515ab" /> | 
| <img width="779" alt="image" src="https://github.com/user-attachments/assets/5eb26d46-43c9-415c-a8d5-ec7b0be1ecf9" /> | <img width="779" alt="image" src="https://github.com/user-attachments/assets/ae7611eb-751c-4e49-aa94-c0c1ae8fa454" /> |

---

## How did you test this change?

Ran `yarn dev` and compared http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty#try_it to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty#try_it.
