### PR TITLE
ci(review-deploy): remove --ingress-settings=internal-and-gclb

### DIFF
--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -76,7 +76,6 @@ jobs:
             --source=cloud-function \
             --trigger-http \
             --allow-unauthenticated \
-            --ingress-settings=internal-and-gclb \
             --entry-point=mdnHandler \
             --concurrency=100 \
             --min-instances=0 \


### PR DESCRIPTION


<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

Our Review environment wasn't using the latest CSP (including tmo), because newly deployed Cloud Function revisions weren't serving any traffic, because they were deployed with the `--ingress-settings=internal-and-gclb` option.

### Solution

Remove that option.

---

## How did you test this change?

Ran the `review-deploy` workflow on this branch, and verified that the CSP are up-to-date now.