### PR TITLE
chore(surveys): remove Italian locale survey

### DIFF
--- a/client/src/ui/molecules/document-survey/surveys.tsx
+++ b/client/src/ui/molecules/document-survey/surveys.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import { Doc } from "../../../../../libs/types/document";
-import { survey_duration, survey_rates } from "../../../env";
 
 export interface Survey {
   key: SurveyKey;
@@ -98,23 +97,5 @@ export const SURVEYS: Survey[] = [
     rateTill: 1,
     start: 0,
     end: Infinity,
-  },
-  {
-    key: SurveyKey.IT_LOCALE_2025,
-    bucket: SurveyBucket.IT_LOCALE_2025,
-    show: () => (navigator?.language || "").startsWith("it"),
-    src: (doc: Pick<Doc, "mdn_url">) => {
-      const url = new URL(
-        "https://survey.alchemer.com/s3/8319535/MDN-Italian-Locale-Interest-Survey"
-      );
-      url.searchParams.set("referrer", doc.mdn_url);
-      return url.toString();
-    },
-    teaser: "What if MDN was available in Italian?",
-    question: "Which language would you then use?",
-    footnote:
-      "You're seeing this survey, because your browser indicates Italian as your preferred language.",
-    ...survey_duration(SurveyBucket.IT_LOCALE_2025),
-    ...survey_rates(SurveyKey.IT_LOCALE_2025),
   },
 ];


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We're running an Italian locale survey since Thursday, May 15th, and we have received enough responses.

### Solution

Close the survey, removing it from the site.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
