### PR TITLE
chore(observatory): update HTTP Headers links

### DIFF
--- a/client/src/observatory/results/headers.tsx
+++ b/client/src/observatory/results/headers.tsx
@@ -43,11 +43,11 @@ function HeaderLink({ header }: { header: string }) {
 function useHeaderLink(header: string) {
   const prettyHeaderName = upperCaseHeaderName(header);
   return useSWRImmutable(`headerLink-${header}`, async (key) => {
-    const url = `/en-US/docs/Web/HTTP/Headers/${encodeURIComponent(prettyHeaderName)}/metadata.json`;
+    const url = `/en-US/docs/Web/HTTP/Reference/Headers/${encodeURIComponent(prettyHeaderName)}/metadata.json`;
     try {
       const res = await fetch(url, { method: "HEAD" });
       return res.ok
-        ? `/en-US/docs/Web/HTTP/Headers/${encodeURIComponent(prettyHeaderName)}`
+        ? `/en-US/docs/Web/HTTP/Reference/Headers/${encodeURIComponent(prettyHeaderName)}`
         : null;
     } catch (e) {
       return null;


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The HTTP Headers reference pages were moved, but Observatory still links to the old URLs.

### Solution

Update the links.

---

## How did you test this change?

Trivial change, didn't test explicitly.