### PR TITLE
fix(bcd): limit length of long bcd tables

### DIFF
--- a/client/src/lit/compat/compat-table.js
+++ b/client/src/lit/compat/compat-table.js
@@ -266,7 +266,15 @@ class CompatTable extends GleanMixin(LitElement) {
   _renderTableBody() {
     // <FeatureListAccordion>
     const { data, _browsers: browsers, browserInfo, locale } = this;
-    const features = listFeatures(data, "", this._name);
+    let features = listFeatures(data, "", this._name);
+
+    // enormous BCD tables are unusable and have terrible performance: crashing in some browsers
+    if (features.length > 100) {
+      features = features.filter(({ depth }) => depth < 2);
+      if (features.length > 100) {
+        features = features.filter(({ depth }) => depth < 1);
+      }
+    }
 
     return html`<tbody>
       ${features.map((feature) => {


### PR DESCRIPTION
## Summary

### Problem

Very long BCD tables, like the ones on [Window](http://localhost:3000/en-US/docs/Web/API/Window#browser_compatibility) and [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal#browser_compatibility) cause laggy browser behaviour, and even crashes: especially noticed on Chrome. They're also not particularly usable.

### Solution

Limit the depth of the table if it has more than 100 rows.

---

## Screenshots

### Before

![Screen Shot 2025-05-22 at 11 47 17](https://github.com/user-attachments/assets/b41591e3-dce5-4375-a2bf-68d8658ff7fa)


### After

![Screen Shot 2025-05-22 at 11 47 29](https://github.com/user-attachments/assets/71da604f-370f-48bc-89a7-f349f0459fec)


---

## How did you test this change?

`yarn dev`, across various pages