### PR TITLE
chore(cloud-function): set "Referrer-Policy: no-referrer" on ad clicks

### DIFF
--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -65,6 +65,7 @@ export async function proxyBSA(req: Request, res: Response) {
         userAgent
       );
       if (location && (status === 301 || status === 302)) {
+        res.setHeader("Referrer-Policy", "no-referrer");
         return res.redirect(location);
       } else {
         return res.sendStatus(502).end();


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We currently don't see referrers server-side on placement links,
which prevents us from understanding where these requests originated.

### Solution

1. In Fred: Remove the `rel="noreferrer"` (see https://github.com/mdn/fred/pull/749)
2. In Yari: Add `Referrer-Policy: no-referrer` to prevent the referrer from being passed to the redirect location

---

## How did you test this change?

Will deploy to stage once https://github.com/mdn/fred/pull/749 is merged.