### PR TITLE
fix(workflows): disable cache in privileged workflows

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -111,7 +111,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,6 @@ jobs:
         if: steps.release.outputs.release_created
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache @vscode/ripgrep bin

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -151,7 +151,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
 
       - name: Prepare Cloud Function
         working-directory: cloud-function

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -174,7 +174,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: yarn
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -134,7 +134,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
-          cache: ${{ github.event.inputs.rari-ref == '' && 'yarn' || '' }}
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We use the GitHub Cache in privileged workflows, which is risky, because vulnerabilities in less privileged workflows may propagate.

### Solution

Disable the cache in privileged workflows.

---

## How did you test this change?

This isn't really testable. Caching should not impact the result of the workflows, except for their runtime.
