### PR TITLE
fix(csp): add latest hash from fred

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -89,7 +89,7 @@ export const CSP_SCRIPT_SRC_VALUES = [
   // - Current hash:
   "'sha256-XNBp89FG76amD8BqrJzyflxOF9PaWPqPqvJfKZPCv7M='",
   // - Fred hash:
-  "'sha256-2dyzdbMORLrDxGYHyWprcjKoUyX5BjOre2gynWqc8mM='",
+  "'sha256-YCNoU9DNiinACbd8n6UPyB/8vj0kXvhkOni9/06SuYw='",
 ];
 export const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -75,7 +75,7 @@ export const CSP_SCRIPT_SRC_VALUES = [
   "https://js.stripe.com",
 
   /*
-   * Inline scripts (imported in `ssr/render.tsx`).
+   * Inline scripts (imported in fred).
    *
    * If we modify them, we must always update their CSP hash here.
    *
@@ -83,12 +83,10 @@ export const CSP_SCRIPT_SRC_VALUES = [
    * previous hash to avoid issues shortly after cache invalidation.
    */
 
-  // 1. Theme switching.
+  // 1. `entry.inline.js`
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-EehWlTYp7Bqy57gDeQttaWKp0ukTTEUKGP44h8GVeik='",
-  // - Current hash:
   "'sha256-XNBp89FG76amD8BqrJzyflxOF9PaWPqPqvJfKZPCv7M='",
-  // - Fred hash:
+  // - Current hash:
   "'sha256-YCNoU9DNiinACbd8n6UPyB/8vj0kXvhkOni9/06SuYw='",
 ];
 export const CSP_DIRECTIVES = {


### PR DESCRIPTION
With the merge of https://github.com/mdn/fred/commit/e0794cc57177b3ded5e39ac40f1c78b24c46529d our inline js hash changed: https://github.com/mdn/yari/actions/runs/17070179057/job/48396777059#step:24:159