### PR TITLE
ci(npm-published-simulation): use content node version

### DIFF
--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -8,12 +8,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/checkout@v4
-        with:
-          repository: mdn/content
-          path: mdn/content
+      - name: Checkout (yari)
+        uses: actions/checkout@v4
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -34,6 +30,12 @@ jobs:
           # This, resolves that.
           # Source https://github.com/expo/expo-github-action/issues/20#issuecomment-541676895
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
+      - name: Checkout (content)
+        uses: actions/checkout@v4
+        with:
+          repository: mdn/content
+          path: mdn/content
 
       - name: Start the dev server
         env:

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/checkout@v4
+      - name: (mdn/yari) Checkout
+        uses: actions/checkout@v4
         with:
-          repository: mdn/content
-          path: mdn/content
+          path: mdn/yari
 
-      - name: Setup Node.js environment
+      - name: (mdn/yari) Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
-          cache: "yarn"
+          node-version-file: mdn/yari/.nvmrc
+          cache: yarn
+          cache-dependency-path: mdn/yari/yarn.lock
 
-      - name: Install all yarn packages
+      - name: (mdn/yari) Install all yarn packages
+        working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
           # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
@@ -40,7 +40,8 @@ jobs:
           # Source https://github.com/expo/expo-github-action/issues/20#issuecomment-541676895
           echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-      - name: Prepare to build
+      - name: (mdn/yari) Prepare to build
+        working-directory: mdn/yari
         env:
           # The following env vars is what we do in npm-publish.yml
           # Each variable set is documented there.
@@ -51,15 +52,34 @@ jobs:
         run: |
           yarn build:legacy:prepare
 
-      - name: Build and install tarball
+      - name: (mdn/content) Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: mdn/content
+          path: mdn/content
+
+      - name: (mdn/yari) Build tarball
+        id: build
+        working-directory: mdn/yari
         run: |
-          echo mdn/content/ >> .npmignore
           npm pack
           TARBALL=`ls mdn-yari-*.tgz`
           echo $TARBALL
           ls -lh $TARBALL
-          mv $TARBALL mdn/content/
-          cd mdn/content
+          echo "tarball=$(realpath $TARBALL)" >> "$GITHUB_OUTPUT"
+
+      - name: (mdn/content) Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: mdn/content/.nvmrc
+          cache: yarn
+          cache-dependency-path: mdn/content/yarn.lock
+
+      - name: (mdn/content) Install tarball
+        working-directory: mdn/content
+        env:
+          TARBALL: ${{ steps.build.outputs.tarball }}
+        run: |
           yarn cache clean --all
           yarn add file:$TARBALL
           yarn install
@@ -96,7 +116,8 @@ jobs:
           curl --fail http://localhost:5042/en-US/ > /dev/null
           curl --fail http://localhost:5042/en-US/docs/MDN/Kitchensink > /dev/null
 
-      - name: Test viewing the dev server
+      - name: (mdn/yari) Test viewing the dev server
+        working-directory: mdn/yari
         env:
           # When running Yari from within mdn/content it only starts 1 server;
           # the one on localhost:5042. No React dev server; the one


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `npm-published-simulation` workflow uses the Node version specified in yari's `.nvmrc`, but this may not be compatible with content's engine requirement. (Because content needs to needs to be bumped first.)

### Solution

To test the scripts in content, use content's `.nvmrc`.

---

## How did you test this change?

Tests should pass on this PR.