### PR TITLE
ci(stage-build): only build on next branch

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -73,6 +73,9 @@ jobs:
     environment: stage
     runs-on: ubuntu-latest
 
+    # We only ever want to deploy the `next` branch to stage.
+    if: ${{ github.repository == 'mdn/yari' && github.ref_name == 'next' }}
+
     steps:
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,
       # we rely on the env vars defined at the top of the file. But if it's a manual


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

The `stage-build` currently builds twice (once on `main`, and once on `next`), because the `if` condition on the `build` job was removed in https://github.com/mdn/yari/pull/13398.

### Solution

Restore the condition, so that the `build` job only runs on the `next` branch.

---

## How did you test this change?

Hard to test, but the next schedule run will confirm.