### PR TITLE
fix(macro): French translation in PreviousMenuNext use wrong whitespace

### DIFF
--- a/kumascript/macros/PreviousMenuNext.ejs
+++ b/kumascript/macros/PreviousMenuNext.ejs
@@ -31,7 +31,7 @@ const menuStr = mdn.localString({
     "de"   : " Übersicht: ",
     "en-US": " Overview: ",
     "pt-BR": " Menu: ",
-    "fr"   : " Aperçu&nbsp;: ",
+    "fr"   : " Aperçu : ",
     "ru"   : " Обзор: ",
     "zh-CN": " 概述：",
     "zh-TW": " 概述：",


### PR DESCRIPTION
## Summary

Currently, HTML space is not properly supported by the macro. To avoid displaying the HTML code for non-breaking spaces, it is replaced by its keyboard version.

### Observed

<img width="734" height="46" alt="image" src="https://github.com/user-attachments/assets/cf648146-ad8b-45c8-bce6-c13a0843dd2d" />

### Expected

<img width="734" height="46" alt="image" src="https://github.com/user-attachments/assets/ea8510a7-5fee-47c3-8ec5-aa9b322f4b0d" />
