### PR TITLE
chore(deps): replace got with fetch

### DIFF
--- a/build/flaws/index.ts
+++ b/build/flaws/index.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import chalk from "chalk";
-import { RequestError } from "got";
 
 import { Document } from "../../content/index.js";
 import {
@@ -238,19 +237,6 @@ export async function fixFixableFlaws(doc: Partial<Doc>, options, document) {
           console.log(`Downloaded ${flaw.src} to ${destination}`);
           newSrc = path.basename(destination);
         } catch (error) {
-          if (error instanceof RequestError) {
-            if (error.response.statusCode === 404) {
-              console.log(chalk.yellow(`Skipping ${flaw.src} (404)`));
-              continue;
-            } else if (
-              error.code === "ETIMEDOUT" ||
-              error.code === "ENOTFOUND"
-            ) {
-              console.log(chalk.yellow(`Skipping ${flaw.src} (${error.code})`));
-              continue;
-            }
-          }
-
           console.error(error);
           throw error;
         }

--- a/build/spas.ts
+++ b/build/spas.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 
 import frontmatter from "front-matter";
 import { fdir, PathsOutput } from "fdir";
-import got from "got";
 
 import { m2h } from "../markdown/index.js";
 import * as kumascript from "../kumascript/index.js";
@@ -487,7 +486,9 @@ async function fetchGitHubPRs(repo, count = 5) {
   ].join("+");
   const pullRequestUrl = `https://api.github.com/search/issues?q=${pullRequestsQuery}&per_page=${count}`;
   try {
-    const pullRequestsData = (await got(pullRequestUrl).json()) as {
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    const response = await fetch(pullRequestUrl);
+    const pullRequestsData = (await response.json()) as {
       items: any[];
     };
     const prDataRepo = pullRequestsData.items.map((item) => ({

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -5,7 +5,6 @@ import path from "node:path";
 import { cwd } from "node:process";
 
 import * as cheerio from "cheerio";
-import got from "got";
 import { fileTypeFromBuffer } from "file-type";
 import imagemin from "imagemin";
 import imageminPngquant from "imagemin-pngquant";
@@ -62,19 +61,15 @@ export async function downloadAndResizeImage(
   out: string,
   basePath: string
 ) {
-  const imageResponse = await got(forceExternalURL(src), {
-    responseType: "buffer",
-    timeout: { request: 10000 },
-    retry: { limit: 3 },
-  });
-  const imageBuffer = imageResponse.body;
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const response = await fetch(forceExternalURL(src));
+  const arrayBuffer = await response.arrayBuffer();
+  const imageBuffer = Buffer.from(arrayBuffer);
   let fileType = await fileTypeFromBuffer(imageBuffer);
   if (
     !fileType &&
     src.toLowerCase().endsWith(".svg") &&
-    imageResponse.headers["content-type"]
-      .toLowerCase()
-      .startsWith("image/svg+xml")
+    response.headers["content-type"].toLowerCase().startsWith("image/svg+xml")
   ) {
     // If the SVG doesn't have the `<?xml version="1.0" encoding="UTF-8"?>`
     // and/or the `<!DOCTYPE svg PUBLIC ...` in the first couple of bytes

--- a/kumascript/src/api/mdn.ts
+++ b/kumascript/src/api/mdn.ts
@@ -1,4 +1,3 @@
-import got from "got";
 import { KumaThis } from "../environment.js";
 import * as util from "./util.js";
 
@@ -144,13 +143,11 @@ const mdn = {
   async fetchWebExtExamples() {
     if (!webExtExamples) {
       try {
-        webExtExamples = await got(
-          "https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json",
-          {
-            timeout: { request: 1000 },
-            retry: { limit: 5 },
-          }
-        ).json();
+        // eslint-disable-next-line n/no-unsupported-features/node-builtins
+        const response = await fetch(
+          "https://raw.githubusercontent.com/mdn/webextensions-examples/master/examples.json"
+        );
+        webExtExamples = await response.json();
       } catch (error) {
         webExtExamples = error;
       }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "file-type": "^21.0.0",
     "front-matter": "^4.0.2",
     "fs-extra": "^11.3.0",
-    "got": "^13.0.0",
     "he": "^1.2.0",
     "http-proxy-middleware": "^2.0.9",
     "image-size": "^1.2.1",

--- a/testing/tests/developing.spec.ts
+++ b/testing/tests/developing.spec.ts
@@ -1,5 +1,5 @@
+/* eslint-disable n/no-unsupported-features/node-builtins */
 import { test, expect } from "@playwright/test";
-import got from "got";
 
 export {};
 
@@ -71,9 +71,11 @@ test.describe("Testing the kitchensink page", () => {
     test.skip(withDevelop());
 
     // Loading the index.json doesn't require a headless browser
-    const { doc } = await got(
+    // eslint-disable-next-line n/no-unsupported-features/node-builtins
+    const response = await fetch(
       serverURL("/en-US/docs/MDN/Kitchensink/index.json")
-    ).json<any>();
+    );
+    const { doc } = await response.json();
 
     expect(doc.title).toBe("The MDN Content Kitchensink");
   });
@@ -87,84 +89,80 @@ test.describe("Testing the Express server", () => {
   test("redirect without any useful headers", async () => {
     test.skip(withDevelop());
 
-    let response = await got(serverURL("/"), { followRedirect: false });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/en-US/");
+    let response = await fetch(serverURL("/"), { redirect: "manual" });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/en-US/");
 
-    response = await got(serverURL("/docs/Web"), {
-      followRedirect: false,
-    });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/en-US/docs/Web");
+    response = await fetch(serverURL("/docs/Web"), { redirect: "manual" });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/en-US/docs/Web");
 
     // Trailing slashed
-    response = await got(serverURL("/docs/Web/"), {
-      followRedirect: false,
-    });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/en-US/docs/Web");
+    response = await fetch(serverURL("/docs/Web/"), { redirect: "manual" });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/en-US/docs/Web");
   });
 
   test("redirect by preferred locale cookie", async () => {
     test.skip(withDevelop());
 
-    let response = await got(serverURL("/"), {
-      followRedirect: false,
+    let response = await fetch(serverURL("/"), {
+      redirect: "manual",
       headers: {
         // Note! Case insensitive
         Cookie: "preferredlocale=zH-cN; foo=bar",
       },
     });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/zh-CN/");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/zh-CN/");
 
     // Some bogus locale we definitely don't recognized
-    response = await got(serverURL("/"), {
-      followRedirect: false,
+    response = await fetch(serverURL("/"), {
+      redirect: "manual",
       headers: {
         Cookie: "preferredlocale=xyz; foo=bar",
       },
     });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/en-US/");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/en-US/");
   });
 
   test("redirect by 'Accept-Language' header", async () => {
     test.skip(withDevelop());
 
-    let response = await got(serverURL("/"), {
-      followRedirect: false,
+    let response = await fetch(serverURL("/"), {
+      redirect: "manual",
       headers: {
         // Based on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language
         "Accept-language": "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
       },
     });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/fr/");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/fr/");
 
     // Some bogus locale we definitely don't recognized
-    response = await got(serverURL("/"), {
-      followRedirect: false,
+    response = await fetch(serverURL("/"), {
+      redirect: "manual",
       headers: {
         "accept-language": "xyz, X;q=0.9, Y;q=0.8, Z;q=0.7, *;q=0.5",
       },
     });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/en-US/");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/en-US/");
   });
 
   test("redirect by cookie trumps", async () => {
     test.skip(withDevelop());
 
-    const response = await got(serverURL("/"), {
-      followRedirect: false,
+    const response = await fetch(serverURL("/"), {
+      redirect: "manual",
       headers: {
         Cookie: "preferredlocale=ja",
         "Accept-language": "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5",
       },
     });
-    expect(response.statusCode).toBe(302);
-    expect(response.headers.location).toBe("/ja/");
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("/ja/");
   });
 });
 

--- a/testing/tests/redirects.test.ts
+++ b/testing/tests/redirects.test.ts
@@ -1,4 +1,3 @@
-import got from "got";
 import braces from "braces";
 
 function serverURL(pathname = "/") {
@@ -12,13 +11,11 @@ function url_test(from, to, { statusCode = 301 } = {}) {
   return expanded.map((f) => [
     f,
     async () => {
-      const res = await got(serverURL(f), {
-        followRedirect: false,
-        throwHttpErrors: false,
-      });
-      expect(res.statusCode).toBe(statusCode);
+      // eslint-disable-next-line n/no-unsupported-features/node-builtins
+      const res = await fetch(serverURL(f), { redirect: "manual" });
+      expect(res.status).toBe(statusCode);
       if (to) {
-        expect((res.headers.location || "").toLowerCase()).toBe(
+        expect((res.headers.get("location") || "").toLowerCase()).toBe(
           encodeURI(to).toLowerCase()
         );
       }

--- a/tool/popularities.ts
+++ b/tool/popularities.ts
@@ -8,12 +8,13 @@
 import fs from "node:fs";
 
 import * as csv from "@fast-csv/parse";
-import got from "got";
 
 const CURRENT_URL = "https://popularities.mdn.mozilla.net/current.csv";
 
 async function fetchPopularities() {
-  const { body: csv } = await got(CURRENT_URL);
+  // eslint-disable-next-line n/no-unsupported-features/node-builtins
+  const response = await fetch(CURRENT_URL);
+  const csv = await response.text();
   return csv;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3054,11 +3054,6 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sindresorhus/is@^5.2.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.6.0.tgz#41dd6093d34652cddb5d5bdeee04eafc33826668"
-  integrity sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==
-
 "@sindresorhus/is@^6.3.0":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-6.3.1.tgz#43bbe2a94de0d7a11b95b7fc8100fa0e4694bbe0"
@@ -3286,13 +3281,6 @@
   integrity sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==
   dependencies:
     "@swc/counter" "^0.1.3"
-
-"@szmarczak/http-timer@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
-  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
-  dependencies:
-    defer-to-connect "^2.0.1"
 
 "@testing-library/dom@^10.0.0":
   version "10.4.0"
@@ -3564,11 +3552,6 @@
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz#4fc33a00c1d0c16987b1a20cf92d20614c55ac35"
   integrity sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==
-
-"@types/http-cache-semantics@^4.0.2":
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
-  integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
 "@types/http-errors@*":
   version "2.0.4"
@@ -5203,24 +5186,6 @@ bytes@3.1.2:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
   integrity sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==
 
-cacheable-lookup@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
-  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
-
-cacheable-request@^10.2.8:
-  version "10.2.14"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.14.tgz#eb915b665fda41b79652782df3f553449c406b9d"
-  integrity sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==
-  dependencies:
-    "@types/http-cache-semantics" "^4.0.2"
-    get-stream "^6.0.1"
-    http-cache-semantics "^4.1.1"
-    keyv "^4.5.3"
-    mimic-response "^4.0.0"
-    normalize-url "^8.0.0"
-    responselike "^3.0.0"
-
 cacheable-request@^2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
@@ -6278,13 +6243,6 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
   dependencies:
     mimic-response "^1.0.0"
 
-decompress-response@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
-  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
-  dependencies:
-    mimic-response "^3.1.0"
-
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/decompress-tar/-/decompress-tar-4.1.1.tgz#718cbd3fcb16209716e70a26b84e7ba4592e5af1"
@@ -6365,11 +6323,6 @@ default-browser@^5.2.1:
   dependencies:
     bundle-name "^4.1.0"
     default-browser-id "^5.0.0"
-
-defer-to-connect@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
-  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
@@ -8009,11 +7962,6 @@ fork-ts-checker-webpack-plugin@^9.1.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data-encoder@^2.1.2:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
-  integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
-
 forwarded-parse@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz#08511eddaaa2ddfd56ba11138eee7df117a09325"
@@ -8420,23 +8368,6 @@ gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
-got@^13.0.0:
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-13.0.0.tgz#a2402862cef27a5d0d1b07c0fb25d12b58175422"
-  integrity sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==
-  dependencies:
-    "@sindresorhus/is" "^5.2.0"
-    "@szmarczak/http-timer" "^5.0.1"
-    cacheable-lookup "^7.0.0"
-    cacheable-request "^10.2.8"
-    decompress-response "^6.0.0"
-    form-data-encoder "^2.1.2"
-    get-stream "^6.0.1"
-    http2-wrapper "^2.1.10"
-    lowercase-keys "^3.0.0"
-    p-cancelable "^3.0.0"
-    responselike "^3.0.0"
 
 got@^7.0.0:
   version "7.1.0"
@@ -8936,7 +8867,7 @@ htmlparser2@^8.0.1:
     domutils "^3.0.1"
     entities "^4.4.0"
 
-http-cache-semantics@3.8.1, http-cache-semantics@>=4.1.1, http-cache-semantics@^4.1.1:
+http-cache-semantics@3.8.1, http-cache-semantics@>=4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
   integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
@@ -8999,14 +8930,6 @@ http-proxy@^1.17.0, http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
-
-http2-wrapper@^2.1.10:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.2.1.tgz#310968153dcdedb160d8b72114363ef5fce1f64a"
-  integrity sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==
-  dependencies:
-    quick-lru "^5.1.1"
-    resolve-alpn "^1.2.0"
 
 https-proxy-agent@^7.0.2, https-proxy-agent@^7.0.6:
   version "7.0.6"
@@ -10876,11 +10799,6 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lowercase-keys@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
-  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
-
 lru-cache@^10.2.0, lru-cache@^10.4.3:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -11633,16 +11551,6 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-mimic-response@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
-  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
-mimic-response@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
-  integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
-
 min-indent@^1.0.0, min-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -11914,11 +11822,6 @@ normalize-url@2.0.1:
     prepend-http "^2.0.0"
     query-string "^5.0.1"
     sort-keys "^2.0.0"
-
-normalize-url@^8.0.0:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.0.1.tgz#9b7d96af9836577c58f5883e939365fa15623a4a"
-  integrity sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==
 
 npm-conf@^1.1.0:
   version "1.1.3"
@@ -12193,11 +12096,6 @@ p-cancelable@^0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.1.tgz#35f363d67d52081c8d9585e37bcceb7e0bbcb2a0"
   integrity sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==
-
-p-cancelable@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
-  integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
 
 p-event@^1.0.0:
   version "1.3.0"
@@ -13949,11 +13847,6 @@ reserved-identifiers@^1.0.0:
   resolved "https://registry.yarnpkg.com/reserved-identifiers/-/reserved-identifiers-1.0.0.tgz#a4878ea2b5130ec2bf5aba40074edcb9704d2623"
   integrity sha512-h0bP2Katmvf3hv4Z3WtDl4+6xt/OglQ2Xa6TnhZ/Rm9/7IH1crXQqMwD4J2ngKBonVv+fB55zfGgNDAmsevLVQ==
 
-resolve-alpn@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
-  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -14016,13 +13909,6 @@ responselike@1.0.2:
   integrity sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==
   dependencies:
     lowercase-keys "^1.0.0"
-
-responselike@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
-  integrity sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==
-  dependencies:
-    lowercase-keys "^3.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

`got` is outdated and has security issues.

### Solution

Migrate to `fetch`.

_Note_: `fetch` is still considered experimental in Node.js 20, so we need to ignore the corresponding warnings.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

1. Relying on tests.
2. The `build` and `kumascript` folder are no longer used in production.
