### PR TITLE
fix(meta): remove hreflang attr from Blog RSS feed

### DIFF
--- a/ssr/render.tsx
+++ b/ssr/render.tsx
@@ -198,7 +198,6 @@ export default function render(
             type="application/rss+xml"
             title="MDN Blog RSS Feed"
             href={`${BASE_URL}/${DEFAULT_LOCALE}/blog/rss.xml`}
-            hrefLang="en"
           />
           {robotsContent && <meta name="robots" content={robotsContent} />}
           <meta

--- a/testing/tests/index.test.ts
+++ b/testing/tests/index.test.ts
@@ -117,7 +117,7 @@ test("content built foo page", () => {
 
   // Because this en-US page has a French translation
   expect($('link[rel="alternate"]')).toHaveLength(5);
-  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(2);
+  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);
@@ -169,7 +169,7 @@ test("content built French foo page", () => {
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
   expect($('link[rel="alternate"]')).toHaveLength(5);
-  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(2);
+  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);
@@ -223,7 +223,7 @@ test("content built zh-CN page for hreflang tag and copying image testing", () =
   // The built page should not have duplicate hreflang tags,
   // when zh-TW translation is also available.
   expect($('link[rel="alternate"]')).toHaveLength(5);
-  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(2);
+  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);
@@ -255,7 +255,7 @@ test("content built zh-TW page with en-US fallback image", () => {
   const html = fs.readFileSync(htmlFile, "utf-8");
   const $ = cheerio.load(html);
   expect($('link[rel="alternate"]')).toHaveLength(5);
-  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(2);
+  expect($('link[rel="alternate"][hreflang="en"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="fr"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh"]')).toHaveLength(1);
   expect($('link[rel="alternate"][hreflang="zh-Hant"]')).toHaveLength(1);


### PR DESCRIPTION
## Summary

`hreflang` with `rel="alternate"` should be used to declare the language for an alternate version of the document, for that reason, there should be no duplicates (2x `<link rel="alternate" … hreflang="en"/>`)

### Problem

We currently have:

```html
<link
  rel="alternate"
  title="Accessibility on the web"
  href="https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility"
  hreflang="en"
/>
<link
  rel="alternate"
  type="application/rss+xml"
  title="MDN Blog RSS Feed"
  href="https://developer.mozilla.org/en-US/blog/rss.xml"
  hreflang="en"
/>
```

### Solution

```diff
<link
  rel="alternate"
  title="Accessibility on the web"
  href="https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Accessibility"
  hreflang="en"
/>
<link
  rel="alternate"
  type="application/rss+xml"
  title="MDN Blog RSS Feed"
  href="https://developer.mozilla.org/en-US/blog/rss.xml"
-  hreflang="en"
/>
```

## How did you test this change?

Not yet, but we can test on staging / previews with https://technicalseo.com/tools/hreflang/