### PR TITLE
chore(deps): relax @mdn/rari version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@mdn/bcd-utils-api": "^0.0.8",
     "@mdn/browser-compat-data": "^6.0.28",
     "@mdn/minimalist": "^2.0.4",
-    "@mdn/rari": "0.1.49",
+    "@mdn/rari": "^0.1.49",
     "@mdn/watify": "^1.1.3",
     "@mozilla/glean": "5.0.5",
     "@sentry/node": "^8.55.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,7 +2559,7 @@
   resolved "https://registry.yarnpkg.com/@mdn/minimalist/-/minimalist-2.0.4.tgz#6488ab0cb65b059446dcd9bf542246b81febe241"
   integrity sha512-jocePw/fsGcBxO67D+iWQLZ0TQjwNVonaME2BFN98QIm/e1kTY1/k2s4fOqH5MMa3QYURxa098bI4sChn6s/7Q==
 
-"@mdn/rari@0.1.49":
+"@mdn/rari@^0.1.49":
   version "0.1.49"
   resolved "https://registry.yarnpkg.com/@mdn/rari/-/rari-0.1.49.tgz#abee70b8b1f0778b6d0bea0a1d3947ae796d4f56"
   integrity sha512-7Qha/9PZXGbTImQ+8IfW+eKQnAJWgFY3d1gvuhH/ZXTiISoM9rEjOnD6JMjvBrqJzEy59y7E6gOTNIKjHuXoWg==


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

With https://github.com/mdn/fred/pull/737 merged, now both Fred and Yari require an exact `@mdn/rari` version, and both are still dependencies in mdn/content.

### Solution

Relax the `@mdn/rari` version range in yari, so that Fred decides.

---

## How did you test this change?

We will see once the next fred and yari release landed in content.