### PR TITLE
fix(plus): update staging/test base URLs for subscription platform

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -284,7 +284,7 @@ jobs:
           REACT_APP_MDN_PLUS_10Y_PLAN: price_1K6X8VKb9q6OnNsLFlUcEiu4
 
           # Support for SP3
-          REACT_APP_MDN_PLUS_SUBSCRIBE_URL_SP3_BASE: https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net
+          REACT_APP_MDN_PLUS_SUBSCRIBE_URL_SP3_BASE: https://payments-next.allizom.org
           REACT_APP_MDN_PLUS_5M_SP3_ID: mdnplus5mstage
           REACT_APP_MDN_PLUS_5Y_SP3_ID: mdnplus5ystage
           REACT_APP_MDN_PLUS_10M_SP3_ID: mdnsupporter10mstage

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -266,7 +266,7 @@ jobs:
           REACT_APP_MDN_PLUS_10Y_PLAN: price_1K6X8VKb9q6OnNsLFlUcEiu4
 
           # Support for SP3
-          REACT_APP_MDN_PLUS_SUBSCRIBE_URL_SP3_BASE: https://payments-next.stage.fxa.nonprod.webservices.mozgcp.net
+          REACT_APP_MDN_PLUS_SUBSCRIBE_URL_SP3_BASE: https://payments-next.allizom.org
           REACT_APP_MDN_PLUS_5M_SP3_ID: mdnplus5mstage
           REACT_APP_MDN_PLUS_5Y_SP3_ID: mdnplus5ystage
           REACT_APP_MDN_PLUS_10M_SP3_ID: mdnsupporter10mstage


### PR DESCRIPTION
## Summary

There are new (pretty) base URLs for Subscription Platform 3, here is the integration into our staging and test environments.

### Problem

The old URLs have stopped working.

fixes https://github.com/mdn/fred/issues/536

