### PR TITLE
Revert "chore: update CSP hash for fred entry.inline.js"

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -85,9 +85,9 @@ export const CSP_SCRIPT_SRC_VALUES = [
 
   // 1. `entry.inline.js`
   // - Previous hash (to avoid cache invalidation issues):
-  "'sha256-YCNoU9DNiinACbd8n6UPyB/8vj0kXvhkOni9/06SuYw='",
+  "'sha256-XNBp89FG76amD8BqrJzyflxOF9PaWPqPqvJfKZPCv7M='",
   // - Current hash:
-  "'sha256-NDybBb51I8NqtfjL2Sht/WVOtGSUWYZ4IK8tYdqRljo='",
+  "'sha256-YCNoU9DNiinACbd8n6UPyB/8vj0kXvhkOni9/06SuYw='",
 ];
 export const CSP_DIRECTIVES = {
   "default-src": ["'self'"],

--- a/testing/tests/csp.test.ts
+++ b/testing/tests/csp.test.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { CSP_SCRIPT_SRC_VALUES } from "../../libs/constants/index.js";
+
+describe("Content-Security-Policy", () => {
+  test('All inline <script> tags must have a corresponding "script-src" CSP entry.', () => {
+    function cspValueOf(content: string) {
+      const algo = "sha256";
+      const hash = crypto.createHash(algo).update(content).digest("base64");
+      return `'${algo}-${hash}'`;
+    }
+
+    const indexHtmlPath = path.join("client", "build", "en-us", "index.html");
+    const indexHtmlContent = fs.readFileSync(indexHtmlPath).toString();
+
+    const inlineScriptMatches = [
+      ...indexHtmlContent.matchAll(/(<script.*?>)(.*?)(<\/script>)/gi),
+    ];
+
+    const inlineScriptContents = inlineScriptMatches
+      .filter(
+        (match) =>
+          !(
+            match[1].includes("src=") ||
+            match[1].includes(`type="application/json"`)
+          )
+      )
+      .map((match) => match[2]);
+
+    // If this assertion fails, an inline script was added to `ssr/render.tsx`.
+    // Please consider merging it with the other inline script, or increment this number.
+    expect(inlineScriptContents).toHaveLength(1);
+
+    const inlineScriptCspValues = inlineScriptContents.map(cspValueOf);
+
+    const missingInlineScriptCspValues = inlineScriptCspValues.filter(
+      (value) => !CSP_SCRIPT_SRC_VALUES.includes(value)
+    );
+
+    // If this assertion fails, an inline script in `ssr/render.tsx` was
+    // updated without updating the "script-src" CSP entry in `libs/constants/index.js`.
+    expect(missingInlineScriptCspValues).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
https://github.com/mdn/fred/pull/656 is not final, so the CSP hash likely won't change.

Reverts mdn/yari#13443