### PR TITLE
Add Japanese translation for "View this page in GitHub"

### DIFF
--- a/client/src/document/on-github.tsx
+++ b/client/src/document/on-github.tsx
@@ -4,9 +4,11 @@ export function OnGitHubLink({ doc }: { doc: Doc }) {
   return (
     <div id="on-github" className="on-github">
       <SourceOnGitHubLink doc={doc}>
-        {doc.locale !== "de"
-          ? "View this page on GitHub"
-          : "Übersetzung auf GitHub anzeigen"}
+        {doc.locale === "de"
+          ? "Übersetzung auf GitHub anzeigen"
+          : doc.locale === "ja"
+            ? "GitHub でこのページを表示する"
+            : "View this page on GitHub"}
       </SourceOnGitHubLink>{" "}
       •{" "}
       <NewIssueOnGitHubLink doc={doc}>


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary
Add Japanese translation for "View this page in GitHub"
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
I want to translation of the message for local "ja". Now the message has only translation for locale "de".
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution
Added Japanese translation in on-github.tsx
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots
By this PR a message at the bottom is changed. Here are before and after:

### Before
![image](https://github.com/user-attachments/assets/917bf774-0153-4e86-ae14-f8bc22c6fc6b)

### After
![image](https://github.com/user-attachments/assets/b00da864-3fad-4ccf-a8cc-7b06f642d218)
---

## How did you test this change?
I confirmed this translation is shown in only for Japanese translated page, switching the language at the left top.