### PR TITLE
 fix: prevent horizontal overflow on contributor name (mobile)

### DIFF
--- a/client/src/homepage/contributor-spotlight/index.scss
+++ b/client/src/homepage/contributor-spotlight/index.scss
@@ -83,8 +83,10 @@
     font-size: 1.5rem;
     font-weight: 650;
     line-height: 1.4;
+    overflow-wrap: break-word;
     text-transform: uppercase;
     width: fit-content;
+    word-break: break-word;
 
     &::after,
     &::before {


### PR DESCRIPTION
## Summary

Fixes mdn/fred#1185

### Problem

On mobile devices, the homepage has an unwanted horizontal scroll caused by the "Contributor Spotlight" section. Long contributor names (like "VASS ARUNACHALAM BALASUBRAMANIAN") don't wrap properly, which pushes the page width and breaks responsiveness.

### Solution

Added `overflow-wrap: break-word` to the `.contributor-name` class in the Contributor Spotlight component styles. This allows long names to wrap naturally instead of overflowing the container.

---

## Screenshots

### Before
![Horizontal overflow on mobile](https://github.com/mdn/fred/issues/1185)
*(See issue mdn/fred#1185 for screenshot of the overflow)*

### After
Long contributor names now wrap within the container, preventing horizontal scroll on mobile viewports.

---

## How did you test this change?

- Added a test string with a long name ("Shrinivass Arunachalam Balasubramanian") to the Contributor Spotlight component locally
- Verified the CSS property is applied correctly using browser DevTools
- Confirmed the fix matches the solution suggested in the original issue
