### PR TITLE
chore(cloud-function): set Referrer-Policy explicitly

### DIFF
--- a/cloud-function/src/headers.ts
+++ b/cloud-function/src/headers.ts
@@ -92,6 +92,7 @@ export function setContentResponseHeaders(
   { csp = true, xFrame = true }: { csp?: boolean; xFrame?: boolean }
 ): void {
   [
+    ["Referrer-Policy", "strict-origin-when-cross-origin"],
     ["X-Content-Type-Options", "nosniff"],
     ["Strict-Transport-Security", "max-age=63072000"],
     ...(csp ? [["Content-Security-Policy", CSP_VALUE]] : []),


### PR DESCRIPTION
## Summary

Fixes https://github.com/mdn/fred/issues/697.

### Problem

We don't set `Referrer-Policy` explicitly, so we use the browser default, which is configurable (e.g. `network.http.referer.defaultPolicy` in Firefox), and breaks the Playground runner iframes if configured differently than what we expect.

### Solution

Set the expected browser default as `Referrer-Policy` explicitly.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Will deploy to stage, and check with `network.http.referer.defaultPolicy` set to `1`. 