### PR TITLE
fix(cloud-function): proxy blog assets for live samples incl. avif

### DIFF
--- a/cloud-function/src/app.ts
+++ b/cloud-function/src/app.ts
@@ -78,7 +78,10 @@ router.get(
 );
 // Attachments.
 router.get(
-  `/[^/]+/docs/*/*.(${ANY_ATTACHMENT_EXT.join("|")})`,
+  [
+    `/[^/]+/docs/*/*.(${ANY_ATTACHMENT_EXT.join("|")})`,
+    `/[^/]+/blog/*/*.(${ANY_ATTACHMENT_EXT.join("|")})`,
+  ],
   requireOrigin(Origin.main, Origin.liveSamples, Origin.play),
   resolveIndexHTML,
   proxyContentAssets

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -197,7 +197,7 @@ export const CSP_VALUE = cspToString(CSP_DIRECTIVES);
 // Always update client/src/setupProxy.js when adding/removing extensions, or it won't work on the dev server!
 export const AUDIO_EXT = ["mp3", "ogg"];
 export const FONT_EXT = ["woff2"];
-export const BINARY_IMAGE_EXT = ["gif", "jpeg", "jpg", "png", "webp"];
+export const BINARY_IMAGE_EXT = ["gif", "jpeg", "jpg", "png", "webp", "avif"];
 export const ANY_IMAGE_EXT = ["svg", ...BINARY_IMAGE_EXT];
 export const VIDEO_EXT = ["mp4", "webm"];
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The images in the live sample on https://developer.mozilla.org/en-US/blog/color-models-humans-devices/#from_camera_to_screen aren't loading, this is because we don't proxy assets on the blog for our live samples/playground

### Solution

Proxy assets like in docs, add avif as a image extension.

---

## How did you test this change?

I haven't, will run a test build.
