### PR TITLE
fix(offline): don't show 'your content is up to date' when it isn't

### DIFF
--- a/client/src/settings/update.tsx
+++ b/client/src/settings/update.tsx
@@ -23,7 +23,10 @@ export default function UpdateButton({
       break;
 
     case ContentStatusPhase.IDLE:
-      if (updateStatus?.local?.version === updateStatus?.remote?.latest) {
+      if (
+        updateStatus?.local?.version &&
+        updateStatus.local.version === updateStatus?.remote?.latest
+      ) {
         info = "Your content is up to date";
         button = <button disabled>Up to date</button>;
       } else {


### PR DESCRIPTION
## Summary

Relates to https://github.com/mdn/fred/issues/525

### Problem

When initially enabling offline, the "Update status" section would show "Your content is up to date" when nothing was downloaded, making the download button inoperable.

### Solution

Guard against finding two falsy values to be equal.

---

## Screenshots

### Before

<img width="512" height="113" alt="developer allizom org_en-US_plus_settings" src="https://github.com/user-attachments/assets/d35a67be-bd46-4954-bbb5-c791a29ae6dd" />


### After

<img width="512" height="113" alt="localhost_3000_en-US_plus_settings" src="https://github.com/user-attachments/assets/2b6a536e-4edb-44fd-97cf-09ed9ea87410" />

---

## How did you test this change?

Tested locally in fred.

Testing remotely with https://github.com/mdn/yari/actions/runs/16905038052 (in progress).
