### PR TITLE
ci(build): increase GitHub API rate limit

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -188,6 +188,8 @@ jobs:
           # This removes the ability to sign in
           REACT_APP_DISABLE_AUTH: true
 
+          # Increase GitHub API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
 

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -303,6 +303,8 @@ jobs:
           # AI Help.
           REACT_APP_AI_FEEDBACK_GITHUB_REPO: mdn/ai-feedback
 
+          # Increase GitHub API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -317,6 +317,8 @@ jobs:
           SENTRY_ENVIRONMENT: stage
           SENTRY_RELEASE: ${{ github.sha }}
 
+          # Increase GitHub API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -255,6 +255,9 @@ jobs:
 
           # Observatory
           REACT_APP_OBSERVATORY_API_URL: https://observatory-api.mdn.allizom.net
+
+          # Increase GitHub API rate limit.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
 


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Our builds fail occasionally (and more frequently since we disabled caching in privileged workflows) with `Error: invalid type: map, expected a sequence`, most likely due to GitHub API requests failing due to rate limits.

### Solution

Use `GITHUB_TOKEN` to authenticate GitHub API requests, increasing the rate limit.

---

## How did you test this change?

Time will tell, and I'll kick off a prod build once this is merged.