### PR TITLE
chore(cloud-function): support Glean for Fred

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -112,6 +112,9 @@ export const CSP_DIRECTIVES = {
     "https://*.analytics.google.com",
     "https://*.googletagmanager.com",
 
+    // Glean
+    "https://incoming.telemetry.mozilla.org",
+
     // Observatory
     "https://observatory-api.mdn.allizom.net",
     "https://observatory-api.mdn.mozilla.net",


### PR DESCRIPTION
## Summary

Allows Fred to submit telemetry to `incoming.telemetry.m.o`.

## How did you test this change?

1. Deployed to the review environment: https://github.com/mdn/yari/actions/runs/15160062374
2. Verified that Telemetry is sent after disabling uBlock Origin.