### PR TITLE
fix(dotenv): set `quiet: true` everywhere

### DIFF
--- a/bins/build.mjs
+++ b/bins/build.mjs
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 import { rariBin } from "@mdn/rari";
 import { spawn } from "cross-spawn";
-import { config } from "dotenv";
+import dotenv from "dotenv";
 import path from "node:path";
 import { cwd } from "node:process";
 
 import { BUILD_OUT_ROOT } from "../libs/env/index.js";
 
-config({
+dotenv.config({
   path: path.join(cwd(), process.env.ENV_FILE || ".env"),
+  quiet: true,
 });
 
 process.env.BUILD_OUT_ROOT = process.env.BUILD_OUT_ROOT || BUILD_OUT_ROOT;

--- a/bins/server.mjs
+++ b/bins/server.mjs
@@ -2,12 +2,13 @@
 import { concurrently } from "concurrently";
 import { rariBin } from "@mdn/rari";
 import { filename } from "../server/filename.js";
-import { config } from "dotenv";
+import dotenv from "dotenv";
 import path from "node:path";
 import { cwd } from "node:process";
 
-config({
+dotenv.config({
   path: path.join(cwd(), process.env.ENV_FILE || ".env"),
+  quiet: true,
 });
 
 const { commands, result } = concurrently(

--- a/bins/tool.mjs
+++ b/bins/tool.mjs
@@ -2,14 +2,15 @@
 import { rariBin } from "@mdn/rari";
 import { spawn } from "cross-spawn";
 
-import { config } from "dotenv";
+import dotenv from "dotenv";
 import path from "node:path";
 import { cwd } from "node:process";
 
 import { BUILD_OUT_ROOT } from "../libs/env/index.js";
 
-config({
+dotenv.config({
   path: path.join(cwd(), process.env.ENV_FILE || ".env"),
+  quiet: true,
 });
 
 process.env.BUILD_OUT_ROOT = process.env.BUILD_OUT_ROOT || BUILD_OUT_ROOT;

--- a/build/build-options.ts
+++ b/build/build-options.ts
@@ -1,4 +1,4 @@
-import * as dotenv from "dotenv";
+import dotenv from "dotenv";
 dotenv.config({ quiet: true });
 
 import { FLAW_LEVELS, VALID_FLAW_CHECKS } from "../libs/constants/index.js";

--- a/client/config/env.js
+++ b/client/config/env.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import * as dotenv from "dotenv";
+import dotenv from "dotenv";
 import paths from "./paths.js";
 
 // Double-check to make sure NODE_ENV is defined

--- a/cloud-function/src/build-canonicals.ts
+++ b/cloud-function/src/build-canonicals.ts
@@ -2,7 +2,7 @@ import { readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import * as dotenv from "dotenv";
+import dotenv from "dotenv";
 
 import { normalizePath } from "./utils.js";
 

--- a/libs/env/index.js
+++ b/libs/env/index.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import { cwd } from "node:process";
 import { fileURLToPath } from "node:url";
 
-import * as dotenv from "dotenv";
+import dotenv from "dotenv";
 
 import { VALID_FLAW_CHECKS } from "../constants/index.js";
 

--- a/server/cli.ts
+++ b/server/cli.ts
@@ -2,12 +2,13 @@
 import { concurrently } from "concurrently";
 import { rariBin } from "@mdn/rari";
 import { filename } from "./filename.js";
-import { config } from "dotenv";
+import dotenv from "dotenv";
 import path from "node:path";
 import { cwd } from "node:process";
 
-config({
+dotenv.config({
   path: path.join(cwd(), process.env.ENV_FILE || ".env"),
+  quiet: true,
 });
 
 const { commands, result } = concurrently(


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/yari/issues/13254.

### Problem

Dotenv v17 introduced a breaking change defaulting to `quiet: false`, and in https://github.com/mdn/yari/pull/13228 I migrated existing calls to set `quiet: true` explicitly to keep the previous behavior, but I missed some occurrences.

### Solution

Set `quiet: true` everywhere, and call dotenv consistently

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
