### PR TITLE
fix(workflows): assign explicit permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+# No GITHUB_TOKEN permissions, as we use AUTOMERGE_TOKEN instead.
+permissions: {}
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -115,7 +115,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Python

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -3,6 +3,9 @@ name: Developing with Yari
 on:
   pull_request:
 
+# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/developing.yml
+++ b/.github/workflows/developing.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup kernel for react native, increase watchers

--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   glean-probe-scraper:
     if: github.repository == 'mdn/yari'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,10 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/mark-as-idle-issues-pr.yml
+++ b/.github/workflows/mark-as-idle-issues-pr.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: "49 11,23 * * *"
 
+permissions:
+  # Label issues.
+  issues: write
+  # Label pull requests.
+  pull-requests: write
+
 jobs:
   idle-issues-prs:
     uses: mdn/workflows/.github/workflows/idle.yml@main

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -5,6 +5,10 @@ on:
       - reopened
       - opened
 
+permissions:
+  # Label issues.
+  issues: write
+
 jobs:
   label-new-issues:
     uses: mdn/workflows/.github/workflows/new-issues.yml@main

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,7 +34,6 @@ jobs:
         if: steps.release.outputs.release_created
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -32,7 +32,6 @@ jobs:
         working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup kernel for react native, increase watchers

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -8,6 +8,9 @@ on:
       - package.json
       - yarn.lock
 
+# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
+permissions: {}
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -41,7 +41,6 @@ jobs:
         working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build select important pages

--- a/.github/workflows/pr-bundlesize-compare.yml
+++ b/.github/workflows/pr-bundlesize-compare.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
@@ -63,7 +62,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build

--- a/.github/workflows/pr-bundlesize-compare.yml
+++ b/.github/workflows/pr-bundlesize-compare.yml
@@ -3,6 +3,9 @@ name: Compare bundle size
 on:
   pull_request:
 
+# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
+permissions: {}
+
 jobs:
   # Build current and upload stats.json
   build-head:

--- a/.github/workflows/pr-commit-signatures.yml
+++ b/.github/workflows/pr-commit-signatures.yml
@@ -3,6 +3,9 @@ name: "Commit signatures"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -6,6 +6,9 @@ on:
       - deployer/**
       - .github/workflows/pr-deployer.yml
 
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-docs.yml
+++ b/.github/workflows/pr-docs.yml
@@ -6,6 +6,10 @@ on:
       - docs/**/*.md
       - README.md
       - .github/workflows/pr-docs.yml
+
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -18,6 +18,9 @@ on:
       - package.json
       - yarn.lock
 
+# No GITHUB_TOKEN permissions, as we only use it to increase API limit.
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-kumascript.yml
+++ b/.github/workflows/pr-kumascript.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit testing kumascript

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions:
+  # Label pull requests.
+  pull-requests: write
+
 jobs:
   label-rebase-needed:
     uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -156,8 +156,7 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD }}
         run: yarn --frozen-lockfile
         env:
-          # Use a GITHUB_TOKEN to bypass rate limiting for ripgrep and rari.
-          # See https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          # Use a GITHUB_TOKEN to bypass rate limiting for rari.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Python

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -179,8 +179,7 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD }}
         run: yarn --frozen-lockfile
         env:
-          # Use a GITHUB_TOKEN to bypass rate limiting for ripgrep and rari.
-          # See https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          # Use a GITHUB_TOKEN to bypass rate limiting for rari.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Python

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -139,8 +139,7 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD }}
         run: yarn --frozen-lockfile
         env:
-          # Use a GITHUB_TOKEN to bypass rate limiting for ripgrep and rari.
-          # See https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          # Use a GITHUB_TOKEN to bypass rate limiting for rari.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Install all yarn packages (ROOT)
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install all yarn packages (pwa)
@@ -63,7 +62,6 @@ jobs:
       - name: Install all yarn packages
         run: yarn --frozen-lockfile
         env:
-          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit testing client


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

Part of [MP-1882](https://mozilla-hub.atlassian.net/browse/MP-1882) (Mozilla-internal).

### Problem

There are several CodeQL code scanning alerts about workflows without explicit permissions.

### Solution

Assign explicit workflow permissions.

---

## How did you test this change?

Will check the CodeQL results for this branch, and post merge.

[MP-1882]: https://mozilla-hub.atlassian.net/browse/MP-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ