### PR TITLE
fix(scrims): show outline on focus-visible

### DIFF
--- a/client/src/lit/curriculum/scrim-inline.js
+++ b/client/src/lit/curriculum/scrim-inline.js
@@ -86,6 +86,9 @@ export class ScrimInline extends LitElement {
               @click=${this.#toggle}
               class="toggle ${this._fullscreen ? "exit" : "enter"}"
             >
+              <div
+                class="scrim-fullscreen ${this._fullscreen ? "exit" : "enter"}"
+              ></div>
               <span class="visually-hidden">Toggle fullscreen</span>
             </button>
             <a
@@ -95,6 +98,7 @@ export class ScrimInline extends LitElement {
               class="external"
               data-glean="${CURRICULUM}: scrim link id:${this._scrimId}"
             >
+              <div class="scrim-link"></div>
               <span class="visually-hidden">Open on Scrimba</span>
             </a>
           </div>

--- a/client/src/lit/curriculum/scrim-inline.js
+++ b/client/src/lit/curriculum/scrim-inline.js
@@ -81,11 +81,7 @@ export class ScrimInline extends LitElement {
         <div class="inner">
           <div class="header">
             <span>Clicking will load content from scrimba.com</span>
-            <button
-              tabindex="0"
-              @click=${this.#toggle}
-              class="toggle ${this._fullscreen ? "exit" : "enter"}"
-            >
+            <button tabindex="0" @click=${this.#toggle} class="toggle">
               <div
                 class="scrim-fullscreen ${this._fullscreen ? "exit" : "enter"}"
               ></div>

--- a/client/src/lit/curriculum/scrim-inline.scss
+++ b/client/src/lit/curriculum/scrim-inline.scss
@@ -67,38 +67,39 @@ dialog {
 
 .toggle,
 .external {
-  background-color: #fff;
-  cursor: pointer;
-  height: 1rem;
-  mask-position: center;
-  mask-repeat: no-repeat;
-  mask-size: contain;
-  width: 1rem;
+  .scrim-fullscreen,
+  .scrim-link {
+    background-color: #fff;
+    cursor: pointer;
+    height: 1rem;
+    mask-position: center;
+    mask-repeat: no-repeat;
+    mask-size: contain;
+    width: 1rem;
 
-  &:hover {
-    background-color: var(--curriculum-color);
+    &:hover {
+      background-color: var(--curriculum-color);
+    }
+
+    &:focus-visible {
+      outline-color: var(--accent-primary);
+      outline-offset: 1px;
+      outline-style: auto;
+    }
+
+    &.enter {
+      mask-image: url("../../assets/icons/fullscreen-enter.svg");
+    }
+
+    &.exit {
+      mask-image: url("../../assets/icons/cancel.svg");
+    }
+
+    &.scrim-link {
+      mask-image: url("../../assets/icons/external.svg");
+      mask-size: 75%;
+    }
   }
-
-  &:focus-visible {
-    outline-color: var(--accent-primary);
-    outline-offset: 1px;
-    outline-style: auto;
-  }
-}
-
-.toggle {
-  &.enter {
-    mask-image: url("../../assets/icons/fullscreen-enter.svg");
-  }
-
-  &.exit {
-    mask-image: url("../../assets/icons/cancel.svg");
-  }
-}
-
-.external {
-  mask-image: url("../../assets/icons/external.svg");
-  mask-size: 75%;
 }
 
 .body {


### PR DESCRIPTION
## Summary

Move icons into a div to make focus-visible work for fullscreen/link in the scrim header.

---

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/bc5d6bd4-0b19-470d-8854-1b1a70fad2b0)


### After

![image](https://github.com/user-attachments/assets/d2aa394a-0825-41ea-9616-dd62e5c70543)


---

## How did you test this change?

locally