### PR TITLE
chore(cloud-function): set "X-Robots-Tag: noindex, nofollow" on ad clicks

### DIFF
--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -66,6 +66,7 @@ export async function proxyBSA(req: Request, res: Response) {
       );
       if (location && (status === 301 || status === 302)) {
         res.setHeader("Referrer-Policy", "no-referrer");
+        res.setHeader("X-Robots-Tag", "noindex, nofollow");
         return res.redirect(location);
       } else {
         return res.sendStatus(502).end();


### PR DESCRIPTION
<!--
  Thanks for taking the time to submit a pull request (PR)!
  Please provide enough information so that others can review your changes.

  The sections below are mandatory.
  If you don't follow this template, your PR will very likely be closed.

  Before submitting the PR, please make sure the following is done:
  1. Read the Community Participation Guidelines: https://www.mozilla.org/about/governance/policies/participation/
  2. Ensure that there is an open issue for the problem you're solving, or create it first: https://github.com/mdn/yari/issues/new/choose
  3. Fork the repository and create your branch from `main`.
  4. Run `yarn` in the repository root.
  5. Make sure to sign all your commits: https://docs.github.com/authentication/managing-commit-signature-verification/signing-commits
-->

## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

There is a potential for ad links to appear on search engines.

### Solution

Avoid this by sending `X-Robots: noindex, nofollow` on that endpoint.

---

## How did you test this change?

Trivial change, we have already successfully added this header elsewhere:

https://github.com/mdn/yari/blob/f27debfcaa18a706331662aef82fee68cb869024/cloud-function/src/headers.ts#L39-L41
