### PR TITLE
fix(scrim-inline): load within Prose only if it contains the element

### DIFF
--- a/client/src/curriculum/module.tsx
+++ b/client/src/curriculum/module.tsx
@@ -5,7 +5,6 @@ import { PrevNext } from "./prev-next";
 import { RenderCurriculumBody } from "./body";
 import { CurriculumLayout } from "./layout";
 import { topic2css, useCurriculumDoc } from "./utils";
-import { useEffect } from "react";
 
 import "./index.scss";
 import "./module.scss";

--- a/client/src/curriculum/module.tsx
+++ b/client/src/curriculum/module.tsx
@@ -13,10 +13,6 @@ import "./module.scss";
 export function CurriculumModule(props: HydrationData<any, CurriculumDoc>) {
   const doc = useCurriculumDoc(props as CurriculumData);
 
-  useEffect(() => {
-    import("../lit/curriculum/scrim-inline");
-  }, []);
-
   return (
     <CurriculumLayout
       doc={doc}

--- a/client/src/document/index.scss
+++ b/client/src/document/index.scss
@@ -246,6 +246,14 @@
     blockquote > :last-child {
       margin-bottom: 0;
     }
+
+    scrim-inline {
+      aspect-ratio: 1.5;
+      display: block;
+      margin: 0.5rem auto;
+      max-width: 36rem;
+      width: 100%;
+    }
   }
 
   #specifications + table {

--- a/client/src/document/ingredients/prose.tsx
+++ b/client/src/document/ingredients/prose.tsx
@@ -1,9 +1,15 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { DisplayH2, DisplayH3 } from "./utils";
 
 export function Prose({ section }: { section: any }) {
   const { id } = section;
   const html = useMemo(() => ({ __html: section.content }), [section.content]);
+
+  useEffect(() => {
+    if (html.__html.includes("<scrim-inline")) {
+      import("../../lit/curriculum/scrim-inline");
+    }
+  }, [html]);
 
   if (!id) {
     return <div className="section-content" dangerouslySetInnerHTML={html} />;


### PR DESCRIPTION
## Summary

### Problem

We load the code for the `scrim-inline` element on all curriculum pages, rather than just the ones its necessary.

### Solution

Only load the code if the custom element is within the Prose.

---

## How did you test this change?

Locally with `yarn dev`, visited curriculum pages with `<scrim-inline>` to check they loaded