### PR TITLE
ci(build): avoid install in content

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: mdn/yari
 
       - name: Checkout (content)
         uses: actions/checkout@v4
@@ -117,9 +119,10 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: mdn/yari/.nvmrc
 
       - name: Install all yarn packages
+        working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -133,11 +136,11 @@ jobs:
         uses: snok/install-poetry@v1
 
       - name: Install deployer
-        run: |
-          cd deployer
-          poetry install
+        working-directory: mdn/yari/deployer
+        run: poetry install
 
       - name: Display Python & Poetry version
+        working-directory: mdn/yari/deployer
         run: |
           python --version
           poetry --version
@@ -151,6 +154,7 @@ jobs:
         run: cat /proc/cpuinfo
 
       - name: Build everything
+        working-directory: mdn/yari
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
@@ -211,11 +215,10 @@ jobs:
           yarn tool:legacy whatsdeployed $CONTENT_TRANSLATED_ROOT --output client/build/_whatsdeployed/translated-content.json
 
       - name: Update search index
+        working-directory: mdn/yari/deployer
         env:
           DEPLOYER_ELASTICSEARCH_URL: ${{ secrets.DEPLOYER_DEV_ELASTICSEARCH_URL }}
-        run: |
-          cd deployer
-          poetry run deployer search-index ../client/build
+        run: poetry run deployer search-index ../client/build
 
       - name: Authenticate with GCP
         uses: google-github-actions/auth@v2
@@ -228,9 +231,9 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
 
       - name: Sync build with GCS
-        uses: "google-github-actions/upload-cloud-storage@v2"
+        uses: google-github-actions/upload-cloud-storage@v2
         with:
-          path: "client/build"
+          path: mdn/yari/client/build
           destination: "${{ vars.GCP_BUCKET_NAME }}/${{ env.PREFIX }}"
           resumable: false
           concurrency: 500

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -69,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: mdn/yari
 
       - name: Checkout (content)
         uses: actions/checkout@v4
@@ -157,10 +159,11 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: mdn/yari/.nvmrc
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
           # Use a GITHUB_TOKEN to bypass rate limiting for rari.
@@ -178,12 +181,12 @@ jobs:
 
       - name: Install deployer
         if: ${{ ! vars.SKIP_BUILD }}
-        run: |
-          cd deployer
-          poetry install
+        working-directory: mdn/yari/deployer
+        run: poetry install
 
       - name: Display Python & Poetry version
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari/deployer
         run: |
           python --version
           poetry --version
@@ -199,6 +202,7 @@ jobs:
 
       - name: Build everything
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
@@ -331,11 +335,10 @@ jobs:
 
       - name: Update search index
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari/deployer
         env:
           DEPLOYER_ELASTICSEARCH_URL: ${{ secrets.DEPLOYER_PROD_ELASTICSEARCH_URL }}
-        run: |
-          cd deployer
-          poetry run deployer search-index ../client/build
+        run: poetry run deployer search-index ../client/build
 
       - name: Authenticate with GCP
         if: ${{ ! vars.SKIP_BUILD }}
@@ -351,6 +354,7 @@ jobs:
 
       - name: Sync build
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: |-
           gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r client/build/static gs://${{ vars.GCP_BUCKET_NAME }}/main/
           gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
@@ -371,7 +375,7 @@ jobs:
 
       - name: Generate redirects map
         if: ${{ ! vars.SKIP_FUNCTION }}
-        working-directory: cloud-function
+        working-directory: mdn/yari/cloud-function
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
@@ -382,6 +386,7 @@ jobs:
 
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
+        working-directory: mdn/yari
         run: |-
           set -eo pipefail
 
@@ -425,6 +430,7 @@ jobs:
           done
 
       - name: Update AI Help index with macros
+        working-directory: mdn/yari
         run: yarn ai-help-macros update-index
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -93,8 +93,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          path: mdn/yari
 
       - name: Merge main
+        working-directory: mdn/yari
         run: |
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
@@ -180,10 +182,11 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: mdn/yari/.nvmrc
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
           # Use a GITHUB_TOKEN to bypass rate limiting for rari.
@@ -201,12 +204,12 @@ jobs:
 
       - name: Install deployer
         if: ${{ ! vars.SKIP_BUILD }}
-        run: |
-          cd deployer
-          poetry install
+        working-directory: mdn/yari/deployer
+        run: poetry install
 
       - name: Display Python & Poetry version
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari/deployer
         run: |
           python --version
           poetry --version
@@ -222,6 +225,7 @@ jobs:
 
       - name: Build everything
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
@@ -345,11 +349,10 @@ jobs:
 
       - name: Update search index
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari/deployer
         env:
           DEPLOYER_ELASTICSEARCH_URL: ${{ secrets.DEPLOYER_STAGE_ELASTICSEARCH_URL }}
-        run: |
-          cd deployer
-          poetry run deployer search-index ../client/build
+        run: poetry run deployer search-index ../client/build
 
       - name: Authenticate with GCP
         if: ${{ ! vars.SKIP_BUILD }}
@@ -365,6 +368,7 @@ jobs:
 
       - name: Sync build
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: |-
           gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r client/build/static gs://${{ vars.GCP_BUCKET_NAME }}/main/
           gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
@@ -385,7 +389,7 @@ jobs:
 
       - name: Generate redirects map
         if: ${{ ! vars.SKIP_FUNCTION }}
-        working-directory: cloud-function
+        working-directory: mdn/yari/cloud-function
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
@@ -396,6 +400,7 @@ jobs:
 
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
+        working-directory: mdn/yari
         run: |-
           set -eo pipefail
 
@@ -439,6 +444,7 @@ jobs:
           done
 
       - name: Update AI Help index with macros
+        working-directory: mdn/yari
         run: yarn ai-help-macros update-index
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_KEY }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: mdn/yari
 
       - name: Checkout (content)
         uses: actions/checkout@v4
@@ -140,10 +142,11 @@ jobs:
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version-file: mdn/yari/.nvmrc
 
       - name: Install all yarn packages
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: yarn --frozen-lockfile
         env:
           # Use a GITHUB_TOKEN to bypass rate limiting for rari.
@@ -186,6 +189,7 @@ jobs:
 
       - name: Build everything
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         env:
           # Remember, the mdn/content repo got cloned into `pwd` into a
           # sub-folder called "mdn/content"
@@ -293,6 +297,7 @@ jobs:
 
       - name: Sync build
         if: ${{ ! vars.SKIP_BUILD }}
+        working-directory: mdn/yari
         run: |-
           gsutil -q -m -h "Cache-Control: public, max-age=3600" cp -r client/build/static gs://${{ vars.GCP_BUCKET_NAME }}/main/
           gsutil -q -m -h "Cache-Control: public, max-age=3600" rsync -cdrj html,json,txt -y "^static/" client/build gs://${{ vars.GCP_BUCKET_NAME }}/main
@@ -313,7 +318,7 @@ jobs:
 
       - name: Generate redirects map
         if: ${{ ! vars.SKIP_FUNCTION }}
-        working-directory: cloud-function
+        working-directory: mdn/yari/cloud-function
         env:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
@@ -324,6 +329,7 @@ jobs:
 
       - name: Deploy Function
         if: ${{ ! vars.SKIP_FUNCTION }}
+        working-directory: mdn/yari
         run: |-
           set -eo pipefail
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Our prod build failed, because it was running `yarn install` in the context of the content repo (as part of [`yarn install:all`](https://github.com/mdn/yari/blob/bf2da8e7a2a8ba374574c5b9ad1048ecf6023016/package.json#L40)).

### Solution

Checkout yari into `mdn/yari`, separating it from `mdn/content`.

---

## How did you test this change?

Will run a stage build, and review extremely carefully.