### PR TITLE
ci(npm-publish): add manual release recovery

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -48,7 +48,6 @@ jobs:
         env:
           PUBLISH_TAG: ${{ inputs.tag || needs.release.outputs.tag_name }}
         run: |
-          test "$(git describe --tags --exact-match)" = "$PUBLISH_TAG"
           test "v$(node -p "require('./package.json').version")" = "$PUBLISH_TAG"
 
       - name: Setup

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,28 +22,39 @@ jobs:
 
     steps:
       - name: Release
+        if: github.event_name == 'push'
         uses: googleapis/release-please-action@v4
         id: release
 
       - name: Checkout
         uses: actions/checkout@v5
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
+        with:
+          ref: ${{ inputs.tag || github.sha }}
+
+      - name: Validate manual publish
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PUBLISH_TAG: ${{ inputs.tag }}
+        run: |
+          test "$(git describe --tags --exact-match)" = "$PUBLISH_TAG"
+          test "v$(node -p "require('./package.json').version")" = "$PUBLISH_TAG"
 
       - name: Setup
         uses: actions/setup-node@v4
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         run: yarn --frozen-lockfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         env:
           # What this does is it makes sure the built client is made for
           # doing CRUD work (e.g. previewing, toolbar, flaws UI, etc)
@@ -60,7 +77,7 @@ jobs:
         run: yarn build:legacy:prepare
 
       - name: Publish
-        if: steps.release.outputs.release_created
+        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,14 +11,18 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  build:
+  release:
     if: github.repository == 'mdn/yari'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
 
     steps:
       - name: Release
@@ -26,11 +30,19 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
 
+  publish:
+    needs: release
+    if: needs.release.outputs.release_created || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
       - name: Checkout
         uses: actions/checkout@v5
-        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         with:
-          ref: ${{ inputs.tag || github.sha }}
+          ref: ${{ inputs.tag || needs.release.outputs.tag_name }}
 
       - name: Validate manual publish
         if: github.event_name == 'workflow_dispatch'
@@ -42,19 +54,16 @@ jobs:
 
       - name: Setup
         uses: actions/setup-node@v4
-        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install
-        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         run: yarn --frozen-lockfile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         env:
           # What this does is it makes sure the built client is made for
           # doing CRUD work (e.g. previewing, toolbar, flaws UI, etc)
@@ -77,7 +86,6 @@ jobs:
         run: yarn build:legacy:prepare
 
       - name: Publish
-        if: steps.release.outputs.release_created || github.event_name == 'workflow_dispatch'
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,10 +44,9 @@ jobs:
         with:
           ref: ${{ inputs.tag || needs.release.outputs.tag_name }}
 
-      - name: Validate manual publish
-        if: github.event_name == 'workflow_dispatch'
+      - name: Validate
         env:
-          PUBLISH_TAG: ${{ inputs.tag }}
+          PUBLISH_TAG: ${{ inputs.tag || needs.release.outputs.tag_name }}
         run: |
           test "$(git describe --tags --exact-match)" = "$PUBLISH_TAG"
           test "v$(node -p "require('./package.json').version")" = "$PUBLISH_TAG"


### PR DESCRIPTION
## Summary

### Problem

If `npm publish` fails after Release Please has created a GitHub release, rerunning the workflow skips the publish steps because no new release is created. This happened for `v6.0.0`, where `npm publish` failed with `EOTP` due to an outdated `NPM_AUTH_TOKEN` (since replaced).

### Solution

Allow manually dispatching the workflow for an existing release tag, and split the workflow into a `release` job (Release Please, push only) and a `publish` job that checks out the release tag, verifies it matches the `package.json` version, and runs the existing install, build, and publish steps.

---

## How did you test this change?

- Ran `actionlint` and Prettier against the workflow.
- Confirmed `v6.0.0` matches package version `6.0.0`.
- The publish path itself cannot be dry-run, since `npm publish` runs for real.
