### PR TITLE
enhance(cloud-function): refine `cache-control` header

### DIFF
--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -64,7 +64,7 @@ function getCacheControl(statusCode: number, url: string) {
 
   if (200 <= statusCode && statusCode < 300) {
     if (WILDCARD_ENABLED) {
-      return "max-age=0, no-cache, no-store, must-revalidate";
+      return NO_CACHE_VALUE;
     }
 
     const maxAge = getCacheMaxAgeForUrl(url);

--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -63,7 +63,7 @@ function getCacheControl(statusCode: number, url: string) {
   }
 
   if (200 <= statusCode && statusCode < 300) {
-    if (WILDCARD_ENABLED) {
+    if (WILDCARD_ENABLED && !HASHED_REGEX.test(url)) {
       return NO_CACHE_VALUE;
     }
 

--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -7,7 +7,7 @@ import { ORIGIN_TRIAL_TOKEN, WILDCARD_ENABLED } from "./env.js";
 const HASHED_MAX_AGE = 60 * 60 * 24 * 365;
 const DEFAULT_MAX_AGE = 60 * 60;
 
-const NO_CACHE_VALUE = "no-store, must-revalidate";
+const NO_CACHE_VALUE = "no-store";
 
 const HASHED_REGEX = /\.[a-f0-9]{8,32}\./;
 


### PR DESCRIPTION
## Summary

### Problem

1. The Review environment was sending an unnecessarily verbose `cache-control` header.
2. The `NO_CACHE_VALUE` value unnecessarily included `must-revalidate`.
3. The Review environment didn't allow caching hashed urls.

### Solution

1. Reuse `NO_CACHE_VALUE` for the Review environment.
2. Reduce `NO_CACHE_VALUE` to `no-store` (see [Preventing storing](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control#preventing_storing)).
3. Only apply this value in the Review environment for unhashed urls.

---

## How did you test this change?

Will deploy to the review environment.