### PR TITLE
chore(compat-table): replace "Released" with "Release date" to account for upcoming releases

### DIFF
--- a/client/src/lit/compat/compat-table.js
+++ b/client/src/lit/compat/compat-table.js
@@ -704,12 +704,12 @@ class CompatTable extends GleanMixin(LitElement) {
         <span
           class="bc-version-label"
           title=${browserReleaseDate && !timeline
-            ? `${browser.name} ${added} – Released ${browserReleaseDate}`
+            ? `${browser.name} ${added} – Release date: ${browserReleaseDate}`
             : ""}
         >
           ${!timeline || added ? label : null}
           ${browserReleaseDate && timeline
-            ? ` (Released ${browserReleaseDate})`
+            ? ` (Release date: ${browserReleaseDate})`
             : ""}
         </span>
       </div>


### PR DESCRIPTION

### Problem

The BCD table currently uses the label "Released" for the release date, even when the date might be in the future.

For example, at https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/hidden#browser_compatibility, the release version/date label in the Firefox column says "Firefox 139 (**Released** 2025-05-27)", but that date is in the future.

<kbd><img src="https://github.com/user-attachments/assets/0fb9473b-75e0-48bb-978b-f56ffe97c317" /></kbd>

### Solution

This PR proposes changing the label to a time-agnostic label such as "Release date:". This could work for both past and future dates.

