### PR TITLE
enhance(deps): require exact rari version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@mdn/bcd-utils-api": "^0.0.8",
     "@mdn/browser-compat-data": "^6.0.23",
     "@mdn/minimalist": "^2.0.4",
-    "@mdn/rari": "^0.1.42",
+    "@mdn/rari": "0.1.42",
     "@mdn/watify": "^1.1.3",
     "@mozilla/glean": "5.0.4",
     "@sentry/node": "^8.54.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2350,7 +2350,7 @@
   resolved "https://registry.yarnpkg.com/@mdn/minimalist/-/minimalist-2.0.4.tgz#6488ab0cb65b059446dcd9bf542246b81febe241"
   integrity sha512-jocePw/fsGcBxO67D+iWQLZ0TQjwNVonaME2BFN98QIm/e1kTY1/k2s4fOqH5MMa3QYURxa098bI4sChn6s/7Q==
 
-"@mdn/rari@^0.1.42":
+"@mdn/rari@0.1.42":
   version "0.1.42"
   resolved "https://registry.yarnpkg.com/@mdn/rari/-/rari-0.1.42.tgz#4b4703cc87fddecfa75d1addd432e1c99136e8c3"
   integrity sha512-LRFm0QWfLxWGSEDbnOykh1tl4ktGiaWVVjzGKM/DpTt2XK38V3Q0LapjAVEzaN7hJRGAsAHJKXgFV0ev8kFGrA==


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

When updating `@mdn/yari` in mdn/content, Dependabot may choose a newer version of `@mdn/rari`, which hasn't been tested with yari yet.

### Solution

Migrate from a version range to an exact version.

_Note_: Dependabot should still update the dependency.

---

## How did you test this change?

Trivial change, didn't test.