### PR TITLE
chore(cloud-function): send `X-Robots-Tag: noindex` on pimg

### DIFF
--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -116,7 +116,7 @@ export async function proxyBSA(req: Request, res: Response) {
 
     const { status, buf, contentType } = await fetchImage(src);
 
-    if (status > 400) {
+    if (status >= 400) {
       console.warn(`[pimg] Image fetch failed: HTTP ${status}`);
       return res
         .status(status)

--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -105,6 +105,20 @@ export async function proxyBSA(req: Request, res: Response) {
       return res.sendStatus(405).end();
     }
 
+    const referer = req.get("referer");
+    if (!referer) {
+      console.warn("[pimg] Missing Referer (expected MDN host)");
+      return res.sendStatus(400).end();
+    }
+
+    const refererUrl = new URL(referer);
+    if (refererUrl.host != parsedUrl.host) {
+      console.warn(
+        `[pimg] Disallowed Referer (expected MDN host, was ${JSON.stringify(referer)})`
+      );
+      return res.sendStatus(400).end();
+    }
+
     const src = coder.decodeAndVerify(
       decodeURIComponent(pathname.substring("/pimg/".length))
     );

--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -105,20 +105,6 @@ export async function proxyBSA(req: Request, res: Response) {
       return res.sendStatus(405).end();
     }
 
-    const referer = req.get("referer");
-    if (!referer) {
-      console.warn("[pimg] Missing Referer (expected MDN host)");
-      return res.sendStatus(400).end();
-    }
-
-    const refererUrl = new URL(referer);
-    if (refererUrl.host != parsedUrl.host) {
-      console.warn(
-        `[pimg] Disallowed Referer (expected MDN host, was ${JSON.stringify(referer)})`
-      );
-      return res.sendStatus(400).end();
-    }
-
     const src = coder.decodeAndVerify(
       decodeURIComponent(pathname.substring("/pimg/".length))
     );

--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -122,10 +122,25 @@ export async function proxyBSA(req: Request, res: Response) {
     const src = coder.decodeAndVerify(
       decodeURIComponent(pathname.substring("/pimg/".length))
     );
+
     if (!src) {
+      console.warn("[pimg] Invalid src");
       return res.sendStatus(400).end();
     }
-    const { buf, contentType } = await fetchImage(src);
+
+    const { status, buf, contentType } = await fetchImage(src);
+
+    if (status > 400) {
+      console.warn(`[pimg] Image fetch failed: HTTP ${status}`);
+      return res
+        .status(status)
+        .set({
+          "cache-control": "no-store",
+          "content-type": contentType,
+        })
+        .end(Buffer.from(buf));
+    }
+
     return res
       .status(200)
       .set({

--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -101,6 +101,10 @@ export async function proxyBSA(req: Request, res: Response) {
       console.error(e);
     }
   } else if (pathname.startsWith("/pimg/")) {
+    if (req.method !== "GET") {
+      return res.sendStatus(405).end();
+    }
+
     const src = coder.decodeAndVerify(
       decodeURIComponent(pathname.substring("/pimg/".length))
     );

--- a/cloud-function/src/handlers/proxy-bsa.ts
+++ b/cloud-function/src/handlers/proxy-bsa.ts
@@ -113,6 +113,7 @@ export async function proxyBSA(req: Request, res: Response) {
       .set({
         "cache-control": "max-age=86400",
         "content-type": contentType,
+        "x-robots-tag": "noindex, nofollow",
       })
       .end(Buffer.from(buf));
   }

--- a/libs/pong/image.d.ts
+++ b/libs/pong/image.d.ts
@@ -1,4 +1,5 @@
 export function fetchImage(src: string): Promise<{
+  status: number;
   buf: ArrayBuffer;
   contentType: string;
 }>;

--- a/libs/pong/image.js
+++ b/libs/pong/image.js
@@ -1,7 +1,8 @@
 /* global fetch */
 export async function fetchImage(src) {
-  const imageResponse = await fetch(src);
-  const imageBuffer = await imageResponse.arrayBuffer();
-  const contentType = imageResponse.headers.get("content-type");
-  return { buf: imageBuffer, contentType };
+  const res = await fetch(src);
+  const status = res.status;
+  const buf = await res.arrayBuffer();
+  const contentType = res.headers.get("content-type");
+  return { status, buf, contentType };
 }


### PR DESCRIPTION
## Summary

<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem

We have seen some ad images being indexed by Google.

### Solution

Send `X-Robots-Tag: noindex, nofollow` on the images.

While we're here, we also:
- filter requests with unexpected HTTP method, 
- add `console.warn()` to distinguish the different error cases in the server logs,
- handle failed image fetches.

PS: In theory, `nofollow` on an image doesn't make sense, but in theory the fetch endpoint could also return SVG or similar with links included.

---

## How did you test this change?

Deploying to stage: https://github.com/mdn/yari/actions/runs/17761632422