### PR TITLE
fix(server): wrap rariBin in quotes

### DIFF
--- a/bins/server.mjs
+++ b/bins/server.mjs
@@ -21,7 +21,7 @@ const { commands, result } = concurrently(
       prefixColor: "red",
     },
     {
-      command: `${rariBin} serve -vv`,
+      command: `"${rariBin}" serve -vv`,
       name: "rari",
       prefixColor: "blue",
       env: {

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -21,7 +21,7 @@ const { commands, result } = concurrently(
       prefixColor: "red",
     },
     {
-      command: `${rariBin} serve -vv`,
+      command: `"${rariBin}" serve -vv`,
       name: "rari",
       prefixColor: "blue",
       env: {


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Fixes https://github.com/mdn/yari/issues/13011.

### Problem

In mdn/content, `yarn start` fails if the checked out path contains a space.

### Solution

Quote the rari path.

---

## How did you test this change?

1. Checked out yari in a path with spaces:
    ```
    git worktree add "/tmp/Git Repositories/yari" 13011-rari-with-spaces-in-path
    cd "/tmp/Git Repositories/yari"
    yarn install
    ```
2. Tested the server:
    ```
     npx cross-env NODE_OPTIONS="--no-warnings=ExperimentalWarning --loader ts-node/esm" node bins/server.mjs
    ```