### PR TITLE
chore(plus/updates): hide filters if non-authenticated

### DIFF
--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -21,7 +21,6 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DataError } from "../common";
 import { useCollections } from "../collections/api";
-import { PlusLoginBanner } from "../common/login-banner";
 import React from "react";
 
 const LazyCompatTable = React.lazy(
@@ -191,23 +190,19 @@ function UpdatesLayout() {
         </Container>
       </header>
       <Container>
-        <SearchFilter
-          filters={filters}
-          sorts={SORTS}
-          isDisabled={!canFilter}
-          onChange={(key, newValue, oldValue) =>
-            gleanClick(
-              `${PLUS_UPDATES.FILTER_CHANGE}_${key}: ${
-                oldValue ?? "(default)"
-              } -> ${newValue ?? "(default)"}`
-            )
-          }
-        />
-
-        {user && !user.isAuthenticated && (
-          <PlusLoginBanner gleanPrefix={PLUS_UPDATES.MDN_PLUS}>
-            Want to use filters?
-          </PlusLoginBanner>
+        {user && user.isAuthenticated && (
+          <SearchFilter
+            filters={filters}
+            sorts={SORTS}
+            isDisabled={!canFilter}
+            onChange={(key, newValue, oldValue) =>
+              gleanClick(
+                `${PLUS_UPDATES.FILTER_CHANGE}_${key}: ${
+                  oldValue ?? "(default)"
+                } -> ${newValue ?? "(default)"}`
+              )
+            }
+          />
         )}
 
         {user && user.isAuthenticated && hasFilters && (

--- a/client/src/plus/updates/index.tsx
+++ b/client/src/plus/updates/index.tsx
@@ -190,7 +190,7 @@ function UpdatesLayout() {
         </Container>
       </header>
       <Container>
-        {user && user.isAuthenticated && (
+        {canFilter && (
           <SearchFilter
             filters={filters}
             sorts={SORTS}
@@ -205,7 +205,7 @@ function UpdatesLayout() {
           />
         )}
 
-        {user && user.isAuthenticated && hasFilters && (
+        {canFilter && hasFilters && (
           <Button
             type="action"
             extraClasses="reset-filters"


### PR DESCRIPTION
## Summary

Hides the (disabled) filters on the MDN Plus Updates page if not authenticated, and removes the login banner.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/140fa332-8825-4c94-b523-158f58b42182" />

### After

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/93cad90b-445c-4959-9cbb-1ef62258db12" />


---

## How did you test this change?

Ran `yarn dev` locally and opened http://localhost:3000/en-US/plus/updates