### PR TITLE
chore(telemetry): renew metrics

### DIFF
--- a/client/src/telemetry/metrics.yaml
+++ b/client/src/telemetry/metrics.yaml
@@ -19,7 +19,7 @@ page:
       - https://github.com/mdn/yari/pull/6813#issuecomment-1203705308
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
   referrer:
     type: url
     lifetime: application
@@ -36,7 +36,7 @@ page:
       - https://github.com/mdn/yari/pull/6813#issuecomment-1203705308
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
   utm:
     type: labeled_string
     lifetime: application
@@ -58,7 +58,7 @@ page:
       - "https://bugzilla.mozilla.org/show_bug.cgi?id=1851150"
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
     labels:
       - source
       - medium
@@ -83,7 +83,7 @@ navigator:
       - https://github.com/mdn/yari/pull/7457#issuecomment-1296934544
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
   geo_iso:
     type: string
     lifetime: application
@@ -100,7 +100,7 @@ navigator:
       - https://github.com/mdn/yari/pull/7457#issuecomment-1296934544
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
   subscription_type:
     type: string
     lifetime: application
@@ -118,7 +118,7 @@ navigator:
       - https://github.com/mdn/yari/pull/7457#issuecomment-1296934544
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
 
 element:
   clicked:
@@ -136,7 +136,7 @@ element:
       - https://github.com/mdn/yari/pull/6813#issuecomment-1203705308
     notification_emails:
       - mdn-team@mozilla.com
-    expires: 2026-09-05
+    expires: 2027-09-05
     extra_keys:
       source:
         description: |


### PR DESCRIPTION
## Summary

Renew all Glean metrics by bumping their `expires` date from 2026-09-05 to 2027-09-05.

Unlike last year, we don't drop any metric.

### Problem

All metrics in `client/src/telemetry/metrics.yaml` expired on 2026-09-05.

### Solution

Bump `expires` to 2027-09-05 for all metrics.

---

## How did you test this change?

No code changes, only metric expiry dates. The generated TypeScript does not embed expiry dates, so no regeneration was required.

---

Same as:

- https://github.com/mdn/yari/pull/13468 (September 2025)
- https://github.com/mdn/yari/pull/11724 (September 2024)
