### PR TITLE
ci: run `pull_request` workflows on stacked PRs

### DIFF
--- a/.github/workflows/npm-published-simulation.yml
+++ b/.github/workflows/npm-published-simulation.yml
@@ -5,8 +5,6 @@ name: NPM Publish simulation
 
 on:
   pull_request:
-    branches:
-      - main
 
 # No GITHUB_TOKEN permissions, as we only use it to increase API limit.
 permissions: {}


### PR DESCRIPTION
## Summary

Part of mdn/fred#1872.

### Problem

The NPM Publish simulation workflow only runs for PRs that target `main`, so it is skipped for stacked PRs (PRs that target another PR branch).

### Solution

Drop the `branches: [main]` filter from the `pull_request` trigger.
