### PR TITLE
chore(deps): remove `@vscode/ripgrep`

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -21,12 +21,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -30,13 +30,6 @@ jobs:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        if: steps.release.outputs.release_created
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install
         if: steps.release.outputs.release_created
         run: yarn --frozen-lockfile

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -26,12 +26,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "yarn"
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -30,12 +30,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/pr-bundlesize-compare.yml
+++ b/.github/workflows/pr-bundlesize-compare.yml
@@ -22,12 +22,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
@@ -62,12 +56,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -31,12 +31,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: yarn
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,12 +26,6 @@ jobs:
             client/pwa/yarn.lock
             libs/**/*.js
 
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
-
       - name: Install all yarn packages (ROOT)
         run: yarn --frozen-lockfile
         env:
@@ -65,12 +59,6 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: yarn
-
-      - name: Cache @vscode/ripgrep bin
-        uses: actions/cache@v4
-        with:
-          key: vscode-ripgrep-bin-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('yarn.lock') }}
-          path: node_modules/@vscode/ripgrep/bin/
 
       - name: Install all yarn packages
         run: yarn --frozen-lockfile

--- a/build/utils.ts
+++ b/build/utils.ts
@@ -12,7 +12,6 @@ import imageminPngquant from "imagemin-pngquant";
 import imageminMozjpeg from "imagemin-mozjpeg";
 import imageminGifsicle from "imagemin-gifsicle";
 import imageminSvgo from "imagemin-svgo";
-import { rgPath } from "@vscode/ripgrep";
 import sanitizeFilename from "sanitize-filename";
 
 import {
@@ -319,7 +318,7 @@ export function findPostFileBySlug(slug: string): string | null {
     return null;
   }
   try {
-    const { stdout, stderr, status } = spawnSync(rgPath, [
+    const { stdout, stderr, status } = spawnSync("rg", [
       "-il",
       `slug: ${slug}`,
       BLOG_ROOT,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@sentry/node": "^8.55.0",
     "@stripe/stripe-js": "^7.4.0",
     "@use-it/interval": "^1.0.0",
-    "@vscode/ripgrep": "^1.15.13",
     "@webref/css": "^6.17.5",
     "accept-language-parser": "^1.5.0",
     "async": "^3.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4229,15 +4229,6 @@
   resolved "https://registry.yarnpkg.com/@use-it/interval/-/interval-1.0.0.tgz#c42c68f22ca29a0dc929041746373d94496d2b3a"
   integrity sha512-WQFcnSt/xM/mS8ZtJ0ut5lhPrl+V0HDPPcI/J0eUClsfiD+/r8A7IeW/pVcfpSVGWRmN3+WnjNteWuKyWs2WZg==
 
-"@vscode/ripgrep@^1.15.13":
-  version "1.15.13"
-  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.13.tgz#e8f7c8782b2fafa32069826cb970f86b0f31b92e"
-  integrity sha512-c62On5sLEIMv9yfetIZ8c0Mg0s6lvq54G0YLW2zY/XiPsJPyBBgrP54MR1s0hK3gsPy423cY+e2BDU6mOB2Yaw==
-  dependencies:
-    https-proxy-agent "^7.0.2"
-    proxy-from-env "^1.1.0"
-    yauzl "^2.9.2"
-
 "@vscode/web-custom-data@^0.4.2":
   version "0.4.12"
   resolved "https://registry.yarnpkg.com/@vscode/web-custom-data/-/web-custom-data-0.4.12.tgz#11026146d58d82f6dcf543e1e155a288c2b5c9e9"
@@ -16857,7 +16848,7 @@ yargs@^17.3.1, yargs@^17.7.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yauzl@^2.10.0, yauzl@^2.4.2, yauzl@^2.9.2:
+yauzl@^2.10.0, yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
   integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Removes `@vscode/ripgrep` from our dependencies.

### Problem

We no longer use the code that uses `@vscode/ripgrep`.

### Solution

Remove `@vscode/ripgrep` from our dependency, and use `rg` directly instead (like in one other location already).

---

## How did you test this change?

Trivial low risk change.