### PR TITLE
ci(build): remove GA3 measurement id

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -233,11 +233,10 @@ jobs:
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 
-          # These are the Google Analytics measurement IDs for:
-          # - developer.mozilla.org (UA)
+          # This is the Google Analytics measurement ID for:
           # - developer.mozilla.org (GA4)
           # Using measurement ids on other domains is okay, as GA will filter these events.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5,G-PWTK27XVWP
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-PWTK27XVWP
 
           # This enables the MDN Plus
           REACT_APP_ENABLE_PLUS: true

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -259,11 +259,10 @@ jobs:
           # Now is not the time to worry about flaws.
           BUILD_FLAW_LEVELS: "*:ignore"
 
-          # These are the Google Analytics measurement IDs for:
-          # - developer.mozilla.org (UA)
+          # This is the Google Analytics measurement ID for:
           # - developer.allizom.org (GA4)
           # Using measurement ids on other domains is okay, as GA will filter these events.
-          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: UA-36116321-5,G-ZG5HNVZRY0
+          BUILD_GOOGLE_ANALYTICS_MEASUREMENT_ID: G-ZG5HNVZRY0
 
           # This enables the Plus call-to-action banner and the Plus landing page
           REACT_APP_ENABLE_PLUS: true


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We still use the GA3 measurement ID, which is EOL since July 2024.

### Solution

Remove it.

---

## How did you test this change?

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
