### PR TITLE
fix: pin npx tsc to the typescript package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:ssr": "cross-env NODE_ENV=production NODE_OPTIONS=\"--no-warnings=ExperimentalWarning --loader ts-node/esm\" node ssr/prepare.ts && webpack --mode=production --config=ssr/webpack.config.js",
     "build:sw": "cd client/pwa && yarn && yarn build:prod",
     "build:sw-dev": "cd client/pwa && yarn && yarn build",
-    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' ! -wholename '**/cloud-function/src/internal/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
+    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' ! -wholename '**/cloud-function/src/internal/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx --package=typescript tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
     "dev": "yarn build:prepare && nf -j Procfile.rari.dev start",
     "dev:legacy": "yarn build:legacy:prepare && nf -j Procfile.dev start",
     "eslint": "eslint .",


### PR DESCRIPTION
## Summary

Part of https://github.com/mdn/fred/issues/1680.

### Problem

`package.json`'s `check:tsc` script runs `npx tsc --noEmit`. `tsc` is a bin of `typescript`, but a standalone `tsc` package also exists on npm (a deprecated TypeScript-compiler release). If `typescript` isn't installed locally, `npx tsc` falls back to fetching that package instead, a dependency-confusion risk.

### Solution

Pin the binary to its package: `npx tsc --noEmit` → `npx --package=typescript tsc --noEmit`. This guarantees the intended compiler is used.

---

## Screenshots

<!--
  Did you change the user interface?
  If not, you can remove this section.
  If yes, please attach screenshots (or videos) of how the interface looks (or behaves) before and after your changes.
-->

### Before

<!-- Replace this line with your screenshot (or video). -->

### After

<!-- Replace this line with your screenshot (or video). -->

---

## How did you test this change?

Verified the `check:tsc` script still resolves `tsc` from the local `typescript` dependency, and confirmed the surrounding `find … | xargs …` pipeline is unchanged.
