### PR TITLE
fix(plus): replace ads free "Get started" link

### DIFF
--- a/client/src/plus/offer-overview/offer-overview-feature/index.tsx
+++ b/client/src/plus/offer-overview/offer-overview-feature/index.tsx
@@ -38,9 +38,7 @@ export default function OfferOverviewFeatures() {
             offline access, and more. Subscribers to paid tiers of MDN Plus have
             the option to browse MDN without ads.
           </p>
-          <Button href="/en-US/advertising" target="_self">
-            Learn more →
-          </Button>
+          <Button href="#subscribe">Get started →</Button>
         </section>
       </OfferOverviewFeature>
       <OfferOverviewFeature id="ai-help" img={screenshotAiHelp} imgAlt="">


### PR DESCRIPTION
## Summary

Replaced link to advertiser's page with a link to subscription options

### Problem

The existing link was to the advertiser's page ("advertise with us"), which is really not what is expected when people want to buy out of ads.

### Solution

Instead of "Learn more", use "Get started" and link to the subscription offers down at the bottom of the page.

## How did you test this change?

locally