### PR TITLE
chore(github): update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # ----------------------------------------------------------------------------
 # DEFAULT OWNERS
 # ----------------------------------------------------------------------------
-*    @mdn/core-dev
+*    @mdn/engineering
 
 # These are @mdn-bot because the auto-merge GHA workflow uses the PAT of this account.
 # If another reviewer is specified, update the PAT token or auto-merge will cease to be automatic.


### PR DESCRIPTION
## Summary
Change default codeowners from `@mdn/core-dev` to `@mdn/engineering`
For all changes, refer to mdn/mdn/issues/807
<!--
  Please reference the issue you're solving here.
  Example: Fixes #1234.
-->

### Problem
Old teams are codeowners
<!--
  Explain what problem the PR resolves in 1-3 sentences.
-->

### Solution
Linked codeowners to new and updated teams
<!--
  Explain how your PR solves this problem in 1-3 sentences.
  Please mention alternative solutions you have discarded, if any.
-->

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before
Calls @mdn/core-dev, a deprecated team.
<!-- Replace this line with your screenshot (or video). -->

### After
Calls @mdn/engineering, an active team.
<!-- Replace this line with your screenshot (or video). -->

---

<!--
  Did you change anything else (other than the user interface)?
  If not, you can remove this section.
  If yes, please explain how you verified that your PR solves the problem you wanted to solve.
-->
