### PR TITLE
chore(filecheck): ignore .gitignore/jsonc/yaml

### DIFF
--- a/filecheck/checker.ts
+++ b/filecheck/checker.ts
@@ -294,7 +294,7 @@ function canCheckFile(filePath: string) {
   return (
     filePathParts.includes("files") &&
     !filePathParts.includes("node_modules") &&
-    !/\.(DS_Store|html|json|md|txt|yml)$/i.test(filePath)
+    !/\.(DS_Store|gitignore|html|json|jsonc|md|txt|yaml|yml)$/i.test(filePath)
   );
 }
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Running `yarn filecheck` in the content repo yields several false positives.

### Solution

Update the files that filecheck ignores.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
