### PR TITLE
ci(workflows): rename mdn/{mdn-studio => blog}

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -65,11 +65,11 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
 
-      - name: Checkout (mdn-studio)
+      - name: Checkout (blog)
         uses: actions/checkout@v5
         with:
-          repository: mdn/mdn-studio
-          path: mdn/mdn-studio
+          repository: mdn/blog
+          path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
@@ -161,7 +161,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
           CONTRIBUTOR_SPOTLIGHT_ROOT: ${{ github.workspace }}/mdn/mdn-contributor-spotlight/contributors
-          BLOG_ROOT: ${{ github.workspace }}/mdn/mdn-studio/content/posts
+          BLOG_ROOT: ${{ github.workspace }}/mdn/blog/content/posts
           CURRICULUM_ROOT: ${{ github.workspace }}/mdn/curriculum
           GENERIC_CONTENT_ROOT: ${{ github.workspace }}/mdn/generic-content/files
 

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -84,12 +84,12 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
 
-      - name: Checkout (mdn-studio)
+      - name: Checkout (blog)
         uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}
         with:
-          repository: mdn/mdn-studio
-          path: mdn/mdn-studio
+          repository: mdn/blog
+          path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
@@ -215,7 +215,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
           CONTRIBUTOR_SPOTLIGHT_ROOT: ${{ github.workspace }}/mdn/mdn-contributor-spotlight/contributors
-          BLOG_ROOT: ${{ github.workspace }}/mdn/mdn-studio/content/posts
+          BLOG_ROOT: ${{ github.workspace }}/mdn/blog/content/posts
           CURRICULUM_ROOT: ${{ github.workspace }}/mdn/curriculum
           GENERIC_CONTENT_ROOT: ${{ github.workspace }}/mdn/generic-content/files
           YARI_ROOT: ${{ github.workspace }}/mdn/yari

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -116,12 +116,12 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
 
-      - name: Checkout (mdn-studio)
+      - name: Checkout (blog)
         uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}
         with:
-          repository: mdn/mdn-studio
-          path: mdn/mdn-studio
+          repository: mdn/blog
+          path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
@@ -235,7 +235,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
           CONTRIBUTOR_SPOTLIGHT_ROOT: ${{ github.workspace }}/mdn/mdn-contributor-spotlight/contributors
-          BLOG_ROOT: ${{ github.workspace }}/mdn/mdn-studio/content/posts
+          BLOG_ROOT: ${{ github.workspace }}/mdn/blog/content/posts
           CURRICULUM_ROOT: ${{ github.workspace }}/mdn/curriculum
           GENERIC_CONTENT_ROOT: ${{ github.workspace }}/mdn/generic-content/files
           YARI_ROOT: ${{ github.workspace }}/mdn/yari

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -110,12 +110,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.content-ref }}
 
-      - name: Checkout (mdn-studio)
+      - name: Checkout (blog)
         uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}
         with:
-          repository: mdn/mdn-studio
-          path: mdn/mdn-studio
+          repository: mdn/blog
+          path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
 
@@ -235,7 +235,7 @@ jobs:
           CONTENT_ROOT: ${{ github.workspace }}/mdn/content/files
           CONTENT_TRANSLATED_ROOT: ${{ github.workspace }}/mdn/translated-content/files
           CONTRIBUTOR_SPOTLIGHT_ROOT: ${{ github.workspace }}/mdn/mdn-contributor-spotlight/contributors
-          BLOG_ROOT: ${{ github.workspace }}/mdn/mdn-studio/content/posts
+          BLOG_ROOT: ${{ github.workspace }}/mdn/blog/content/posts
           CURRICULUM_ROOT: ${{ github.workspace }}/mdn/curriculum
           GENERIC_CONTENT_ROOT: ${{ github.workspace }}/mdn/generic-content/files
           YARI_ROOT: ${{ github.workspace }}/mdn/yari


### PR DESCRIPTION
## Summary

Part of https://github.com/mdn/fred/issues/605.

### Problem

The Blog repo was renamed, but the workflows still point to the old name.

### Solution

Update the references.

---

## How did you test this change?

Trivial search and replace change with low risk.